### PR TITLE
Avoid sharing .hegel directory between subsequent runs of cargo test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "ctor"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,6 +198,7 @@ version = "0.8.0"
 dependencies = [
  "ciborium",
  "crc32fast",
+ "ctor",
  "hegeltest-macros",
  "insta",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ regex = "1.0"
 rand = "0.10"
 serde_json = "1.0.61"
 insta = "1.47.2"
+ctor = "0.2"
 
 [features]
 default = []

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,2 +1,24 @@
 pub mod project;
 pub mod utils;
+
+// Each cargo test run of this project spawns its own set of integration-test
+// binaries, and each one of those binaries normally inherits the crate root as
+// its cwd. The hegel library creates `.hegel/` in the process's cwd, so
+// without this setup the test binaries would all share (and clobber) one
+// `.hegel/` inside the crate root across concurrent and successive `cargo
+// test` runs. This ctor chdir's every test binary into its own tempdir before
+// main, so each binary's `.hegel/` lands in a fresh, private location.
+//
+// Note: this is purely a test-harness concern. The library's documented
+// behaviour (`.hegel/` in the caller's cwd) is deliberate for real users.
+static TEST_CWD: std::sync::OnceLock<tempfile::TempDir> = std::sync::OnceLock::new();
+
+#[ctor::ctor]
+fn chdir_to_isolated_tempdir() {
+    let tempdir = tempfile::Builder::new()
+        .prefix("hegel-rust-test-")
+        .tempdir()
+        .expect("Failed to create test cwd tempdir");
+    std::env::set_current_dir(tempdir.path()).expect("Failed to chdir into test cwd tempdir");
+    let _ = TEST_CWD.set(tempdir);
+}

--- a/tests/test_backend.rs
+++ b/tests/test_backend.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use hegel::backend::DataSourceError;
 
 #[test]

--- a/tests/test_flaky_global_state.rs
+++ b/tests/test_flaky_global_state.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use hegel::TestCase;
 use hegel::generators as gs;
 use std::sync::atomic::{AtomicI32, Ordering};

--- a/tests/test_hang.rs
+++ b/tests/test_hang.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use hegel::generators as gs;
 use hegel::{HealthCheck, TestCase};
 

--- a/tests/test_health_check.rs
+++ b/tests/test_health_check.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use hegel::HealthCheck;
 use hegel::TestCase;
 use hegel::generators as gs;

--- a/tests/test_lifetimes.rs
+++ b/tests/test_lifetimes.rs
@@ -3,6 +3,8 @@
 //! These tests exercise the lifetime logic in BasicGenerator<'a, T> and
 //! the phantom type parameters on composite generators.
 
+mod common;
+
 use hegel::TestCase;
 use hegel::generators::{self as gs, Generator};
 

--- a/tests/test_loop.rs
+++ b/tests/test_loop.rs
@@ -7,6 +7,8 @@
 //! named-variable rewriting that `#[hegel::test]` performs — this is what
 //! makes `let x_1 = ...` appear in the snapshots instead of `let draw_1 = ...`.
 
+mod common;
+
 use std::cell::Cell;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::rc::Rc;

--- a/tests/test_randoms.rs
+++ b/tests/test_randoms.rs
@@ -1,5 +1,7 @@
 #![cfg(feature = "rand")]
 
+mod common;
+
 use hegel::TestCase;
 use hegel::generators as gs;
 use rand::RngExt;

--- a/tests/test_reject.rs
+++ b/tests/test_reject.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use hegel::generators as gs;
 use hegel::{HealthCheck, TestCase};
 

--- a/tests/test_runtime_dir_isolation.rs
+++ b/tests/test_runtime_dir_isolation.rs
@@ -1,0 +1,51 @@
+//! Regression tests: every integration-test binary should be chdir'd into a
+//! fresh per-process tempdir, so the hegel library (which creates `.hegel/`
+//! in cwd) doesn't leak state across concurrent or successive `cargo test`
+//! runs of this repo.
+//!
+//! The setup lives in `tests/common/mod.rs` behind a `#[ctor::ctor]`; these
+//! tests just assert its observable effects.
+
+mod common;
+
+use hegel::Hegel;
+use hegel::generators as gs;
+
+#[test]
+fn cwd_is_not_crate_root() {
+    let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let cwd = std::env::current_dir().unwrap();
+    assert_ne!(
+        cwd, manifest_dir,
+        "test binary cwd should have been chdir'd away from the crate root",
+    );
+}
+
+#[test]
+fn cwd_is_a_hegel_rust_test_tempdir() {
+    let cwd = std::env::current_dir().unwrap();
+    let name = cwd.file_name().unwrap().to_string_lossy();
+    assert!(
+        name.starts_with("hegel-rust-test-"),
+        "cwd {cwd:?} should be a tempdir whose name starts with hegel-rust-test-",
+    );
+}
+
+#[test]
+fn running_hegel_creates_dot_hegel_in_tempdir_not_crate_root() {
+    Hegel::new(|tc| {
+        let _: bool = tc.draw(gs::booleans());
+    })
+    .run();
+
+    let cwd = std::env::current_dir().unwrap();
+    assert!(
+        cwd.join(".hegel").exists(),
+        ".hegel should exist in the test-binary tempdir cwd {cwd:?}",
+    );
+    let crate_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    assert_ne!(
+        cwd, crate_root,
+        ".hegel landed in the crate root, which means isolation isn't working",
+    );
+}

--- a/tests/test_settings.rs
+++ b/tests/test_settings.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use hegel::generators as gs;
 
 #[test]

--- a/tests/test_threading.rs
+++ b/tests/test_threading.rs
@@ -9,6 +9,8 @@
 //! thread work but does not race — that is, one thread does work, another
 //! picks up after it, and the outcome is independent of scheduling.
 
+mod common;
+
 use hegel::TestCase;
 use hegel::generators as gs;
 use std::sync::{Arc, Mutex};

--- a/tests/test_validation.rs
+++ b/tests/test_validation.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use hegel::TestCase;
 use hegel::generators::{self as gs, Generator};
 


### PR DESCRIPTION
<details>
<summary>AI-generated implementation notes</summary>

## Summary
- Library behaviour is unchanged — `.hegel/` still lives in the caller's cwd for real users.
- Every integration-test binary in this repo now chdir's into a fresh tempdir (`/tmp/hegel-rust-test-*`) before `main` runs, via a `#[ctor::ctor]` in `tests/common/mod.rs`. The tempdir is held in a `OnceLock` for the process lifetime.
- The 11 test files that didn't already pull in `common` get a bare `mod common;` declaration so the ctor is linked in.
- Added `ctor = \"0.2\"` as a dev-dependency.

## Test plan
- [x] New `tests/test_runtime_dir_isolation.rs` asserts that cwd is no longer the crate root, that it starts with `hegel-rust-test-`, and that running a hegel test creates `.hegel/` inside the tempdir (not in the crate root).
- [x] `just check` is green (88 test-result blocks, 0 failures).
- [x] `just check-coverage` is green (0 uncovered new lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>