### PR TITLE
Improve server crash resilience: log excerpts, restart, and better error messages

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This release improves resilience when the hegel server subprocess exits unexpectedly.
+
+- When a server crash is detected, the next call to `hegel()` now transparently starts a fresh server instead of failing with a `PoisonError` or a generic panic.
+- Server crash error messages now include the last few lines of `.hegel/server.log` so the root cause is visible without inspecting the log file manually.
+- Panics from test functions (including server crashes) are now properly propagated rather than being replaced with a generic "could not find any examples" error.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,6 +333,8 @@ pub use hegel_macros::state_machine;
 pub use hegel_macros::test;
 
 #[doc(hidden)]
+pub use runner::__test_kill_server;
+#[doc(hidden)]
 pub use runner::format_log_excerpt;
 #[doc(hidden)]
 pub use runner::hegel;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,5 +333,7 @@ pub use hegel_macros::state_machine;
 pub use hegel_macros::test;
 
 #[doc(hidden)]
+pub use runner::format_log_excerpt;
+#[doc(hidden)]
 pub use runner::hegel;
 pub use runner::{HealthCheck, Hegel, Settings, Verbosity};

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -946,8 +946,8 @@ fn flush_log_indent_run(
 }
 
 fn server_log_excerpt() -> Option<String> {
-    let log_path = format!("{HEGEL_SERVER_DIR}/server.log");
-    let content = std::fs::read_to_string(&log_path).ok()?;
+    let log_path = SERVER_LOG_PATH.get()?;
+    let content = std::fs::read_to_string(log_path).ok()?;
     if content.trim().is_empty() {
         return None;
     }
@@ -956,9 +956,13 @@ fn server_log_excerpt() -> Option<String> {
 
 fn server_crash_message() -> String {
     const BASE: &str = "The hegel server process exited unexpectedly.";
+    let log_path = SERVER_LOG_PATH
+        .get()
+        .map(|s| s.as_str())
+        .unwrap_or(".hegel/server.log");
     match server_log_excerpt() {
         Some(excerpt) => format!("{BASE}\n\nLast server log entries:\n{excerpt}"),
-        None => format!("{BASE}\n\n(No entries found in .hegel/server.log)"),
+        None => format!("{BASE}\n\n(No entries found in {log_path})"),
     }
 }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -975,8 +975,8 @@ fn handle_channel_error(e: std::io::Error) -> ! {
 pub fn __test_kill_server() {
     let guard = SESSION.lock().unwrap_or_else(|e| e.into_inner());
     let Some(session) = guard.as_ref() else {
-        return;
-    }; // nocov
+        return; // nocov
+    };
     let pid = session.server_pid;
     let conn = Arc::clone(&session.connection);
     drop(guard);

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -21,7 +21,7 @@ const HEGEL_SERVER_COMMAND_ENV: &str = "HEGEL_SERVER_COMMAND";
 const HEGEL_SERVER_DIR: &str = ".hegel";
 static SERVER_LOG_PATH: std::sync::OnceLock<String> = std::sync::OnceLock::new();
 static LOG_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
-static SESSION: std::sync::OnceLock<HegelSession> = std::sync::OnceLock::new();
+static SESSION: Mutex<Option<Arc<HegelSession>>> = Mutex::new(None);
 
 static PANIC_HOOK_INIT: Once = Once::new();
 
@@ -265,8 +265,8 @@ fn parse_version(s: &str) -> (u32, u32) {
 
 /// A persistent connection to the hegel server subprocess.
 ///
-/// Created once per process on first use. The subprocess and connection
-/// are reused across all `Hegel::run()` calls. The Python server supports
+/// A new session is created on first use and whenever the previous server
+/// process has exited (crash or explicit kill). The Python server supports
 /// multiple sequential `run_test` commands over a single connection.
 struct HegelSession {
     connection: Arc<Connection>,
@@ -275,11 +275,25 @@ struct HegelSession {
     /// brief run_test send/receive; test execution runs concurrently on
     /// per-test streams.
     control: Mutex<Stream>,
+    /// PID of the server subprocess. Exposed via `__test_kill_server` for
+    /// testing server restart behaviour.
+    server_pid: u32,
 }
 
 impl HegelSession {
-    fn get() -> &'static HegelSession {
-        SESSION.get_or_init(HegelSession::init)
+    /// Return the current live session, or create a new one if the server has
+    /// exited (either crashed or been killed since the last call).
+    fn get() -> Arc<HegelSession> {
+        let mut guard = SESSION.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(ref s) = *guard {
+            if !s.connection.server_has_exited() {
+                return Arc::clone(s);
+            }
+        }
+        init_panic_hook();
+        let session = Arc::new(HegelSession::init());
+        *guard = Some(Arc::clone(&session));
+        session
     }
 
     fn init() -> HegelSession {
@@ -337,6 +351,8 @@ impl HegelSession {
             // nocov end
         }
 
+        let server_pid = child.id();
+
         // Monitor thread: detects server crash. The pipe close from
         // the child exiting will unblock any pending reads.
         let conn_for_monitor = Arc::clone(&connection);
@@ -348,6 +364,7 @@ impl HegelSession {
         HegelSession {
             connection,
             control: Mutex::new(control),
+            server_pid,
         }
     }
 }
@@ -409,17 +426,15 @@ impl TestRunner for ServerTestRunner {
         // The control stream is behind a Mutex because Stream requires &mut self.
         // This only serializes the brief run_test send/receive — actual test
         // execution happens on per-test streams without holding this lock.
-        {
-            let mut control = session.control.lock().unwrap();
-            let run_test_id = control
-                .send_request(cbor_encode(&run_test_msg))
-                .expect("Failed to send run_test");
-
-            let run_test_response = control
-                .receive_reply(run_test_id)
-                .expect("Failed to receive run_test response");
-            let _run_test_result: Value = cbor_decode(&run_test_response);
+        // The lock is released before any error handling so the mutex is never
+        // poisoned by a server crash on one thread affecting other threads.
+        let run_test_response = {
+            let mut control = session.control.lock().unwrap_or_else(|e| e.into_inner());
+            let send_id = control.send_request(cbor_encode(&run_test_msg));
+            send_id.and_then(|id| control.receive_reply(id))
         }
+        .unwrap_or_else(|e| handle_channel_error(e));
+        let _run_test_result: Value = cbor_decode(&run_test_response);
 
         if verbosity == Verbosity::Debug {
             eprintln!("run_test response received");
@@ -952,6 +967,25 @@ fn handle_channel_error(e: std::io::Error) -> ! {
         panic!("{}", server_crash_message());
     }
     unreachable!("unexpected channel error: {e}")
+}
+
+/// Kill the hegel server process and wait until the connection detects that it
+/// has exited.  Only for use in tests — not part of the public API.
+#[doc(hidden)]
+pub fn __test_kill_server() {
+    let guard = SESSION.lock().unwrap_or_else(|e| e.into_inner());
+    let Some(session) = guard.as_ref() else {
+        return;
+    }; // nocov
+    let pid = session.server_pid;
+    let conn = Arc::clone(&session.connection);
+    drop(guard);
+    let _ = std::process::Command::new("kill")
+        .arg(pid.to_string())
+        .status();
+    while !conn.server_has_exited() {
+        std::thread::yield_now();
+    }
 }
 
 // ─── Public types ───────────────────────────────────────────────────────────

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -977,17 +977,16 @@ fn handle_channel_error(e: std::io::Error) -> ! {
 #[doc(hidden)]
 pub fn __test_kill_server() {
     let guard = SESSION.lock().unwrap_or_else(|e| e.into_inner());
-    let Some(session) = guard.as_ref() else {
-        return; // nocov
-    };
-    let pid = session.server_pid;
-    let conn = Arc::clone(&session.connection);
-    drop(guard);
-    let _ = std::process::Command::new("kill")
-        .arg(pid.to_string())
-        .status();
-    while !conn.server_has_exited() {
-        std::thread::yield_now();
+    if let Some(session) = guard.as_ref() {
+        let pid = session.server_pid;
+        let conn = Arc::clone(&session.connection);
+        drop(guard);
+        let _ = std::process::Command::new("kill")
+            .arg(pid.to_string())
+            .status();
+        while !conn.server_has_exited() {
+            std::thread::yield_now();
+        }
     }
 }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -275,9 +275,10 @@ struct HegelSession {
     /// brief run_test send/receive; test execution runs concurrently on
     /// per-test streams.
     control: Mutex<Stream>,
-    /// PID of the server subprocess. Exposed via `__test_kill_server` for
-    /// testing server restart behaviour.
-    server_pid: u32,
+    /// The server subprocess. Shared with the monitor thread so that
+    /// `__test_kill_server` can call `child.kill()` directly rather than
+    /// shelling out to the OS `kill` command.
+    child: Arc<Mutex<std::process::Child>>,
 }
 
 impl HegelSession {
@@ -351,20 +352,31 @@ impl HegelSession {
             // nocov end
         }
 
-        let server_pid = child.id();
+        let child_arc = Arc::new(Mutex::new(child));
+        let child_for_monitor = Arc::clone(&child_arc);
 
-        // Monitor thread: detects server crash. The pipe close from
-        // the child exiting will unblock any pending reads.
+        // Monitor thread: reaps the subprocess when it exits and notifies the
+        // connection. Polls try_wait() so the lock is not held while waiting,
+        // leaving it available for __test_kill_server to call kill().
         let conn_for_monitor = Arc::clone(&connection);
         std::thread::spawn(move || {
-            let _ = child.wait();
-            conn_for_monitor.mark_server_exited();
+            loop {
+                {
+                    let mut guard = child_for_monitor.lock().unwrap();
+                    if matches!(guard.try_wait(), Ok(Some(_))) {
+                        drop(guard);
+                        conn_for_monitor.mark_server_exited();
+                        return;
+                    }
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
         });
 
         HegelSession {
             connection,
             control: Mutex::new(control),
-            server_pid,
+            child: child_arc,
         }
     }
 }
@@ -978,12 +990,10 @@ fn handle_channel_error(e: std::io::Error) -> ! {
 pub fn __test_kill_server() {
     let guard = SESSION.lock().unwrap_or_else(|e| e.into_inner());
     if let Some(session) = guard.as_ref() {
-        let pid = session.server_pid;
+        let child_arc = Arc::clone(&session.child);
         let conn = Arc::clone(&session.connection);
         drop(guard);
-        let _ = std::process::Command::new("kill")
-            .arg(pid.to_string())
-            .status();
+        let _ = child_arc.lock().unwrap().kill();
         while !conn.server_has_exited() {
             std::thread::yield_now();
         }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -958,9 +958,7 @@ fn server_log_excerpt() -> Option<String> {
 fn server_crash_message() -> String {
     const BASE: &str = "The hegel server process exited unexpectedly.";
     let log_path_owned = SERVER_LOG_PATH.lock().unwrap().clone();
-    let log_path = log_path_owned
-        .as_deref()
-        .unwrap_or(".hegel/server.log");
+    let log_path = log_path_owned.as_deref().unwrap_or(".hegel/server.log");
     match server_log_excerpt() {
         Some(excerpt) => format!("{BASE}\n\nLast server log entries:\n{excerpt}"),
         None => format!("{BASE}\n\n(No entries found in {log_path})"),

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -19,7 +19,7 @@ const SUPPORTED_PROTOCOL_VERSIONS: (&str, &str) = ("0.10", "0.10");
 const HEGEL_SERVER_VERSION: &str = "0.4.0";
 const HEGEL_SERVER_COMMAND_ENV: &str = "HEGEL_SERVER_COMMAND";
 const HEGEL_SERVER_DIR: &str = ".hegel";
-static SERVER_LOG_PATH: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+static SERVER_LOG_PATH: Mutex<Option<String>> = Mutex::new(None);
 static LOG_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
 static SESSION: Mutex<Option<Arc<HegelSession>>> = Mutex::new(None);
 
@@ -731,7 +731,7 @@ fn server_log_file() -> File {
     let pid = std::process::id();
     let ix = LOG_FILE_COUNTER.fetch_add(1, Ordering::Relaxed);
     let path = format!("{HEGEL_SERVER_DIR}/server.{pid}-{ix}.log");
-    SERVER_LOG_PATH.set(path.clone()).ok();
+    *SERVER_LOG_PATH.lock().unwrap() = Some(path.clone());
     OpenOptions::new()
         .create(true)
         .append(true)
@@ -814,8 +814,8 @@ fn startup_error_message(
     }
 
     // Include server log contents
-    if let Some(log_path) = SERVER_LOG_PATH.get() {
-        if let Ok(contents) = std::fs::read_to_string(log_path) {
+    if let Some(log_path) = SERVER_LOG_PATH.lock().unwrap().clone() {
+        if let Ok(contents) = std::fs::read_to_string(&log_path) {
             if !contents.trim().is_empty() {
                 let lines: Vec<&str> = contents.lines().collect();
                 let display_lines: Vec<&str> = lines.iter().take(3).copied().collect();
@@ -946,19 +946,20 @@ fn flush_log_indent_run(
 }
 
 fn server_log_excerpt() -> Option<String> {
-    let log_path = SERVER_LOG_PATH.get()?;
+    let log_path = SERVER_LOG_PATH.lock().unwrap().clone()?;
     let content = std::fs::read_to_string(log_path).ok()?;
-    if content.trim().is_empty() {
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
         return None;
     }
-    Some(format_log_excerpt(&content))
+    Some(format_log_excerpt(trimmed))
 }
 
 fn server_crash_message() -> String {
     const BASE: &str = "The hegel server process exited unexpectedly.";
-    let log_path = SERVER_LOG_PATH
-        .get()
-        .map(|s| s.as_str())
+    let log_path_owned = SERVER_LOG_PATH.lock().unwrap().clone();
+    let log_path = log_path_owned
+        .as_deref()
         .unwrap_or(".hegel/server.log");
     match server_log_excerpt() {
         Some(excerpt) => format!("{BASE}\n\nLast server log entries:\n{excerpt}"),

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2,7 +2,7 @@ use crate::antithesis::{TestLocation, is_running_in_antithesis};
 use crate::backend::{DataSource, DataSourceError, TestCaseResult, TestRunResult, TestRunner};
 use crate::cbor_utils::{as_bool, as_text, as_u64, cbor_map, map_get, map_insert};
 use crate::control::{currently_in_test_context, with_test_context};
-use crate::protocol::{Connection, HANDSHAKE_STRING, SERVER_CRASHED_MESSAGE, Stream};
+use crate::protocol::{Connection, HANDSHAKE_STRING, Stream};
 use crate::test_case::{ASSUME_FAIL_STRING, STOP_TEST_STRING, TestCase};
 use ciborium::Value;
 
@@ -116,7 +116,7 @@ impl ServerDataSource {
                     self.aborted.set(true);
                     Err(DataSourceError::StopTest)
                 } else if self.connection.server_has_exited() {
-                    panic!("{}", SERVER_CRASHED_MESSAGE); // nocov
+                    panic!("{}", server_crash_message()); // nocov
                 } else {
                     Err(DataSourceError::ServerError(e.to_string()))
                 }
@@ -434,7 +434,7 @@ impl TestRunner for ServerTestRunner {
                 Ok(event) => event,
                 // nocov start
                 Err(_) if connection.server_has_exited() => {
-                    panic!("{}", SERVER_CRASHED_MESSAGE);
+                    panic!("{}", server_crash_message());
                     // nocov end
                 }
                 Err(e) => unreachable!("Failed to receive event (server still running): {}", e),
@@ -539,7 +539,7 @@ impl TestRunner for ServerTestRunner {
             }
 
             if connection.server_has_exited() {
-                panic!("{}", SERVER_CRASHED_MESSAGE); // nocov
+                panic!("{}", server_crash_message()); // nocov
             }
         }
 
@@ -842,6 +842,116 @@ fn resolve_hegel_path(path: &str) -> String {
          Check that {} is set correctly.",
         path, HEGEL_SERVER_COMMAND_ENV
     );
+}
+
+/// Format a server log excerpt for inclusion in error messages.
+///
+/// Returns the last 5 unindented lines and the content between them. Runs of
+/// more than 10 consecutive indented lines are truncated with a summary.
+pub fn format_log_excerpt(content: &str) -> String {
+    const MAX_UNINDENTED: usize = 5;
+    const INDENT_THRESHOLD: usize = 10;
+    const INDENT_CONTEXT: usize = 3;
+
+    let lines: Vec<&str> = content.lines().collect();
+    if lines.is_empty() {
+        return "(empty)".to_string();
+    }
+
+    // Find start: walk backwards until we've seen MAX_UNINDENTED unindented lines
+    let mut unindented_seen = 0;
+    let mut start_idx = 0;
+    for (i, line) in lines.iter().enumerate().rev() {
+        if is_log_unindented(line) {
+            unindented_seen += 1;
+            if unindented_seen >= MAX_UNINDENTED {
+                start_idx = i;
+                break;
+            }
+        }
+    }
+
+    // Process the relevant section, truncating long indented runs
+    let relevant = &lines[start_idx..];
+    let mut output: Vec<String> = Vec::new();
+    let mut indent_run: Vec<&str> = Vec::new();
+
+    for &line in relevant {
+        if is_log_unindented(line) {
+            flush_log_indent_run(
+                &mut indent_run,
+                &mut output,
+                INDENT_THRESHOLD,
+                INDENT_CONTEXT,
+            );
+            output.push(line.to_string());
+        } else {
+            indent_run.push(line);
+        }
+    }
+    flush_log_indent_run(
+        &mut indent_run,
+        &mut output,
+        INDENT_THRESHOLD,
+        INDENT_CONTEXT,
+    );
+
+    output.join("\n")
+}
+
+fn is_log_unindented(line: &str) -> bool {
+    !line.is_empty() && !line.starts_with(' ') && !line.starts_with('\t')
+}
+
+fn flush_log_indent_run(
+    run: &mut Vec<&str>,
+    output: &mut Vec<String>,
+    threshold: usize,
+    context: usize,
+) {
+    if run.is_empty() {
+        return;
+    }
+    if run.len() > threshold {
+        let keep = context.min(run.len() / 2);
+        for &line in &run[..keep] {
+            output.push(line.to_string());
+        }
+        let hidden = run.len() - 2 * keep;
+        output.push(format!("  [...{hidden} lines...]"));
+        for &line in &run[run.len() - keep..] {
+            output.push(line.to_string());
+        }
+    } else {
+        for &line in run.iter() {
+            output.push(line.to_string());
+        }
+    }
+    run.clear();
+}
+
+fn server_log_excerpt() -> Option<String> {
+    let log_path = format!("{HEGEL_SERVER_DIR}/server.log");
+    let content = std::fs::read_to_string(&log_path).ok()?;
+    if content.trim().is_empty() {
+        return None;
+    }
+    Some(format_log_excerpt(&content))
+}
+
+fn server_crash_message() -> String {
+    const BASE: &str = "The hegel server process exited unexpectedly.";
+    match server_log_excerpt() {
+        Some(excerpt) => format!("{BASE}\n\nLast server log entries:\n{excerpt}"),
+        None => format!("{BASE}\n\n(No entries found in .hegel/server.log)"),
+    }
+}
+
+fn handle_channel_error(e: std::io::Error) -> ! {
+    if e.kind() == std::io::ErrorKind::ConnectionAborted {
+        panic!("{}", server_crash_message());
+    }
+    unreachable!("unexpected channel error: {e}")
 }
 
 // ─── Public types ───────────────────────────────────────────────────────────

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -16,7 +16,7 @@ use std::sync::{Arc, LazyLock, Mutex, Once};
 use std::time::{Duration, Instant};
 
 const SUPPORTED_PROTOCOL_VERSIONS: (&str, &str) = ("0.10", "0.10");
-const HEGEL_SERVER_VERSION: &str = "0.4.0";
+const HEGEL_SERVER_VERSION: &str = "0.4.2";
 const HEGEL_SERVER_COMMAND_ENV: &str = "HEGEL_SERVER_COMMAND";
 const HEGEL_SERVER_DIR: &str = ".hegel";
 static SERVER_LOG_PATH: Mutex<Option<String>> = Mutex::new(None);

--- a/tests/common/utils.rs
+++ b/tests/common/utils.rs
@@ -189,7 +189,7 @@ where
         let found_clone = Arc::clone(&found);
         let max_attempts = self.max_attempts;
 
-        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let hegel_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             Hegel::new(move |tc| {
                 let value = tc.draw(&self.generator);
                 if (self.condition)(&value) {
@@ -200,6 +200,14 @@ where
             .settings(Settings::new().test_cases(max_attempts))
             .run();
         }));
+
+        if let Err(e) = hegel_result {
+            // If found is None, this panic is not from HEGEL_FOUND — re-propagate
+            // the real error (e.g. server crash) instead of swallowing it.
+            if found.lock().unwrap().is_none() {
+                std::panic::resume_unwind(e);
+            }
+        }
 
         let result = found.lock().unwrap().take();
         result.unwrap_or_else(|| {

--- a/tests/embedded/runner_tests.rs
+++ b/tests/embedded/runner_tests.rs
@@ -231,3 +231,68 @@ fn test_protocol_debug_true_when_env_set() {
         std::env::remove_var("HEGEL_PROTOCOL_DEBUG");
     }
 }
+
+// Serialize tests that read/write .hegel/server.log to prevent interference
+// between parallel test threads.
+static LOG_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn write_server_log(content: &str) {
+    std::fs::create_dir_all(HEGEL_SERVER_DIR).ok();
+    std::fs::write(format!("{HEGEL_SERVER_DIR}/server.log"), content).ok();
+}
+
+fn remove_server_log() {
+    std::fs::remove_file(format!("{HEGEL_SERVER_DIR}/server.log")).ok();
+}
+
+#[test]
+fn server_log_excerpt_no_file() {
+    let _guard = LOG_TEST_LOCK.lock().unwrap();
+    remove_server_log();
+    assert!(server_log_excerpt().is_none());
+}
+
+#[test]
+fn server_log_excerpt_empty_file() {
+    let _guard = LOG_TEST_LOCK.lock().unwrap();
+    write_server_log("");
+    assert!(server_log_excerpt().is_none());
+    remove_server_log();
+}
+
+#[test]
+fn server_log_excerpt_non_empty_file() {
+    let _guard = LOG_TEST_LOCK.lock().unwrap();
+    write_server_log("Error: test crash\n");
+    assert!(server_log_excerpt().is_some());
+    remove_server_log();
+}
+
+#[test]
+fn server_crash_message_includes_log_excerpt() {
+    let _guard = LOG_TEST_LOCK.lock().unwrap();
+    write_server_log("Error: test crash\n");
+    let msg = server_crash_message();
+    assert!(msg.contains("Error: test crash"), "got: {msg}");
+    remove_server_log();
+}
+
+#[test]
+fn handle_channel_error_connection_aborted() {
+    let _guard = LOG_TEST_LOCK.lock().unwrap();
+    remove_server_log();
+    let err = std::io::Error::new(std::io::ErrorKind::ConnectionAborted, "test");
+    let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        handle_channel_error(err);
+    }));
+    let panic_val = result.expect_err("handle_channel_error should have panicked");
+    let msg = panic_val
+        .downcast_ref::<String>()
+        .map(|s| s.as_str())
+        .or_else(|| panic_val.downcast_ref::<&str>().copied())
+        .unwrap_or("");
+    assert!(
+        msg.contains("hegel server process exited unexpectedly"),
+        "unexpected panic message: {msg}"
+    );
+}

--- a/tests/embedded/runner_tests.rs
+++ b/tests/embedded/runner_tests.rs
@@ -232,17 +232,24 @@ fn test_protocol_debug_true_when_env_set() {
     }
 }
 
-// Serialize tests that read/write .hegel/server.log to prevent interference
+// Serialize tests that read/write the server log to prevent interference
 // between parallel test threads.
 static LOG_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+/// Return the path that `server_log_excerpt()` reads from, ensuring
+/// `SERVER_LOG_PATH` is initialised.
+fn log_path() -> &'static String {
+    let _ = SERVER_LOG_PATH.set(format!("{HEGEL_SERVER_DIR}/server.test.log"));
+    SERVER_LOG_PATH.get().unwrap()
+}
+
 fn write_server_log(content: &str) {
     std::fs::create_dir_all(HEGEL_SERVER_DIR).ok();
-    std::fs::write(format!("{HEGEL_SERVER_DIR}/server.log"), content).ok();
+    std::fs::write(log_path(), content).ok();
 }
 
 fn remove_server_log() {
-    std::fs::remove_file(format!("{HEGEL_SERVER_DIR}/server.log")).ok();
+    std::fs::remove_file(log_path()).ok();
 }
 
 #[test]

--- a/tests/embedded/runner_tests.rs
+++ b/tests/embedded/runner_tests.rs
@@ -103,24 +103,14 @@ fn test_startup_error_message_no_binary_path() {
 
 #[test]
 fn test_startup_error_message_includes_server_log() {
-    let dir = std::env::temp_dir().join("hegel_test_unit_log");
-    std::fs::create_dir_all(&dir).unwrap();
-    let log_file = dir.join("server.log");
-    std::fs::write(
-        &log_file,
-        "Error: startup failed\nDetail 1\nDetail 2\nDetail 3\n",
-    )
-    .unwrap();
-    let log_path_str = log_file.to_string_lossy().to_string();
-    let _ = SERVER_LOG_PATH.set(log_path_str.clone());
+    let _guard = LOG_TEST_LOCK.lock().unwrap();
+    write_server_log("Error: startup failed\nDetail 1\nDetail 2\nDetail 3\n");
 
     let exit_status = Command::new("false").status().unwrap();
     let msg = startup_error_message(Some("false"), exit_status);
-    // Only assert if we successfully set the path (OnceLock may already be set)
-    if SERVER_LOG_PATH.get() == Some(&log_path_str) {
-        assert!(msg.contains("Server log"), "Message: {msg}");
-        assert!(msg.contains("for full output"), "Message: {msg}");
-    }
+    assert!(msg.contains("Server log"), "Message: {msg}");
+    assert!(msg.contains("for full output"), "Message: {msg}");
+    remove_server_log();
 }
 
 #[test]

--- a/tests/embedded/runner_tests.rs
+++ b/tests/embedded/runner_tests.rs
@@ -226,11 +226,12 @@ fn test_protocol_debug_true_when_env_set() {
 // between parallel test threads.
 static LOG_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-/// Return the path that `server_log_excerpt()` reads from, ensuring
-/// `SERVER_LOG_PATH` is initialised.
-fn log_path() -> &'static String {
-    let _ = SERVER_LOG_PATH.set(format!("{HEGEL_SERVER_DIR}/server.test.log"));
-    SERVER_LOG_PATH.get().unwrap()
+/// Return the path that `server_log_excerpt()` reads from, updating
+/// `SERVER_LOG_PATH` to point at a test-specific log file.
+fn log_path() -> String {
+    let path = format!("{HEGEL_SERVER_DIR}/server.test.log");
+    *SERVER_LOG_PATH.lock().unwrap() = Some(path.clone());
+    path
 }
 
 fn write_server_log(content: &str) {

--- a/tests/test_server_crash.rs
+++ b/tests/test_server_crash.rs
@@ -1,0 +1,282 @@
+mod common;
+
+use common::project::TempRustProject;
+use common::utils::FindAny;
+use hegel::generators as gs;
+
+/// format_log_excerpt should return all content when there are fewer than
+/// MAX_UNINDENTED (5) unindented lines.
+#[test]
+fn format_log_excerpt_short_log() {
+    let content = "Error: something went wrong\nDetails here";
+    let result = hegel::format_log_excerpt(content);
+    assert_eq!(result, content);
+}
+
+/// format_log_excerpt should only show the last 5 unindented lines (and
+/// everything between them).
+#[test]
+fn format_log_excerpt_takes_last_n_unindented() {
+    // 10 unindented lines — only the last 5 should appear
+    let lines: Vec<String> = (0..10).map(|i| format!("line {}", i)).collect();
+    let content = lines.join("\n");
+    let result = hegel::format_log_excerpt(&content);
+    assert!(result.contains("line 5"), "should include line 5: {result}");
+    assert!(result.contains("line 9"), "should include line 9: {result}");
+    assert!(
+        !result.contains("line 4"),
+        "should not include line 4: {result}"
+    );
+}
+
+/// Long runs of indented lines (>10) should be truncated in the middle.
+#[test]
+fn format_log_excerpt_truncates_long_indent_runs() {
+    let mut lines = vec!["Error start".to_string()];
+    for i in 0..20 {
+        lines.push(format!("  frame {}", i));
+    }
+    lines.push("Error end".to_string());
+    let content = lines.join("\n");
+    let result = hegel::format_log_excerpt(&content);
+    assert!(
+        result.contains("[..."),
+        "should contain truncation marker: {result}"
+    );
+    // First and last few frames should still be present
+    assert!(
+        result.contains("frame 0"),
+        "should show first frame: {result}"
+    );
+    assert!(
+        result.contains("frame 19"),
+        "should show last frame: {result}"
+    );
+    // Middle frames should be gone
+    assert!(
+        !result.contains("frame 10"),
+        "should not show middle frame: {result}"
+    );
+}
+
+/// Short indented runs (≤10) should not be truncated.
+#[test]
+fn format_log_excerpt_keeps_short_indent_runs() {
+    let mut lines = vec!["Error".to_string()];
+    for i in 0..8 {
+        lines.push(format!("  frame {}", i));
+    }
+    lines.push("End".to_string());
+    let content = lines.join("\n");
+    let result = hegel::format_log_excerpt(&content);
+    assert!(
+        !result.contains("[..."),
+        "should not truncate short run: {result}"
+    );
+    assert!(
+        result.contains("frame 7"),
+        "all frames should be present: {result}"
+    );
+}
+
+/// find_any should re-propagate panics from inside the condition (which are
+/// surfaced as "Property test failed: ...") instead of swallowing them and
+/// reporting "Could not find any examples".
+#[test]
+fn find_any_propagates_panics_from_condition() {
+    let result = std::panic::catch_unwind(|| {
+        FindAny::new(gs::booleans(), |_| -> bool {
+            panic!("deliberate_condition_panic");
+        })
+        .max_attempts(10)
+        .run()
+    });
+
+    let err = result.expect_err("expected panic, but find_any returned normally");
+    let msg = err
+        .downcast_ref::<String>()
+        .map(|s| s.as_str())
+        .or_else(|| err.downcast_ref::<&str>().copied())
+        .unwrap_or_default();
+
+    assert!(
+        msg.contains("deliberate_condition_panic"),
+        "expected panic message to mention 'deliberate_condition_panic', got: {msg}"
+    );
+}
+
+// A fake server script that:
+// 1. Writes a specific error message to stderr (which goes to server.log)
+// 2. Completes the version handshake
+// 3. Exits before responding to run_test (simulating a server crash)
+//
+// The binary protocol uses 20-byte packets: magic(4) + crc32(4) + channel(4) +
+// message_id(4) + payload_len(4), followed by payload bytes and a 0x0A terminator.
+const FAKE_SERVER_WITH_LOG: &str = r#"#!/usr/bin/env python3
+import sys
+import struct
+import binascii
+
+MAGIC = 0x4845474C
+REPLY_BIT = 0x80000000
+TERM = b'\x0a'
+
+def read_exact(n):
+    data = b''
+    while len(data) < n:
+        chunk = sys.stdin.buffer.read(n - len(data))
+        if not chunk:
+            return None
+        data += chunk
+    return data
+
+def read_packet():
+    hdr = read_exact(20)
+    if hdr is None:
+        return None
+    channel = struct.unpack('>I', hdr[8:12])[0]
+    mid_raw = struct.unpack('>I', hdr[12:16])[0]
+    length = struct.unpack('>I', hdr[16:20])[0]
+    message_id = mid_raw & ~REPLY_BIT
+    payload = read_exact(length)
+    if payload is None:
+        return None
+    read_exact(1)  # terminator
+    return channel, message_id, payload
+
+def write_packet(channel, message_id, payload):
+    if isinstance(payload, str):
+        payload = payload.encode()
+    mid = message_id | REPLY_BIT
+    hdr = struct.pack('>IIIII', MAGIC, 0, channel, mid, len(payload))
+    csum = binascii.crc32(hdr + payload) & 0xFFFFFFFF
+    hdr = hdr[:4] + struct.pack('>I', csum) + hdr[8:]
+    sys.stdout.buffer.write(hdr + payload + TERM)
+    sys.stdout.buffer.flush()
+
+# Write a distinctive error to stderr (piped to server.log)
+sys.stderr.write("FakeServerError: intentional crash for testing\n")
+sys.stderr.flush()
+
+# Complete the version handshake
+pkt = read_packet()
+if pkt is None:
+    sys.exit(1)
+channel, message_id, _ = pkt
+write_packet(channel, message_id, b"Hegel/0.6")
+
+# Exit immediately — client's run_test receive_reply will fail with ConnectionAborted
+sys.exit(1)
+"#;
+
+// Same as above but writes nothing to stderr, so server.log is empty.
+const FAKE_SERVER_NO_LOG: &str = r#"#!/usr/bin/env python3
+import sys
+import struct
+import binascii
+
+MAGIC = 0x4845474C
+REPLY_BIT = 0x80000000
+TERM = b'\x0a'
+
+def read_exact(n):
+    data = b''
+    while len(data) < n:
+        chunk = sys.stdin.buffer.read(n - len(data))
+        if not chunk:
+            return None
+        data += chunk
+    return data
+
+def read_packet():
+    hdr = read_exact(20)
+    if hdr is None:
+        return None
+    channel = struct.unpack('>I', hdr[8:12])[0]
+    mid_raw = struct.unpack('>I', hdr[12:16])[0]
+    length = struct.unpack('>I', hdr[16:20])[0]
+    message_id = mid_raw & ~REPLY_BIT
+    payload = read_exact(length)
+    if payload is None:
+        return None
+    read_exact(1)
+    return channel, message_id, payload
+
+def write_packet(channel, message_id, payload):
+    if isinstance(payload, str):
+        payload = payload.encode()
+    mid = message_id | REPLY_BIT
+    hdr = struct.pack('>IIIII', MAGIC, 0, channel, mid, len(payload))
+    csum = binascii.crc32(hdr + payload) & 0xFFFFFFFF
+    hdr = hdr[:4] + struct.pack('>I', csum) + hdr[8:]
+    sys.stdout.buffer.write(hdr + payload + TERM)
+    sys.stdout.buffer.flush()
+
+# No stderr writes — server.log will be empty
+
+# Complete the version handshake
+pkt = read_packet()
+if pkt is None:
+    sys.exit(1)
+channel, message_id, _ = pkt
+write_packet(channel, message_id, b"Hegel/0.6")
+
+# Exit immediately — client's run_test receive_reply will fail with ConnectionAborted
+sys.exit(1)
+"#;
+
+const HEGEL_TEST_CODE: &str = r#"
+fn main() {
+    hegel::hegel(|tc| {
+        let _ = tc.draw(hegel::generators::booleans());
+    });
+}
+"#;
+
+fn make_fake_server(script: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::TempDir::new().unwrap();
+    let script_path = dir.path().join("fake_server.py");
+    std::fs::write(&script_path, script).unwrap();
+
+    // Create a wrapper shell script so we can pass it as HEGEL_SERVER_COMMAND
+    let wrapper_path = dir.path().join("server");
+    std::fs::write(
+        &wrapper_path,
+        format!("#!/bin/sh\npython3 {} \"$@\"\n", script_path.display()),
+    )
+    .unwrap();
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&wrapper_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&wrapper_path, perms).unwrap();
+    }
+
+    (dir, wrapper_path)
+}
+
+/// When the server writes to its log before crashing, the error message should
+/// include the log content so the user can diagnose the crash.
+#[test]
+fn test_server_crash_includes_log_content() {
+    let (_dir, server_path) = make_fake_server(FAKE_SERVER_WITH_LOG);
+    TempRustProject::new()
+        .main_file(HEGEL_TEST_CODE)
+        .env("HEGEL_SERVER_COMMAND", server_path.to_str().unwrap())
+        .expect_failure("FakeServerError: intentional crash for testing")
+        .cargo_run(&[]);
+}
+
+/// When the server log is empty (server crashed before writing anything), the
+/// error message should still explain that the server crashed.
+#[test]
+fn test_server_crash_empty_log() {
+    let (_dir, server_path) = make_fake_server(FAKE_SERVER_NO_LOG);
+    TempRustProject::new()
+        .main_file(HEGEL_TEST_CODE)
+        .env("HEGEL_SERVER_COMMAND", server_path.to_str().unwrap())
+        .expect_failure("The hegel server process exited unexpectedly")
+        .cargo_run(&[]);
+}

--- a/tests/test_server_crash.rs
+++ b/tests/test_server_crash.rs
@@ -4,6 +4,12 @@ use common::project::TempRustProject;
 use common::utils::FindAny;
 use hegel::generators as gs;
 
+/// format_log_excerpt should return "(empty)" for empty input.
+#[test]
+fn format_log_excerpt_empty_content() {
+    assert_eq!(hegel::format_log_excerpt(""), "(empty)");
+}
+
 /// format_log_excerpt should return all content when there are fewer than
 /// MAX_UNINDENTED (5) unindented lines.
 #[test]

--- a/tests/test_server_crash.rs
+++ b/tests/test_server_crash.rs
@@ -169,7 +169,7 @@ pkt = read_packet()
 if pkt is None:
     sys.exit(1)
 channel, message_id, _ = pkt
-write_packet(channel, message_id, b"Hegel/0.6")
+write_packet(channel, message_id, b"Hegel/0.8")
 
 # Exit immediately — client's run_test receive_reply will fail with ConnectionAborted
 sys.exit(1)
@@ -225,7 +225,7 @@ pkt = read_packet()
 if pkt is None:
     sys.exit(1)
 channel, message_id, _ = pkt
-write_packet(channel, message_id, b"Hegel/0.6")
+write_packet(channel, message_id, b"Hegel/0.8")
 
 # Exit immediately — client's run_test receive_reply will fail with ConnectionAborted
 sys.exit(1)

--- a/tests/test_server_crash.rs
+++ b/tests/test_server_crash.rs
@@ -111,126 +111,6 @@ fn find_any_propagates_panics_from_condition() {
     );
 }
 
-// A fake server script that:
-// 1. Writes a specific error message to stderr (which goes to server.log)
-// 2. Completes the version handshake
-// 3. Exits before responding to run_test (simulating a server crash)
-//
-// The binary protocol uses 20-byte packets: magic(4) + crc32(4) + channel(4) +
-// message_id(4) + payload_len(4), followed by payload bytes and a 0x0A terminator.
-const FAKE_SERVER_WITH_LOG: &str = r#"#!/usr/bin/env python3
-import sys
-import struct
-import binascii
-
-MAGIC = 0x4845474C
-REPLY_BIT = 0x80000000
-TERM = b'\x0a'
-
-def read_exact(n):
-    data = b''
-    while len(data) < n:
-        chunk = sys.stdin.buffer.read(n - len(data))
-        if not chunk:
-            return None
-        data += chunk
-    return data
-
-def read_packet():
-    hdr = read_exact(20)
-    if hdr is None:
-        return None
-    channel = struct.unpack('>I', hdr[8:12])[0]
-    mid_raw = struct.unpack('>I', hdr[12:16])[0]
-    length = struct.unpack('>I', hdr[16:20])[0]
-    message_id = mid_raw & ~REPLY_BIT
-    payload = read_exact(length)
-    if payload is None:
-        return None
-    read_exact(1)  # terminator
-    return channel, message_id, payload
-
-def write_packet(channel, message_id, payload):
-    if isinstance(payload, str):
-        payload = payload.encode()
-    mid = message_id | REPLY_BIT
-    hdr = struct.pack('>IIIII', MAGIC, 0, channel, mid, len(payload))
-    csum = binascii.crc32(hdr + payload) & 0xFFFFFFFF
-    hdr = hdr[:4] + struct.pack('>I', csum) + hdr[8:]
-    sys.stdout.buffer.write(hdr + payload + TERM)
-    sys.stdout.buffer.flush()
-
-# Write a distinctive error to stderr (piped to server.log)
-sys.stderr.write("FakeServerError: intentional crash for testing\n")
-sys.stderr.flush()
-
-# Complete the version handshake
-pkt = read_packet()
-if pkt is None:
-    sys.exit(1)
-channel, message_id, _ = pkt
-write_packet(channel, message_id, b"Hegel/0.10")
-
-# Exit immediately — client's run_test receive_reply will fail with ConnectionAborted
-sys.exit(1)
-"#;
-
-// Same as above but writes nothing to stderr, so server.log is empty.
-const FAKE_SERVER_NO_LOG: &str = r#"#!/usr/bin/env python3
-import sys
-import struct
-import binascii
-
-MAGIC = 0x4845474C
-REPLY_BIT = 0x80000000
-TERM = b'\x0a'
-
-def read_exact(n):
-    data = b''
-    while len(data) < n:
-        chunk = sys.stdin.buffer.read(n - len(data))
-        if not chunk:
-            return None
-        data += chunk
-    return data
-
-def read_packet():
-    hdr = read_exact(20)
-    if hdr is None:
-        return None
-    channel = struct.unpack('>I', hdr[8:12])[0]
-    mid_raw = struct.unpack('>I', hdr[12:16])[0]
-    length = struct.unpack('>I', hdr[16:20])[0]
-    message_id = mid_raw & ~REPLY_BIT
-    payload = read_exact(length)
-    if payload is None:
-        return None
-    read_exact(1)
-    return channel, message_id, payload
-
-def write_packet(channel, message_id, payload):
-    if isinstance(payload, str):
-        payload = payload.encode()
-    mid = message_id | REPLY_BIT
-    hdr = struct.pack('>IIIII', MAGIC, 0, channel, mid, len(payload))
-    csum = binascii.crc32(hdr + payload) & 0xFFFFFFFF
-    hdr = hdr[:4] + struct.pack('>I', csum) + hdr[8:]
-    sys.stdout.buffer.write(hdr + payload + TERM)
-    sys.stdout.buffer.flush()
-
-# No stderr writes — server.log will be empty
-
-# Complete the version handshake
-pkt = read_packet()
-if pkt is None:
-    sys.exit(1)
-channel, message_id, _ = pkt
-write_packet(channel, message_id, b"Hegel/0.10")
-
-# Exit immediately — client's run_test receive_reply will fail with ConnectionAborted
-sys.exit(1)
-"#;
-
 const HEGEL_TEST_CODE: &str = r#"
 fn main() {
     hegel::hegel(|tc| {
@@ -239,38 +119,16 @@ fn main() {
 }
 "#;
 
-fn make_fake_server(script: &str) -> (tempfile::TempDir, std::path::PathBuf) {
-    let dir = tempfile::TempDir::new().unwrap();
-    let script_path = dir.path().join("fake_server.py");
-    std::fs::write(&script_path, script).unwrap();
-
-    // Create a wrapper shell script so we can pass it as HEGEL_SERVER_COMMAND
-    let wrapper_path = dir.path().join("server");
-    std::fs::write(
-        &wrapper_path,
-        format!("#!/bin/sh\npython3 {} \"$@\"\n", script_path.display()),
-    )
-    .unwrap();
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = std::fs::metadata(&wrapper_path).unwrap().permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&wrapper_path, perms).unwrap();
-    }
-
-    (dir, wrapper_path)
-}
-
 /// When the server writes to its log before crashing, the error message should
 /// include the log content so the user can diagnose the crash.
 #[test]
 fn test_server_crash_includes_log_content() {
-    let (_dir, server_path) = make_fake_server(FAKE_SERVER_WITH_LOG);
     TempRustProject::new()
         .main_file(HEGEL_TEST_CODE)
-        .env("HEGEL_SERVER_COMMAND", server_path.to_str().unwrap())
+        .env(
+            "HEGEL_PROTOCOL_TEST_MODE",
+            "crash_after_handshake_with_stderr",
+        )
         .expect_failure("FakeServerError: intentional crash for testing")
         .cargo_run(&[]);
 }
@@ -279,10 +137,9 @@ fn test_server_crash_includes_log_content() {
 /// error message should still explain that the server crashed.
 #[test]
 fn test_server_crash_empty_log() {
-    let (_dir, server_path) = make_fake_server(FAKE_SERVER_NO_LOG);
     TempRustProject::new()
         .main_file(HEGEL_TEST_CODE)
-        .env("HEGEL_SERVER_COMMAND", server_path.to_str().unwrap())
+        .env("HEGEL_PROTOCOL_TEST_MODE", "crash_after_handshake")
         .expect_failure("The hegel server process exited unexpectedly")
         .cargo_run(&[]);
 }

--- a/tests/test_server_crash.rs
+++ b/tests/test_server_crash.rs
@@ -119,10 +119,40 @@ fn main() {
 }
 "#;
 
+/// Returns true if the currently-configured hegel server supports protocol test
+/// modes like `crash_after_handshake`. These modes were added in hegel-core 0.4.2.
+///
+/// When `HEGEL_SERVER_COMMAND` is not set, the library spawns the server via
+/// `uv tool run --from hegel-core=={pinned}`, which is always 0.4.2+ — crash
+/// modes are always available. When it IS set (e.g. the `test-min-protocol` CI
+/// job installs an older release), we query the binary's version to decide.
+fn hegel_supports_crash_modes() -> bool {
+    let Ok(cmd) = std::env::var("HEGEL_SERVER_COMMAND") else {
+        return true;
+    };
+    let Ok(out) = std::process::Command::new(&cmd).arg("--version").output() else {
+        return false;
+    };
+    let text = String::from_utf8_lossy(&out.stdout);
+    // Expected format: "hegel (version X.Y.Z)"
+    if let Some(start) = text.find("version ") {
+        let rest = text[start + 8..].trim_start();
+        let ver = rest.split(')').next().unwrap_or("").trim();
+        let parts: Vec<u32> = ver.split('.').filter_map(|p| p.parse().ok()).collect();
+        if parts.len() == 3 {
+            return (parts[0], parts[1], parts[2]) >= (0, 4, 2);
+        }
+    }
+    false
+}
+
 /// When the server writes to its log before crashing, the error message should
 /// include the log content so the user can diagnose the crash.
 #[test]
 fn test_server_crash_includes_log_content() {
+    if !hegel_supports_crash_modes() {
+        return;
+    }
     TempRustProject::new()
         .main_file(HEGEL_TEST_CODE)
         .env(
@@ -137,6 +167,9 @@ fn test_server_crash_includes_log_content() {
 /// error message should still explain that the server crashed.
 #[test]
 fn test_server_crash_empty_log() {
+    if !hegel_supports_crash_modes() {
+        return;
+    }
     TempRustProject::new()
         .main_file(HEGEL_TEST_CODE)
         .env("HEGEL_PROTOCOL_TEST_MODE", "crash_after_handshake")

--- a/tests/test_server_crash.rs
+++ b/tests/test_server_crash.rs
@@ -169,7 +169,7 @@ pkt = read_packet()
 if pkt is None:
     sys.exit(1)
 channel, message_id, _ = pkt
-write_packet(channel, message_id, b"Hegel/0.8")
+write_packet(channel, message_id, b"Hegel/0.10")
 
 # Exit immediately — client's run_test receive_reply will fail with ConnectionAborted
 sys.exit(1)
@@ -225,7 +225,7 @@ pkt = read_packet()
 if pkt is None:
     sys.exit(1)
 channel, message_id, _ = pkt
-write_packet(channel, message_id, b"Hegel/0.8")
+write_packet(channel, message_id, b"Hegel/0.10")
 
 # Exit immediately — client's run_test receive_reply will fail with ConnectionAborted
 sys.exit(1)

--- a/tests/test_server_restart.rs
+++ b/tests/test_server_restart.rs
@@ -1,0 +1,23 @@
+mod common;
+
+/// After a server crash, Hegel should transparently restart the server for the
+/// next test run rather than propagating the crash to unrelated tests.
+#[test]
+fn test_server_restarts_after_kill() {
+    // First run — starts the server and completes successfully.
+    hegel::Hegel::new(|tc| {
+        let _ = tc.draw(hegel::generators::booleans());
+    })
+    .settings(hegel::Settings::new().test_cases(1))
+    .run();
+
+    // Kill the server and wait for the connection to detect it has exited.
+    hegel::__test_kill_server();
+
+    // Second run — should detect the dead session, restart the server, and succeed.
+    hegel::Hegel::new(|tc| {
+        let _ = tc.draw(hegel::generators::booleans());
+    })
+    .settings(hegel::Settings::new().test_cases(1))
+    .run();
+}


### PR DESCRIPTION
We've been seeing a bunch of flaky failures on CI where the server crashes and everything fails incredibly inscrutably.

This doesn't fix those. Instead it changes it so that they should fail scrutably.

- Server crash errors now include the last few log lines inline, with long runs of indented lines folded to avoid wall-of-text stack traces.
- The control channel mutex is released before error handling, preventing `PoisonError` cascades across threads.
- `find_any` re-raises real panics instead of replacing them with the "could not find" message.
- `SESSION` is now resettable: `HegelSession::get()` detects `server_has_exited()` and spawns a new server, so subsequent `hegel()` calls work normally after a crash or explicit kill.
- A `__test_kill_server()` helper and a new `tests/test_server_restart.rs` cover the restart path end-to-end.