### PR TITLE
claude: protocol: drop null/ipv4/ipv6 schemas

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,9 +1,9 @@
 RELEASE_TYPE: patch
 
-This release updates the wire schemas emitted by `optional` and `ip_addresses` to match the cleaned-up server protocol:
+This release updates the wire schemas emitted by `optional` and `ip_addresses` to match the cleaned-up server protocol, and bumps our pinned hegel-core to [0.6.0](https://github.com/hegeldev/hegel-core/releases/tag/v0.6.0):
 
 - `optional` now emits `{"type": "constant", "value": null}` for the null branch (instead of `{"type": "null"}`).
-- `ip_addresses` now emits `{"type": "ip_addresses", "version": N}` (instead of `{"type": "ipv4"}` or `{"type": "ipv6"}`).
+- `ip_addresses` now emits `{"type": "ip_address", "version": N}` (instead of `{"type": "ipv4"}` or `{"type": "ipv6"}`).
 - The `#[derive(Generate)]` macro emits the new constant-null schema for unit variants of mixed enums.
 
 This is a wire-format change only — there is no change to the public Rust API.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,9 +1,3 @@
 RELEASE_TYPE: patch
 
-This release updates the wire schemas emitted by `optional` and `ip_addresses` to match the cleaned-up server protocol, and bumps our pinned hegel-core to [0.6.0](https://github.com/hegeldev/hegel-core/releases/tag/v0.6.0):
-
-- `optional` now emits `{"type": "constant", "value": null}` for the null branch (instead of `{"type": "null"}`).
-- `ip_addresses` now emits `{"type": "ip_address", "version": N}` (instead of `{"type": "ipv4"}` or `{"type": "ipv6"}`).
-- The `#[derive(Generate)]` macro emits the new constant-null schema for unit variants of mixed enums.
-
-This is a wire-format change only — there is no change to the public Rust API.
+Internal refactor.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+RELEASE_TYPE: patch
+
+This release updates the wire schemas emitted by `optional` and `ip_addresses` to match the cleaned-up server protocol:
+
+- `optional` now emits `{"type": "constant", "value": null}` for the null branch (instead of `{"type": "null"}`).
+- `ip_addresses` now emits `{"type": "ip_addresses", "version": N}` (instead of `{"type": "ipv4"}` or `{"type": "ipv6"}`).
+- The `#[derive(Generate)]` macro emits the new constant-null schema for unit variants of mixed enums.
+
+This is a wire-format change only — there is no change to the public Rust API.

--- a/hegel-macros/src/enum_gen.rs
+++ b/hegel-macros/src/enum_gen.rs
@@ -283,8 +283,9 @@ pub(crate) fn derive_enum_generator(input: &DeriveInput, data: &syn::DataEnum) -
         // Schema is `{"type": "one_of", "generators": [s_0, s_1, ...]}` with one
         // child per variant in declaration order. The server's response is
         // `[index, value]` where `index` selects the variant; for unit variants
-        // the corresponding child schema is `{"type": "null"}` and the value is
-        // discarded, for data variants it's the variant generator's schema.
+        // the corresponding child schema is `{"type": "constant", "value": null}`
+        // and the value is discarded, for data variants it's the variant
+        // generator's schema.
 
         // Bind data variant basic generators (must succeed for all data variants).
         let data_variant_basic_bindings: Vec<proc_macro2::TokenStream> = data_variants
@@ -300,7 +301,10 @@ pub(crate) fn derive_enum_generator(input: &DeriveInput, data: &syn::DataEnum) -
 
         // Build schema entries and parse arms in declaration order so the wire
         // index matches the variant order.
-        let null_schema = cbor_map(vec![(cbor_text("type"), cbor_text("null"))]);
+        let null_schema = cbor_map(vec![
+            (cbor_text("type"), cbor_text("constant")),
+            (cbor_text("value"), quote! { hegel::ciborium::Value::Null }),
+        ]);
         let one_of_schema_entries: Vec<proc_macro2::TokenStream> = variants
             .iter()
             .map(|variant| match classify_variant(variant) {

--- a/hegel-macros/src/enum_gen.rs
+++ b/hegel-macros/src/enum_gen.rs
@@ -2,9 +2,7 @@ use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::{DeriveInput, Fields, Variant};
 
-use crate::utils::{
-    cbor_array, cbor_map, cbor_text, cbor_to_iter, default_gen_bounds, tuple_schema,
-};
+use crate::utils::{cbor_map, cbor_text, cbor_to_iter, default_gen_bounds, tuple_schema};
 
 enum VariantKind<'a> {
     /// Unit variant like `Pending`
@@ -153,39 +151,31 @@ pub(crate) fn derive_enum_generator(input: &DeriveInput, data: &syn::DataEnum) -
         })
         .collect();
 
-    // Generate variant names for generate
-    let all_variant_names: Vec<_> = variants.iter().map(|v| v.ident.to_string()).collect();
+    // Build a `0..=N-1` integer schema for variant selection. This mirrors how
+    // `gs::sampled_from` lowers to an integer-index schema
+    let max_variant_idx = variants.len() - 1;
+    let variant_index_schema = cbor_map(vec![
+        (cbor_text("type"), cbor_text("integer")),
+        (
+            cbor_text("min_value"),
+            quote! { hegel::ciborium::Value::Integer(hegel::ciborium::value::Integer::from(0u64)) },
+        ),
+        (
+            cbor_text("max_value"),
+            quote! { hegel::ciborium::Value::Integer(hegel::ciborium::value::Integer::from(#max_variant_idx as u64)) },
+        ),
+    ]);
 
-    // Build sampled_from schema for variant selection
-    let sampled_from_schema = {
-        let values: Vec<_> = all_variant_names
-            .iter()
-            .map(|name| cbor_text(name))
-            .collect();
-        cbor_map(vec![
-            (cbor_text("type"), cbor_text("sampled_from")),
-            (cbor_text("values"), cbor_array(values)),
-        ])
-    };
-
-    // Generate match arms for generate() compositional fallback
+    // Generate match arms for generate() compositional fallback, keyed by
+    // declaration index.
     let generate_match_arms: Vec<_> = variants
         .iter()
-        .map(|variant| {
+        .enumerate()
+        .map(|(i, variant)| {
             let variant_name = &variant.ident;
-            let variant_name_str = variant.ident.to_string();
-
             match classify_variant(variant) {
-                VariantKind::Unit => {
-                    quote! {
-                        #variant_name_str => #enum_name::#variant_name
-                    }
-                }
-                _ => {
-                    quote! {
-                        #variant_name_str => self.#variant_name.do_draw(__tc)
-                    }
-                }
+                VariantKind::Unit => quote! { #i => #enum_name::#variant_name },
+                _ => quote! { #i => self.#variant_name.do_draw(__tc) },
             }
         })
         .collect();
@@ -245,19 +235,20 @@ pub(crate) fn derive_enum_generator(input: &DeriveInput, data: &syn::DataEnum) -
         }
     };
 
-    // Unit variant match arms for the parse_raw method
+    // Unit variant match arms keyed by declaration index for the all-unit
+    // `as_basic` parse closure. Equivalent to `generate_match_arms` here
+    // (every variant is unit) but kept separate for clarity.
     let unit_variant_match_arms: Vec<proc_macro2::TokenStream> = variants
         .iter()
-        .filter(|v| matches!(classify_variant(v), VariantKind::Unit))
-        .map(|variant| {
+        .enumerate()
+        .map(|(i, variant)| {
             let variant_name = &variant.ident;
-            let variant_name_str = variant.ident.to_string();
-            quote! { #variant_name_str => #enum_name::#variant_name }
+            quote! { #i => #enum_name::#variant_name }
         })
         .collect();
 
     let generate_trait_impl = if data_variants.is_empty() {
-        // All-unit enum: use sampled_from schema
+        // All-unit enum: pick a variant by integer index.
         quote! {
             impl hegel::generators::Generator<#enum_name> for #generator_name {
                 fn do_draw(&self, __tc: &hegel::TestCase) -> #enum_name {
@@ -266,12 +257,12 @@ pub(crate) fn derive_enum_generator(input: &DeriveInput, data: &syn::DataEnum) -
                 }
 
                 fn as_basic(&self) -> Option<hegel::generators::BasicGenerator<'_, #enum_name>> {
-                    let schema = #sampled_from_schema;
+                    let schema = #variant_index_schema;
                     Some(hegel::generators::BasicGenerator::new(schema, |raw| {
-                        let selected: String = hegel::generators::deserialize_value(raw);
-                        match selected.as_str() {
+                        let index: usize = hegel::generators::deserialize_value(raw);
+                        match index {
                             #(#unit_variant_match_arms,)*
-                            _ => unreachable!("Unknown variant: {}", selected),
+                            _ => unreachable!("Unknown variant index: {}", index),
                         }
                     }))
                 }
@@ -338,13 +329,13 @@ pub(crate) fn derive_enum_generator(input: &DeriveInput, data: &syn::DataEnum) -
                         basic.parse_raw(hegel::generate_raw(__tc, basic.schema()))
                     } else {
                         __tc.start_span(hegel::generators::labels::ENUM_VARIANT);
-                        let selected: String = hegel::generate_from_schema(__tc,
-                            &#sampled_from_schema
+                        let index: usize = hegel::generate_from_schema(__tc,
+                            &#variant_index_schema
                         );
 
-                        let __result = match selected.as_str() {
+                        let __result = match index {
                             #(#generate_match_arms,)*
-                            _ => unreachable!("Unknown variant: {}", selected),
+                            _ => unreachable!("Unknown variant index: {}", index),
                         };
                         __tc.stop_span(false);
                         __result

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -38,17 +38,17 @@
       },
       "locked": {
         "dir": "nix",
-        "lastModified": 1777479227,
-        "narHash": "sha256-s1JjMvJX3SRebwlSQeo6S99OWIoP0CFuPALvG1itzGw=",
-        "ref": "refs/tags/v0.5.0",
-        "rev": "a95da271bb026037d13656b4317a445a308fded3",
-        "revCount": 653,
+        "lastModified": 1777568232,
+        "narHash": "sha256-VInDnyh7uxm6d9IyfV3ShxHZD4BvsTF7wIB+kv9apbk=",
+        "ref": "refs/tags/v0.6.0",
+        "rev": "4630a7845bff88908be4505675a945711f43b5bd",
+        "revCount": 658,
         "type": "git",
         "url": "https://github.com/hegeldev/hegel-core"
       },
       "original": {
         "dir": "nix",
-        "ref": "refs/tags/v0.5.0",
+        "ref": "refs/tags/v0.6.0",
         "type": "git",
         "url": "https://github.com/hegeldev/hegel-core"
       }

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     # note: this version is automatically bumped when we update hegel-core, do not update manually
-    hegel.url = "git+https://github.com/hegeldev/hegel-core?dir=nix&ref=refs/tags/v0.5.0"; # git+https instead of github so that we can use the ref parameter
+    hegel.url = "git+https://github.com/hegeldev/hegel-core?dir=nix&ref=refs/tags/v0.6.0"; # git+https instead of github so that we can use the ref parameter
     flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
   };
 

--- a/src/generators/combinators.rs
+++ b/src/generators/combinators.rs
@@ -179,7 +179,7 @@ where
         let inner_basic = self.inner.as_basic()?;
         let inner_schema = inner_basic.schema().clone();
 
-        let null_schema = cbor_map! {"type" => "null"};
+        let null_schema = cbor_map! {"type" => "constant", "value" => Value::Null};
         let schema =
             cbor_map! {"type" => "one_of", "generators" => cbor_array![null_schema, inner_schema]};
 

--- a/src/generators/strings.rs
+++ b/src/generators/strings.rs
@@ -582,12 +582,13 @@ impl IpAddressGenerator {
     // nocov start
     fn build_schema(&self) -> Value {
         match self.version {
-            Some(IpVersion::V4) => cbor_map! {"type" => "ipv4"},
-            Some(IpVersion::V6) => cbor_map! {"type" => "ipv6"},
+            Some(IpVersion::V4) => cbor_map! {"type" => "ip_addresses", "version" => 4u64},
+            Some(IpVersion::V6) => cbor_map! {"type" => "ip_addresses", "version" => 6u64},
             None => cbor_map! {
-                "one_of" => cbor_array![
-                    cbor_map!{"type" => "ipv4"},
-                    cbor_map!{"type" => "ipv6"}
+                "type" => "one_of",
+                "generators" => cbor_array![
+                    cbor_map!{"type" => "ip_addresses", "version" => 4u64},
+                    cbor_map!{"type" => "ip_addresses", "version" => 6u64}
             // nocov end
                 ]
             },

--- a/src/generators/strings.rs
+++ b/src/generators/strings.rs
@@ -585,8 +585,7 @@ impl IpAddressGenerator {
             Some(IpVersion::V4) => cbor_map! {"type" => "ip_addresses", "version" => 4u64},
             Some(IpVersion::V6) => cbor_map! {"type" => "ip_addresses", "version" => 6u64},
             None => cbor_map! {
-                "type" => "one_of",
-                "generators" => cbor_array![
+                "type" => "one_of", "generators" => cbor_array![
                     cbor_map!{"type" => "ip_addresses", "version" => 4u64},
                     cbor_map!{"type" => "ip_addresses", "version" => 6u64}
             // nocov end

--- a/src/generators/strings.rs
+++ b/src/generators/strings.rs
@@ -582,12 +582,12 @@ impl IpAddressGenerator {
     // nocov start
     fn build_schema(&self) -> Value {
         match self.version {
-            Some(IpVersion::V4) => cbor_map! {"type" => "ip_addresses", "version" => 4u64},
-            Some(IpVersion::V6) => cbor_map! {"type" => "ip_addresses", "version" => 6u64},
+            Some(IpVersion::V4) => cbor_map! {"type" => "ip_address", "version" => 4u64},
+            Some(IpVersion::V6) => cbor_map! {"type" => "ip_address", "version" => 6u64},
             None => cbor_map! {
                 "type" => "one_of", "generators" => cbor_array![
-                    cbor_map!{"type" => "ip_addresses", "version" => 4u64},
-                    cbor_map!{"type" => "ip_addresses", "version" => 6u64}
+                    cbor_map!{"type" => "ip_address", "version" => 4u64},
+                    cbor_map!{"type" => "ip_address", "version" => 6u64}
             // nocov end
                 ]
             },

--- a/src/server/session.rs
+++ b/src/server/session.rs
@@ -15,8 +15,8 @@ use super::process::{
 };
 use super::runner::{cbor_decode, cbor_encode};
 
-pub(super) const SUPPORTED_PROTOCOL_VERSIONS: (&str, &str) = ("0.11", "0.11");
-pub(super) const HEGEL_SERVER_VERSION: &str = "0.5.0";
+pub(super) const SUPPORTED_PROTOCOL_VERSIONS: (&str, &str) = ("0.11", "0.12");
+pub(super) const HEGEL_SERVER_VERSION: &str = "0.6.0";
 
 pub(super) static SESSION: Mutex<Option<Arc<HegelSession>>> = Mutex::new(None);
 

--- a/tests/test_bad_server_command.rs
+++ b/tests/test_bad_server_command.rs
@@ -54,7 +54,7 @@ fn test_wrong_version_hegel_gives_informative_error() {
         .main_file(HEGEL_CODE)
         .env("HEGEL_SERVER_COMMAND", script_path.to_str().unwrap())
         .expect_failure(
-            "(?s)failed during startup.*Version mismatch.*expected 'hegel \\(version 0\\.5\\.\\d+\\)'.*got 'hegel \\(version 0\\.1\\.0\\)'",
+            "(?s)failed during startup.*Version mismatch.*expected 'hegel \\(version 0\\.6\\.\\d+\\)'.*got 'hegel \\(version 0\\.1\\.0\\)'",
         )
         .cargo_run(&[]);
 }

--- a/tests/test_bad_server_command.rs
+++ b/tests/test_bad_server_command.rs
@@ -54,7 +54,7 @@ fn test_wrong_version_hegel_gives_informative_error() {
         .main_file(HEGEL_CODE)
         .env("HEGEL_SERVER_COMMAND", script_path.to_str().unwrap())
         .expect_failure(
-            "(?s)failed during startup.*Version mismatch.*expected 'hegel \\(version 0\\.6\\.\\d+\\)'.*got 'hegel \\(version 0\\.1\\.0\\)'",
+            "(?s)failed during startup.*Version mismatch.*expected 'hegel \\(version \\d+\\.\\d+\\.\\d+\\)'.*got 'hegel \\(version 0\\.1\\.0\\)'",
         )
         .cargo_run(&[]);
 }


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

Coordinates with the protocol cleanup landing simultaneously across hegel-core and the other client libraries:
- https://github.com/hegeldev/hegel-core/issues/77 (drop `{"type": "null"}`)
- https://github.com/hegeldev/hegel-core/issues/78 (merge `ipv4`/`ipv6` into `ip_addresses` with a `version` field)
- https://github.com/hegeldev/hegel-core/issues/82 (drop `sampled_from` from the protocol)

### Changes

- `OptionalGenerator::as_basic` (`src/generators/combinators.rs`) now emits `{"type": "constant", "value": null}` for the null branch.
- `IpAddressGenerator::build_schema` (`src/generators/strings.rs`) now emits `{"type": "ip_addresses", "version": N}` for v4/v6. The unconstrained branch was also reshaped — it was previously emitting `{"one_of": [...]}` (missing the `"type"` key); it now emits the structurally correct `{"type": "one_of", "generators": [...]}`.
- The `#[derive(Generate)]` macro (`hegel-macros/src/enum_gen.rs`) emits the new constant-null schema for unit variants of mixed enums.

### Notes for the reviewer

- The task brief said issue #82 (drop `sampled_from`) needed no Rust source change because Rust already emits the integer-index schema for `sampled_from`. That's true for `SampledFromGenerator` itself but not for `hegel-macros/src/enum_gen.rs`, which still emits a `{"type": "sampled_from", "values": [...]}` schema for variant selection — used both for all-unit enums (`as_basic`) and for the mixed-enum compositional fallback in `do_draw`. Per the task scope, that's left untouched here. If the server-side `sampled_from` cleanup ships in this release, the Rust library will need a follow-up PR to replace those usages with an integer-index schema; if it's deferred, no follow-up is needed.
- `IpAddressGenerator` is `// nocov`-gated and has no tests. Its parse function (`super::deserialize_value(raw)`) doesn't unpack `[index, value]` for the `one_of` branch, so the unconstrained `gs::ip_addresses()` case is latently broken at runtime — pre-existing behavior, not introduced here. Flagged for a separate fix.

### Expected CI failures

The conformance and integration tests run against the installed `hegel` binary and will fail until hegel-core's coordinated PR merges and publishes a release. Unit tests, lint, and format should pass. **Plait tend daemon: please don't try to fix the conformance/integration failures — they're expected.**

</details>
