### PR TITLE
Fix some test issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ result
 .claude/*.local.json
 .claude/*.local
 .claude-reliability/
+lcov.info

--- a/tests/common/project.rs
+++ b/tests/common/project.rs
@@ -8,12 +8,21 @@ use std::sync::LazyLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 use tempfile::TempDir;
 
-// cache build output from TempRustProject across tests. Compilation time is substantial
-// (10+ seconds) and this lets us only incur that cost on the first test.
+// Cache build output from TempRustProject across tests within the same process.
 //
-// We clear the dir at the start to ensure a fresh environment on each test run.
+// Under coverage (CARGO_LLVM_COV=1), we reuse the main project's llvm-cov target
+// dir so that subprocess builds share the same instrumented artifacts. This lets
+// cargo-llvm-cov's report phase map subprocess profraw data back to source files.
+// Cargo's internal file locks prevent corruption from concurrent access.
+//
+// Outside coverage, each test binary gets its own target dir (via PID) to avoid
+// heavy lock contention when multiple test binaries build in parallel.
 static SHARED_TARGET_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
-    let path = std::env::temp_dir().join("hegel-test-cargo-target");
+    if std::env::var("CARGO_LLVM_COV").is_ok() {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target/llvm-cov-target");
+        return path;
+    }
+    let path = std::env::temp_dir().join(format!("hegel-test-cargo-target-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&path);
     std::fs::create_dir_all(&path).unwrap();
     path

--- a/tests/test_output.rs
+++ b/tests/test_output.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::project::TempRustProject;
-use common::utils::{assert_matches_regex, is_nightly};
+use common::utils::assert_matches_regex;
 
 const FAILING_TEST_CODE: &str = r#"
 use hegel::generators;
@@ -44,11 +44,8 @@ fn test_failing_test_output_with_backtrace() {
         .expect_failure("intentional failure")
         .cargo_run(&[]);
 
-    let closure_name = if is_nightly() {
-        r"\{closure#0\}"
-    } else {
-        r"\{\{closure\}\}"
-    };
+    // Rust >= 1.92 uses {closure#0}, older stable uses {{closure}}
+    let closure_name = r"(\{closure#0\}|\{\{closure\}\})";
     // For example:
     //   Draw 1: 0
     //   thread 'main' (1) panicked at src/main.rs:7:9:
@@ -97,11 +94,8 @@ fn test_failing_test_output_with_full_backtrace() {
         .expect_failure("intentional failure")
         .cargo_run(&[]);
 
-    let closure_name = if is_nightly() {
-        r"\{closure#0\}"
-    } else {
-        r"\{\{closure\}\}"
-    };
+    // Rust >= 1.92 uses {closure#0}, older stable uses {{closure}}
+    let closure_name = r"(\{closure#0\}|\{\{closure\}\})";
     assert_matches_regex(
         &output.stderr,
         &format!(


### PR DESCRIPTION
Fix two flaky/broken tests:

- `TempRustProject`: PID-based temp target dirs to prevent parallel test binary races
- `test_output`: accept both `{closure#0}` and `{{closure}}` backtrace formats (Rust 1.92 changed the stable format)