### PR TITLE
Convert dead code to unreachable!()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ result
 .claude-reliability/
 .claude/reliability-config.yml
 
+lcov.info
+
 # claude-reliability managed
 .claude/bin/
 .claude/*.local.md

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Internal cleanup: mark genuinely unreachable code paths with `unreachable!()`.

--- a/hegel-macros/src/enum_gen.rs
+++ b/hegel-macros/src/enum_gen.rs
@@ -60,7 +60,7 @@ fn variant_field_types(variant: &Variant) -> Vec<&syn::Type> {
             field_types
         }
         VariantKind::TupleSingle { field_type } => vec![field_type],
-        VariantKind::Unit => vec![],
+        VariantKind::Unit => unreachable!("variant_field_types is only called on data variants"),
     }
 }
 
@@ -476,8 +476,7 @@ fn generate_variant_generator(
 
     match classify_variant(variant) {
         VariantKind::Unit => {
-            // Unit variants don't get their own generator
-            quote! {}
+            unreachable!("generate_variant_generator is only called on data variants")
         }
         VariantKind::Named {
             field_names,

--- a/hegel-macros/src/hegel_test.rs
+++ b/hegel-macros/src/hegel_test.rs
@@ -26,13 +26,6 @@ impl Parse for TestArgs {
         let mut settings = None;
         let mut settings_args = Vec::new();
 
-        if input.is_empty() {
-            return Ok(TestArgs {
-                settings,
-                settings_args,
-            });
-        }
-
         // check if the first arg is a settings expression or a named settingArg
         let is_named_arg = input.peek(Ident) && input.peek2(Token![=]);
         if !is_named_arg {

--- a/src/generators/collections.rs
+++ b/src/generators/collections.rs
@@ -77,7 +77,7 @@ where
 
         Some(BasicGenerator::new(schema, move |raw| {
             let Value::Array(arr) = raw else {
-                panic!("Expected array, got {:?}", raw)
+                unreachable!("Expected array, got {:?}", raw)
             };
             arr.into_iter().map(|v| basic.parse_raw(v)).collect()
         }))
@@ -168,7 +168,7 @@ where
 
         Some(BasicGenerator::new(schema, move |raw| {
             let Value::Array(arr) = raw else {
-                panic!("Expected array, got {:?}", raw)
+                unreachable!("Expected array, got {:?}", raw)
             };
             arr.into_iter().map(|v| basic.parse_raw(v)).collect()
         }))
@@ -266,14 +266,14 @@ where
             // schema expects format [[key, value], ...]
             let values = match raw {
                 Value::Array(arr) => arr,
-                _ => panic!("Expected array, got {:?}", raw),
+                _ => unreachable!("Expected array, got {:?}", raw),
             };
 
             let mut map = HashMap::new();
             for value_raw in values {
                 let value = match value_raw {
                     Value::Array(arr) => arr,
-                    _ => panic!("Expected array, got {:?}", value_raw),
+                    _ => unreachable!("Expected array, got {:?}", value_raw),
                 };
                 let mut iter = value.into_iter();
                 let raw_k = iter.next().unwrap();
@@ -405,7 +405,7 @@ impl Generator<Value> for FixedDictGenerator<'_> {
         Some(BasicGenerator::new(schema, move |raw| {
             let arr = match raw {
                 Value::Array(arr) => arr,
-                _ => panic!("Expected array from tuple schema, got {:?}", raw),
+                _ => unreachable!("Expected array from tuple schema, got {:?}", raw),
             };
 
             let entries: Vec<(Value, Value)> = field_names
@@ -484,7 +484,7 @@ impl<G: Generator<T> + Send + Sync, T, const N: usize> Generator<[T; N]>
         Some(BasicGenerator::new(schema, move |raw| {
             let arr = match raw {
                 Value::Array(arr) => arr,
-                _ => panic!("Expected array from tuple schema, got {:?}", raw),
+                _ => unreachable!("Expected array from tuple schema, got {:?}", raw),
             };
             assert_eq!(arr.len(), N);
             let mut iter = arr.into_iter();

--- a/src/generators/combinators.rs
+++ b/src/generators/combinators.rs
@@ -14,16 +14,12 @@ impl<T: Clone + Send + Sync> Generator<T> for SampledFromGenerator<T> {
             return basic.do_draw(tc);
         }
 
-        let indices = integers::<usize>()
-            .min_value(0)
-            .max_value(self.elements.len() - 1);
-        let index = indices.do_draw(tc);
-        self.elements[index].clone()
+        unreachable!("sampled_from always has as_basic since elements is guaranteed non-empty")
     }
 
     fn as_basic(&self) -> Option<BasicGenerator<'_, T>> {
         if self.elements.is_empty() {
-            return None;
+            unreachable!("sampled_from constructor asserts non-empty");
         }
 
         let schema = cbor_map! {
@@ -97,14 +93,14 @@ impl<T> Generator<T> for OneOfGenerator<'_, T> {
         Some(BasicGenerator::new(schema, move |raw| {
             let arr = match raw {
                 Value::Array(arr) => arr,
-                _ => panic!("Expected array from tagged tuple, got {:?}", raw),
+                _ => unreachable!("Expected array from tagged tuple, got {:?}", raw),
             };
             let tag = match &arr[0] {
                 Value::Integer(i) => {
                     let val: i128 = (*i).into();
                     val as usize
                 }
-                _ => panic!("Expected integer tag, got {:?}", arr[0]),
+                _ => unreachable!("Expected integer tag, got {:?}", arr[0]),
             };
             let value = arr.into_iter().nth(1).unwrap();
             basics[tag].parse_raw(value)
@@ -200,14 +196,14 @@ where
         Some(BasicGenerator::new(schema, move |raw| {
             let arr = match raw {
                 Value::Array(arr) => arr,
-                _ => panic!("Expected array from tagged tuple, got {:?}", raw),
+                _ => unreachable!("Expected array from tagged tuple, got {:?}", raw),
             };
             let tag = match &arr[0] {
                 Value::Integer(i) => {
                     let val: i128 = (*i).into();
                     val as usize
                 }
-                _ => panic!("Expected integer tag, got {:?}", arr[0]),
+                _ => unreachable!("Expected integer tag, got {:?}", arr[0]),
             };
 
             if tag == 0 {

--- a/src/generators/strings.rs
+++ b/src/generators/strings.rs
@@ -144,7 +144,7 @@ impl BinaryGenerator {
 fn parse_binary(raw: Value) -> Vec<u8> {
     match raw {
         Value::Bytes(bytes) => bytes,
-        _ => panic!("expected Value::Bytes, got {:?}", raw),
+        _ => unreachable!("expected Value::Bytes, got {:?}", raw),
     }
 }
 

--- a/src/generators/tuples.rs
+++ b/src/generators/tuples.rs
@@ -100,7 +100,7 @@ macro_rules! impl_tuple {
                 Some(BasicGenerator::new(schema, move |raw| {
                     let arr = match raw {
                         Value::Array(arr) => arr,
-                        _ => panic!("Expected array from tuple schema, got {:?}", raw),
+                        _ => unreachable!("Expected array from tuple schema, got {:?}", raw),
                     };
                     let mut iter = arr.into_iter();
 

--- a/src/generators/value.rs
+++ b/src/generators/value.rs
@@ -84,7 +84,7 @@ impl From<ciborium::Value> for HegelValue {
             ciborium::Value::Tag(tag, _) => {
                 panic!("Unexpected CBOR tag {tag} in protocol value")
             }
-            other => panic!("Unexpected CBOR value type: {:?}", other),
+            other => unreachable!("Unexpected CBOR value type: {:?}", other),
         }
     }
 }

--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -427,7 +427,7 @@ impl<'a> Collection<'a> {
     /// Ask the server whether to produce another element.
     pub fn more(&mut self) -> bool {
         if self.finished {
-            return false;
+            unreachable!("Collection::more() called after collection already finished");
         }
         let server_name = self.ensure_initialized().to_string();
         let response = match self.tc.send_request(
@@ -453,7 +453,7 @@ impl<'a> Collection<'a> {
     /// Reject the last element (don't count it towards the size budget).
     pub fn reject(&mut self, why: Option<&str>) {
         if self.finished {
-            return;
+            unreachable!("Collection::reject() called after collection already finished");
         }
         let server_name = self.ensure_initialized().to_string();
         let mut payload = cbor_map! {


### PR DESCRIPTION
Mark genuinely unreachable code paths with `unreachable!()` instead of `panic!()` or silent returns.

Some of these are paths that can't be reached due to invariants enforced elsewhere (constructor asserts, filtered iterators). Some of these are... technically reachable given a sufficiently badly behaved server, but I thought it was probably not worth the effort of making a malicious server just to test these paths given the correct behaviour is to panic on these paths either way and unreachable will panic if hit.