### PR TITLE
Update keyword for crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "http://hegel.dev"
 description = "Property-based testing for Rust, built on Hypothesis"
 # Ideally we would replace "property testing" with "property based testing",
 # but crates.io enforces that keywords be less than 20 characters.
-keywords = ["testing", "fuzzing", "property testing"]
+keywords = ["testing", "fuzzing", "property-testing"]
 categories = ["development-tools::testing"]
 
 [lib]


### PR DESCRIPTION
`cargo publish --dry-run` didn't warn me about this so I only discovered post-merge when trying to publish 🙃

Here is the actual logic: https://github.com/rust-lang/crates.io/blob/f41626e423db61309b4ff2e5415e085d03a645af/src/models/keyword.rs#L52, see https://github.com/rust-lang/cargo/issues/4300