### PR TITLE
Add #[hegel::main] and #[hegel::standalone_function] entry points

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This adds two new macros to allow more flexible use of hegel.
+
+* `#[hegel::main]` wraps a function as a standalone binary entry point, exposing CLI flags for every Settings option.
+* `#[hegel::standalone_function]` rewrites fn(tc: TestCase, args...) into fn(args...) so a property test can be invoked directly.

--- a/hegel-macros/src/common.rs
+++ b/hegel-macros/src/common.rs
@@ -1,0 +1,355 @@
+//! Shared helpers used by `#[hegel::test]`, `#[hegel::main]`, and
+//! `#[hegel::standalone_function]`.
+//!
+//! All three macros expand to essentially the same core: rewrite
+//! `tc.draw(gen)` calls into `tc.__draw_named(gen, "name", repeatable)`,
+//! pick up any `#[hegel::explicit_test_case]` sibling attributes, build
+//! a `Settings` expression, and then call `Hegel::new(...).settings(...).run()`.
+//! They differ only in the wrapping function that holds the call.
+
+use std::collections::HashMap;
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::parse::{Parse, ParseStream};
+use syn::visit_mut::VisitMut;
+use syn::{Expr, Ident, Pat, Token};
+
+/// A single named argument in a `#[hegel::test(...)]`-style attribute.
+pub struct SettingArg {
+    pub key: Ident,
+    pub value: Expr,
+}
+
+/// Parsed contents of a `#[hegel::test(...)]`-style attribute.
+///
+/// Acceptable formats:
+/// - empty
+/// - `settings_expr`
+/// - `settings_expr, seed = 42`
+/// - `seed = 42, test_cases = 10`
+pub struct SettingsAttrArgs {
+    pub settings: Option<Expr>,
+    pub settings_args: Vec<SettingArg>,
+}
+
+impl Parse for SettingsAttrArgs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut settings = None;
+        let mut settings_args = Vec::new();
+
+        if input.is_empty() {
+            return Ok(SettingsAttrArgs {
+                settings,
+                settings_args,
+            });
+        }
+
+        let is_named_arg = input.peek(Ident) && input.peek2(Token![=]);
+        if !is_named_arg {
+            settings = Some(input.parse::<Expr>()?);
+            if !input.is_empty() {
+                let _comma: Token![,] = input.parse()?;
+            }
+        }
+
+        while !input.is_empty() {
+            let key: Ident = input.parse()?;
+            let _eq: Token![=] = input.parse()?;
+            let value: Expr = input.parse()?;
+            settings_args.push(SettingArg { key, value });
+            if !input.is_empty() {
+                let _comma: Token![,] = input.parse()?;
+            }
+        }
+
+        Ok(SettingsAttrArgs {
+            settings,
+            settings_args,
+        })
+    }
+}
+
+impl SettingsAttrArgs {
+    /// Build a token stream that evaluates to a `hegel::Settings` value.
+    pub fn to_settings_expr(&self) -> TokenStream {
+        let chain: Vec<TokenStream> = self
+            .settings_args
+            .iter()
+            .map(|arg| {
+                let key = &arg.key;
+                let value = &arg.value;
+                quote! { .#key(#value) }
+            })
+            .collect();
+
+        match &self.settings {
+            Some(expr) => quote! { #expr #(#chain)* },
+            None if chain.is_empty() => quote! { hegel::Settings::new() },
+            None => quote! { hegel::Settings::new() #(#chain)* },
+        }
+    }
+}
+
+/// Extract a simple identifier from a pattern, handling type annotations.
+pub fn extract_ident_from_pat(pat: &Pat) -> Option<String> {
+    match pat {
+        Pat::Ident(pat_ident) => Some(pat_ident.ident.to_string()),
+        Pat::Type(pat_type) => extract_ident_from_pat(&pat_type.pat),
+        _ => None,
+    }
+}
+
+/// Check if a `let` binding is of the form `let <ident> = <test_case_ident>.draw(<one_arg>)`.
+fn is_test_case_draw_binding(node: &syn::Local, test_case_ident: &str) -> Option<String> {
+    let var_name = extract_ident_from_pat(&node.pat)?;
+
+    let init = node.init.as_ref()?;
+    let method_call = match &*init.expr {
+        Expr::MethodCall(mc) => mc,
+        _ => return None,
+    };
+
+    if method_call.method != "draw" || method_call.args.len() != 1 {
+        return None;
+    }
+
+    let is_tc = match &*method_call.receiver {
+        Expr::Path(path) => path.path.is_ident(test_case_ident),
+        _ => false,
+    };
+    if !is_tc {
+        return None;
+    }
+
+    Some(var_name)
+}
+
+struct DrawNameCollector {
+    test_case_ident: String,
+    block_depth: usize,
+    name_flags: HashMap<String, bool>,
+}
+
+impl VisitMut for DrawNameCollector {
+    fn visit_block_mut(&mut self, node: &mut syn::Block) {
+        self.block_depth += 1;
+        syn::visit_mut::visit_block_mut(self, node);
+        self.block_depth -= 1;
+    }
+
+    fn visit_expr_closure_mut(&mut self, node: &mut syn::ExprClosure) {
+        self.block_depth += 1;
+        syn::visit_mut::visit_expr_closure_mut(self, node);
+        self.block_depth -= 1;
+    }
+
+    fn visit_item_fn_mut(&mut self, _node: &mut syn::ItemFn) {}
+
+    fn visit_local_mut(&mut self, node: &mut syn::Local) {
+        syn::visit_mut::visit_local_mut(self, node);
+
+        if let Some(var_name) = is_test_case_draw_binding(node, &self.test_case_ident) {
+            let repeatable = self.block_depth > 0 || self.name_flags.contains_key(&var_name);
+            let entry = self.name_flags.entry(var_name).or_insert(false);
+            if repeatable {
+                *entry = true;
+            }
+        }
+    }
+}
+
+struct DrawRewriter {
+    test_case_ident: String,
+    name_flags: HashMap<String, bool>,
+}
+
+impl VisitMut for DrawRewriter {
+    fn visit_item_fn_mut(&mut self, _node: &mut syn::ItemFn) {}
+
+    fn visit_local_mut(&mut self, node: &mut syn::Local) {
+        syn::visit_mut::visit_local_mut(self, node);
+
+        let var_name = match is_test_case_draw_binding(node, &self.test_case_ident) {
+            Some(name) => name,
+            None => return,
+        };
+
+        let repeatable = self.name_flags.get(&var_name).copied().unwrap_or(false);
+
+        let init = node.init.as_mut().unwrap();
+        let method_call = match &mut *init.expr {
+            Expr::MethodCall(mc) => mc,
+            _ => unreachable!(),
+        };
+
+        let span = method_call.method.span();
+        method_call.method = Ident::new("__draw_named", span);
+        method_call.args.push(Expr::Lit(syn::ExprLit {
+            attrs: vec![],
+            lit: syn::Lit::Str(syn::LitStr::new(&var_name, span)),
+        }));
+        method_call.args.push(Expr::Lit(syn::ExprLit {
+            attrs: vec![],
+            lit: syn::Lit::Bool(syn::LitBool::new(repeatable, span)),
+        }));
+    }
+}
+
+/// Rewrite `let x = <test_case_ident>.draw(gen)` into
+/// `let x = <test_case_ident>.__draw_named(gen, "x", repeatable)` throughout a block.
+///
+/// Uses a two-pass approach so that if a name is used in a repeatable context
+/// anywhere (nested block or closure), every use of that name becomes repeatable.
+pub fn rewrite_draws_in_block(body: &mut syn::Block, test_case_ident: &str) {
+    let mut collector = DrawNameCollector {
+        test_case_ident: test_case_ident.to_string(),
+        block_depth: 0,
+        name_flags: HashMap::new(),
+    };
+    for stmt in &mut body.stmts {
+        collector.visit_stmt_mut(stmt);
+    }
+
+    let mut rewriter = DrawRewriter {
+        test_case_ident: test_case_ident.to_string(),
+        name_flags: collector.name_flags,
+    };
+    for stmt in &mut body.stmts {
+        rewriter.visit_stmt_mut(stmt);
+    }
+}
+
+/// A parsed explicit test case: a list of (name, expression_source) pairs.
+pub struct ParsedExplicitTestCase {
+    pub entries: Vec<(String, String)>,
+}
+
+fn is_explicit_test_case_attr(attr: &syn::Attribute) -> bool {
+    let segments: Vec<_> = attr.path().segments.iter().collect();
+    segments.len() == 2 && segments[0].ident == "hegel" && segments[1].ident == "explicit_test_case"
+}
+
+/// Parsed arguments for a single `#[hegel::explicit_test_case(name = expr, ...)]`.
+struct ExplicitTestCaseAttrArgs {
+    entries: Vec<ExplicitTestCaseEntry>,
+}
+
+struct ExplicitTestCaseEntry {
+    name: Ident,
+    value: Expr,
+}
+
+impl syn::parse::Parse for ExplicitTestCaseAttrArgs {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let mut entries = Vec::new();
+        while !input.is_empty() {
+            let name: Ident = input.parse()?;
+            let _eq: Token![=] = input.parse()?;
+            let value: Expr = input.parse()?;
+            entries.push(ExplicitTestCaseEntry { name, value });
+            if !input.is_empty() {
+                let _comma: Token![,] = input.parse()?;
+            }
+        }
+        Ok(ExplicitTestCaseAttrArgs { entries })
+    }
+}
+
+/// Extract `#[hegel::explicit_test_case(...)]` attributes from the attribute list,
+/// removing them in-place. Returns `Err` with a compile error if any attribute is
+/// malformed.
+pub fn extract_explicit_test_cases(
+    attrs: &mut Vec<syn::Attribute>,
+) -> Result<Vec<ParsedExplicitTestCase>, TokenStream> {
+    let mut cases = Vec::new();
+    let mut error = None;
+    attrs.retain(|attr| {
+        if !is_explicit_test_case_attr(attr) {
+            return true;
+        }
+
+        let syn::Meta::List(list) = &attr.meta else {
+            error = Some(
+                syn::Error::new_spanned(
+                    attr,
+                    "#[hegel::explicit_test_case] requires arguments.\n\
+                     Usage: #[hegel::explicit_test_case(name = value, ...)]",
+                )
+                .to_compile_error(),
+            );
+            return false;
+        };
+
+        let parsed: syn::Result<ExplicitTestCaseAttrArgs> = syn::parse2(list.tokens.clone());
+        match parsed {
+            Ok(args) if args.entries.is_empty() => {
+                error = Some(
+                    syn::Error::new_spanned(
+                        attr,
+                        "#[hegel::explicit_test_case] requires at least one name = value pair.\n\
+                         Usage: #[hegel::explicit_test_case(name = value, ...)]",
+                    )
+                    .to_compile_error(),
+                );
+            }
+            Ok(args) => {
+                let entries = args
+                    .entries
+                    .iter()
+                    .map(|arg| {
+                        let name = arg.name.to_string();
+                        let expr = &arg.value;
+                        let expr_source = quote::quote!(#expr).to_string();
+                        (name, expr_source)
+                    })
+                    .collect();
+                cases.push(ParsedExplicitTestCase { entries });
+            }
+            Err(e) => {
+                error = Some(e.to_compile_error());
+            }
+        }
+        false
+    });
+    if let Some(err) = error {
+        return Err(err);
+    }
+    Ok(cases)
+}
+
+/// Generate a sequence of explicit test case blocks. Each block constructs an
+/// `ExplicitTestCase` populated with `with_value` calls and then runs the body
+/// via `ExplicitTestCase::run`.
+pub fn build_explicit_blocks(
+    cases: &[ParsedExplicitTestCase],
+    param_pat: &Pat,
+    body: &syn::Block,
+) -> Vec<TokenStream> {
+    cases
+        .iter()
+        .map(|case| {
+            let with_value_calls: Vec<TokenStream> = case
+                .entries
+                .iter()
+                .map(|(name, expr_source)| {
+                    let expr: syn::Expr = syn::parse_str(expr_source).unwrap_or_else(|e| {
+                        panic!("Failed to parse explicit_test_case expression: {}", e)
+                    });
+                    let source_lit = syn::LitStr::new(expr_source, proc_macro2::Span::call_site());
+                    quote! {
+                        .with_value(#name, #source_lit, #expr)
+                    }
+                })
+                .collect();
+
+            quote! {
+                {
+                    let __hegel_etc = hegel::ExplicitTestCase::new()
+                        #(#with_value_calls)*;
+                    __hegel_etc.run(|#param_pat: &hegel::ExplicitTestCase| #body);
+                }
+            }
+        })
+        .collect()
+}

--- a/hegel-macros/src/hegel_main.rs
+++ b/hegel-macros/src/hegel_main.rs
@@ -7,8 +7,8 @@ use crate::common::{
     rewrite_draws_in_block,
 };
 
-pub fn expand_test(attr: TokenStream, item: TokenStream) -> TokenStream {
-    let test_args: SettingsAttrArgs = if attr.is_empty() {
+pub fn expand_main(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let main_args: SettingsAttrArgs = if attr.is_empty() {
         SettingsAttrArgs {
             settings: None,
             settings_args: Vec::new(),
@@ -28,7 +28,7 @@ pub fn expand_test(attr: TokenStream, item: TokenStream) -> TokenStream {
     if func.sig.inputs.len() != 1 {
         return syn::Error::new_spanned(
             &func.sig,
-            "#[hegel::test] functions must take exactly one parameter of type hegel::TestCase.",
+            "#[hegel::main] functions must take exactly one parameter of type hegel::TestCase.",
         )
         .to_compile_error();
     }
@@ -39,7 +39,7 @@ pub fn expand_test(attr: TokenStream, item: TokenStream) -> TokenStream {
         FnArg::Receiver(_) => {
             return syn::Error::new_spanned(
                 param,
-                "#[hegel::test] functions cannot have a self parameter.",
+                "#[hegel::main] functions cannot have a self parameter.",
             )
             .to_compile_error();
         }
@@ -51,8 +51,8 @@ pub fn expand_test(attr: TokenStream, item: TokenStream) -> TokenStream {
         if attr.path().is_ident("test") {
             return syn::Error::new_spanned(
                 attr,
-                "#[hegel::test] used on a function with #[test].\
-                Remove the #[test] attribute; [hegel::test] automatically adds #[test].",
+                "#[hegel::main] used on a function with #[test]. \
+                 Remove the #[test] attribute.",
             )
             .to_compile_error();
         }
@@ -71,19 +71,25 @@ pub fn expand_test(attr: TokenStream, item: TokenStream) -> TokenStream {
         body
     };
 
-    let test_name = func.sig.ident.to_string();
-    let settings_expr = test_args.to_settings_expr();
+    let fn_name = func.sig.ident.to_string();
+    let default_settings_expr = main_args.to_settings_expr();
     let explicit_blocks = build_explicit_blocks(&explicit_cases, param_pat, &body);
 
     let new_body: TokenStream = quote! {
         {
+            let __hegel_default_settings: hegel::Settings = #default_settings_expr;
+            let __hegel_settings: hegel::Settings = hegel::__apply_cli_args(
+                __hegel_default_settings,
+                ::std::env::args(),
+            );
+
             #(#explicit_blocks)*
 
             hegel::Hegel::new(|#param_pat: #param_ty| #body)
-            .settings(#settings_expr)
-            .__database_key(format!("{}::{}", module_path!(), #test_name))
+            .settings(__hegel_settings)
+            .__database_key(format!("{}::{}", module_path!(), #fn_name))
             .test_location(hegel::TestLocation {
-                function: #test_name.to_string(),
+                function: #fn_name.to_string(),
                 file: file!().to_string(),
                 class: module_path!().to_string(),
                 begin_line: line!(),
@@ -99,7 +105,6 @@ pub fn expand_test(attr: TokenStream, item: TokenStream) -> TokenStream {
     *func.block = new_block;
 
     quote! {
-        #[test]
         #func
     }
 }

--- a/hegel-macros/src/hegel_main.rs
+++ b/hegel-macros/src/hegel_main.rs
@@ -78,10 +78,20 @@ pub fn expand_main(attr: TokenStream, item: TokenStream) -> TokenStream {
     let new_body: TokenStream = quote! {
         {
             let __hegel_default_settings: hegel::Settings = #default_settings_expr;
-            let __hegel_settings: hegel::Settings = hegel::__apply_cli_args(
+            let __hegel_settings: hegel::Settings = match hegel::__apply_cli_args(
                 __hegel_default_settings,
                 ::std::env::args(),
-            );
+            ) {
+                hegel::CliOutcome::Success(s) => s,
+                hegel::CliOutcome::Help(msg) => {
+                    println!("{}", msg);
+                    ::std::process::exit(0);
+                }
+                hegel::CliOutcome::ParseError(msg) => {
+                    eprintln!("{}", msg);
+                    ::std::process::exit(2);
+                }
+            };
 
             #(#explicit_blocks)*
 

--- a/hegel-macros/src/lib.rs
+++ b/hegel-macros/src/lib.rs
@@ -1,8 +1,11 @@
+mod common;
 mod composite;
 mod enum_gen;
 mod explicit_test_case;
+mod hegel_main;
 mod hegel_test;
 mod rewrite_draws;
+mod standalone_function;
 mod stateful;
 mod struct_gen;
 mod utils;
@@ -28,6 +31,16 @@ pub fn derive_generator(input: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn test(attr: TokenStream, item: TokenStream) -> TokenStream {
     hegel_test::expand_test(attr.into(), item.into()).into()
+}
+
+#[proc_macro_attribute]
+pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
+    hegel_main::expand_main(attr.into(), item.into()).into()
+}
+
+#[proc_macro_attribute]
+pub fn standalone_function(attr: TokenStream, item: TokenStream) -> TokenStream {
+    standalone_function::expand_standalone_function(attr.into(), item.into()).into()
 }
 
 #[proc_macro_attribute]

--- a/hegel-macros/src/rewrite_draws.rs
+++ b/hegel-macros/src/rewrite_draws.rs
@@ -2,7 +2,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{Expr, ExprClosure};
 
-use crate::hegel_test::{extract_ident_from_pat, rewrite_draws_in_stmts};
+use crate::common::{extract_ident_from_pat, rewrite_draws_in_block};
 
 /// Expand `hegel::rewrite_draws!(|tc| { ... })`.
 ///
@@ -37,7 +37,7 @@ pub fn expand_rewrite_draws(input: TokenStream) -> TokenStream {
     };
 
     if let Expr::Block(block_expr) = &mut *closure.body {
-        rewrite_draws_in_stmts(&mut block_expr.block.stmts, &tc_ident);
+        rewrite_draws_in_block(&mut block_expr.block, &tc_ident);
     }
 
     quote! { #closure }

--- a/hegel-macros/src/standalone_function.rs
+++ b/hegel-macros/src/standalone_function.rs
@@ -1,5 +1,7 @@
 use proc_macro2::TokenStream;
 use quote::quote;
+use syn::punctuated::Punctuated;
+use syn::token::Comma;
 use syn::{FnArg, ItemFn};
 
 use crate::common::{
@@ -7,8 +9,8 @@ use crate::common::{
     rewrite_draws_in_block,
 };
 
-pub fn expand_test(attr: TokenStream, item: TokenStream) -> TokenStream {
-    let test_args: SettingsAttrArgs = if attr.is_empty() {
+pub fn expand_standalone_function(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let settings_args: SettingsAttrArgs = if attr.is_empty() {
         SettingsAttrArgs {
             settings: None,
             settings_args: Vec::new(),
@@ -25,34 +27,42 @@ pub fn expand_test(attr: TokenStream, item: TokenStream) -> TokenStream {
         Err(e) => return e.to_compile_error(),
     };
 
-    if func.sig.inputs.len() != 1 {
+    if func.sig.inputs.is_empty() {
         return syn::Error::new_spanned(
             &func.sig,
-            "#[hegel::test] functions must take exactly one parameter of type hegel::TestCase.",
+            "#[hegel::standalone_function] functions must take at least one parameter of type hegel::TestCase (as the first parameter).",
         )
         .to_compile_error();
     }
 
-    let param = &func.sig.inputs[0];
-    let param_typed = match param {
+    let tc_param = match &func.sig.inputs[0] {
         FnArg::Typed(pat_type) => pat_type,
         FnArg::Receiver(_) => {
             return syn::Error::new_spanned(
-                param,
-                "#[hegel::test] functions cannot have a self parameter.",
+                &func.sig.inputs[0],
+                "#[hegel::standalone_function] functions cannot have a self parameter.",
             )
             .to_compile_error();
         }
     };
-    let param_pat = &*param_typed.pat;
-    let param_ty = &*param_typed.ty;
+    let tc_pat = (*tc_param.pat).clone();
+    let tc_ty = (*tc_param.ty).clone();
+
+    if let syn::ReturnType::Type(_, _) = &func.sig.output {
+        return syn::Error::new_spanned(
+            &func.sig.output,
+            "#[hegel::standalone_function] functions must not have a return type; \
+             the property test is expected to panic on failure and return `()` on success.",
+        )
+        .to_compile_error();
+    }
 
     for attr in &func.attrs {
         if attr.path().is_ident("test") {
             return syn::Error::new_spanned(
                 attr,
-                "#[hegel::test] used on a function with #[test].\
-                Remove the #[test] attribute; [hegel::test] automatically adds #[test].",
+                "#[hegel::standalone_function] cannot be combined with #[test]. \
+                 Use #[hegel::test] for test functions.",
             )
             .to_compile_error();
         }
@@ -65,25 +75,27 @@ pub fn expand_test(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let body = {
         let mut body = (*func.block).clone();
-        if let Some(test_case_name) = extract_ident_from_pat(param_pat) {
+        if let Some(test_case_name) = extract_ident_from_pat(&tc_pat) {
             rewrite_draws_in_block(&mut body, &test_case_name);
         }
         body
     };
 
-    let test_name = func.sig.ident.to_string();
-    let settings_expr = test_args.to_settings_expr();
-    let explicit_blocks = build_explicit_blocks(&explicit_cases, param_pat, &body);
+    let fn_name = func.sig.ident.to_string();
+    let settings_expr = settings_args.to_settings_expr();
+    let explicit_blocks = build_explicit_blocks(&explicit_cases, &tc_pat, &body);
+
+    let passthrough: Punctuated<FnArg, Comma> = func.sig.inputs.iter().skip(1).cloned().collect();
 
     let new_body: TokenStream = quote! {
         {
             #(#explicit_blocks)*
 
-            hegel::Hegel::new(|#param_pat: #param_ty| #body)
+            hegel::Hegel::new(move |#tc_pat: #tc_ty| #body)
             .settings(#settings_expr)
-            .__database_key(format!("{}::{}", module_path!(), #test_name))
+            .__database_key(format!("{}::{}", module_path!(), #fn_name))
             .test_location(hegel::TestLocation {
-                function: #test_name.to_string(),
+                function: #fn_name.to_string(),
                 file: file!().to_string(),
                 class: module_path!().to_string(),
                 begin_line: line!(),
@@ -95,11 +107,10 @@ pub fn expand_test(attr: TokenStream, item: TokenStream) -> TokenStream {
     let new_block: syn::Block = syn::parse2(new_body).unwrap();
 
     let mut func = func;
-    func.sig.inputs.clear();
+    func.sig.inputs = passthrough;
     *func.block = new_block;
 
     quote! {
-        #[test]
         #func
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,192 @@
+//! Command line argument parsing for standalone Hegel binaries produced by
+//! `#[hegel::main]`.
+//!
+//! The parser starts from a caller-provided [`Settings`] value (so that
+//! `#[hegel::main(test_cases = 500)]` produces a binary whose `--test-cases`
+//! flag defaults to 500) and applies CLI overrides on top of it.
+
+use crate::runner::{HealthCheck, Settings, Verbosity};
+
+/// Apply CLI overrides to `settings`.
+///
+/// `args` should include the program name at index 0 (i.e., pass
+/// `std::env::args()` directly). Parsing is very simple — unknown arguments
+/// and malformed values cause the process to exit with code 2. `--help` /
+/// `-h` prints usage to stdout and exits with code 0.
+///
+/// This is called from the entry point produced by `#[hegel::main]`; it is
+/// exported here so that other main wrappers can construct Settings from
+/// the same CLI surface.
+pub fn apply_cli_args<I>(settings: Settings, args: I) -> Settings
+where
+    I: IntoIterator<Item = String>,
+{
+    match try_apply_cli_args(settings, args) {
+        Ok(s) => s,
+        Err(CliError::Help(msg)) => {
+            println!("{}", msg);
+            std::process::exit(0);
+        }
+        Err(CliError::Parse(msg)) => {
+            eprintln!("{}", msg);
+            eprintln!();
+            eprintln!("{}", usage());
+            std::process::exit(2);
+        }
+    }
+}
+
+#[derive(Debug)]
+enum CliError {
+    Help(String),
+    Parse(String),
+}
+
+fn try_apply_cli_args<I>(mut settings: Settings, args: I) -> Result<Settings, CliError>
+where
+    I: IntoIterator<Item = String>,
+{
+    let mut iter = args.into_iter();
+    let _program = iter.next();
+    let args: Vec<String> = iter.collect();
+
+    let mut i = 0;
+    while i < args.len() {
+        let arg = args[i].as_str();
+        match arg {
+            "--help" | "-h" => {
+                return Err(CliError::Help(usage()));
+            }
+            "--test-cases" => {
+                let value = next_value(&args, &mut i, "--test-cases")?;
+                let n: u64 = value.parse().map_err(|_| {
+                    CliError::Parse(format!(
+                        "--test-cases expects a non-negative integer, got {value:?}"
+                    ))
+                })?;
+                settings = settings.test_cases(n);
+            }
+            "--seed" => {
+                let value = next_value(&args, &mut i, "--seed")?;
+                if value == "none" {
+                    settings = settings.seed(None);
+                } else {
+                    let n: u64 = value.parse().map_err(|_| {
+                        CliError::Parse(format!(
+                            "--seed expects an integer or 'none', got {value:?}"
+                        ))
+                    })?;
+                    settings = settings.seed(Some(n));
+                }
+            }
+            "--verbosity" => {
+                let value = next_value(&args, &mut i, "--verbosity")?;
+                let v = parse_verbosity(&value)?;
+                settings = settings.verbosity(v);
+            }
+            "--derandomize" => {
+                let value = next_value(&args, &mut i, "--derandomize")?;
+                let b = parse_bool(&value, "--derandomize")?;
+                settings = settings.derandomize(b);
+            }
+            "--database" => {
+                let value = next_value(&args, &mut i, "--database")?;
+                if value == "disabled" || value == "none" {
+                    settings = settings.database(None);
+                } else {
+                    settings = settings.database(Some(value));
+                }
+            }
+            "--suppress-health-check" => {
+                let value = next_value(&args, &mut i, "--suppress-health-check")?;
+                let checks = parse_health_check(&value)?;
+                settings = settings.suppress_health_check(checks);
+            }
+            _ => {
+                return Err(CliError::Parse(format!("Unknown argument: {arg}")));
+            }
+        }
+        i += 1;
+    }
+    Ok(settings)
+}
+
+fn next_value(args: &[String], i: &mut usize, name: &str) -> Result<String, CliError> {
+    *i += 1;
+    args.get(*i)
+        .cloned()
+        .ok_or_else(|| CliError::Parse(format!("{name} requires a value")))
+}
+
+fn parse_verbosity(s: &str) -> Result<Verbosity, CliError> {
+    match s {
+        "quiet" => Ok(Verbosity::Quiet),
+        "normal" => Ok(Verbosity::Normal),
+        "verbose" => Ok(Verbosity::Verbose),
+        "debug" => Ok(Verbosity::Debug),
+        other => Err(CliError::Parse(format!(
+            "--verbosity expects one of quiet|normal|verbose|debug, got {other:?}"
+        ))),
+    }
+}
+
+fn parse_bool(s: &str, name: &str) -> Result<bool, CliError> {
+    match s {
+        "true" | "1" | "yes" => Ok(true),
+        "false" | "0" | "no" => Ok(false),
+        other => Err(CliError::Parse(format!(
+            "{name} expects true|false, got {other:?}"
+        ))),
+    }
+}
+
+fn parse_health_check(s: &str) -> Result<Vec<HealthCheck>, CliError> {
+    if s == "all" {
+        return Ok(HealthCheck::all().to_vec());
+    }
+    let mut checks = Vec::new();
+    for part in s.split(',') {
+        let part = part.trim();
+        let hc = match part {
+            "filter_too_much" => HealthCheck::FilterTooMuch,
+            "too_slow" => HealthCheck::TooSlow,
+            "test_cases_too_large" => HealthCheck::TestCasesTooLarge,
+            "large_initial_test_case" => HealthCheck::LargeInitialTestCase,
+            other => {
+                return Err(CliError::Parse(format!(
+                    "--suppress-health-check does not recognise {other:?}. \
+                     Known names: all, filter_too_much, too_slow, test_cases_too_large, large_initial_test_case"
+                )));
+            }
+        };
+        checks.push(hc);
+    }
+    Ok(checks)
+}
+
+fn usage() -> String {
+    let mut s = String::new();
+    s.push_str("Usage: <program> [options]\n");
+    s.push('\n');
+    s.push_str("Hegel property-based testing binary.\n");
+    s.push('\n');
+    s.push_str("Options:\n");
+    s.push_str("  --test-cases <N>                     Number of test cases to run\n");
+    s.push_str(
+        "  --seed <N|none>                      Seed for randomisation ('none' for unset)\n",
+    );
+    s.push_str("  --verbosity <LEVEL>                  quiet | normal | verbose | debug\n");
+    s.push_str("  --derandomize <true|false>           Use a deterministic derived seed\n");
+    s.push_str(
+        "  --database <PATH|disabled>           Database path for failing-example storage\n",
+    );
+    s.push_str(
+        "  --suppress-health-check <NAMES>      Comma-separated health check names, or 'all'\n",
+    );
+    s.push_str("  -h, --help                           Show this help and exit\n");
+    s
+}
+
+#[cfg(test)]
+#[path = "../tests/embedded/cli_tests.rs"]
+mod tests;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,32 +7,37 @@
 
 use crate::runner::{HealthCheck, Settings, Verbosity};
 
+/// Result of applying CLI overrides. The macro wrapper in `#[hegel::main]`
+/// dispatches on this to print messages and exit the process; keeping the
+/// I/O and process-exit out of this function makes it directly testable.
+#[derive(Debug)]
+pub enum CliOutcome {
+    /// Settings parsed successfully.
+    Success(Settings),
+    /// `--help` / `-h` was passed. Caller should print the message to stdout
+    /// and exit with code 0.
+    Help(String),
+    /// Unknown argument or malformed value. Caller should print the message
+    /// to stderr and exit with a nonzero code.
+    ParseError(String),
+}
+
 /// Apply CLI overrides to `settings`.
 ///
 /// `args` should include the program name at index 0 (i.e., pass
-/// `std::env::args()` directly). Parsing is very simple — unknown arguments
-/// and malformed values cause the process to exit with code 2. `--help` /
-/// `-h` prints usage to stdout and exits with code 0.
+/// `std::env::args()` directly).
 ///
 /// This is called from the entry point produced by `#[hegel::main]`; it is
 /// exported here so that other main wrappers can construct Settings from
 /// the same CLI surface.
-pub fn apply_cli_args<I>(settings: Settings, args: I) -> Settings
+pub fn apply_cli_args<I>(settings: Settings, args: I) -> CliOutcome
 where
     I: IntoIterator<Item = String>,
 {
     match try_apply_cli_args(settings, args) {
-        Ok(s) => s,
-        Err(CliError::Help(msg)) => {
-            println!("{}", msg);
-            std::process::exit(0);
-        }
-        Err(CliError::Parse(msg)) => {
-            eprintln!("{}", msg);
-            eprintln!();
-            eprintln!("{}", usage());
-            std::process::exit(2);
-        }
+        Ok(s) => CliOutcome::Success(s),
+        Err(CliError::Help(msg)) => CliOutcome::Help(msg),
+        Err(CliError::Parse(msg)) => CliOutcome::ParseError(format!("{}\n\n{}", msg, usage())),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,6 +221,7 @@
 pub(crate) mod antithesis;
 pub mod backend;
 pub(crate) mod cbor_utils;
+pub(crate) mod cli;
 pub(crate) mod control;
 pub mod explicit_test_case;
 pub mod generators;
@@ -370,6 +371,57 @@ pub use hegel_macros::state_machine;
 /// ```
 pub use hegel_macros::test;
 
+/// Turn a function into a standalone Hegel binary entry point.
+///
+/// The function must take exactly one parameter of type [`TestCase`]. Behaves
+/// like [`test`] — draws are rewritten to record variable names, and any
+/// `#[hegel::explicit_test_case]` attributes are run first — but instead of
+/// producing a `#[test]` it produces a plain function body that parses CLI
+/// arguments and runs a [`Hegel`] driver.
+///
+/// Supported CLI flags (with defaults taken from the attribute args):
+/// `--test-cases`, `--seed`, `--verbosity`, `--derandomize`, `--database`,
+/// `--suppress-health-check`, `-h` / `--help`.
+///
+/// ```ignore
+/// use hegel::TestCase;
+/// use hegel::generators as gs;
+///
+/// #[hegel::main(test_cases = 500)]
+/// fn main(tc: TestCase) {
+///     let n: i32 = tc.draw(gs::integers());
+///     assert_eq!(n + 0, n);
+/// }
+/// ```
+pub use hegel_macros::main;
+
+/// Rewrite a function taking a [`TestCase`] plus additional arguments into
+/// one that takes just those arguments and internally runs Hegel.
+///
+/// Behaves like [`test`] for name rewriting, explicit test cases, and
+/// settings parsing. The generated function has the original signature
+/// with the `TestCase` parameter removed, and its body is run as an
+/// [`FnMut`] closure inside [`Hegel::run`].
+///
+/// ```ignore
+/// use hegel::TestCase;
+/// use hegel::generators as gs;
+///
+/// #[hegel::standalone_function(test_cases = 10)]
+/// fn check_addition_commutative(tc: TestCase, increment: i32) {
+///     let n: i32 = tc.draw(gs::integers());
+///     assert_eq!(n + increment, increment + n);
+/// }
+///
+/// // callers invoke it as a normal function:
+/// # fn _example() {
+/// check_addition_commutative(5);
+/// # }
+/// ```
+pub use hegel_macros::standalone_function;
+
+#[doc(hidden)]
+pub use cli::apply_cli_args as __apply_cli_args;
 #[doc(hidden)]
 pub use runner::__test_kill_server;
 #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -421,6 +421,8 @@ pub use hegel_macros::main;
 pub use hegel_macros::standalone_function;
 
 #[doc(hidden)]
+pub use cli::CliOutcome;
+#[doc(hidden)]
 pub use cli::apply_cli_args as __apply_cli_args;
 #[doc(hidden)]
 pub use runner::__test_kill_server;

--- a/tests/embedded/cli_tests.rs
+++ b/tests/embedded/cli_tests.rs
@@ -206,3 +206,39 @@ fn test_bool_aliases() {
     let parsed = apply(&["--derandomize", "no"]);
     assert!(!parsed.derandomize);
 }
+
+#[test]
+fn test_invalid_seed_error() {
+    let err = try_apply_cli_args(Settings::new(), s(&["--seed", "abc"])).unwrap_err();
+    match err {
+        CliError::Parse(msg) => assert!(msg.contains("integer or 'none'")),
+        _ => panic!("wrong error kind"),
+    }
+}
+
+#[test]
+fn test_apply_cli_args_success() {
+    match apply_cli_args(Settings::new(), s(&["--test-cases", "13"])) {
+        CliOutcome::Success(settings) => assert_eq!(settings.test_cases, 13),
+        other => panic!("expected Success, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_apply_cli_args_help() {
+    match apply_cli_args(Settings::new(), s(&["--help"])) {
+        CliOutcome::Help(msg) => assert!(msg.contains("Usage:")),
+        other => panic!("expected Help, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_apply_cli_args_parse_error() {
+    match apply_cli_args(Settings::new(), s(&["--not-a-flag"])) {
+        CliOutcome::ParseError(msg) => {
+            assert!(msg.contains("Unknown argument"));
+            assert!(msg.contains("Usage:"));
+        }
+        other => panic!("expected ParseError, got {other:?}"),
+    }
+}

--- a/tests/embedded/cli_tests.rs
+++ b/tests/embedded/cli_tests.rs
@@ -1,0 +1,208 @@
+use super::*;
+use crate::runner::{Database, Settings, Verbosity};
+
+fn s(strs: &[&str]) -> Vec<String> {
+    std::iter::once("prog")
+        .chain(strs.iter().copied())
+        .map(String::from)
+        .collect()
+}
+
+fn apply(args: &[&str]) -> Settings {
+    try_apply_cli_args(Settings::new(), s(args)).unwrap_or_else(|e| match e {
+        CliError::Help(_) => panic!("unexpected help"),
+        CliError::Parse(msg) => panic!("parse error: {msg}"),
+    })
+}
+
+#[test]
+fn test_no_args_returns_default() {
+    let defaults = Settings::new();
+    let parsed = apply(&[]);
+    assert_eq!(parsed.test_cases, defaults.test_cases);
+    assert_eq!(parsed.verbosity, defaults.verbosity);
+    assert_eq!(parsed.seed, defaults.seed);
+}
+
+#[test]
+fn test_test_cases_override() {
+    let parsed = apply(&["--test-cases", "500"]);
+    assert_eq!(parsed.test_cases, 500);
+}
+
+#[test]
+fn test_seed_override() {
+    let parsed = apply(&["--seed", "42"]);
+    assert_eq!(parsed.seed, Some(42));
+}
+
+#[test]
+fn test_seed_none() {
+    let parsed = apply(&["--seed", "none"]);
+    assert_eq!(parsed.seed, None);
+}
+
+#[test]
+fn test_verbosity_override() {
+    let parsed = apply(&["--verbosity", "quiet"]);
+    assert_eq!(parsed.verbosity, Verbosity::Quiet);
+
+    let parsed = apply(&["--verbosity", "verbose"]);
+    assert_eq!(parsed.verbosity, Verbosity::Verbose);
+
+    let parsed = apply(&["--verbosity", "debug"]);
+    assert_eq!(parsed.verbosity, Verbosity::Debug);
+
+    let parsed = apply(&["--verbosity", "normal"]);
+    assert_eq!(parsed.verbosity, Verbosity::Normal);
+}
+
+#[test]
+fn test_derandomize_override() {
+    let parsed = apply(&["--derandomize", "true"]);
+    assert!(parsed.derandomize);
+    let parsed = apply(&["--derandomize", "false"]);
+    assert!(!parsed.derandomize);
+}
+
+#[test]
+fn test_database_path() {
+    let parsed = apply(&["--database", "/tmp/example"]);
+    assert_eq!(parsed.database, Database::Path("/tmp/example".to_string()));
+}
+
+#[test]
+fn test_database_disabled() {
+    let parsed = apply(&["--database", "disabled"]);
+    assert_eq!(parsed.database, Database::Disabled);
+}
+
+#[test]
+fn test_suppress_health_check_single() {
+    let parsed = apply(&["--suppress-health-check", "too_slow"]);
+    assert_eq!(
+        parsed.suppress_health_check,
+        vec![crate::runner::HealthCheck::TooSlow]
+    );
+}
+
+#[test]
+fn test_suppress_health_check_multiple() {
+    let parsed = apply(&["--suppress-health-check", "too_slow,filter_too_much"]);
+    assert_eq!(
+        parsed.suppress_health_check,
+        vec![
+            crate::runner::HealthCheck::TooSlow,
+            crate::runner::HealthCheck::FilterTooMuch
+        ]
+    );
+}
+
+#[test]
+fn test_suppress_health_check_all() {
+    let parsed = apply(&["--suppress-health-check", "all"]);
+    assert_eq!(parsed.suppress_health_check.len(), 4);
+}
+
+#[test]
+fn test_multiple_flags() {
+    let parsed = apply(&["--test-cases", "7", "--seed", "9", "--verbosity", "quiet"]);
+    assert_eq!(parsed.test_cases, 7);
+    assert_eq!(parsed.seed, Some(9));
+    assert_eq!(parsed.verbosity, Verbosity::Quiet);
+}
+
+#[test]
+fn test_unknown_arg_error() {
+    let err = try_apply_cli_args(Settings::new(), s(&["--nope"])).unwrap_err();
+    match err {
+        CliError::Parse(msg) => assert!(msg.contains("Unknown argument")),
+        _ => panic!("wrong error kind"),
+    }
+}
+
+#[test]
+fn test_missing_value_error() {
+    let err = try_apply_cli_args(Settings::new(), s(&["--test-cases"])).unwrap_err();
+    match err {
+        CliError::Parse(msg) => assert!(msg.contains("requires a value")),
+        _ => panic!("wrong error kind"),
+    }
+}
+
+#[test]
+fn test_invalid_value_error() {
+    let err = try_apply_cli_args(Settings::new(), s(&["--test-cases", "abc"])).unwrap_err();
+    match err {
+        CliError::Parse(msg) => assert!(msg.contains("non-negative integer")),
+        _ => panic!("wrong error kind"),
+    }
+}
+
+#[test]
+fn test_help_returns_help_error() {
+    let err = try_apply_cli_args(Settings::new(), s(&["--help"])).unwrap_err();
+    match err {
+        CliError::Help(msg) => assert!(msg.contains("Usage:")),
+        _ => panic!("wrong error kind"),
+    }
+}
+
+#[test]
+fn test_short_help_returns_help_error() {
+    let err = try_apply_cli_args(Settings::new(), s(&["-h"])).unwrap_err();
+    matches!(err, CliError::Help(_));
+}
+
+#[test]
+fn test_default_preserved_when_not_overridden() {
+    let parsed = try_apply_cli_args(Settings::new().test_cases(42), s(&[])).unwrap();
+    assert_eq!(parsed.test_cases, 42);
+}
+
+#[test]
+fn test_explicit_override_wins_over_default() {
+    let parsed =
+        try_apply_cli_args(Settings::new().test_cases(42), s(&["--test-cases", "10"])).unwrap();
+    assert_eq!(parsed.test_cases, 10);
+}
+
+#[test]
+fn test_invalid_verbosity_error() {
+    let err = try_apply_cli_args(Settings::new(), s(&["--verbosity", "loud"])).unwrap_err();
+    match err {
+        CliError::Parse(msg) => assert!(msg.contains("quiet|normal|verbose|debug")),
+        _ => panic!("wrong error kind"),
+    }
+}
+
+#[test]
+fn test_invalid_bool_error() {
+    let err = try_apply_cli_args(Settings::new(), s(&["--derandomize", "maybe"])).unwrap_err();
+    match err {
+        CliError::Parse(msg) => assert!(msg.contains("true|false")),
+        _ => panic!("wrong error kind"),
+    }
+}
+
+#[test]
+fn test_invalid_health_check_error() {
+    let err = try_apply_cli_args(Settings::new(), s(&["--suppress-health-check", "bad_name"]))
+        .unwrap_err();
+    match err {
+        CliError::Parse(msg) => assert!(msg.contains("does not recognise")),
+        _ => panic!("wrong error kind"),
+    }
+}
+
+#[test]
+fn test_bool_aliases() {
+    let parsed = apply(&["--derandomize", "1"]);
+    assert!(parsed.derandomize);
+    let parsed = apply(&["--derandomize", "yes"]);
+    assert!(parsed.derandomize);
+    let parsed = apply(&["--derandomize", "0"]);
+    assert!(!parsed.derandomize);
+    let parsed = apply(&["--derandomize", "no"]);
+    assert!(!parsed.derandomize);
+}

--- a/tests/test_hegel_main.rs
+++ b/tests/test_hegel_main.rs
@@ -1,0 +1,186 @@
+mod common;
+
+use common::project::TempRustProject;
+use common::utils::assert_matches_regex;
+
+const BASIC_MAIN: &str = r#"
+use hegel::TestCase;
+use hegel::generators as gs;
+
+#[hegel::main(test_cases = 7)]
+fn main(tc: TestCase) {
+    let _: i32 = tc.draw(gs::integers());
+    eprintln!("ran");
+}
+"#;
+
+#[test]
+fn test_basic_main_runs() {
+    let output = TempRustProject::new().main_file(BASIC_MAIN).cargo_run(&[]);
+    // The #[hegel::main] wraps the body in an FnMut closure invoked test_cases times.
+    // So `ran` should appear 7 times.
+    let count = output.stderr.matches("ran").count();
+    assert_eq!(count, 7, "stderr:\n{}", output.stderr);
+}
+
+#[test]
+fn test_main_cli_overrides_test_cases() {
+    let output =
+        TempRustProject::new()
+            .main_file(BASIC_MAIN)
+            .cargo_run(&["--", "--test-cases", "3"]);
+    let count = output.stderr.matches("ran").count();
+    assert_eq!(count, 3, "stderr:\n{}", output.stderr);
+}
+
+#[test]
+fn test_main_default_matches_attribute() {
+    // No CLI args => defaults are whatever the attribute said (7).
+    let output = TempRustProject::new().main_file(BASIC_MAIN).cargo_run(&[]);
+    let count = output.stderr.matches("ran").count();
+    assert_eq!(count, 7, "stderr:\n{}", output.stderr);
+}
+
+#[test]
+fn test_main_unknown_arg_exits_with_error() {
+    let output = TempRustProject::new()
+        .main_file(BASIC_MAIN)
+        .expect_failure("Unknown argument")
+        .cargo_run(&["--", "--not-a-real-arg"]);
+    let _ = output;
+}
+
+#[test]
+fn test_main_help_exits_cleanly() {
+    let code = r#"
+use hegel::TestCase;
+use hegel::generators as gs;
+
+#[hegel::main]
+fn main(tc: TestCase) {
+    let _: bool = tc.draw(gs::booleans());
+}
+"#;
+    let output = TempRustProject::new()
+        .main_file(code)
+        .cargo_run(&["--", "--help"]);
+    assert!(
+        output.stdout.contains("Usage:"),
+        "stdout did not contain Usage: {}",
+        output.stdout
+    );
+}
+
+#[test]
+fn test_main_failing_property_exits_nonzero() {
+    let code = r#"
+use hegel::TestCase;
+use hegel::generators as gs;
+
+#[hegel::main(test_cases = 100)]
+fn main(tc: TestCase) {
+    let x: i32 = tc.draw(gs::integers::<i32>().min_value(0).max_value(50));
+    assert!(x < 0, "got nonneg {}", x);
+}
+"#;
+    TempRustProject::new()
+        .main_file(code)
+        .expect_failure("Property test failed")
+        .cargo_run(&[]);
+}
+
+#[test]
+fn test_main_draw_name_rewriting() {
+    let code = r#"
+use hegel::TestCase;
+use hegel::generators as gs;
+
+#[hegel::main(test_cases = 1)]
+fn main(tc: TestCase) {
+    let my_var: i32 = tc.draw(gs::integers());
+    panic!("boom {}", my_var);
+}
+"#;
+    let output = TempRustProject::new()
+        .main_file(code)
+        .expect_failure("boom")
+        .cargo_run(&[]);
+    assert_matches_regex(&output.stderr, r"let my_var = -?\d+;");
+}
+
+#[test]
+fn test_main_explicit_test_case() {
+    let code = r#"
+use hegel::TestCase;
+use hegel::generators as gs;
+
+#[hegel::main(test_cases = 1)]
+#[hegel::explicit_test_case(x = 77i32)]
+fn main(tc: TestCase) {
+    let x: i32 = tc.draw(gs::integers());
+    if x == 77 {
+        panic!("got explicit value");
+    }
+}
+"#;
+    TempRustProject::new()
+        .main_file(code)
+        .expect_failure("got explicit value")
+        .cargo_run(&[]);
+}
+
+#[test]
+fn test_main_verbosity_override() {
+    let code = r#"
+use hegel::TestCase;
+use hegel::generators as gs;
+
+#[hegel::main(test_cases = 1)]
+fn main(tc: TestCase) {
+    let _: bool = tc.draw(gs::booleans());
+}
+"#;
+    // Debug verbosity prints REQUEST/RESPONSE lines via ServerDataSource.
+    let output = TempRustProject::new().main_file(code).cargo_run(&[
+        "--",
+        "--verbosity",
+        "debug",
+        "--test-cases",
+        "1",
+    ]);
+    assert!(
+        output.stderr.contains("REQUEST:") || output.stderr.contains("run_test response"),
+        "Expected debug output, got: {}",
+        output.stderr
+    );
+}
+
+#[test]
+fn test_main_seed_override() {
+    let code = r#"
+use hegel::TestCase;
+use hegel::generators as gs;
+
+#[hegel::main(test_cases = 1)]
+fn main(tc: TestCase) {
+    let _: bool = tc.draw(gs::booleans());
+}
+"#;
+    // With a fixed seed, the run should complete successfully.
+    let output = TempRustProject::new()
+        .main_file(code)
+        .cargo_run(&["--", "--seed", "42"]);
+    let _ = output;
+}
+
+#[test]
+fn test_main_no_params_compile_error() {
+    let code = r#"
+#[hegel::main]
+fn main() {}
+"#;
+    TempRustProject::new()
+        .main_file(code)
+        .expect_failure("must take exactly one parameter")
+        .cargo_run(&[]);
+}

--- a/tests/test_standalone_function.rs
+++ b/tests/test_standalone_function.rs
@@ -1,0 +1,174 @@
+mod common;
+
+use common::project::TempRustProject;
+use common::utils::{assert_matches_regex, expect_panic};
+use hegel::TestCase;
+use hegel::generators as gs;
+
+// ============================================================
+// Success cases using the macro inline
+// ============================================================
+
+#[hegel::standalone_function(test_cases = 5)]
+fn standalone_no_args(tc: TestCase) {
+    let _: bool = tc.draw(gs::booleans());
+}
+
+#[test]
+fn test_standalone_no_args_runs() {
+    standalone_no_args();
+}
+
+#[hegel::standalone_function(test_cases = 5)]
+fn standalone_with_copy_arg(tc: TestCase, target: i32) {
+    let x: i32 = tc.draw(gs::integers::<i32>());
+    assert!(x.checked_add(target).is_some() || x.checked_add(target).is_none());
+}
+
+#[test]
+fn test_standalone_with_copy_arg_runs() {
+    standalone_with_copy_arg(42);
+}
+
+#[hegel::standalone_function(test_cases = 5)]
+fn standalone_with_string_arg(tc: TestCase, prefix: String) {
+    let x: i32 = tc.draw(gs::integers::<i32>());
+    assert!(format!("{}-{}", prefix, x).contains(&prefix));
+}
+
+#[test]
+fn test_standalone_with_string_arg_runs() {
+    standalone_with_string_arg("hello".to_string());
+}
+
+// ============================================================
+// Draw name rewriting
+// ============================================================
+
+#[test]
+fn test_standalone_draw_name_rewriting() {
+    // Use TempRustProject so we can observe the actual rewritten output on failure.
+    let code = r#"
+use hegel::TestCase;
+use hegel::generators as gs;
+
+#[hegel::standalone_function(test_cases = 1)]
+fn fails(tc: TestCase, target: i32) {
+    let my_var: i32 = tc.draw(gs::integers());
+    panic!("got {} (target {})", my_var, target);
+}
+
+fn main() {
+    fails(7);
+}
+"#;
+    let output = TempRustProject::new()
+        .main_file(code)
+        .expect_failure("got")
+        .cargo_run(&[]);
+
+    // Draw rewriting should make the printed variable use the user's name.
+    assert_matches_regex(&output.stderr, r"let my_var = -?\d+;");
+}
+
+// ============================================================
+// Explicit test cases
+// ============================================================
+
+#[hegel::standalone_function(test_cases = 1)]
+#[hegel::explicit_test_case(x = 42i32)]
+fn standalone_with_explicit_case(tc: TestCase) {
+    let x: i32 = tc.draw(gs::integers());
+    let _ = x;
+}
+
+#[test]
+fn test_standalone_explicit_case_runs() {
+    standalone_with_explicit_case();
+}
+
+#[test]
+fn test_standalone_explicit_case_uses_provided_value() {
+    let code = r#"
+use hegel::TestCase;
+use hegel::generators as gs;
+
+#[hegel::standalone_function(test_cases = 1)]
+#[hegel::explicit_test_case(x = 99i32)]
+fn fails(tc: TestCase) {
+    let x: i32 = tc.draw(gs::integers());
+    panic!("got {}", x);
+}
+
+fn main() {
+    fails();
+}
+"#;
+    let output = TempRustProject::new()
+        .main_file(code)
+        .expect_failure("got 99")
+        .cargo_run(&[]);
+    let _ = output;
+}
+
+// ============================================================
+// Panic on failing property
+// ============================================================
+
+#[test]
+fn test_standalone_function_fails_on_failing_property() {
+    #[hegel::standalone_function(test_cases = 200)]
+    fn always_fails(tc: TestCase) {
+        let x: i32 = tc.draw(gs::integers::<i32>().min_value(0).max_value(100));
+        assert!(x < 0, "unexpectedly got nonneg {}", x);
+    }
+
+    expect_panic(always_fails, "Property test failed");
+}
+
+// ============================================================
+// Compile errors
+// ============================================================
+
+#[test]
+fn test_standalone_function_no_params_compile_error() {
+    let code = r#"
+#[hegel::standalone_function]
+fn bad() {}
+
+fn main() {}
+"#;
+    TempRustProject::new()
+        .main_file(code)
+        .expect_failure("at least one parameter")
+        .cargo_run(&[]);
+}
+
+#[test]
+fn test_standalone_function_return_type_compile_error() {
+    let code = r#"
+#[hegel::standalone_function]
+fn bad(tc: hegel::TestCase) -> i32 { 0 }
+
+fn main() {}
+"#;
+    TempRustProject::new()
+        .main_file(code)
+        .expect_failure("must not have a return type")
+        .cargo_run(&[]);
+}
+
+#[test]
+fn test_standalone_function_with_test_attribute_compile_error() {
+    let code = r#"
+#[hegel::standalone_function]
+#[test]
+fn bad(tc: hegel::TestCase) {}
+
+fn main() {}
+"#;
+    TempRustProject::new()
+        .main_file(code)
+        .expect_failure("cannot be combined with.*test")
+        .cargo_run(&[]);
+}


### PR DESCRIPTION
This adds two new macros to allow more flexible use of hegel. Closes #153 

- #[hegel::main] wraps a function as a standalone binary entry point, exposing CLI flags for every Settings option.
- #[hegel::standalone_function] rewrites fn(tc: TestCase, args...) into fn(args...) so a property test can be invoked directly.

`hegel::main` is the primary goal of this, because it makes it easier to use hegel in workload contexts, but in #153 we'd talked about also providing a way of invoking hegel tests directly, so it seemed worth adding that at the same time.

I am very much not in love with the name `standalone_function` and would appreciate suggestions of better names, but I couldn't come up with any off the top of my head that weren't worse. Consider it a placeholder in the spirit of `explicit_test_case`

