### PR TITLE
Update keyword for `crates.io` limitation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,9 @@ readme = "README.md"
 repository = "https://github.com/hegeldev/hegel-rust"
 homepage = "http://hegel.dev"
 description = "Property-based testing for Rust, built on Hypothesis"
-keywords = ["testing", "fuzzing", "property-based-testing"]
+# Ideally we would replace "property testing" with "property based testing",
+# but crates.io enforces that keywords be less than 20 characters.
+keywords = ["testing", "fuzzing", "property testing"]
 categories = ["development-tools::testing"]
 
 [lib]


### PR DESCRIPTION
A bit sad that `property-based-testing` is only 2 characters longer than the crates.io limit of 20!