### PR TITLE
Fix `gs::vecs().unique(true)` in some cases

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix `VecGenerator::unique(true)` silently ignoring the unique constraint when used with composite (non-basic) generators. The fallback draw path now performs client-side deduplication using `collection.reject()`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,5 @@
-RELEASE_TYPE: patch
+RELEASE_TYPE: minor
 
-Fix `VecGenerator::unique(true)` silently ignoring the unique constraint when used with composite (non-basic) generators. The fallback draw path now performs client-side deduplication using `collection.reject()`.
+Fix `vecs(...).unique(true)` not actually enforcing element uniqueness in some cases.
+
+Calling `.unique()` now requires the elements produced by the generator passed to `vecs()` to implement `PartialEq`. This is therefore technically a breaking change, though we expect that the only case where you will need to update your code is when it was previously not working anyway.

--- a/src/generators/collections.rs
+++ b/src/generators/collections.rs
@@ -11,7 +11,7 @@ pub struct VecGenerator<G, T> {
     pub(crate) elements: G,
     pub(crate) min_size: usize,
     pub(crate) max_size: Option<usize>,
-    pub(crate) unique: bool,
+    pub(crate) unique_eq: Option<fn(&T, &T) -> bool>,
     pub(crate) _phantom: PhantomData<fn(T)>,
 }
 
@@ -27,10 +27,16 @@ impl<G, T> VecGenerator<G, T> {
         self.max_size = Some(max_size);
         self
     }
+}
 
+impl<G, T: PartialEq> VecGenerator<G, T> {
     /// Require all elements to be unique.
     pub fn unique(mut self, unique: bool) -> Self {
-        self.unique = unique;
+        self.unique_eq = if unique {
+            Some(<T as PartialEq>::eq)
+        } else {
+            None
+        };
         self
     }
 }
@@ -50,7 +56,14 @@ where
             let mut collection = Collection::new(tc, self.min_size, self.max_size);
             let mut result = Vec::new();
             while collection.more() {
-                result.push(self.elements.do_draw(tc));
+                let element = self.elements.do_draw(tc);
+                if let Some(eq_fn) = &self.unique_eq {
+                    if result.iter().any(|existing| eq_fn(existing, &element)) {
+                        collection.reject(Some("duplicate element"));
+                        continue;
+                    }
+                }
+                result.push(element);
             }
             tc.stop_span(false);
             result
@@ -65,7 +78,7 @@ where
 
         let mut schema = cbor_map! {
             "type" => "list",
-            "unique" => self.unique,
+            "unique" => self.unique_eq.is_some(),
             "elements" => basic.schema().clone(),
             "min_size" => self.min_size as u64
         };
@@ -89,7 +102,7 @@ pub fn vecs<T, G: Generator<T>>(elements: G) -> VecGenerator<G, T> {
         elements,
         min_size: 0,
         max_size: None,
-        unique: false,
+        unique_eq: None,
         _phantom: PhantomData,
     }
 }

--- a/src/generators/collections.rs
+++ b/src/generators/collections.rs
@@ -11,7 +11,7 @@ pub struct VecGenerator<G, T> {
     pub(crate) elements: G,
     pub(crate) min_size: usize,
     pub(crate) max_size: Option<usize>,
-    pub(crate) unique_eq: Option<fn(&T, &T) -> bool>,
+    pub(crate) unique_by: Option<fn(&T, &T) -> bool>,
     pub(crate) _phantom: PhantomData<fn(T)>,
 }
 
@@ -32,7 +32,7 @@ impl<G, T> VecGenerator<G, T> {
 impl<G, T: PartialEq> VecGenerator<G, T> {
     /// Require all elements to be unique.
     pub fn unique(mut self, unique: bool) -> Self {
-        self.unique_eq = if unique {
+        self.unique_by = if unique {
             Some(<T as PartialEq>::eq)
         } else {
             None
@@ -57,7 +57,7 @@ where
             let mut result = Vec::new();
             while collection.more() {
                 let element = self.elements.do_draw(tc);
-                if let Some(eq_fn) = &self.unique_eq {
+                if let Some(eq_fn) = &self.unique_by {
                     if result.iter().any(|existing| eq_fn(existing, &element)) {
                         collection.reject(Some("duplicate element"));
                         continue;
@@ -78,7 +78,7 @@ where
 
         let mut schema = cbor_map! {
             "type" => "list",
-            "unique" => self.unique_eq.is_some(),
+            "unique" => self.unique_by.is_some(),
             "elements" => basic.schema().clone(),
             "min_size" => self.min_size as u64
         };
@@ -102,7 +102,7 @@ pub fn vecs<T, G: Generator<T>>(elements: G) -> VecGenerator<G, T> {
         elements,
         min_size: 0,
         max_size: None,
-        unique_eq: None,
+        unique_by: None,
         _phantom: PhantomData,
     }
 }

--- a/tests/test_collections.rs
+++ b/tests/test_collections.rs
@@ -56,6 +56,51 @@ fn test_vec_unique_with_min_size(tc: TestCase) {
     assert_eq!(set.len(), vec.len());
 }
 
+#[hegel::composite]
+fn composite_integer(tc: TestCase) -> i32 {
+    tc.draw(gs::integers())
+}
+
+#[hegel::test]
+fn test_vec_unique_composite(tc: TestCase) {
+    let max_size: usize = tc.draw(gs::integers().min_value(0).max_value(50));
+    let vec: Vec<i32> = tc.draw(
+        gs::vecs(composite_integer())
+            .max_size(max_size)
+            .unique(true),
+    );
+
+    let set: HashSet<_> = vec.iter().collect();
+    assert_eq!(set.len(), vec.len());
+}
+
+#[hegel::test]
+fn test_vec_unique_false(tc: TestCase) {
+    // Verify that .unique(false) unsets uniqueness (e.g. after .unique(true))
+    let vec: Vec<bool> = tc.draw(
+        gs::vecs(gs::booleans())
+            .min_size(2)
+            .unique(true)
+            .unique(false),
+    );
+    assert!(vec.len() >= 2);
+}
+
+#[hegel::test]
+fn test_vec_unique_composite_with_min_size(tc: TestCase) {
+    let min_size: usize = tc.draw(gs::integers().min_value(0).max_value(20));
+    let vec: Vec<i32> = tc.draw(
+        gs::vecs(composite_integer())
+            .min_size(min_size)
+            .unique(true),
+    );
+
+    assert!(vec.len() >= min_size);
+
+    let set: HashSet<_> = vec.iter().collect();
+    assert_eq!(set.len(), vec.len());
+}
+
 #[hegel::test]
 fn test_vec_with_mapped_elements(tc: TestCase) {
     let vec: Vec<i32> = tc.draw(

--- a/tests/test_collections.rs
+++ b/tests/test_collections.rs
@@ -79,6 +79,18 @@ fn composite_integer(tc: TestCase) -> i32 {
     tc.draw(gs::integers())
 }
 
+// explicit regression test for https://github.com/hegeldev/hegel-rust/issues/179
+#[hegel::composite]
+fn composite_u8(tc: TestCase) -> u8 {
+    tc.draw(gs::integers())
+}
+
+#[hegel::test]
+fn test_vec_unique_composite_u8(tc: TestCase) {
+    let vec: Vec<u8> = tc.draw(gs::vecs(composite_u8()).unique(true));
+    assert_all_unique(&vec);
+}
+
 #[hegel::test]
 fn test_vec_unique_composite(tc: TestCase) {
     let max_size: usize = tc.draw(gs::integers());

--- a/tests/test_collections.rs
+++ b/tests/test_collections.rs
@@ -93,15 +93,16 @@ fn test_vec_unique_composite(tc: TestCase) {
 }
 
 #[hegel::test]
-fn test_vec_unique_false(tc: TestCase) {
-    // Verify that .unique(false) unsets uniqueness (e.g. after .unique(true))
+fn test_vec_unique_false_after_true(tc: TestCase) {
+    // .unique(false) unsets uniqueness. With unique(true), min_size(5) on booleans
+    // would be impossible (only 2 distinct values), so this proves it was unset.
     let vec: Vec<bool> = tc.draw(
         gs::vecs(gs::booleans())
-            .min_size(2)
+            .min_size(5)
             .unique(true)
             .unique(false),
     );
-    assert!(vec.len() >= 2);
+    assert!(vec.len() >= 5);
 }
 
 #[hegel::test]

--- a/tests/test_collections.rs
+++ b/tests/test_collections.rs
@@ -1,24 +1,42 @@
+mod common;
+
+use common::project::TempRustProject;
 use hegel::TestCase;
-use hegel::generators::{self as gs, Generator};
+use hegel::generators::{self as gs, DefaultGenerator, Generator};
 use std::collections::{HashMap, HashSet};
+
+#[derive(Debug, PartialEq, hegel::DefaultGenerator)]
+struct Wrapper {
+    value: i32,
+}
+
+// writing this more nicely requires Eq + Hash on our test structs; but I want to test structs
+// which have minimal traits.
+fn assert_all_unique<T: PartialEq + std::fmt::Debug>(items: &[T]) {
+    for (i, a) in items.iter().enumerate() {
+        for b in &items[i + 1..] {
+            assert_ne!(a, b);
+        }
+    }
+}
 
 #[hegel::test]
 fn test_vec_with_max_size(tc: TestCase) {
-    let max_size: usize = tc.draw(gs::integers().min_value(0).max_value(20));
+    let max_size: usize = tc.draw(gs::integers());
     let vec: Vec<i32> = tc.draw(gs::vecs(gs::integers::<i32>()).max_size(max_size));
     assert!(vec.len() <= max_size);
 }
 
 #[hegel::test]
 fn test_vec_with_min_size(tc: TestCase) {
-    let min_size: usize = tc.draw(gs::integers().min_value(0).max_value(20));
+    let min_size: usize = tc.draw(gs::integers().max_value(20));
     let vec: Vec<i32> = tc.draw(gs::vecs(gs::integers::<i32>()).min_size(min_size));
     assert!(vec.len() >= min_size);
 }
 
 #[hegel::test]
 fn test_vec_with_min_and_max_size(tc: TestCase) {
-    let min_size: usize = tc.draw(gs::integers().min_value(0).max_value(10));
+    let min_size: usize = tc.draw(gs::integers().max_value(10));
     let max_size = tc.draw(gs::integers().min_value(min_size));
     let vec: Vec<i32> = tc.draw(
         gs::vecs(gs::integers::<i32>())
@@ -30,7 +48,7 @@ fn test_vec_with_min_and_max_size(tc: TestCase) {
 
 #[hegel::test]
 fn test_vec_unique(tc: TestCase) {
-    let max_size: usize = tc.draw(gs::integers().min_value(0).max_value(50));
+    let max_size: usize = tc.draw(gs::integers());
     let vec: Vec<i32> = tc.draw(
         gs::vecs(gs::integers::<i32>())
             .max_size(max_size)
@@ -43,7 +61,7 @@ fn test_vec_unique(tc: TestCase) {
 
 #[hegel::test]
 fn test_vec_unique_with_min_size(tc: TestCase) {
-    let min_size: usize = tc.draw(gs::integers().min_value(0).max_value(20));
+    let min_size: usize = tc.draw(gs::integers().max_value(20));
     let vec: Vec<i32> = tc.draw(
         gs::vecs(gs::integers::<i32>())
             .min_size(min_size)
@@ -63,7 +81,7 @@ fn composite_integer(tc: TestCase) -> i32 {
 
 #[hegel::test]
 fn test_vec_unique_composite(tc: TestCase) {
-    let max_size: usize = tc.draw(gs::integers().min_value(0).max_value(50));
+    let max_size: usize = tc.draw(gs::integers());
     let vec: Vec<i32> = tc.draw(
         gs::vecs(composite_integer())
             .max_size(max_size)
@@ -88,7 +106,7 @@ fn test_vec_unique_false(tc: TestCase) {
 
 #[hegel::test]
 fn test_vec_unique_composite_with_min_size(tc: TestCase) {
-    let min_size: usize = tc.draw(gs::integers().min_value(0).max_value(20));
+    let min_size: usize = tc.draw(gs::integers().max_value(20));
     let vec: Vec<i32> = tc.draw(
         gs::vecs(composite_integer())
             .min_size(min_size)
@@ -117,21 +135,21 @@ fn test_vec_with_mapped_elements(tc: TestCase) {
 
 #[hegel::test]
 fn test_hashset_with_max_size(tc: TestCase) {
-    let max_size: usize = tc.draw(gs::integers().min_value(0).max_value(20));
+    let max_size: usize = tc.draw(gs::integers());
     let set: HashSet<i32> = tc.draw(gs::hashsets(gs::integers::<i32>()).max_size(max_size));
     assert!(set.len() <= max_size);
 }
 
 #[hegel::test]
 fn test_hashset_with_min_size(tc: TestCase) {
-    let min_size: usize = tc.draw(gs::integers().min_value(0).max_value(20));
+    let min_size: usize = tc.draw(gs::integers().max_value(20));
     let set: HashSet<i32> = tc.draw(gs::hashsets(gs::integers::<i32>()).min_size(min_size));
     assert!(set.len() >= min_size);
 }
 
 #[hegel::test]
 fn test_hashset_with_min_and_max_size(tc: TestCase) {
-    let min_size: usize = tc.draw(gs::integers().min_value(0).max_value(10));
+    let min_size: usize = tc.draw(gs::integers().max_value(10));
     let max_size = tc.draw(gs::integers().min_value(min_size));
     let set: HashSet<i32> = tc.draw(
         gs::hashsets(gs::integers::<i32>())
@@ -169,7 +187,7 @@ fn test_vec_of_hashsets(tc: TestCase) {
 
 #[hegel::test]
 fn test_hashmap_with_max_size(tc: TestCase) {
-    let max_size: usize = tc.draw(gs::integers().min_value(0).max_value(20));
+    let max_size: usize = tc.draw(gs::integers());
     let map: HashMap<i32, i32> =
         tc.draw(gs::hashmaps(gs::integers::<i32>(), gs::integers::<i32>()).max_size(max_size));
     assert!(map.len() <= max_size);
@@ -177,7 +195,7 @@ fn test_hashmap_with_max_size(tc: TestCase) {
 
 #[hegel::test]
 fn test_hashmap_with_min_size(tc: TestCase) {
-    let min_size: usize = tc.draw(gs::integers().min_value(0).max_value(20));
+    let min_size: usize = tc.draw(gs::integers().max_value(20));
     let map: HashMap<i32, i32> =
         tc.draw(gs::hashmaps(gs::integers::<i32>(), gs::integers::<i32>()).min_size(min_size));
     assert!(map.len() >= min_size);
@@ -185,7 +203,7 @@ fn test_hashmap_with_min_size(tc: TestCase) {
 
 #[hegel::test]
 fn test_hashmap_with_min_and_max_size(tc: TestCase) {
-    let min_size: usize = tc.draw(gs::integers().min_value(0).max_value(10));
+    let min_size: usize = tc.draw(gs::integers().max_value(10));
     let max_size = tc.draw(gs::integers().min_value(min_size));
     let map: HashMap<i32, i32> = tc.draw(
         gs::hashmaps(gs::integers::<i32>(), gs::integers::<i32>())
@@ -214,4 +232,52 @@ fn test_hashmap_with_mapped_keys(tc: TestCase) {
 fn test_binary_with_max_size(tc: TestCase) {
     let data = tc.draw(gs::binary().max_size(50));
     assert!(data.len() <= 50);
+}
+
+#[hegel::test]
+fn test_vec_unique_partial_eq_struct(tc: TestCase) {
+    let vec: Vec<Wrapper> = tc.draw(gs::vecs(Wrapper::default_generator()).unique(true));
+    assert_all_unique(&vec);
+}
+
+#[hegel::composite]
+fn composite_wrapper(tc: TestCase) -> Wrapper {
+    Wrapper {
+        value: tc.draw(gs::integers()),
+    }
+}
+
+#[hegel::test]
+fn test_vec_unique_partial_eq_struct_composite(tc: TestCase) {
+    let vec: Vec<Wrapper> = tc.draw(gs::vecs(composite_wrapper()).unique(true));
+    assert_all_unique(&vec);
+}
+
+#[test]
+fn test_vec_no_partial_eq_compiles_without_unique() {
+    #[derive(hegel::DefaultGenerator)]
+    struct NoEq {
+        #[allow(dead_code)]
+        value: i32,
+    }
+    let _ = gs::vecs(NoEq::default_generator());
+}
+
+#[test]
+fn test_vec_unique_requires_partial_eq() {
+    TempRustProject::new()
+        .expect_failure("doesn't satisfy `NoEq: PartialEq`")
+        .main_file(
+            r#"
+use hegel::generators::{self as gs, DefaultGenerator, Generator};
+
+#[derive(hegel::DefaultGenerator)]
+struct NoEq { value: i32 }
+
+fn main() {
+    let _ = gs::vecs(NoEq::default_generator()).unique(true);
+}
+"#,
+        )
+        .cargo_run(&[]);
 }


### PR DESCRIPTION
Closes https://github.com/hegeldev/hegel-rust/issues/179.

This prompted me to improve our conformance testing: https://github.com/hegeldev/hegel-rust/pull/181. That would have caught this if we had it!

<details><summary>Claude-written description</summary>

Fixes #179.

When `VecGenerator::unique(true)` is used with a composite generator (or any non-basic generator), the `unique` flag was silently ignored because the fallback draw path had no client-side deduplication logic. The basic (schema-based) path correctly sent `"unique": true` to the server, but the non-basic path just accumulated elements without checking for duplicates.

The fix stores a type-erased equality function pointer (`fn(&T, &T) -> bool`) instead of a plain `bool` flag. This approach:

- Avoids adding `PartialEq` bounds to the `Generator<Vec<T>>` impl (which would break `DefaultGenerator` and derive macros for types without `PartialEq`)
- Only requires `T: PartialEq` when `.unique(true)` is actually called
- Uses `collection.reject("duplicate element")` in the fallback path to tell the server the element was rejected, matching how `HashSetGenerator` already handles deduplication

Added tests for unique vecs with composite generators (with and without min_size) and for `unique(false)` to verify it properly unsets the constraint.

</details>
