### PR TITLE
feat: add PathBuf DefaultGenerator

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+This release adds a `DefaultGenerator` impl for `PathBuf`, so `#[derive(DefaultGenerator)]` works for structs with path fields and exercises common filesystem edge cases by default.

--- a/src/generators/default.rs
+++ b/src/generators/default.rs
@@ -6,6 +6,7 @@ use super::{
 };
 use std::collections::HashMap;
 use std::hash::Hash;
+use std::path::PathBuf;
 use std::time::Duration;
 
 /// Trait for types that have a default generator.
@@ -200,6 +201,72 @@ impl DefaultGenerator for Duration {
     type Generator = DurationGenerator;
     fn default_generator() -> Self::Generator {
         durations()
+    }
+}
+
+/// Generates filesystem paths covering common edge cases.
+///
+/// The generator produces paths from 0 to 8 segments joined with the
+/// platform path separator. Segments are drawn from a mix of:
+///
+/// - Short alphanumeric text (the common case)
+/// - `.` and `..` (traversal)
+/// - Empty string (consecutive separators / trailing slash)
+/// - Dot-prefixed names (`.hidden`)
+/// - Long names near the typical 255-byte NAME_MAX limit
+/// - Whitespace-only names
+///
+/// Roughly 10% of generated paths are absolute (prefixed with `/` on
+/// Unix, `C:\` on Windows). An empty segment vector produces `""`,
+/// the empty path.
+impl DefaultGenerator for PathBuf {
+    type Generator = BoxedGenerator<'static, PathBuf>;
+    fn default_generator() -> Self::Generator {
+        use super::{just, one_of};
+
+        let segment = one_of([
+            // common short text
+            text().max_size(12).boxed(),
+            // traversal
+            just(".".to_string()).boxed(),
+            just("..".to_string()).boxed(),
+            // empty segment (trailing/consecutive separators)
+            just(String::new()).boxed(),
+            // dot-prefixed
+            text()
+                .min_size(1)
+                .max_size(8)
+                .map(|s| format!(".{s}"))
+                .boxed(),
+            // long segment near NAME_MAX
+            text().min_size(200).max_size(255).boxed(),
+            // whitespace-only
+            just(" ".to_string()).boxed(),
+        ]);
+
+        vecs(segment)
+            .max_size(8)
+            .map(|segs| {
+                let rel: PathBuf = segs.iter().collect();
+                // ~10% absolute paths
+                if segs.first().is_some_and(|s| s.len() % 10 == 0) {
+                    #[cfg(unix)]
+                    {
+                        PathBuf::from("/").join(rel)
+                    }
+                    #[cfg(windows)]
+                    {
+                        PathBuf::from("C:\\").join(rel)
+                    }
+                    #[cfg(not(any(unix, windows)))]
+                    {
+                        PathBuf::from("/").join(rel)
+                    }
+                } else {
+                    rel
+                }
+            })
+            .boxed()
     }
 }
 

--- a/src/generators/default.rs
+++ b/src/generators/default.rs
@@ -9,6 +9,45 @@ use std::hash::Hash;
 use std::path::PathBuf;
 use std::time::Duration;
 
+fn path_segment_generator() -> BoxedGenerator<'static, String> {
+    use super::{just, one_of};
+
+    one_of([
+        text().max_size(12).boxed(),
+        just(".".to_string()).boxed(),
+        just("..".to_string()).boxed(),
+        just(String::new()).boxed(),
+        text()
+            .min_size(1)
+            .max_size(8)
+            .map(|segment| format!(".{segment}"))
+            .boxed(),
+        text().min_size(200).max_size(255).boxed(),
+        just(" ".to_string()).boxed(),
+    ])
+    .boxed()
+}
+
+fn build_pathbuf(segments: Vec<String>, absolute: bool) -> PathBuf {
+    let path: PathBuf = segments.iter().collect();
+    if segments.is_empty() || !absolute {
+        return path;
+    }
+
+    absolute_path_root().join(path)
+}
+
+fn absolute_path_root() -> PathBuf {
+    #[cfg(windows)]
+    {
+        PathBuf::from("C:\\")
+    }
+    #[cfg(not(windows))]
+    {
+        PathBuf::from("/")
+    }
+}
+
 /// Trait for types that have a default generator.
 ///
 /// This is used by derive macros to automatically generate values for fields.
@@ -222,51 +261,44 @@ impl DefaultGenerator for Duration {
 impl DefaultGenerator for PathBuf {
     type Generator = BoxedGenerator<'static, PathBuf>;
     fn default_generator() -> Self::Generator {
-        use super::{just, one_of};
+        use super::sampled_from;
 
-        let segment = one_of([
-            // common short text
-            text().max_size(12).boxed(),
-            // traversal
-            just(".".to_string()).boxed(),
-            just("..".to_string()).boxed(),
-            // empty segment (trailing/consecutive separators)
-            just(String::new()).boxed(),
-            // dot-prefixed
-            text()
-                .min_size(1)
+        sampled_from(&[
+            false, false, false, false, false, false, false, false, false, true,
+        ])
+        .flat_map(|absolute| {
+            vecs(path_segment_generator())
                 .max_size(8)
-                .map(|s| format!(".{s}"))
-                .boxed(),
-            // long segment near NAME_MAX
-            text().min_size(200).max_size(255).boxed(),
-            // whitespace-only
-            just(" ".to_string()).boxed(),
-        ]);
+                .map(move |segments| build_pathbuf(segments, absolute))
+        })
+        .boxed()
+    }
+}
 
-        vecs(segment)
-            .max_size(8)
-            .map(|segs| {
-                let rel: PathBuf = segs.iter().collect();
-                // ~10% absolute paths
-                if segs.first().is_some_and(|s| s.len() % 10 == 0) {
-                    #[cfg(unix)]
-                    {
-                        PathBuf::from("/").join(rel)
-                    }
-                    #[cfg(windows)]
-                    {
-                        PathBuf::from("C:\\").join(rel)
-                    }
-                    #[cfg(not(any(unix, windows)))]
-                    {
-                        PathBuf::from("/").join(rel)
-                    }
-                } else {
-                    rel
-                }
-            })
-            .boxed()
+#[cfg(test)]
+mod tests {
+    use super::{absolute_path_root, build_pathbuf};
+    use std::path::PathBuf;
+
+    #[test]
+    fn empty_absolute_path_stays_empty() {
+        assert_eq!(build_pathbuf(Vec::new(), true), PathBuf::new());
+    }
+
+    #[test]
+    fn relative_path_stays_relative() {
+        assert_eq!(
+            build_pathbuf(vec!["alpha".to_string(), "beta".to_string()], false),
+            PathBuf::from("alpha").join("beta")
+        );
+    }
+
+    #[test]
+    fn absolute_path_uses_platform_root() {
+        assert_eq!(
+            build_pathbuf(vec!["alpha".to_string(), "beta".to_string()], true),
+            absolute_path_root().join("alpha").join("beta")
+        );
     }
 }
 

--- a/src/generators/default.rs
+++ b/src/generators/default.rs
@@ -275,33 +275,6 @@ impl DefaultGenerator for PathBuf {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::{absolute_path_root, build_pathbuf};
-    use std::path::PathBuf;
-
-    #[test]
-    fn empty_absolute_path_stays_empty() {
-        assert_eq!(build_pathbuf(Vec::new(), true), PathBuf::new());
-    }
-
-    #[test]
-    fn relative_path_stays_relative() {
-        assert_eq!(
-            build_pathbuf(vec!["alpha".to_string(), "beta".to_string()], false),
-            PathBuf::from("alpha").join("beta")
-        );
-    }
-
-    #[test]
-    fn absolute_path_uses_platform_root() {
-        assert_eq!(
-            build_pathbuf(vec!["alpha".to_string(), "beta".to_string()], true),
-            absolute_path_root().join("alpha").join("beta")
-        );
-    }
-}
-
 impl<K: DefaultGenerator + 'static, V: DefaultGenerator + 'static> DefaultGenerator
     for HashMap<K, V>
 where
@@ -414,4 +387,31 @@ macro_rules! derive_generator {
             }
         };
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{absolute_path_root, build_pathbuf};
+    use std::path::PathBuf;
+
+    #[test]
+    fn empty_absolute_path_stays_empty() {
+        assert_eq!(build_pathbuf(Vec::new(), true), PathBuf::new());
+    }
+
+    #[test]
+    fn relative_path_stays_relative() {
+        assert_eq!(
+            build_pathbuf(vec!["alpha".to_string(), "beta".to_string()], false),
+            PathBuf::from("alpha").join("beta")
+        );
+    }
+
+    #[test]
+    fn absolute_path_uses_platform_root() {
+        assert_eq!(
+            build_pathbuf(vec!["alpha".to_string(), "beta".to_string()], true),
+            absolute_path_root().join("alpha").join("beta")
+        );
+    }
 }

--- a/tests/test_default.rs
+++ b/tests/test_default.rs
@@ -4,6 +4,7 @@ use common::utils::check_can_generate_examples;
 use hegel::TestCase;
 use hegel::generators as gs;
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 #[test]
 fn test_default_bool() {
@@ -75,6 +76,11 @@ fn test_default_tuple() {
     check_can_generate_examples(gs::default::<(i32, bool)>());
     check_can_generate_examples(gs::default::<(i32, bool, String)>());
     check_can_generate_examples(gs::default::<(i32, bool, String, f64)>());
+}
+
+#[test]
+fn test_default_pathbuf() {
+    check_can_generate_examples(gs::default::<PathBuf>());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add a `DefaultGenerator` impl for `PathBuf`
- generate common filesystem edge cases including traversal, empty segments, hidden names, long names, whitespace, and occasional absolute paths
- keep `#[derive(DefaultGenerator)]` working for structs that contain `PathBuf` fields

## Why
Downstreams using Hegel for filesystem models need structured path generation without writing a custom generator for every type that embeds a `PathBuf`.