### PR TITLE
Fix ledger example clippy map iteration

### DIFF
--- a/examples/ledger.rs
+++ b/examples/ledger.rs
@@ -77,7 +77,7 @@ impl LedgerTest {
 
     #[invariant]
     fn nonnegative_balances(&mut self, _: TestCase) {
-        for (_account, balance) in &self.ledger.balances {
+        for balance in self.ledger.balances.values() {
             assert!(*balance >= 0);
         }
     }


### PR DESCRIPTION
## Why this is needed
- `cargo clippy --all-targets --all-features -- -D warnings` currently fails on `examples/ledger.rs` with `clippy::for_kv_map`
- that blocks the repo's warning-free clippy gate for a no-behavior-change issue in the example

## Summary
- replace key/value iteration with `HashMap::values()` in the ledger invariant
- keep the example behavior unchanged while satisfying `clippy::for_kv_map`

## Validation
- `cargo clippy --all-targets --all-features -- -D warnings`