### PR TITLE
Fix busy file race in tests

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch fixes a flaky test. There are no user visible changes.

--- a/src/server/process.rs
+++ b/src/server/process.rs
@@ -81,36 +81,22 @@ fn startup_error_message(
     binary_path: Option<&str>,
     exit_status: std::process::ExitStatus,
 ) -> String {
+    let version_check = binary_path.map(|p| (p, Command::new(p).arg("--version").output()));
+    startup_error_message_from_version(version_check, exit_status)
+}
+
+fn startup_error_message_from_version(
+    version_check: Option<(&str, std::io::Result<std::process::Output>)>,
+    exit_status: std::process::ExitStatus,
+) -> String {
     let mut parts = Vec::new();
 
     parts.push("The hegel server failed during startup handshake.".to_string());
     parts.push(format!("The server process exited with {}.", exit_status));
 
-    // Version detection via --version (only when we have a binary path to check)
-    if let Some(binary_path) = binary_path {
-        let expected_version_string = format!("hegel (version {})", HEGEL_SERVER_VERSION);
-        match Command::new(binary_path).arg("--version").output() {
-            Ok(output) if output.status.success() => {
-                let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-                if stdout != expected_version_string {
-                    parts.push(format!(
-                        "Version mismatch: expected '{}', got '{}'.",
-                        expected_version_string, stdout
-                    ));
-                }
-            }
-            Ok(_) => {
-                parts.push(format!(
-                    "'{}' --version exited unsuccessfully. Is this a hegel binary?",
-                    binary_path
-                ));
-            }
-            Err(e) => {
-                parts.push(format!(
-                    "Could not run '{}' --version: {}. Is this a hegel binary?",
-                    binary_path, e
-                ));
-            }
+    if let Some((binary_path, version_result)) = version_check {
+        if let Some(msg) = version_check_message(binary_path, version_result) {
+            parts.push(msg);
         }
     }
 
@@ -131,6 +117,34 @@ fn startup_error_message(
     }
 
     parts.join("\n\n")
+}
+
+fn version_check_message(
+    binary_path: &str,
+    version_result: std::io::Result<std::process::Output>,
+) -> Option<String> {
+    let expected_version_string = format!("hegel (version {})", HEGEL_SERVER_VERSION);
+    match version_result {
+        Ok(output) if output.status.success() => {
+            let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if stdout != expected_version_string {
+                Some(format!(
+                    "Version mismatch: expected '{}', got '{}'.",
+                    expected_version_string, stdout
+                ))
+            } else {
+                None
+            }
+        }
+        Ok(_) => Some(format!(
+            "'{}' --version exited unsuccessfully. Is this a hegel binary?",
+            binary_path
+        )),
+        Err(e) => Some(format!(
+            "Could not run '{}' --version: {}. Is this a hegel binary?",
+            binary_path, e
+        )),
+    }
 }
 
 fn resolve_hegel_path(path: &str) -> String {

--- a/tests/embedded/server/process_tests.rs
+++ b/tests/embedded/server/process_tests.rs
@@ -51,25 +51,42 @@ fn test_wait_for_exit_timeout() {
     let _ = child.wait();
 }
 
+fn exit_success_status() -> std::process::ExitStatus {
+    #[cfg(unix)]
+    use std::os::unix::process::ExitStatusExt;
+    #[cfg(windows)]
+    use std::os::windows::process::ExitStatusExt;
+    std::process::ExitStatus::from_raw(0)
+}
+
+fn fake_output(status: std::process::ExitStatus, stdout: &str) -> std::process::Output {
+    std::process::Output {
+        status,
+        stdout: stdout.as_bytes().to_vec(),
+        stderr: Vec::new(),
+    }
+}
+
+#[test]
+fn test_version_check_message_mismatch() {
+    let output = fake_output(exit_success_status(), "hegel (version 0.0.0)\n");
+    let msg = version_check_message("/fake/path", Ok(output)).unwrap();
+    assert!(msg.contains("Version mismatch"), "Message: {msg}");
+}
+
+#[test]
+fn test_version_check_message_match() {
+    let expected = format!("hegel (version {HEGEL_SERVER_VERSION})\n");
+    let output = fake_output(exit_success_status(), &expected);
+    assert!(version_check_message("/fake/path", Ok(output)).is_none());
+}
+
 #[test]
 fn test_startup_error_message_version_mismatch() {
-    let dir = tempfile::tempdir().unwrap();
-    #[cfg(unix)]
-    let script = {
-        let s = dir.path().join("fake_version");
-        std::fs::write(&s, "#!/bin/sh\necho 'hegel (version 0.0.0)'\n").unwrap();
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&s, std::fs::Permissions::from_mode(0o755)).unwrap();
-        s
-    };
-    #[cfg(windows)]
-    let script = {
-        let s = dir.path().join("fake_version.bat");
-        std::fs::write(&s, "@echo off\r\necho hegel (version 0.0.0)\r\n").unwrap();
-        s
-    };
     let exit_status = exit_failure_status();
-    let msg = startup_error_message(Some(script.to_str().unwrap()), exit_status);
+    let version_output = fake_output(exit_success_status(), "hegel (version 0.0.0)\n");
+    let msg =
+        startup_error_message_from_version(Some(("/fake/path", Ok(version_output))), exit_status);
     assert!(msg.contains("Version mismatch"), "Message: {msg}");
 }
 


### PR DESCRIPTION
<details>
<summary>AI-generated implementation notes</summary>

`test_startup_error_message_version_mismatch` was failing in CI with `Could not run '/tmp/.tmpUxXKN8/fake_version' --version: Text file busy (os error 26)`.

The test wrote a fresh shell script into a tempdir, chmod'd it +x, then ran `Command::new(script).arg(\"--version\").output()` from inside `startup_error_message`. Under parallel tests on Linux this hits ETXTBSY: while the test thread held the writable fd for the script (during `std::fs::write`), a sibling thread's `Command::spawn` could fork, briefly inheriting the fd. `O_CLOEXEC` only closes the fd at *exec* time, not *fork* time, so until the sibling subprocess execs, the kernel sees the file as held open for writing and refuses to exec it.

Fix: split `startup_error_message` into the part that runs `--version` and the part that formats its result (`version_check_message`). The flaky test now constructs a synthetic `std::process::Output` and calls the formatter directly — no fresh executable needed. Other tests in `test_bad_server_command.rs` write executables too, but each uses its own tempdir and only execs through `cargo_run` (cargo → built user binary → server spawn), several forks deep and seconds later, so the fork-race window has long closed by then.