### PR TITLE
Restore CHANGELOG.md accidentally deleted in 472f90f

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+## 0.1.5 - 2026-02-26
+
+Rename the `gen` module to `generators`, avoiding a conflict with rust edition 2024, which made `gen` a reserved keyword.
+
+
+## 0.1.4 - 2026-02-26
+
+Refactor internals for better encapsulation of per-test-case state.
+
+
+## 0.1.3 - 2026-02-25
+
+Change how to draw a value from a generator from `generator.generate()` to `hegel::draw(generator)`.
+
+
+## 0.1.2 - 2026-02-25
+
+This patch adds support for setting `seed` as an option to `hegel`.
+
+
+## 0.1.1 - 2026-02-24
+
+Add `gen::from_type`, for use together with `#[derive(Generate)]`.
+


### PR DESCRIPTION
## Summary

- Commit 472f90f ("Remove check.yml and RELEASE.md from cherry-pick") accidentally also deleted `CHANGELOG.md`
- This broke the release workflow, which tries to read `CHANGELOG.md` at line 66 of `release.py` ([failed run](https://github.com/antithesishq/hegel-rust/actions/runs/22492326822/job/65157930959))
- Restores the file from commit 9084ffd (the last release commit, v0.1.5)

## Test plan

- [ ] Verify `CHANGELOG.md` is present with all entries (0.1.1 through 0.1.5)
- [ ] Verify the release workflow no longer fails with `FileNotFoundError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)