### PR TITLE
claude: lint examples with clippy in CI

### DIFF
--- a/justfile
+++ b/justfile
@@ -35,8 +35,8 @@ check-format-nix:
     nix run nixpkgs#nixfmt -- --check nix/flake.nix
 
 check-clippy:
-    cargo clippy --all-features --tests -- -D warnings
-    cargo clippy --manifest-path tests/conformance/rust/Cargo.toml -- -D warnings
+    cargo clippy --all-features --all-targets -- -D warnings
+    cargo clippy --manifest-path tests/conformance/rust/Cargo.toml --all-targets -- -D warnings
 
 check-docs:
     cargo +nightly docs-rs


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

Follow-up to #207, where a `clippy::for_kv_map` warning in `examples/ledger.rs` slipped past CI. The cause: `just check-clippy` used `cargo clippy --all-features --tests`, which only lints the library and test targets — examples (and bins/benches) are skipped.

This PR changes both clippy invocations in the justfile (main crate and conformance crate) to `--all-targets`, which covers lib, bins, tests, examples, and benches. Both pass locally without any further code changes, since #207 already fixed the only outstanding example warning.

</details>
