### PR TITLE
feat: add a public custom runner hook

### DIFF
--- a/.github/actions/install-tools/action.yml
+++ b/.github/actions/install-tools/action.yml
@@ -16,11 +16,9 @@ runs:
           esac
         done
       shell: bash
-    - if: steps.parse.outputs.just == 'true' && runner.os == 'Linux'
-      run: sudo apt-get update && sudo apt-get install -y just
-      shell: bash
-    - if: steps.parse.outputs.just == 'true' && runner.os == 'Windows'
-      run: choco install just -y --no-progress
-      shell: pwsh
+    - if: steps.parse.outputs.just == 'true'
+      uses: taiki-e/install-action@5f57d6cb7cd20b14a8a27f522884c4bc8a187458 # v2.75.19
+      with:
+        tool: just
     - if: steps.parse.outputs.uv == 'true'
       uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+This release adds a public `Hegel::run_with_runner(...)` hook so downstreams can provide custom execution backends without forking Hegel’s test runner wiring.

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,15 +1,15 @@
-use crate::antithesis::{TestLocation, is_running_in_antithesis};
+use crate::antithesis::{is_running_in_antithesis, TestLocation};
 use crate::backend::{DataSource, DataSourceError, TestCaseResult, TestRunResult, TestRunner};
 use crate::cbor_utils::{as_bool, as_text, as_u64, cbor_map, map_get, map_insert};
 use crate::control::{currently_in_test_context, with_test_context};
-use crate::protocol::{Connection, HANDSHAKE_STRING, Stream};
-use crate::test_case::{ASSUME_FAIL_STRING, LOOP_DONE_STRING, STOP_TEST_STRING, TestCase};
+use crate::protocol::{Connection, Stream, HANDSHAKE_STRING};
+use crate::test_case::{TestCase, ASSUME_FAIL_STRING, LOOP_DONE_STRING, STOP_TEST_STRING};
 use ciborium::Value;
 
 use std::backtrace::{Backtrace, BacktraceStatus};
 use std::cell::RefCell;
 use std::fs::{File, OpenOptions};
-use std::panic::{self, AssertUnwindSafe, catch_unwind};
+use std::panic::{self, catch_unwind, AssertUnwindSafe};
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, Mutex, Once};
@@ -369,18 +369,16 @@ impl HegelSession {
         // connection. Polls try_wait() so the lock is not held while waiting,
         // leaving it available for __test_kill_server to call kill().
         let conn_for_monitor = Arc::clone(&connection);
-        std::thread::spawn(move || {
-            loop {
-                {
-                    let mut guard = child_for_monitor.lock().unwrap();
-                    if matches!(guard.try_wait(), Ok(Some(_))) {
-                        drop(guard);
-                        conn_for_monitor.mark_server_exited();
-                        return;
-                    }
+        std::thread::spawn(move || loop {
+            {
+                let mut guard = child_for_monitor.lock().unwrap();
+                if matches!(guard.try_wait(), Ok(Some(_))) {
+                    drop(guard);
+                    conn_for_monitor.mark_server_exited();
+                    return;
                 }
-                std::thread::sleep(Duration::from_millis(10));
             }
+            std::thread::sleep(Duration::from_millis(10));
         });
 
         HegelSession {
@@ -1215,6 +1213,31 @@ impl Settings {
         }
     }
 
+    /// Return the execution mode.
+    pub fn mode_value(&self) -> Mode {
+        self.mode
+    }
+
+    /// Return the configured number of test cases.
+    pub fn test_cases_value(&self) -> u64 {
+        self.test_cases
+    }
+
+    /// Return the configured verbosity.
+    pub fn verbosity_value(&self) -> Verbosity {
+        self.verbosity
+    }
+
+    /// Return the configured explicit seed, if any.
+    pub fn seed_value(&self) -> Option<u64> {
+        self.seed
+    }
+
+    /// Return whether derandomization is enabled.
+    pub fn derandomize_value(&self) -> bool {
+        self.derandomize
+    }
+
     /// Set the execution mode. Defaults to [`Mode::TestRun`].
     pub fn mode(mut self, mode: Mode) -> Self {
         self.mode = mode;
@@ -1367,9 +1390,17 @@ where
     ///
     /// Panics if any test case fails.
     pub fn run(self) {
-        init_panic_hook();
+        self.run_with_runner(ServerTestRunner);
+    }
 
-        let runner = ServerTestRunner;
+    /// Run the property-based tests with a custom runner.
+    ///
+    /// This is the extension point for alternative backends that still want
+    /// Hegel's normal test-case execution, panic handling, and test builder API.
+    ///
+    /// Panics if any test case fails.
+    pub fn run_with_runner(self, runner: impl TestRunner) {
+        init_panic_hook();
         let mut test_fn = self.test_fn;
         let got_interesting = AtomicBool::new(false);
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,15 +1,15 @@
-use crate::antithesis::{is_running_in_antithesis, TestLocation};
+use crate::antithesis::{TestLocation, is_running_in_antithesis};
 use crate::backend::{DataSource, DataSourceError, TestCaseResult, TestRunResult, TestRunner};
 use crate::cbor_utils::{as_bool, as_text, as_u64, cbor_map, map_get, map_insert};
 use crate::control::{currently_in_test_context, with_test_context};
-use crate::protocol::{Connection, Stream, HANDSHAKE_STRING};
-use crate::test_case::{TestCase, ASSUME_FAIL_STRING, LOOP_DONE_STRING, STOP_TEST_STRING};
+use crate::protocol::{Connection, HANDSHAKE_STRING, Stream};
+use crate::test_case::{ASSUME_FAIL_STRING, LOOP_DONE_STRING, STOP_TEST_STRING, TestCase};
 use ciborium::Value;
 
 use std::backtrace::{Backtrace, BacktraceStatus};
 use std::cell::RefCell;
 use std::fs::{File, OpenOptions};
-use std::panic::{self, catch_unwind, AssertUnwindSafe};
+use std::panic::{self, AssertUnwindSafe, catch_unwind};
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, Mutex, Once};
@@ -369,16 +369,18 @@ impl HegelSession {
         // connection. Polls try_wait() so the lock is not held while waiting,
         // leaving it available for __test_kill_server to call kill().
         let conn_for_monitor = Arc::clone(&connection);
-        std::thread::spawn(move || loop {
-            {
-                let mut guard = child_for_monitor.lock().unwrap();
-                if matches!(guard.try_wait(), Ok(Some(_))) {
-                    drop(guard);
-                    conn_for_monitor.mark_server_exited();
-                    return;
+        std::thread::spawn(move || {
+            loop {
+                {
+                    let mut guard = child_for_monitor.lock().unwrap();
+                    if matches!(guard.try_wait(), Ok(Some(_))) {
+                        drop(guard);
+                        conn_for_monitor.mark_server_exited();
+                        return;
+                    }
                 }
+                std::thread::sleep(Duration::from_millis(10));
             }
-            std::thread::sleep(Duration::from_millis(10));
         });
 
         HegelSession {

--- a/tests/test_custom_runner.rs
+++ b/tests/test_custom_runner.rs
@@ -1,0 +1,121 @@
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+
+use ciborium::Value;
+use hegel::{
+    backend::{DataSource, DataSourceError, TestCaseResult, TestRunResult, TestRunner},
+    Hegel, Mode, Settings, TestCase, Verbosity,
+};
+
+struct NoopDataSource;
+
+impl DataSource for NoopDataSource {
+    fn generate(&self, _schema: &Value) -> Result<Value, DataSourceError> {
+        Err(DataSourceError::StopTest)
+    }
+
+    fn start_span(&self, _label: u64) -> Result<(), DataSourceError> {
+        Ok(())
+    }
+
+    fn stop_span(&self, _discard: bool) -> Result<(), DataSourceError> {
+        Ok(())
+    }
+
+    fn new_collection(
+        &self,
+        _min_size: u64,
+        _max_size: Option<u64>,
+    ) -> Result<String, DataSourceError> {
+        Ok("0".to_string())
+    }
+
+    fn collection_more(&self, _collection: &str) -> Result<bool, DataSourceError> {
+        Ok(false)
+    }
+
+    fn collection_reject(
+        &self,
+        _collection: &str,
+        _why: Option<&str>,
+    ) -> Result<(), DataSourceError> {
+        Ok(())
+    }
+
+    fn new_pool(&self) -> Result<i128, DataSourceError> {
+        Ok(0)
+    }
+
+    fn pool_add(&self, _pool_id: i128) -> Result<i128, DataSourceError> {
+        Ok(0)
+    }
+
+    fn pool_generate(&self, _pool_id: i128, _consume: bool) -> Result<i128, DataSourceError> {
+        Ok(0)
+    }
+
+    fn mark_complete(&self, _status: &str, _origin: Option<&str>) {}
+
+    fn test_aborted(&self) -> bool {
+        false
+    }
+}
+
+struct AssertingRunner {
+    saw_run_case: Arc<AtomicBool>,
+}
+
+impl TestRunner for AssertingRunner {
+    fn run(
+        &self,
+        settings: &Settings,
+        database_key: Option<&str>,
+        run_case: &mut dyn FnMut(Box<dyn DataSource>, bool) -> TestCaseResult,
+    ) -> TestRunResult {
+        assert_eq!(settings.mode_value(), Mode::SingleTestCase);
+        assert_eq!(settings.test_cases_value(), 7);
+        assert_eq!(settings.verbosity_value(), Verbosity::Debug);
+        assert_eq!(settings.seed_value(), Some(9));
+        assert!(settings.derandomize_value());
+        assert_eq!(database_key, Some("custom-runner-test"));
+
+        self.saw_run_case.store(true, Ordering::SeqCst);
+        let result = run_case(Box::new(NoopDataSource), false);
+        assert!(matches!(result, TestCaseResult::Valid));
+
+        TestRunResult {
+            passed: true,
+            failure_message: None,
+        }
+    }
+}
+
+#[test]
+fn hegel_can_run_with_custom_runner() {
+    let test_body_ran = Arc::new(AtomicBool::new(false));
+    let saw_run_case = Arc::new(AtomicBool::new(false));
+
+    Hegel::new({
+        let test_body_ran = Arc::clone(&test_body_ran);
+        move |_tc: TestCase| {
+            test_body_ran.store(true, Ordering::SeqCst);
+        }
+    })
+    .settings(
+        Settings::new()
+            .mode(Mode::SingleTestCase)
+            .test_cases(7)
+            .verbosity(Verbosity::Debug)
+            .seed(Some(9))
+            .derandomize(true),
+    )
+    .__database_key("custom-runner-test".to_string())
+    .run_with_runner(AssertingRunner {
+        saw_run_case: Arc::clone(&saw_run_case),
+    });
+
+    assert!(saw_run_case.load(Ordering::SeqCst));
+    assert!(test_body_ran.load(Ordering::SeqCst));
+}

--- a/tests/test_custom_runner.rs
+++ b/tests/test_custom_runner.rs
@@ -1,12 +1,12 @@
 use std::sync::{
-    atomic::{AtomicBool, Ordering},
     Arc,
+    atomic::{AtomicBool, Ordering},
 };
 
 use ciborium::Value;
 use hegel::{
-    backend::{DataSource, DataSourceError, TestCaseResult, TestRunResult, TestRunner},
     Hegel, Mode, Settings, TestCase, Verbosity,
+    backend::{DataSource, DataSourceError, TestCaseResult, TestRunResult, TestRunner},
 };
 
 struct NoopDataSource;


### PR DESCRIPTION
## Summary
- add a public `Hegel::run_with_runner(...)` hook for alternative backends
- expose read-only `Settings` accessors needed by external runners
- add a regression test covering a custom runner implementation

## Why
This lets downstreams plug in non-server execution backends without forking Hegel's test builder and panic/shrinking wiring.