### PR TITLE
Replace exit(134) on socket errors with panic

### DIFF
--- a/src/gen/mod.rs
+++ b/src/gen/mod.rs
@@ -41,9 +41,6 @@ use ciborium::Value;
 
 use crate::cbor_helpers::{cbor_map, map_insert};
 
-pub(crate) mod exit_codes {
-    pub const SOCKET_ERROR: i32 = 134;
-}
 use std::cell::{Cell, RefCell};
 use std::marker::PhantomData;
 use std::sync::{Arc, LazyLock};
@@ -236,8 +233,7 @@ pub(crate) fn send_request(command: &str, payload: &Value) -> Result<Value, Stop
                     TEST_ABORTED.with(|aborted| aborted.set(true));
                     Err(StopTestError)
                 } else {
-                    eprintln!("Failed to communicate with Hegel: {}", e);
-                    std::process::exit(exit_codes::SOCKET_ERROR);
+                    panic!("Failed to communicate with Hegel: {}", e);
                 }
             }
         }


### PR DESCRIPTION
## Summary

Remove legacy behaviour where connection/socket errors cause `std::process::exit(134)`. Instead, panic normally with the error message.

This was a holdover from a previous design where exit code 134 (SIGABRT) was used to signal socket errors. It's no longer relevant — connection errors should propagate normally.

## Changes

- Remove `exit_codes` module and `SOCKET_ERROR` constant from `src/gen/mod.rs`
- Replace `std::process::exit(exit_codes::SOCKET_ERROR)` with `panic!()` including the error message