### PR TITLE
Modify most URLs to point to new repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
 
   release:
     name: release
-    if: github.event_name == 'push' && github.repository == 'antithesishq/hegel-rust'
+    if: github.event_name == 'push' && github.repository == 'hegeldev/hegel-rust'
     needs: [lint, test, test-all-features, docs, coverage, conformance, nix]
     runs-on: ubuntu-latest
     permissions:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ rust-version = "1.86"
 description = "Property-based testing SDK for the Hegel test data generator"
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/antithesishq/hegel-rust"
+repository = "https://github.com/hegeldev/hegel-rust"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hegel-rust
 
-A Rust SDK for [Hegel](https://github.com/antithesishq/hegel-core) — universal
+A Rust SDK for [Hegel](https://github.com/hegeldev/hegel-core) — universal
 property-based testing powered by [Hypothesis](https://hypothesis.works/).
 
 Hegel generates random inputs for your tests, finds failures, and automatically

--- a/justfile
+++ b/justfile
@@ -38,7 +38,7 @@ coverage:
 update-hegel-core-version:
     #!/usr/bin/env bash
     set -euo pipefail
-    tag=$(gh api repos/antithesishq/hegel-core/releases/latest --jq '.tag_name')
+    tag=$(gh api repos/hegeldev/hegel-core/releases/latest --jq '.tag_name')
     sed -i '' "s/^const HEGEL_SERVER_VERSION: &str = \".*\"/const HEGEL_SERVER_VERSION: \&str = \"${tag}\"/" src/runner.rs
     sed -i '' "s/refs\/tags\/.*\";/refs\/tags\/${tag}\";/" nix/flake.nix
     nix --extra-experimental-features "nix-command flakes" flake lock ./nix
@@ -50,5 +50,5 @@ build-conformance:
     cargo build --release --manifest-path tests/conformance/rust/Cargo.toml
 
 conformance: build-conformance
-    uv run --with "hegel @ git+ssh://git@github.com/antithesishq/hegel-core.git" \
+    uv run --with "hegel @ https://github.com/antithesishq/hegel-core.git" \
         --with pytest --with hypothesis pytest tests/conformance/test_conformance.py

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -44,13 +44,13 @@
         "rev": "3485130c83d314febf439fb1cb0ca895f90c7030",
         "revCount": 346,
         "type": "git",
-        "url": "ssh://git@github.com/antithesishq/hegel-core"
+        "url": "https://github.com/hegeldev/hegel-core"
       },
       "original": {
         "dir": "nix",
         "ref": "refs/tags/v0.4.0",
         "type": "git",
-        "url": "ssh://git@github.com/antithesishq/hegel-core"
+        "url": "https://github.com/hegeldev/hegel-core"
       }
     },
     "nixpkgs": {

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    hegel.url = "git+ssh://git@github.com/antithesishq/hegel-core?dir=nix&ref=refs/tags/v0.4.0";
+    hegel.url = "git+https://github.com/hegeldev/hegel-core?dir=nix&ref=refs/tags/v0.4.0"; # git+https instead of github so that we can use the ref parameter
     flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
   };
 


### PR DESCRIPTION
Intentionally leaving out things that we intend to switch before release, like `src/runner.rs` pointing to PyPI.

Depends on #49.