### PR TITLE
claude: whitelist .claude in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,14 +12,19 @@ __pycache__
 target/
 result
 .claude-reliability/
-.claude/reliability-config.yml
 CLAUDE.local.md
 
 lcov.info
 
-.claude/bin/
-.claude/*.local.md
-.claude/*.local.json
-.claude/*.local
+# whitelist .claude files, rather than blacklist. Some local claude files
+# (skills, agents) have to live in .claude - as opposed to eg CLAUDE.local.md,
+# which we gitignore at the top level.
+.claude/*
+!.claude/CLAUDE.md
+!.claude/skills/
+.claude/skills/*
+!.claude/skills/changelog/
+!.claude/skills/coverage/
+!.claude/skills/self-review/
 
 docs/superpowers


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

Switch the `.claude/` section of `.gitignore` from a blacklist (`.claude/reliability-config.yml`, `.claude/bin/`, `.claude/*.local.md`, `.claude/*.local.json`, `.claude/*.local`) to a whitelist. Local files (skills, agents, settings, plans) inside `.claude/` are now untracked by default; only explicitly-allowed entries are committed:

- `.claude/CLAUDE.md`
- `.claude/skills/changelog/`
- `.claude/skills/coverage/` (including `references/`)
- `.claude/skills/self-review/`

The two-level pattern (`.claude/*` re-including `.claude/skills/`, then `.claude/skills/*` re-including each shared skill dir) lets each `!.claude/skills/<name>/` recursively un-ignore everything inside, including nested `references/` files.

Top-level `CLAUDE.local.md` and the sibling `.claude-reliability/` were already correctly placed and are left as-is. The slate task asked me to add `CLAUDE.local.md` to the top-level blacklist if missing — it's already present at line 15, so no change was needed there.

The release-check CI job only triggers on changes under `src/` or `hegel-macros/`, so no `RELEASE.md` is required for this `.gitignore`-only change.

Verification:
- `git status --short` shows only `.gitignore` modified.
- `git ls-files .claude/` lists all 6 originally-tracked files (`CLAUDE.md`, `skills/changelog/SKILL.md`, `skills/coverage/SKILL.md`, `skills/coverage/references/internals.md`, `skills/coverage/references/patterns.md`, `skills/self-review/SKILL.md`).
- `git check-ignore` confirms plait-injected files like `.claude/agents/foo` and `.claude/skills/code-review/SKILL.md` are correctly ignored.

</details>
