### PR TITLE
Clarify readme failure example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ fn test_addition_commutative(tc: TestCase) {
 }
 ```
 
-This test will fail! Integer addition panics on overflow. Hegel will produce a minimal failing test case for us:
+This test will fail when run with `cargo test`! Integer addition panics on overflow in the `test` profile. Hegel will produce a minimal failing test case for us:
 
 ```
 Draw 1: 1


### PR DESCRIPTION
Integer overflow only panics when running cargo test with the test or dev profiles. Bit me in the butt earlier.