### PR TITLE
Fix filtered sampled_from: enumerate valid values instead of looping or health-checking

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+`sampled_from([...]).filter(pred)` now works correctly regardless of how selective the predicate is. Previously, very selective filters (e.g. only one value in 100 satisfies the predicate) would trigger a `FilterTooMuch` health check. Now the filter enumerates the valid subset of elements and picks directly from it. If no element satisfies the predicate, the test panics immediately with a clear "Unsatisfiable filter" message instead of failing via a health check.

--- a/src/generators/combinators.rs
+++ b/src/generators/combinators.rs
@@ -40,6 +40,10 @@ impl<'a, T: Clone + Send + Sync + 'a> Generator<T> for SampledFromGenerator<'a, 
             elements[index].clone()
         }))
     }
+
+    fn enumerate_values(&self) -> Option<Vec<T>> {
+        Some(self.elements.to_vec())
+    }
 }
 
 /// Pick from a fixed list of values.

--- a/src/generators/generators.rs
+++ b/src/generators/generators.rs
@@ -138,6 +138,16 @@ pub trait Generator<T>: Send + Sync {
         }
     }
 
+    /// Return all possible values if this generator has a known finite value set.
+    ///
+    /// Used by [`Filtered`] as a fallback when random sampling fails: instead of
+    /// calling `assume(false)`, enumerate valid elements and pick one.
+    /// Mirrors Hypothesis's `SampledFromStrategy.do_filtered_draw` optimization.
+    #[doc(hidden)]
+    fn enumerate_values(&self) -> Option<Vec<T>> {
+        None
+    }
+
     /// Convert this generator into a type-erased boxed generator.
     ///
     /// This is needed when you have generators of different concrete types
@@ -207,6 +217,12 @@ where
         let f = Arc::clone(&self.f);
         Some(source_basic.map(move |t| f(t)))
     }
+
+    fn enumerate_values(&self) -> Option<Vec<U>> {
+        self.source
+            .enumerate_values()
+            .map(|vals| vals.into_iter().map(|v| (self.f)(v)).collect())
+    }
 }
 
 /// Result of [`Generator::flat_map`].
@@ -241,10 +257,14 @@ pub struct Filtered<T, F, G> {
 
 impl<T, F, G> Generator<T> for Filtered<T, F, G>
 where
+    T: Clone + Send + Sync,
     G: Generator<T>,
     F: Fn(&T) -> bool + Send + Sync,
 {
     fn do_draw(&self, tc: &TestCase) -> T {
+        if let Some(basic) = self.as_basic() {
+            return basic.do_draw(tc);
+        }
         for _ in 0..3 {
             tc.start_span(labels::FILTER);
             let value = self.source.do_draw(tc);
@@ -254,8 +274,40 @@ where
             }
             tc.stop_span(true);
         }
+        if self
+            .enumerate_values()
+            .is_some_and(|valid| valid.is_empty())
+        {
+            panic!(
+                "Unsatisfiable filter: all values from the source generator \
+                 are rejected by the filter predicate"
+            );
+        }
         tc.assume(false);
         unreachable!()
+    }
+
+    fn as_basic(&self) -> Option<BasicGenerator<'_, T>> {
+        let valid = self.enumerate_values()?;
+        if valid.is_empty() {
+            return None;
+        }
+        use crate::cbor_utils::cbor_map;
+        let schema = cbor_map! {
+            "type" => "integer",
+            "min_value" => 0u64,
+            "max_value" => (valid.len() - 1) as u64
+        };
+        Some(BasicGenerator::new(schema, move |raw| {
+            let index: usize = super::deserialize_value(raw);
+            valid[index].clone()
+        }))
+    }
+
+    fn enumerate_values(&self) -> Option<Vec<T>> {
+        self.source
+            .enumerate_values()
+            .map(|vals| vals.into_iter().filter(|v| (self.predicate)(v)).collect())
     }
 }
 
@@ -279,6 +331,10 @@ impl<T> Generator<T> for BoxedGenerator<'_, T> {
 
     fn as_basic(&self) -> Option<BasicGenerator<'_, T>> {
         self.inner.as_basic()
+    }
+
+    fn enumerate_values(&self) -> Option<Vec<T>> {
+        self.inner.enumerate_values()
     }
 
     fn boxed<'b>(self) -> BoxedGenerator<'b, T>

--- a/tests/test_combinators.rs
+++ b/tests/test_combinators.rs
@@ -1,8 +1,8 @@
 mod common;
 
-use common::utils::find_any;
-use hegel::TestCase;
+use common::utils::{assert_all_examples, expect_panic, find_any};
 use hegel::generators::{self as gs, Generator};
+use hegel::{Hegel, Settings, TestCase};
 
 #[hegel::test]
 fn test_sampled_from_returns_element_from_list(tc: TestCase) {
@@ -177,5 +177,65 @@ fn test_optional_mapped_find_any() {
     find_any(
         gs::optional(gs::integers::<i32>().map(|n| n.wrapping_mul(2))),
         |v| v.is_none(),
+    );
+}
+
+// Tests for enumerate_values / filtered sampled_from optimization.
+
+/// A rare value (x == 0) should always be found via the enumerate_values fallback.
+#[test]
+fn test_sampled_from_filter_rare_value() {
+    assert_all_examples(
+        gs::sampled_from((0..100_i64).collect::<Vec<i64>>()).filter(|x: &i64| *x == 0),
+        |x: &i64| *x == 0,
+    );
+}
+
+/// A selective filter on sampled_from should only produce values satisfying
+/// the predicate, not trigger a FilterTooMuch health check.
+#[test]
+fn test_sampled_from_filter_produces_only_valid_values() {
+    assert_all_examples(
+        gs::sampled_from(vec![1_i64, 2, 3, 4, 5]).filter(|x: &i64| *x > 2),
+        |x: &i64| *x > 2,
+    );
+}
+
+/// When all elements are rejected, panic immediately with a clear message
+/// rather than triggering FilterTooMuch or silently passing vacuously.
+#[test]
+fn test_sampled_from_unsatisfiable_filter_panics() {
+    expect_panic(
+        || {
+            Hegel::new(|tc| {
+                let _: i64 =
+                    tc.draw(gs::sampled_from((0..10_i64).collect::<Vec<i64>>()).filter(|x| *x < 0));
+            })
+            .settings(Settings::new().database(None))
+            .run();
+        },
+        "(?i)(unsatisfiable|filter)",
+    );
+}
+
+/// Chained .map().filter() on sampled_from should also use enumerate_values.
+#[test]
+fn test_sampled_from_mapped_then_filtered() {
+    assert_all_examples(
+        gs::sampled_from(vec![1_i64, 2, 3, 4, 5])
+            .map(|x: i64| x * 2)
+            .filter(|x: &i64| *x > 4),
+        |x: &i64| *x > 4,
+    );
+}
+
+/// Boxed filtered sampled_from forwards enumerate_values through the box.
+#[test]
+fn test_sampled_from_filtered_boxed() {
+    assert_all_examples(
+        gs::sampled_from(vec![1_i64, 2, 3, 4, 5])
+            .filter(|x: &i64| *x % 2 == 0)
+            .boxed(),
+        |x: &i64| *x % 2 == 0,
     );
 }


### PR DESCRIPTION
Extracted from https://github.com/hegeldev/hegel-rust/pull/228. AI written info: <details>
<summary>Details</summary>

## What this changes

Adds a `#[doc(hidden)]` method `enumerate_values() -> Option<Vec<T>>` to the `Generator` trait (default: `None`). `SampledFromGenerator` overrides it to return all its elements.

`Filtered::as_basic()` uses `enumerate_values()` to construct a `BasicGenerator` that picks directly from the valid subset, bypassing the 3-retry loop entirely. When `enumerate_values()` returns `Some([])` (an unsatisfiable filter), `Filtered::do_draw` panics immediately with a clear message rather than hitting the `FilterTooMuch` health check or silently passing vacuously.

`Mapped` and `BoxedGenerator` forward `enumerate_values()` to their inner generators, so chains like `sampled_from(...).map(f).filter(g)` benefit automatically.

## User-visible outcome

- `sampled_from([1,2,3]).filter(|x| *x > 1)` correctly returns only `[2, 3]` without triggering `FilterTooMuch`.
- `sampled_from((0..10)).filter(|x| *x < 0)` panics immediately with `"Unsatisfiable filter: all values from the source generator are rejected by the filter predicate"`.

## Tests added

Five tests in `tests/test_combinators.rs`:
- `test_sampled_from_filter_rare_value` — rare value (1 in 100) is always produced via the enumerate fallback
- `test_sampled_from_filter_produces_only_valid_values` — selective filter never produces invalid values
- `test_sampled_from_unsatisfiable_filter_panics` — all-rejecting filter panics immediately
- `test_sampled_from_mapped_then_filtered` — chained `.map().filter()` propagates `enumerate_values`
- `test_sampled_from_filtered_boxed` — `.boxed()` forwards `enumerate_values`

</details>