### PR TITLE
Fix flaky test_characters_codepoint_range

### DIFF
--- a/tests/test_strings.rs
+++ b/tests/test_strings.rs
@@ -17,6 +17,9 @@ fn test_characters_ascii() {
 fn test_characters_codepoint_range(tc: hegel::TestCase) {
     let lo = tc.draw(gs::integers::<u32>().min_value(0).max_value(0x10FFFF));
     let hi = tc.draw(gs::integers::<u32>().min_value(lo).max_value(0x10FFFF));
+    // Rust strings cannot contain surrogates (0xD800..=0xDFFF), so a range
+    // entirely within the surrogate block has no valid characters.
+    tc.assume(lo < 0xD800 || hi > 0xDFFF);
     let c: char = tc.draw(gs::characters().min_codepoint(lo).max_codepoint(hi));
     let cp = c as u32;
     assert!(cp >= lo && cp <= hi);
@@ -82,6 +85,9 @@ fn test_text_codec_ascii() {
 fn test_text_codepoint_range(tc: hegel::TestCase) {
     let lo = tc.draw(gs::integers::<u32>().min_value(0).max_value(0x10FFFF));
     let hi = tc.draw(gs::integers::<u32>().min_value(lo).max_value(0x10FFFF));
+    // Rust strings cannot contain surrogates (0xD800..=0xDFFF), so a range
+    // entirely within the surrogate block has no valid characters.
+    tc.assume(lo < 0xD800 || hi > 0xDFFF);
     let s: String = tc.draw(gs::text().min_codepoint(lo).max_codepoint(hi));
     assert!(s.chars().all(|c| {
         let cp = c as u32;


### PR DESCRIPTION
<details>
<summary>Implementation notes (AI-generated)</summary>

## Root cause

`test_text_codepoint_range` and `test_characters_codepoint_range` in `tests/test_strings.rs` drew arbitrary `(lo, hi)` codepoint bounds in `0..=0x10FFFF` and passed them straight to `text()` / `characters()`. Rust strings cannot contain surrogates, and the library always adds the `Cs` category to `exclude_categories`. When Hypothesis happened to shrink both bounds into the surrogate block `0xD800..=0xDFFF`, the effective character set was empty and the server returned `InvalidArgument: No characters are allowed to be generated by this combination of arguments`, which the client propagated as a panic.

Deterministic reproducer pre-fix:

```rust
Hegel::new(|tc| {
    let _s: String = tc.draw(gs::text().min_codepoint(0xD800).max_codepoint(0xD800));
}).run();
// panics: Server error (InvalidArgument): ...
```

## Fix

Added `tc.assume(lo < 0xD800 || hi > 0xDFFF)` to both property tests so inputs that fall entirely inside the surrogate block are marked invalid before reaching `draw`. This mirrors how the floats tests use `tc.assume()` to skip impossible bounds.

## Why not a library-level fix

The library behavior on surrogate-only ranges (error via server `InvalidArgument`) is already pinned by `test_server_invalid_argument_is_reported` in `tests/test_validation.rs`. Changing it would weaken that contract. The flake is a property-test bug — the test's premise that all `(lo, hi)` pairs are valid bounds is wrong — so the fix belongs in the test.

## Verification

- Deterministic reproducer panics pre-fix, passes post-fix.
- 50 consecutive runs of `cargo test --test test_strings codepoint_range` all pass. Given the reported ~1/3 pre-fix flake rate, 50 clean runs corresponds to `(2/3)^50 ≈ 1.6e-9` probability under the null hypothesis that the flake remains.
- `just check` passes.
</details>