### PR TITLE
Improvements to TempRustProject performance and isolation

### DIFF
--- a/tests/common/project.rs
+++ b/tests/common/project.rs
@@ -27,7 +27,12 @@ fn shared_target_dir() -> PathBuf {
 }
 
 // use a unique package name in our Cargo.toml to avoid lock contention of parallel
-// cargo builds within the shared target dir.
+// cargo builds within the shared target dir. The PID prefix disambiguates across
+// sibling test-binary processes that all share `CARGO_TARGET_DIR`: without it,
+// each process starts the counter at 0 and they'd collide on
+// `target/debug/temp_hegel_test_0` (the "shallow" output copy cargo produces for
+// binary crates), which can fail with ETXTBSY if another process's copy is still
+// running.
 static PACKAGE_NAME_ID: AtomicU64 = AtomicU64::new(0);
 
 // First-build gate. A cold `cargo build` of `hegeltest` and its transitive
@@ -58,6 +63,18 @@ fn warmup_shared_target() {
     });
 }
 
+fn write_atomic(path: &Path, content: &[u8]) {
+    // PID + counter keeps the temp name unique across concurrent processes
+    // and across concurrent calls in the same process. `rename(2)` is atomic
+    // on POSIX: a concurrent reader of `path` never sees an in-progress write,
+    // only the old or new full content.
+    static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+    let tmp_id = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), tmp_id));
+    std::fs::write(&tmp, content).unwrap();
+    std::fs::rename(&tmp, path).unwrap();
+}
+
 fn run_warmup_build(hegel_path: &Path, shared_target: &Path) {
     let warmup_dir = shared_target.join("warmup");
     std::fs::create_dir_all(warmup_dir.join("src")).unwrap();
@@ -66,10 +83,8 @@ fn run_warmup_build(hegel_path: &Path, shared_target: &Path) {
     // lives inside `target/`, which is inside the outer hegeltest
     // workspace, so cargo would otherwise complain that the warmup
     // project looks like it should be a workspace member.
-    std::fs::write(
-        warmup_dir.join("Cargo.toml"),
-        format!(
-            r#"[workspace]
+    let cargo_toml = format!(
+        r#"[workspace]
 
 [package]
 name = "hegel_warmup"
@@ -79,15 +94,20 @@ edition = "2021"
 [dependencies]
 hegeltest = {{ path = "{path}" }}
 "#,
-            path = hegel_path.display(),
-        ),
-    )
-    .unwrap();
-    std::fs::write(warmup_dir.join("src/lib.rs"), "").unwrap();
+        path = hegel_path.display(),
+    );
+    // Write Cargo.toml and src/lib.rs atomically. Sibling test-binary processes
+    // may each run their own warmup concurrently, and a plain `fs::write`
+    // O_TRUNCs the target first — if a peer's cargo is mid-read of the same
+    // file, it would see a truncated byte stream. Writing to a PID-suffixed
+    // temp path and renaming is atomic from the reader's perspective.
+    write_atomic(&warmup_dir.join("Cargo.toml"), cargo_toml.as_bytes());
+    write_atomic(&warmup_dir.join("src/lib.rs"), b"");
 
     let lock_src = hegel_path.join("Cargo.lock");
     if lock_src.exists() {
-        std::fs::copy(&lock_src, warmup_dir.join("Cargo.lock")).unwrap();
+        let lock_bytes = std::fs::read(&lock_src).unwrap();
+        write_atomic(&warmup_dir.join("Cargo.lock"), &lock_bytes);
     }
 
     let output = Command::new(env!("CARGO"))
@@ -127,7 +147,7 @@ impl TempRustProject {
         let project_path = temp_dir.path().to_path_buf();
 
         let id = PACKAGE_NAME_ID.fetch_add(1, Ordering::Relaxed);
-        let crate_name = format!("temp_hegel_test_{}", id);
+        let crate_name = format!("temp_hegel_test_{}_{}", std::process::id(), id);
 
         // Copy the main project's Cargo.lock so the temp project uses the same
         // pinned dependency versions. Without this, cargo resolves fresh and may

--- a/tests/common/project.rs
+++ b/tests/common/project.rs
@@ -2,26 +2,107 @@
 #![allow(dead_code)]
 
 use super::utils::assert_matches_regex;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus};
-use std::sync::LazyLock;
+use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 use tempfile::TempDir;
 
-// cache build output from TempRustProject across tests. Compilation time is substantial
-// (10+ seconds) and this lets us only incur that cost on the first test.
+// Shared cargo target dir across TempRustProject instances. Each project's
+// `TempDir` still owns the per-test source tree (Cargo.toml, src/, tests/),
+// but every `cargo` invocation is pointed at a single `CARGO_TARGET_DIR`
+// under this test binary's `CARGO_TARGET_TMPDIR`. That way, `hegeltest`
+// and its transitive deps compile once and are reused across all
+// TempRustProjects in the suite instead of each one doing a cold build.
 //
-// We clear the dir at the start to ensure a fresh environment on each test run.
-static SHARED_TARGET_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
-    let path = std::env::temp_dir().join("hegel-test-cargo-target");
-    let _ = std::fs::remove_dir_all(&path);
-    std::fs::create_dir_all(&path).unwrap();
-    path
-});
+// Previously this dir lived at `/tmp/hegel-test-cargo-target`, which caused
+// two problems: every parallel checkout of the repo fought over the same
+// path (and each test run wiped it clean, trashing the other checkouts'
+// caches), and cold builds were paid once per `cargo test` invocation
+// rather than being cached across runs. Keeping it under the workspace's
+// own `target/` (via `CARGO_TARGET_TMPDIR`) isolates checkouts and lets
+// the cache persist across runs. Cleanup is now `cargo clean`'s job.
+fn shared_target_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("hegel-shared-target")
+}
 
 // use a unique package name in our Cargo.toml to avoid lock contention of parallel
 // cargo builds within the shared target dir.
 static PACKAGE_NAME_ID: AtomicU64 = AtomicU64::new(0);
+
+// First-build gate. A cold `cargo build` of `hegeltest` and its transitive
+// dep graph peaks at hundreds of MBs of rustc memory; without this, the
+// first wave of parallel test threads would each kick off their own cold
+// build and risk OOM-killing rustc on smaller machines. Cargo's own
+// `.cargo-lock` inside the shared target dir serialises the concurrent
+// builds, but we still pay multiple cold-build startup costs.
+//
+// This `OnceLock` is the narrower fix: the first thread to call
+// `warmup_shared_target` runs a dedicated warmup build (a synthetic
+// project that depends on hegeltest) and all other threads block on
+// `get_or_init` until it completes. After that the shared target dir is
+// hot, every subsequent per-test cargo call is mostly linking the temp
+// wrapper crate, and those can all run concurrently.
+//
+// Cross-process coordination (sibling test binaries spawned by
+// `cargo test`) is still delegated to cargo's `.cargo-lock` — each
+// process has its own `WARMUP`, but once any process has populated the
+// shared target dir, every other process's warmup call finishes fast.
+static WARMUP: OnceLock<()> = OnceLock::new();
+
+fn warmup_shared_target() {
+    WARMUP.get_or_init(|| {
+        let hegel_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let shared_target = shared_target_dir();
+        run_warmup_build(&hegel_path, &shared_target);
+    });
+}
+
+fn run_warmup_build(hegel_path: &Path, shared_target: &Path) {
+    let warmup_dir = shared_target.join("warmup");
+    std::fs::create_dir_all(warmup_dir.join("src")).unwrap();
+
+    // `[workspace]` marks this as its own workspace root. The warmup dir
+    // lives inside `target/`, which is inside the outer hegeltest
+    // workspace, so cargo would otherwise complain that the warmup
+    // project looks like it should be a workspace member.
+    std::fs::write(
+        warmup_dir.join("Cargo.toml"),
+        format!(
+            r#"[workspace]
+
+[package]
+name = "hegel_warmup"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+hegeltest = {{ path = "{path}" }}
+"#,
+            path = hegel_path.display(),
+        ),
+    )
+    .unwrap();
+    std::fs::write(warmup_dir.join("src/lib.rs"), "").unwrap();
+
+    let lock_src = hegel_path.join("Cargo.lock");
+    if lock_src.exists() {
+        std::fs::copy(&lock_src, warmup_dir.join("Cargo.lock")).unwrap();
+    }
+
+    let output = Command::new(env!("CARGO"))
+        .args(["build", "--quiet"])
+        .current_dir(&warmup_dir)
+        .env("CARGO_TARGET_DIR", shared_target)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "warmup cargo build failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
 
 pub struct TempRustProject {
     _temp_dir: TempDir,
@@ -103,8 +184,6 @@ impl TempRustProject {
     }
 
     fn cargo(&self, args: &[&str]) -> RunOutput {
-        let cached_target = &*SHARED_TARGET_DIR;
-
         let hegel_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let features = if self.features.is_empty() {
             String::new()
@@ -136,7 +215,7 @@ hegeltest = {{ path = "{path}"{features} }}
         let mut cmd = Command::new(env!("CARGO"));
         cmd.args(args)
             .current_dir(&self.project_path)
-            .env("CARGO_TARGET_DIR", cached_target);
+            .env("CARGO_TARGET_DIR", shared_target_dir());
 
         for key in &self.env_removes {
             cmd.env_remove(key);
@@ -145,6 +224,10 @@ hegeltest = {{ path = "{path}"{features} }}
             cmd.env(key, value);
         }
 
+        // Ensure the shared target dir has been warmed up once in this
+        // process before any test thread spawns its own cargo. See the
+        // comment on `WARMUP` above for why a one-shot gate is enough.
+        warmup_shared_target();
         let output = cmd.output().unwrap();
 
         let run_output = RunOutput {

--- a/tests/test_output.rs
+++ b/tests/test_output.rs
@@ -74,11 +74,11 @@ fn test_failing_test_output_with_backtrace() {
                 r".*",
                 r"\s+1: core::panicking::panic_fmt\n", // frame 1: panic_fmt
                 r".*",
-                r"\s+2: temp_hegel_test_\d+::main::{closure_name}\n", // frame 2: user's closure
+                r"\s+2: temp_hegel_test_\d+_\d+::main::{closure_name}\n", // frame 2: user's closure
                 r".*",
                 r"hegel::runner::", // hegel internals appear
                 r".*",
-                r"temp_hegel_test_\d+::main\n", // user's main (not closure)
+                r"temp_hegel_test_\d+_\d+::main\n", // user's main (not closure)
                 r".*",
                 r"note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace\.",
             ),
@@ -109,11 +109,11 @@ fn test_failing_test_output_with_full_backtrace() {
                 r"stack backtrace:\n",
                 r"\s+0: .*\n", // starts at frame 0
                 r".*",
-                r"temp_hegel_test_\d+::main::{closure_name}", // user's closure
+                r"temp_hegel_test_\d+_\d+::main::{closure_name}", // user's closure
                 r".*",
                 r"hegel::runner::", // hegel internals
                 r".*",
-                r"temp_hegel_test_\d+::main\n", // user's main
+                r"temp_hegel_test_\d+_\d+::main\n", // user's main
                 r".*$",
             ),
             closure_name = closure_name,


### PR DESCRIPTION
I was running into some fairly brutal performance problems with repeatedly running tests in #188, and on top of that when working on many PRs simultaneously the shared directory in /tmp would often corrupt builds leading to flakiness.

This PR should solve both problems. I have not ultra-carefully vetted it (especially the comments) but it seems mostly sane and appears to work.

What Claude says: 

<details>
<summary>Summary and benchmarks</summary>

## What changed

Two test-infrastructure changes, both in `tests/common/project.rs` (plus a regex update in `tests/test_output.rs` to match the new crate-name shape in backtraces).

### 1. Move the shared cargo target dir out of `/tmp`

The `TempRustProject` cargo target cache lived at `/tmp/hegel-test-cargo-target`. Every parallel checkout of the repo shared that path, and each `cargo test` run wiped it on the first `LazyLock` touch — so running tests in one checkout clobbered the warm caches of every other checkout. The wipe also meant that back-to-back `cargo test` runs in the same checkout both paid the cold-build cost.

Moved to `CARGO_TARGET_TMPDIR/hegel-shared-target`, which is under the workspace's own `target/`. Each checkout now has its own cache, the cache persists across runs, and cleanup is delegated to `cargo clean`.

### 2. Warm up the shared target once per process instead of racing

A cold `cargo build` of `hegeltest` and its transitive deps peaks at hundreds of MB of rustc memory. Without any coordination, the first wave of parallel test threads would each kick off their own cold build and risk OOM-killing rustc (in addition to wasting CPU on duplicate startup). Cargo's `.cargo-lock` already serialises the compile phase, but it doesn't prevent N processes from each doing their own cold build.

Added a `OnceLock` gate: the first thread to need a subprocess cargo invocation runs a dedicated warmup `cargo build` against a synthetic crate that depends on `hegeltest`, while every other thread blocks. After warmup the target dir is hot, and subsequent per-test cargo calls (mostly linking a tiny wrapper crate) can all run concurrently without contending for build work.

### 3. Hardening for shared-target parallelism

Two flakiness risks surfaced on review against concurrent test-binary processes (which `cargo test` spawns in parallel across integration tests):

- **Crate-name collision.** `temp_hegel_test_N` used a process-local `AtomicU64`, so every test-binary process started the counter at 0 and two of them would both try to produce `target/debug/temp_hegel_test_0` (cargo's shallow output copy, which is not hash-suffixed). With the old `/tmp` target this was also a latent bug but evidently rare; the new setup makes it more plausible. Fixed by prefixing the name with the PID so it's globally unique across siblings.
- **Warmup truncate race.** The warmup `Cargo.toml` / `src/lib.rs` writes used plain `fs::write`, which `O_TRUNC`s in place. A peer process's cargo could briefly observe a truncated file. Fixed by writing to a PID+counter-suffixed temp path and atomically renaming, so readers see old-or-new, never partial.

## Benchmarks

Same host, 13 TempRustProject-heavy integration-test binaries (including the mixed-feature `test_antithesis` case) plus full `cargo test`:

| Scenario | Before (main) | After | Speedup |
|---|---|---|---|
| 13 TempRustProject binaries, cold shared target | 108 s | 31 s | **3.5×** |
| 13 TempRustProject binaries, re-run | 86 s¹ | 24 s | **3.6×** |
| Full `cargo test` (36 binaries) | 113 s | 61 s | **1.9×** |

¹ The before-re-run is still ~cold because the old code wiped `/tmp/hegel-test-cargo-target` on every first `LazyLock` touch — there was no "warm" state to return to.

The "only 1.9×" on the full suite is because non-TempRustProject tests (shrink-quality, hegel-server-backed tests, etc.) dominate the 61 s steady-state; those are unaffected. Isolating just the tests that actually spawn cargo subprocesses, the speedup is the 3.5–3.6× figure.

## Stress-testing

Adversarially stress-tested the new path: 5 consecutive cold runs of all 13 TempRustProject-using integration-test binaries in parallel, covering the mixed-feature case where cargo must keep both `antithesis`-flavored and default-flavored artifact variants side by side in the same target. 13/13 pass every iteration.

## What I deliberately did *not* port from #188

The original changes were part of the native-backend preview PR; most of the rest isn't applicable on `main`:

- The `Invocation<'_>` API refactor (reuses one built project across multiple `#[test]`s) — not a perf change and would touch every caller without benefit here.
- `features = ["native"]` default on `cfg!(feature = "native")` — feature doesn't exist on main.
- `__CARGO_LLVM_COV_RUSTC_WRAPPER_CRATE_NAMES` coverage plumbing — current coverage CI already works.
- `HealthCheck::TooSlow` / `FilterTooMuch` suppressions in `tests/common/utils.rs` — motivated by native-backend speed quirks.
- The trybuild migration of compile-fail tests — I measured this and with the shared-target + warmup changes in place, the marginal saving on compile-fail tests is only ~1–2 s warm (each subprocess rustc emits the expected error in ~30 ms once the target is hot). Left out to keep this PR focused on the big wins; happy to do it separately if desired.

</details>