### PR TITLE
claude: add DefaultGenerator impl for PathBuf

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+This release adds a `DefaultGenerator` impl for `PathBuf`, so `#[derive(Generate)]` works for structs with `PathBuf` fields and `gs::default::<PathBuf>()` returns a generator.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
-RELEASE_TYPE: minor
+RELEASE_TYPE: patch
 
-This release adds a `DefaultGenerator` impl for `PathBuf`, so `#[derive(Generate)]` works for structs with `PathBuf` fields and `gs::default::<PathBuf>()` returns a generator.
+This release implements `DefaultGenerator` for `PathBuf`.

--- a/src/generators/default.rs
+++ b/src/generators/default.rs
@@ -6,6 +6,7 @@ use super::{
 };
 use std::collections::HashMap;
 use std::hash::Hash;
+use std::path::PathBuf;
 use std::time::Duration;
 
 /// Trait for types that have a default generator.
@@ -200,6 +201,13 @@ impl DefaultGenerator for Duration {
     type Generator = DurationGenerator;
     fn default_generator() -> Self::Generator {
         durations()
+    }
+}
+
+impl DefaultGenerator for PathBuf {
+    type Generator = BoxedGenerator<'static, PathBuf>;
+    fn default_generator() -> Self::Generator {
+        text().map(PathBuf::from).boxed()
     }
 }
 

--- a/tests/test_default.rs
+++ b/tests/test_default.rs
@@ -4,6 +4,7 @@ use common::utils::check_can_generate_examples;
 use hegel::TestCase;
 use hegel::generators as gs;
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 #[test]
 fn test_default_bool() {
@@ -68,6 +69,11 @@ fn test_default_array() {
 fn test_default_hashmap() {
     check_can_generate_examples(gs::default::<HashMap<String, i32>>());
     check_can_generate_examples(gs::default::<HashMap<String, bool>>());
+}
+
+#[test]
+fn test_default_pathbuf() {
+    check_can_generate_examples(gs::default::<PathBuf>());
 }
 
 #[test]


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

Adds a `DefaultGenerator` impl for `PathBuf`, so `#[derive(Generate)]` works for structs with `PathBuf` fields and `gs::default::<PathBuf>()` returns a generator.

Implementation mirrors Hypothesis's default for `os.PathLike` (`st.builds(PurePath, st.text())`): `text().map(PathBuf::from).boxed()`. As discussed in #206, getting a richer path generator right is subtle and probably belongs at the protocol level (a shared `paths()` strategy) rather than reimplemented per-library — so this just unblocks deriving on path-containing structs without committing to a particular set of edge cases.

</details>
