### PR TITLE
Bump minimum serde to 1.0.203

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ categories = ["development-tools::testing"]
 name = "hegel"
 
 [dependencies]
-serde = { version = "1.0.103", features = ["derive"] }
+serde = { version = "1.0.203", features = ["derive"] }
 paste = "1.0"
 tempfile = "3.0"
 ciborium = "0.2.2"


### PR DESCRIPTION
Bump the minimum serde version from 1.0.103 to 1.0.203.

Old serde_derive (pulled in by minimal-versions CI) generates code that triggers `unexpected_cfgs` and `non_local_definitions` warnings on modern Rust nightly.