### PR TITLE
Fix flaky test_list_with_wide_gap overflow

### DIFF
--- a/tests/test_shrink_quality/collections.rs
+++ b/tests/test_shrink_quality/collections.rs
@@ -179,7 +179,8 @@ fn test_list_with_wide_gap() {
             }
             let max = *x.iter().max().unwrap();
             let min = *x.iter().min().unwrap();
-            max > min + 10 && min + 10 > 0
+            min.checked_add(10)
+                .is_some_and(|min_plus_10| max > min_plus_10 && min_plus_10 > 0)
         },
     );
     assert_eq!(xs.len(), 2);


### PR DESCRIPTION
This could overflow sometimes, which caused the test to be flaky. This PR fixes that.