### PR TITLE
Add integration tests for generators, macros, error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ result
 .claude-reliability/
 .claude/reliability-config.yml
 
+lcov.info
+
 # claude-reliability managed
 .claude/bin/
 .claude/*.local.md

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Add integration tests for string generators, non-basic collections, compile-fail macros, and server error handling.

--- a/src/generators/collections.rs
+++ b/src/generators/collections.rs
@@ -1,4 +1,4 @@
-use super::{BasicGenerator, BoxedGenerator, Collection, Generator, TestCase, integers, labels};
+use super::{BasicGenerator, BoxedGenerator, Collection, Generator, TestCase, labels};
 use crate::cbor_utils::{cbor_map, map_insert};
 use ciborium::Value;
 use std::collections::{HashMap, HashSet};
@@ -77,7 +77,7 @@ where
 
         Some(BasicGenerator::new(schema, move |raw| {
             let Value::Array(arr) = raw else {
-                panic!("Expected array, got {:?}", raw)
+                unreachable!("Expected array, got {:?}", raw)
             };
             arr.into_iter().map(|v| basic.parse_raw(v)).collect()
         }))
@@ -130,19 +130,13 @@ where
             basic.do_draw(tc)
         } else {
             tc.start_span(labels::SET);
-            let max = self.max_size.unwrap_or(100);
-            let target_len = integers::<usize>()
-                .min_value(self.min_size)
-                .max_value(max)
-                .do_draw(tc);
-
+            let mut collection = Collection::new(tc, "composite_set", self.min_size, self.max_size);
             let mut set = HashSet::new();
-            let mut attempts = 0;
-            while set.len() < target_len && attempts < target_len * 10 {
-                tc.start_span(labels::SET_ELEMENT);
-                set.insert(self.elements.do_draw(tc));
-                tc.stop_span(false);
-                attempts += 1;
+            while collection.more() {
+                let element = self.elements.do_draw(tc);
+                if !set.insert(element) {
+                    collection.reject(Some("duplicate element"));
+                }
             }
             tc.stop_span(false);
             set
@@ -168,7 +162,7 @@ where
 
         Some(BasicGenerator::new(schema, move |raw| {
             let Value::Array(arr) = raw else {
-                panic!("Expected array, got {:?}", raw)
+                unreachable!("Expected array, got {:?}", raw)
             };
             arr.into_iter().map(|v| basic.parse_raw(v)).collect()
         }))
@@ -222,23 +216,20 @@ where
             basic.do_draw(tc)
         } else {
             tc.start_span(labels::MAP);
-            let max = self.max_size.unwrap_or(100);
-            let len = integers::<usize>()
-                .min_value(self.min_size)
-                .max_value(max)
-                .do_draw(tc);
-
+            let mut collection = Collection::new(tc, "composite_map", self.min_size, self.max_size);
             let mut map = HashMap::new();
-            let max_attempts = len * 10;
-            let mut attempts = 0;
-            while map.len() < len && attempts < max_attempts {
-                tc.start_span(labels::MAP_ENTRY);
+            while collection.more() {
                 let key = self.keys.do_draw(tc);
-                map.entry(key).or_insert_with(|| self.values.do_draw(tc));
-                tc.stop_span(false);
-                attempts += 1;
+                match map.entry(key) {
+                    std::collections::hash_map::Entry::Occupied(_) => {
+                        collection.reject(Some("duplicate key"));
+                    }
+                    std::collections::hash_map::Entry::Vacant(entry) => {
+                        let value = self.values.do_draw(tc);
+                        entry.insert(value);
+                    }
+                }
             }
-            assert!(map.len() >= self.min_size);
             tc.stop_span(false);
             map
         }
@@ -266,14 +257,14 @@ where
             // schema expects format [[key, value], ...]
             let values = match raw {
                 Value::Array(arr) => arr,
-                _ => panic!("Expected array, got {:?}", raw),
+                _ => unreachable!("Expected array, got {:?}", raw),
             };
 
             let mut map = HashMap::new();
             for value_raw in values {
                 let value = match value_raw {
                     Value::Array(arr) => arr,
-                    _ => panic!("Expected array, got {:?}", value_raw),
+                    _ => unreachable!("Expected array, got {:?}", value_raw),
                 };
                 let mut iter = value.into_iter();
                 let raw_k = iter.next().unwrap();
@@ -405,7 +396,7 @@ impl Generator<Value> for FixedDictGenerator<'_> {
         Some(BasicGenerator::new(schema, move |raw| {
             let arr = match raw {
                 Value::Array(arr) => arr,
-                _ => panic!("Expected array from tuple schema, got {:?}", raw),
+                _ => unreachable!("Expected array from tuple schema, got {:?}", raw),
             };
 
             let entries: Vec<(Value, Value)> = field_names
@@ -484,7 +475,7 @@ impl<G: Generator<T> + Send + Sync, T, const N: usize> Generator<[T; N]>
         Some(BasicGenerator::new(schema, move |raw| {
             let arr = match raw {
                 Value::Array(arr) => arr,
-                _ => panic!("Expected array from tuple schema, got {:?}", raw),
+                _ => unreachable!("Expected array from tuple schema, got {:?}", raw),
             };
             assert_eq!(arr.len(), N);
             let mut iter = arr.into_iter();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,3 +221,8 @@ pub use hegel_macros::test;
 #[doc(hidden)]
 pub use runner::hegel;
 pub use runner::{HealthCheck, Hegel, Settings, Verbosity};
+
+/// Mutex for serializing tests that modify environment variables.
+/// Used across runner, antithesis, and integration test modules to prevent races.
+#[doc(hidden)]
+pub static ENV_TEST_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());

--- a/tests/test_collections.rs
+++ b/tests/test_collections.rs
@@ -179,3 +179,184 @@ fn test_binary_with_max_size(tc: TestCase) {
     let data = tc.draw(generators::binary().max_size(50));
     assert!(data.len() <= 50);
 }
+
+#[hegel::test]
+fn test_vec_with_non_basic_elements(tc: TestCase) {
+    // flat_map produces a generator without as_basic(), forcing Vec through the
+    // Collection-based fallback path (new_collection / collection_more protocol)
+    let vec: Vec<String> = tc.draw(
+        generators::vecs(
+            generators::integers::<usize>()
+                .min_value(1)
+                .max_value(3)
+                .flat_map(|n| generators::text().min_size(n).max_size(n)),
+        )
+        .min_size(1)
+        .max_size(5),
+    );
+    assert!(!vec.is_empty());
+    assert!(vec.len() <= 5);
+}
+
+#[hegel::test]
+fn test_hashset_with_non_basic_elements(tc: TestCase) {
+    // flat_map produces a generator without as_basic(), forcing the HashSet fallback path
+    let set: HashSet<String> = tc.draw(
+        generators::hashsets(
+            generators::integers::<usize>()
+                .min_value(1)
+                .max_value(3)
+                .flat_map(|n| generators::text().min_size(n).max_size(n)),
+        )
+        .min_size(1)
+        .max_size(5),
+    );
+    assert!(!set.is_empty());
+    assert!(set.len() <= 5);
+}
+
+#[hegel::test]
+fn test_hashmap_with_non_basic_keys(tc: TestCase) {
+    // flat_map on keys produces a generator without as_basic(), forcing HashMap fallback
+    let map: HashMap<String, i32> = tc.draw(
+        generators::hashmaps(
+            generators::integers::<usize>()
+                .min_value(1)
+                .max_value(5)
+                .flat_map(|n| generators::text().min_size(n).max_size(n)),
+            generators::integers::<i32>(),
+        )
+        .min_size(1)
+        .max_size(5),
+    );
+    assert!(!map.is_empty());
+    assert!(map.len() <= 5);
+}
+
+// Non-basic collection tests with small domains to stress min_size enforcement
+// and duplicate rejection through the Collection protocol.
+
+#[hegel::test]
+fn test_vec_non_basic_min_size_respected(tc: TestCase) {
+    // Small domain (0..4) via flat_map to force non-basic path
+    let vec: Vec<i32> = tc.draw(
+        generators::vecs(
+            generators::integers::<i32>()
+                .min_value(0)
+                .max_value(3)
+                .flat_map(|n| generators::integers::<i32>().min_value(n).max_value(n)),
+        )
+        .min_size(3)
+        .max_size(8),
+    );
+    assert!(
+        vec.len() >= 3,
+        "min_size 3 not respected: got {}",
+        vec.len()
+    );
+    assert!(vec.len() <= 8);
+}
+
+#[hegel::test]
+fn test_hashset_non_basic_small_domain_min_size(tc: TestCase) {
+    // Elements from domain {0,1,2,3,4} via flat_map, min_size=3
+    // This forces many duplicate rejections through collection_reject
+    let set: HashSet<i32> = tc.draw(
+        generators::hashsets(
+            generators::integers::<i32>()
+                .min_value(0)
+                .max_value(4)
+                .flat_map(|n| generators::integers::<i32>().min_value(n).max_value(n)),
+        )
+        .min_size(3)
+        .max_size(5),
+    );
+    assert!(
+        set.len() >= 3,
+        "min_size 3 not respected: got {} elements: {:?}",
+        set.len(),
+        set
+    );
+    assert!(set.len() <= 5);
+    assert!(set.iter().all(|&v| (0..=4).contains(&v)));
+}
+
+#[hegel::test]
+fn test_hashmap_non_basic_small_domain_min_size(tc: TestCase) {
+    // Keys from domain {0,1,2,3,4} via flat_map, min_size=3
+    let map: HashMap<i32, bool> = tc.draw(
+        generators::hashmaps(
+            generators::integers::<i32>()
+                .min_value(0)
+                .max_value(4)
+                .flat_map(|n| generators::integers::<i32>().min_value(n).max_value(n)),
+            generators::booleans(),
+        )
+        .min_size(3)
+        .max_size(5),
+    );
+    assert!(
+        map.len() >= 3,
+        "min_size 3 not respected: got {} entries: {:?}",
+        map.len(),
+        map
+    );
+    assert!(map.len() <= 5);
+    assert!(map.keys().all(|&k| (0..=4).contains(&k)));
+}
+
+#[hegel::test]
+fn test_hashset_non_basic_exact_domain_equals_min_size(tc: TestCase) {
+    // Domain has exactly 3 values, min_size=3 — must produce all 3
+    let set: HashSet<i32> = tc.draw(
+        generators::hashsets(
+            generators::integers::<i32>()
+                .min_value(0)
+                .max_value(2)
+                .flat_map(|n| generators::integers::<i32>().min_value(n).max_value(n)),
+        )
+        .min_size(3),
+    );
+    assert_eq!(set.len(), 3);
+    assert!(set.contains(&0) && set.contains(&1) && set.contains(&2));
+}
+
+#[hegel::test]
+fn test_fixed_dicts_basic(tc: TestCase) {
+    let dict = tc.draw(
+        generators::fixed_dicts()
+            .field("name", generators::text().min_size(1).max_size(10))
+            .field(
+                "age",
+                generators::integers::<i32>().min_value(0).max_value(120),
+            )
+            .build(),
+    );
+    // dict is a ciborium::Value::Map
+    if let ciborium::Value::Map(entries) = dict {
+        assert_eq!(entries.len(), 2);
+    } else {
+        panic!("expected Value::Map, got {:?}", dict);
+    }
+}
+
+#[hegel::test]
+fn test_fixed_dicts_with_non_basic_field(tc: TestCase) {
+    // Use flat_map to force the FixedDict non-basic fallback path
+    let dict = tc.draw(
+        generators::fixed_dicts()
+            .field(
+                "dynamic_text",
+                generators::integers::<usize>()
+                    .min_value(1)
+                    .max_value(3)
+                    .flat_map(|n| generators::text().min_size(n).max_size(n)),
+            )
+            .build(),
+    );
+    if let ciborium::Value::Map(entries) = dict {
+        assert_eq!(entries.len(), 1);
+    } else {
+        panic!("expected Value::Map, got {:?}", dict);
+    }
+}

--- a/tests/test_combinators.rs
+++ b/tests/test_combinators.rs
@@ -164,6 +164,26 @@ fn test_draw_silent_non_debug(tc: TestCase) {
     assert_eq!(f(10), 10 + f(0));
 }
 
+#[hegel::test]
+fn test_unit_generator(tc: TestCase) {
+    tc.draw(generators::unit());
+}
+
+#[hegel::test]
+fn test_optional_with_non_basic_inner(tc: TestCase) {
+    // flat_map produces a generator without as_basic(), forcing the optional fallback path
+    let opt_gen = generators::optional(
+        generators::integers::<usize>()
+            .min_value(1)
+            .max_value(3)
+            .flat_map(|n| generators::text().min_size(n).max_size(n)),
+    );
+    let value = tc.draw(opt_gen);
+    if let Some(s) = value {
+        assert!((1..=3).contains(&s.chars().count()));
+    }
+}
+
 #[test]
 fn test_optional_mapped_find_any() {
     find_any(

--- a/tests/test_derive_compile.rs
+++ b/tests/test_derive_compile.rs
@@ -23,3 +23,136 @@ fn main() {}
         )
         .cargo_run(&[]);
 }
+
+#[test]
+fn test_hegel_test_with_empty_parens() {
+    TempRustProject::new()
+        .test_file(
+            "empty_parens.rs",
+            r#"
+#[hegel::test()]
+fn my_test(tc: hegel::TestCase) {
+    let _ = tc.draw(hegel::generators::booleans());
+}
+"#,
+        )
+        .main_file("fn main() {}")
+        .cargo_test(&[]);
+}
+
+#[test]
+fn test_hegel_test_on_non_function() {
+    TempRustProject::new()
+        .test_file(
+            "not_fn.rs",
+            r#"
+#[hegel::test]
+struct NotAFunction {
+    x: i32,
+}
+"#,
+        )
+        .main_file("fn main() {}")
+        .expect_failure("expected")
+        .cargo_test(&[]);
+}
+
+#[test]
+fn test_hegel_test_rejects_invalid_attribute_args() {
+    TempRustProject::new()
+        .test_file(
+            "bad_attr.rs",
+            r#"
+#[hegel::test(not a = valid expression here)]
+fn my_test(tc: hegel::TestCase) {
+    let _ = tc.draw(hegel::generators::booleans());
+}
+"#,
+        )
+        .main_file("fn main() {}")
+        .expect_failure("expected")
+        .cargo_test(&[]);
+}
+
+#[test]
+fn test_derive_rejects_tuple_struct() {
+    TempRustProject::new()
+        .main_file(
+            r#"
+#[derive(Debug, hegel::DefaultGenerator)]
+struct Pair(i32, i32);
+
+fn main() {}
+"#,
+        )
+        .expect_failure("named fields")
+        .cargo_run(&[]);
+}
+
+#[test]
+fn test_derive_rejects_unit_struct() {
+    TempRustProject::new()
+        .main_file(
+            r#"
+#[derive(Debug, hegel::DefaultGenerator)]
+struct Marker;
+
+fn main() {}
+"#,
+        )
+        .expect_failure("unit structs")
+        .cargo_run(&[]);
+}
+
+#[test]
+fn test_derive_rejects_union() {
+    TempRustProject::new()
+        .main_file(
+            r#"
+#[derive(hegel::DefaultGenerator)]
+union FloatOrInt {
+    f: f32,
+    i: i32,
+}
+
+fn main() {}
+"#,
+        )
+        .expect_failure("unions")
+        .cargo_run(&[]);
+}
+
+#[test]
+fn test_hegel_test_rejects_self_parameter() {
+    TempRustProject::new()
+        .test_file(
+            "selfparam.rs",
+            r#"
+struct Foo;
+
+impl Foo {
+    #[hegel::test]
+    fn my_test(self) {}
+}
+"#,
+        )
+        .main_file("fn main() {}")
+        .expect_failure("exactly one parameter|self parameter")
+        .cargo_test(&[]);
+}
+
+#[test]
+fn test_hegel_test_rejects_duplicate_test_attribute() {
+    TempRustProject::new()
+        .test_file(
+            "duptest.rs",
+            r#"
+#[hegel::test]
+#[test]
+fn my_test(tc: hegel::TestCase) {}
+"#,
+        )
+        .main_file("fn main() {}")
+        .expect_failure(r"Remove the \#\[test\] attribute")
+        .cargo_test(&[]);
+}

--- a/tests/test_error_handling.rs
+++ b/tests/test_error_handling.rs
@@ -1,0 +1,292 @@
+//! Tests for server error handling paths using HEGEL_PROTOCOL_TEST_MODE.
+//!
+//! Each test runs in a separate subprocess (via TempRustProject) because the
+//! hegel server is a process-scoped static — HEGEL_PROTOCOL_TEST_MODE must
+//! be set before the first Hegel test runs.
+
+mod common;
+
+use common::project::TempRustProject;
+
+fn local_hegel_binary() -> String {
+    let local = format!("{}/{}", env!("CARGO_MANIFEST_DIR"), ".hegel/venv/bin/hegel");
+    if std::path::Path::new(&local).exists() {
+        local
+    } else {
+        // In CI, hegel is installed system-wide via pip
+        String::from_utf8(
+            std::process::Command::new("which")
+                .arg("hegel")
+                .output()
+                .expect("hegel not found on PATH")
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_string()
+    }
+}
+
+fn error_test(mode: &str) -> TempRustProject {
+    TempRustProject::new()
+        .env("HEGEL_SERVER_COMMAND", &local_hegel_binary())
+        .env("HEGEL_PROTOCOL_TEST_MODE", mode)
+}
+
+/// Check if hegel-core has the new test modes from hegeldev/hegel-core#68.
+/// The hegel-core sibling project exists with the new modes when developing
+/// locally; in CI, hegel-core is installed from the released version.
+fn has_new_test_modes() -> bool {
+    // Check for the sibling hegel-core checkout with the new test_server code
+    let sibling = format!(
+        "{}/../hegel-core/src/hegel/test_server.py",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    if let Ok(content) = std::fs::read_to_string(&sibling) {
+        content.contains("failed_no_reason")
+    } else {
+        false
+    }
+}
+
+macro_rules! requires_new_modes {
+    () => {
+        if !has_new_test_modes() {
+            eprintln!(
+                "Skipping: hegel-core test modes not available (need hegeldev/hegel-core#68)"
+            );
+            return;
+        }
+    };
+}
+
+const SIMPLE_TEST: &str = r#"
+fn main() {
+    hegel::hegel(|tc| {
+        let _: bool = tc.draw(hegel::generators::booleans());
+    });
+}
+"#;
+
+const SPAN_TEST: &str = r#"
+use hegel::generators::Generator;
+
+fn main() {
+    hegel::hegel(|tc| {
+        let _: String = tc.draw(
+            hegel::generators::integers::<usize>()
+                .min_value(1)
+                .max_value(3)
+                .flat_map(|n| hegel::generators::text().min_size(n).max_size(n)),
+        );
+    });
+}
+"#;
+
+const COLLECTION_TEST: &str = r#"
+use hegel::generators::Generator;
+
+fn main() {
+    hegel::hegel(|tc| {
+        // Use flat_map to force non-basic path which uses Collection protocol
+        let _: Vec<String> = tc.draw(
+            hegel::generators::vecs(
+                hegel::generators::integers::<usize>()
+                    .min_value(1)
+                    .max_value(3)
+                    .flat_map(|n| hegel::generators::text().min_size(n).max_size(n)),
+            )
+            .min_size(1)
+            .max_size(3),
+        );
+    });
+}
+"#;
+
+const POOL_ADD_TEST: &str = r#"
+fn main() {
+    hegel::hegel(|tc| {
+        let mut pool = hegel::stateful::variables::<bool>(&tc);
+        let val: bool = tc.draw(hegel::generators::booleans());
+        pool.add(val);
+    });
+}
+"#;
+
+const NEW_POOL_TEST: &str = r#"
+fn main() {
+    hegel::hegel(|tc| {
+        let _pool = hegel::stateful::variables::<i32>(&tc);
+    });
+}
+"#;
+
+const ANTITHESIS_TEST: &str = r#"
+fn main() {
+    // Set ANTITHESIS_OUTPUT_DIR to trigger the antithesis code path
+    // but don't enable the antithesis feature — this should panic
+    std::env::set_var("ANTITHESIS_OUTPUT_DIR", "/tmp");
+    hegel::hegel(|tc| {
+        let _: bool = tc.draw(hegel::generators::booleans());
+    });
+}
+"#;
+
+const PROTOCOL_DEBUG_TEST: &str = r#"
+fn main() {
+    hegel::hegel(|tc| {
+        let _: bool = tc.draw(hegel::generators::booleans());
+    });
+}
+"#;
+
+// === StopTest modes (released in hegel-core) ===
+
+#[test]
+fn test_stop_test_on_new_collection() {
+    error_test("stop_test_on_new_collection")
+        .main_file(COLLECTION_TEST)
+        .cargo_run(&[]);
+}
+
+#[test]
+fn test_stop_test_on_collection_more() {
+    error_test("stop_test_on_collection_more")
+        .main_file(COLLECTION_TEST)
+        .cargo_run(&[]);
+}
+
+// === StopTest modes (require hegeldev/hegel-core#68) ===
+
+#[test]
+fn test_stop_test_on_start_span() {
+    requires_new_modes!();
+    error_test("stop_test_on_start_span")
+        .main_file(SPAN_TEST)
+        .cargo_run(&[]);
+}
+
+#[test]
+fn test_stop_test_on_pool_add() {
+    requires_new_modes!();
+    error_test("stop_test_on_pool_add")
+        .main_file(POOL_ADD_TEST)
+        .cargo_run(&[]);
+}
+
+#[test]
+fn test_stop_test_on_new_pool() {
+    requires_new_modes!();
+    error_test("stop_test_on_new_pool")
+        .main_file(NEW_POOL_TEST)
+        .cargo_run(&[]);
+}
+
+// === Server error modes (require hegeldev/hegel-core#68) ===
+
+#[test]
+fn test_health_check_failure() {
+    requires_new_modes!();
+    error_test("health_check_failure")
+        .main_file(SIMPLE_TEST)
+        .expect_failure("Health check failure")
+        .cargo_run(&[]);
+}
+
+#[test]
+fn test_server_error_in_results() {
+    requires_new_modes!();
+    error_test("server_error_in_results")
+        .main_file(SIMPLE_TEST)
+        .expect_failure("Server error")
+        .cargo_run(&[]);
+}
+
+#[test]
+fn test_failed_no_reason() {
+    requires_new_modes!();
+    error_test("failed_no_reason")
+        .main_file(SIMPLE_TEST)
+        .expect_failure("Property test failed: unknown")
+        .cargo_run(&[]);
+}
+
+#[test]
+fn test_flaky_replay() {
+    requires_new_modes!();
+    error_test("flaky_replay")
+        .main_file(SIMPLE_TEST)
+        .cargo_run(&[]);
+}
+
+#[test]
+fn test_server_crash() {
+    requires_new_modes!();
+    error_test("server_crash")
+        .main_file(SIMPLE_TEST)
+        .expect_failure("hegel server process exited")
+        .cargo_run(&[]);
+}
+
+// === Communication error (non-StopTest error from server) ===
+
+#[test]
+fn test_error_response_causes_communication_error() {
+    // error_response mode sends a RequestError on generate.
+    // The error message doesn't match StopTest/FlakyReplay patterns,
+    // so it should hit the CommunicationError panic path.
+    error_test("error_response")
+        .main_file(SIMPLE_TEST)
+        .expect_failure("Property test failed")
+        .cargo_run(&[]);
+}
+
+// === Antithesis paths ===
+
+#[test]
+fn test_antithesis_without_feature_panics() {
+    error_test("empty_test")
+        .main_file(ANTITHESIS_TEST)
+        .expect_failure("antithesis")
+        .cargo_run(&[]);
+}
+
+// === Antithesis emit on test failure ===
+
+#[test]
+fn test_antithesis_emit_on_failure() {
+    let output_dir = tempfile::TempDir::new().unwrap();
+    let code = r#"
+#[hegel::test]
+fn my_test(tc: hegel::TestCase) {
+    let _: bool = tc.draw(hegel::generators::booleans());
+    panic!("intentional-failure-for-antithesis");
+}
+
+fn main() {}
+"#;
+    TempRustProject::new()
+        .test_file("test.rs", code)
+        .main_file("fn main() {}")
+        .feature("antithesis")
+        .env("ANTITHESIS_OUTPUT_DIR", output_dir.path().to_str().unwrap())
+        .expect_failure("Property test failed")
+        .cargo_test(&[]);
+
+    let jsonl_path = output_dir.path().join("sdk.jsonl");
+    assert!(
+        jsonl_path.exists(),
+        "Antithesis JSONL should be written on test failure"
+    );
+}
+
+// === Protocol debug ===
+
+#[test]
+fn test_protocol_debug_mode() {
+    // Exercise the HEGEL_PROTOCOL_DEBUG=1 code path
+    error_test("stop_test_on_generate")
+        .main_file(PROTOCOL_DEBUG_TEST)
+        .env("HEGEL_PROTOCOL_DEBUG", "1")
+        .cargo_run(&[]);
+}

--- a/tests/test_hegel_test.rs
+++ b/tests/test_hegel_test.rs
@@ -10,6 +10,11 @@ fn test_basic_usage(tc: TestCase) {
     tc.draw(generators::booleans());
 }
 
+#[hegel::test()]
+fn test_with_empty_parens(tc: TestCase) {
+    tc.draw(generators::booleans());
+}
+
 #[hegel::test(test_cases = 10)]
 fn test_with_named_arg(tc: TestCase) {
     tc.draw(generators::booleans());
@@ -33,6 +38,31 @@ fn test_with_multiple_named_args(tc: TestCase) {
 #[hegel::test(seed = Some(42))]
 fn test_with_seed(tc: TestCase) {
     tc.draw(generators::booleans());
+}
+
+#[test]
+fn test_hegel_server_command_env_override() {
+    // Exercise the HEGEL_SERVER_COMMAND env var override path in find_hegel()
+    let _guard = hegel::ENV_TEST_MUTEX
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+
+    // Use the installed hegel binary from the local venv
+    let hegel_path = format!("{}/{}", env!("CARGO_MANIFEST_DIR"), ".hegel/venv/bin/hegel");
+    let original = std::env::var("HEGEL_SERVER_COMMAND").ok();
+    unsafe { std::env::set_var("HEGEL_SERVER_COMMAND", hegel_path) };
+
+    // Run a simple test — find_hegel() should use the env var override
+    hegel::Hegel::new(|tc| {
+        let _: bool = tc.draw(generators::booleans());
+    })
+    .settings(hegel::Settings::new().test_cases(5).derandomize(true))
+    .run();
+
+    match original {
+        Some(v) => unsafe { std::env::set_var("HEGEL_SERVER_COMMAND", v) },
+        None => unsafe { std::env::remove_var("HEGEL_SERVER_COMMAND") },
+    }
 }
 
 #[test]

--- a/tests/test_lifetimes.rs
+++ b/tests/test_lifetimes.rs
@@ -203,3 +203,23 @@ fn test_boxed_generator_with_local_lifetime(tc: TestCase) {
 
     assert!(t.len() == 3);
 }
+
+#[hegel::test]
+fn test_generator_by_reference(tc: TestCase) {
+    let int_gen = generators::integers::<i32>().min_value(0).max_value(100);
+    // Use the generator by reference to exercise the Generator impl for &G
+    let value = tc.draw(&int_gen);
+    assert!((0..=100).contains(&value));
+    // Draw again from the same reference
+    let value2 = tc.draw(&int_gen);
+    assert!((0..=100).contains(&value2));
+}
+
+#[hegel::test]
+fn test_generator_reference_in_vec(tc: TestCase) {
+    let int_gen = generators::integers::<i32>().min_value(0).max_value(50);
+    // Wrapping &gen in vecs() exercises as_basic() on the &G impl
+    let values: Vec<i32> = tc.draw(generators::vecs(&int_gen).min_size(1).max_size(5));
+    assert!(!values.is_empty());
+    assert!(values.iter().all(|v| (0..=50).contains(v)));
+}

--- a/tests/test_output.rs
+++ b/tests/test_output.rs
@@ -1,7 +1,9 @@
 mod common;
 
 use common::project::TempRustProject;
-use common::utils::{assert_matches_regex, is_nightly};
+use common::utils::assert_matches_regex;
+use hegel::generators::{self, Generator};
+use hegel::{Hegel, Settings};
 
 const FAILING_TEST_CODE: &str = r#"
 use hegel::generators;
@@ -44,11 +46,8 @@ fn test_failing_test_output_with_backtrace() {
         .expect_failure("intentional failure")
         .cargo_run(&[]);
 
-    let closure_name = if is_nightly() {
-        r"\{closure#0\}"
-    } else {
-        r"\{\{closure\}\}"
-    };
+    // Rust >= 1.92 uses {closure#0}, older stable uses {{closure}}
+    let closure_name = r"(\{closure#0\}|\{\{closure\}\})";
     // For example:
     //   Draw 1: 0
     //   thread 'main' (1) panicked at src/main.rs:7:9:
@@ -97,11 +96,8 @@ fn test_failing_test_output_with_full_backtrace() {
         .expect_failure("intentional failure")
         .cargo_run(&[]);
 
-    let closure_name = if is_nightly() {
-        r"\{closure#0\}"
-    } else {
-        r"\{\{closure\}\}"
-    };
+    // Rust >= 1.92 uses {closure#0}, older stable uses {{closure}}
+    let closure_name = r"(\{closure#0\}|\{\{closure\}\})";
     assert_matches_regex(
         &output.stderr,
         &format!(
@@ -128,4 +124,95 @@ fn test_failing_test_output_with_full_backtrace() {
         "Actual: {}",
         output.stderr
     );
+}
+
+/// Exercise the in-process failure path to cover panic info capture,
+/// test result handling, and note() output during final replay.
+#[test]
+#[should_panic(expected = "Property test failed")]
+fn test_in_process_failure_exercises_panic_path() {
+    Hegel::new(|tc| {
+        let x: i32 = tc.draw(generators::integers());
+        tc.note(&format!("testing note output: x={}", x));
+        panic!("intentional-test-failure-42: {}", x);
+    })
+    .settings(Settings::new().test_cases(10).derandomize(true))
+    .run();
+}
+
+/// Exercise the backtrace output path by running a failing test with
+/// RUST_BACKTRACE=1 to force Backtrace::capture() to actually capture.
+#[test]
+fn test_in_process_failure_with_backtrace() {
+    // SAFETY: serialized by ENV_TEST_MUTEX
+    let _guard = hegel::ENV_TEST_MUTEX
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let original = std::env::var("RUST_BACKTRACE").ok();
+    unsafe { std::env::set_var("RUST_BACKTRACE", "1") };
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        Hegel::new(|tc| {
+            let _: bool = tc.draw(generators::booleans());
+            panic!("backtrace-coverage-test-99");
+        })
+        .settings(Settings::new().test_cases(5).derandomize(true))
+        .run();
+    }));
+
+    match original {
+        Some(v) => unsafe { std::env::set_var("RUST_BACKTRACE", v) },
+        None => unsafe { std::env::remove_var("RUST_BACKTRACE") },
+    }
+
+    assert!(result.is_err(), "expected Hegel::run to panic");
+}
+
+/// Exercise the verbosity debug path
+#[test]
+#[should_panic(expected = "Property test failed")]
+fn test_in_process_failure_with_debug_verbosity() {
+    Hegel::new(|tc| {
+        let _: bool = tc.draw(generators::booleans());
+        panic!("debug-verbosity-test-failure");
+    })
+    .settings(
+        Settings::new()
+            .test_cases(5)
+            .derandomize(true)
+            .verbosity(hegel::Verbosity::Debug),
+    )
+    .run();
+}
+
+/// Force the StopTest/overflow path by drawing heavily from span-based
+/// generators (flat_map) in a property that fails. During shrinking, the
+/// server will truncate data, causing StopTest errors in start_span and
+/// collection operations.
+#[test]
+#[should_panic(expected = "Property test failed")]
+fn test_overflow_exercises_stop_test_paths() {
+    Hegel::new(|tc| {
+        // Use flat_map to force span-based generation (not schema-based).
+        // This means start_span/stop_span are called, and during shrinking
+        // the server may exhaust data mid-span, triggering StopTest.
+        for _ in 0..10 {
+            let inner: Vec<String> = tc.draw(
+                generators::vecs(
+                    generators::integers::<usize>()
+                        .min_value(1)
+                        .max_value(5)
+                        .flat_map(|n| generators::text().min_size(n).max_size(n)),
+                )
+                .min_size(1)
+                .max_size(5),
+            );
+            // Fail unconditionally — forces shrinking which triggers StopTest
+            if !inner.is_empty() {
+                panic!("overflow-stop-test-coverage-77");
+            }
+        }
+    })
+    .settings(Settings::new().test_cases(20).derandomize(true))
+    .run();
 }

--- a/tests/test_stateful.rs
+++ b/tests/test_stateful.rs
@@ -93,6 +93,34 @@ fn test_consume(tc: TestCase) {
     hegel::stateful::run(m, tc);
 }
 
+// Test that invariants are checked after each rule application
+struct CounterMachine {
+    count: i32,
+}
+
+impl hegel::stateful::StateMachine for CounterMachine {
+    fn rules(&self) -> Vec<hegel::stateful::Rule<Self>> {
+        vec![hegel::stateful::Rule::new("increment", |m, _tc| {
+            m.count += 1;
+        })]
+    }
+
+    fn invariants(&self) -> Vec<hegel::stateful::Rule<Self>> {
+        vec![hegel::stateful::Rule::new(
+            "count_is_non_negative",
+            |m, _tc| {
+                assert!(m.count >= 0, "count went negative: {}", m.count);
+            },
+        )]
+    }
+}
+
+#[hegel::test]
+fn test_state_machine_with_invariants(tc: TestCase) {
+    let m = CounterMachine { count: 0 };
+    hegel::stateful::run(m, tc);
+}
+
 // Drawing an element from a bundle should always yield an element that was previously added.
 struct TestDrawDomainMachine {
     domain: Vec<i32>,

--- a/tests/test_strings.rs
+++ b/tests/test_strings.rs
@@ -1,0 +1,186 @@
+use hegel::TestCase;
+use hegel::generators;
+
+#[hegel::test]
+fn test_from_regex_generates_matching_string(tc: TestCase) {
+    let value = tc.draw(generators::from_regex("[a-z]{3,5}"));
+    assert!(value.len() >= 3);
+}
+
+#[hegel::test]
+fn test_from_regex_fullmatch(tc: TestCase) {
+    let value = tc.draw(generators::from_regex("[0-9]{4}").fullmatch(true));
+    assert_eq!(value.len(), 4);
+    assert!(value.chars().all(|c| c.is_ascii_digit()));
+}
+
+#[hegel::test]
+fn test_emails_generates_valid_email(tc: TestCase) {
+    let value = tc.draw(generators::emails());
+    assert!(value.contains('@'), "email should contain @: {}", value);
+}
+
+#[hegel::test]
+fn test_urls_generates_valid_url(tc: TestCase) {
+    let value = tc.draw(generators::urls());
+    assert!(
+        value.starts_with("http://") || value.starts_with("https://"),
+        "url should start with http(s)://: {}",
+        value
+    );
+}
+
+#[hegel::test]
+fn test_domains_generates_valid_domain(tc: TestCase) {
+    let value = tc.draw(generators::domains());
+    assert!(
+        value.contains('.'),
+        "domain should contain a dot: {}",
+        value
+    );
+    assert!(value.len() <= 255);
+}
+
+#[hegel::test]
+fn test_domains_with_max_length(tc: TestCase) {
+    let value = tc.draw(generators::domains().max_length(50));
+    assert!(value.len() <= 50);
+}
+
+#[hegel::test]
+fn test_ip_addresses_v4(tc: TestCase) {
+    let value = tc.draw(generators::ip_addresses().v4());
+    let parts: Vec<&str> = value.split('.').collect();
+    assert_eq!(parts.len(), 4, "IPv4 should have 4 octets: {}", value);
+}
+
+#[hegel::test]
+fn test_ip_addresses_v6(tc: TestCase) {
+    let value = tc.draw(generators::ip_addresses().v6());
+    assert!(value.contains(':'), "IPv6 should contain colons: {}", value);
+}
+
+#[hegel::test]
+fn test_ip_addresses_either(tc: TestCase) {
+    let value = tc.draw(generators::ip_addresses());
+    assert!(
+        value.contains('.') || value.contains(':'),
+        "IP should be v4 or v6: {}",
+        value
+    );
+}
+
+#[hegel::test]
+fn test_dates_generates_valid_date(tc: TestCase) {
+    let value = tc.draw(generators::dates());
+    // YYYY-MM-DD format
+    let parts: Vec<&str> = value.split('-').collect();
+    assert_eq!(parts.len(), 3, "date should have 3 parts: {}", value);
+    assert_eq!(parts[0].len(), 4, "year should be 4 digits: {}", value);
+}
+
+#[hegel::test]
+fn test_times_generates_valid_time(tc: TestCase) {
+    let value = tc.draw(generators::times());
+    // HH:MM:SS format
+    let parts: Vec<&str> = value.split(':').collect();
+    assert!(
+        parts.len() >= 2,
+        "time should have at least 2 parts: {}",
+        value
+    );
+}
+
+#[hegel::test]
+fn test_datetimes_generates_valid_datetime(tc: TestCase) {
+    let value = tc.draw(generators::datetimes());
+    // ISO 8601 format contains T separator or space
+    assert!(
+        value.contains('T') || value.contains(' '),
+        "datetime should contain T or space: {}",
+        value
+    );
+}
+
+// Tests that exercise the as_basic() path by wrapping generators in vecs/maps
+// This covers the parse closures inside as_basic() for each string generator type
+
+#[hegel::test]
+fn test_regex_in_vec_uses_basic_path(tc: TestCase) {
+    let values: Vec<String> = tc.draw(
+        generators::vecs(generators::from_regex("[a-z]+").fullmatch(true))
+            .min_size(1)
+            .max_size(3),
+    );
+    assert!(!values.is_empty());
+}
+
+#[hegel::test]
+fn test_emails_in_vec_uses_basic_path(tc: TestCase) {
+    let values: Vec<String> = tc.draw(
+        generators::vecs(generators::emails())
+            .min_size(1)
+            .max_size(3),
+    );
+    assert!(values.iter().all(|v| v.contains('@')));
+}
+
+#[hegel::test]
+fn test_urls_in_vec_uses_basic_path(tc: TestCase) {
+    let values: Vec<String> = tc.draw(generators::vecs(generators::urls()).min_size(1).max_size(3));
+    assert!(
+        values
+            .iter()
+            .all(|v| v.starts_with("http://") || v.starts_with("https://"))
+    );
+}
+
+#[hegel::test]
+fn test_domains_in_vec_uses_basic_path(tc: TestCase) {
+    let values: Vec<String> = tc.draw(
+        generators::vecs(generators::domains().max_length(100))
+            .min_size(1)
+            .max_size(3),
+    );
+    assert!(values.iter().all(|v| v.contains('.')));
+}
+
+#[hegel::test]
+fn test_ip_addresses_in_vec_uses_basic_path(tc: TestCase) {
+    let values: Vec<String> = tc.draw(
+        generators::vecs(generators::ip_addresses())
+            .min_size(1)
+            .max_size(3),
+    );
+    assert!(!values.is_empty());
+}
+
+#[hegel::test]
+fn test_dates_in_vec_uses_basic_path(tc: TestCase) {
+    let values: Vec<String> = tc.draw(
+        generators::vecs(generators::dates())
+            .min_size(1)
+            .max_size(3),
+    );
+    assert!(values.iter().all(|v| v.split('-').count() == 3));
+}
+
+#[hegel::test]
+fn test_times_in_vec_uses_basic_path(tc: TestCase) {
+    let values: Vec<String> = tc.draw(
+        generators::vecs(generators::times())
+            .min_size(1)
+            .max_size(3),
+    );
+    assert!(values.iter().all(|v| v.contains(':')));
+}
+
+#[hegel::test]
+fn test_datetimes_in_vec_uses_basic_path(tc: TestCase) {
+    let values: Vec<String> = tc.draw(
+        generators::vecs(generators::datetimes())
+            .min_size(1)
+            .max_size(3),
+    );
+    assert!(values.iter().all(|v| v.contains('T') || v.contains(' ')));
+}

--- a/tests/test_tuples.rs
+++ b/tests/test_tuples.rs
@@ -296,6 +296,20 @@ fn test_tuple2_all_examples_in_bounds() {
     );
 }
 
+#[hegel::test]
+fn test_tuple2_with_non_basic_element(tc: TestCase) {
+    // flat_map removes as_basic(), forcing the tuple non-basic fallback path
+    let (a, b) = tc.draw(generators::tuples!(
+        generators::integers::<i32>().min_value(0).max_value(10),
+        generators::integers::<usize>()
+            .min_value(1)
+            .max_value(3)
+            .flat_map(|n| generators::text().min_size(n).max_size(n)),
+    ));
+    assert!((0..=10).contains(&a));
+    assert!((1..=3).contains(&b.chars().count()));
+}
+
 #[test]
 fn test_tuple3_all_examples_in_bounds() {
     assert_all_examples(


### PR DESCRIPTION
Integration tests for string generators, non-basic collection paths, compile-fail macro tests, in-process failure/backtrace tests, stateful invariants, and server error mode tests.