### PR TITLE
Remove just_any and serialize bounds from just

### DIFF
--- a/src/gen/mod.rs
+++ b/src/gen/mod.rs
@@ -24,7 +24,7 @@ pub use default::DefaultGenerator;
 pub use fixed_dict::fixed_dicts;
 pub use formats::{dates, datetimes, domains, emails, ip_addresses, times, urls};
 pub use numeric::{floats, integers};
-pub use primitives::{booleans, just, just_any, unit};
+pub use primitives::{booleans, just, unit};
 #[cfg(feature = "rand")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
 pub use random::{randoms, HegelRandom, RandomsGenerator};

--- a/src/gen/primitives.rs
+++ b/src/gen/primitives.rs
@@ -1,5 +1,5 @@
 use super::{generate_from_schema, BasicGenerator, Generate};
-use crate::cbor_helpers::{cbor_map, cbor_serialize};
+use crate::cbor_helpers::cbor_map;
 use ciborium::Value;
 
 pub fn unit() -> JustGenerator<()> {
@@ -8,42 +8,24 @@ pub fn unit() -> JustGenerator<()> {
 
 pub struct JustGenerator<T> {
     value: T,
-    schema: Option<Value>,
 }
 
-impl<T: Clone + Send + Sync + serde::Serialize + serde::de::DeserializeOwned> Generate<T>
-    for JustGenerator<T>
-{
+impl<T: Clone + Send + Sync> Generate<T> for JustGenerator<T> {
     fn generate(&self) -> T {
         self.value.clone()
     }
 
     fn as_basic(&self) -> Option<BasicGenerator<'_, T>> {
-        let schema = self.schema.as_ref()?.clone();
-        Some(BasicGenerator::new(schema, |raw| {
-            super::deserialize_value(raw)
-        }))
+        let value = self.value.clone();
+        Some(BasicGenerator::new(
+            cbor_map! {"const" => Value::Null},
+            move |_| value.clone(),
+        ))
     }
 }
 
-pub fn just<T: Clone + Send + Sync + serde::Serialize + serde::de::DeserializeOwned>(
-    value: T,
-) -> JustGenerator<T> {
-    let schema = Some(cbor_map! {"const" => cbor_serialize(&value)});
-    JustGenerator { value, schema }
-}
-
-pub struct JustAnyGenerator<T> {
-    value: T,
-}
-
-impl<T: Clone + Send + Sync> Generate<T> for JustAnyGenerator<T> {
-    fn generate(&self) -> T {
-        self.value.clone()
-    }
-}
-pub fn just_any<T: Clone + Send + Sync>(value: T) -> JustAnyGenerator<T> {
-    JustAnyGenerator { value }
+pub fn just<T: Clone + Send + Sync>(value: T) -> JustGenerator<T> {
+    JustGenerator { value }
 }
 
 pub struct BoolGenerator;


### PR DESCRIPTION
This was a misguided early attempt at the API from Claude, which the new BasicGenerator work which makes Hegel's approach more Hypothesis-like now renders redundant - there is no need to be able to serialize things for `just` to work, because that's a crazy requirement.