### PR TITLE
Fix flaky test_limitation_chained_method_on_draw

### DIFF
--- a/tests/test_draw_named.rs
+++ b/tests/test_draw_named.rs
@@ -397,11 +397,14 @@ fn test_limitation_destructuring_pattern() {
 
 #[test]
 fn test_limitation_chained_method_on_draw() {
-    // `let _x = tc.draw(gen).abs()` — the init expression is `.abs()`, not
-    // `.draw()`, so is_test_case_draw_binding doesn't match.
+    // `let _x = tc.draw(gen).wrapping_abs()` — the init expression is
+    // `.wrapping_abs()`, not `.draw()`, so is_test_case_draw_binding doesn't
+    // match. We use wrapping_abs rather than abs because abs panics on
+    // i32::MIN, which can cause hegel to discover a second bug during
+    // shrinking, producing extra output lines.
     let lines = draw_lines(
         "
-        let x = tc.draw(gs::integers::<i32>()).abs();
+        let x = tc.draw(gs::integers::<i32>()).wrapping_abs();
     ",
     );
     assert_eq!(lines, vec!["let draw_1 = 0;"]);


### PR DESCRIPTION
This could occasionally produce multiple failures due to an abs() panic

<details>
<summary>Implementation details</summary>

The test used `.abs()` on a drawn `i32`, but `i32::MIN.abs()` panics with overflow in debug mode. When hegel's shrinking happened to encounter `i32::MIN`, it discovered a second bug (overflow), replayed both counterexamples, and the regex picked up two `let draw_1 = ...;` lines instead of one.

Switched to `.wrapping_abs()` which never panics, so only the intended panic (`__draw_lines_fail`) is ever found. Verified with 20 consecutive runs.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)