### PR TITLE
Add TestCase::reject() with never-return type

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,15 @@
+RELEASE_TYPE: minor
+
+This release adds a `reject` method to `TestCase` and `ExplicitTestCase`. It behaves like `assume(false)`, rejecting the current test input, but returns `!` so the compiler knows that code following the call is unreachable.
+
+```rust
+#[hegel::test]
+fn my_test(tc: hegel::TestCase) {
+    let n: i32 = tc.draw(gs::integers());
+    let positive: u32 = match u32::try_from(n) {
+        Ok(v) => v,
+        Err(_) => tc.reject(),
+    };
+    // use `positive` here without needing an extra `unreachable!()` branch
+}
+```

--- a/src/explicit_test_case.rs
+++ b/src/explicit_test_case.rs
@@ -112,8 +112,12 @@ impl ExplicitTestCase {
 
     pub fn assume(&self, condition: bool) {
         if !condition {
-            panic!("{}", ASSUME_FAIL_STRING);
+            self.reject();
         }
+    }
+
+    pub fn reject(&self) -> ! {
+        panic!("{}", ASSUME_FAIL_STRING);
     }
 
     #[doc(hidden)]

--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -190,8 +190,32 @@ impl TestCase {
     /// ```
     pub fn assume(&self, condition: bool) {
         if !condition {
-            panic!("{}", ASSUME_FAIL_STRING);
+            self.reject();
         }
+    }
+
+    /// Reject the current test input unconditionally.
+    ///
+    /// Equivalent to `assume(false)`, but with a `!` return type so that code
+    /// following the call is statically known to be unreachable.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use hegel::generators as gs;
+    ///
+    /// #[hegel::test]
+    /// fn my_test(tc: hegel::TestCase) {
+    ///     let n: i32 = tc.draw(gs::integers());
+    ///     let positive: u32 = match u32::try_from(n) {
+    ///         Ok(v) => v,
+    ///         Err(_) => tc.reject(),
+    ///     };
+    ///     let _ = positive;
+    /// }
+    /// ```
+    pub fn reject(&self) -> ! {
+        panic!("{}", ASSUME_FAIL_STRING);
     }
 
     /// Note a message which will be displayed with the reported failing test case.

--- a/tests/test_explicit_test_case.rs
+++ b/tests/test_explicit_test_case.rs
@@ -221,6 +221,17 @@ fn test_explicit_assume_panics() {
 }
 
 #[test]
+fn test_explicit_reject_panics() {
+    expect_panic(
+        || {
+            let etc = hegel::ExplicitTestCase::new();
+            etc.reject();
+        },
+        "__HEGEL_ASSUME_FAIL",
+    );
+}
+
+#[test]
 fn test_explicit_start_span_panics() {
     expect_panic(
         || {

--- a/tests/test_reject.rs
+++ b/tests/test_reject.rs
@@ -1,0 +1,24 @@
+use hegel::generators as gs;
+use hegel::{HealthCheck, TestCase};
+
+#[hegel::test(suppress_health_check = HealthCheck::all())]
+fn test_does_not_hang_on_reject(tc: TestCase) {
+    tc.draw(gs::integers::<i32>());
+    tc.reject();
+}
+
+#[hegel::test]
+fn test_reject_filters_like_assume_false(tc: TestCase) {
+    let n: i32 = tc.draw(gs::integers().min_value(0).max_value(100));
+    if n >= 50 {
+        tc.reject();
+    }
+    assert!(n < 50);
+}
+
+#[hegel::test]
+fn test_reject_has_never_return_type(tc: TestCase) {
+    let b: bool = tc.draw(gs::booleans());
+    let n: i32 = if b { 1 } else { tc.reject() };
+    assert_eq!(n, 1);
+}


### PR DESCRIPTION
I know you prefer `assume(false)`, @Liam-DeVoe, but a) I'm fond of `reject()` but b) most importantly, in rust in particular this has a static type that lets the compiler realise that code after it is unreachable and allows us to use it in arbitrary expressions, which I think is actually super important ergonomics.