### PR TITLE
Fix unique vecs producing duplicates when element generator is sampled_from

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch fixes `vecs(...).unique(true)` producing duplicate elements when the element generator is `sampled_from`. The server-side uniqueness check was enforcing index-level uniqueness (distinct indices into the pool), not value-level uniqueness, so pools with repeated values could produce duplicates. Unique vecs now always use the client-side uniqueness path that checks actual values.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-This patch fixes `vecs(...).unique(true)` producing duplicate elements when the element generator is `sampled_from`. The server-side uniqueness check was enforcing index-level uniqueness (distinct indices into the pool), not value-level uniqueness, so pools with repeated values could produce duplicates. Unique vecs now always use the client-side uniqueness path that checks actual values.
+This patch fixes `gs::vecs(gs::sampled_from(...)).unique(true)` sometimes producing duplicate elements.

--- a/src/generators/collections.rs
+++ b/src/generators/collections.rs
@@ -74,11 +74,14 @@ where
         if let Some(max) = self.max_size {
             assert!(self.min_size <= max, "Cannot have max_size < min_size");
         }
+        if self.unique_by.is_some() {
+            return None;
+        }
         let basic = self.elements.as_basic()?;
 
         let mut schema = cbor_map! {
             "type" => "list",
-            "unique" => self.unique_by.is_some(),
+            "unique" => false,
             "elements" => basic.schema().clone(),
             "min_size" => self.min_size as u64
         };

--- a/tests/test_collections.rs
+++ b/tests/test_collections.rs
@@ -284,6 +284,19 @@ fn test_vec_non_basic_generator_with_max_size(tc: TestCase) {
     assert!(vec.len() <= 5);
 }
 
+// Regression test: vecs(sampled_from).unique(true) must check value-level uniqueness.
+// Before the fix, as_basic() sent "unique":true to the server, which enforced index-level
+// uniqueness (distinct sampled_from indices), not value-level uniqueness. For a pool of
+// 100 copies of the same value, distinct indices still map to the same value, producing
+// duplicates. The fix makes as_basic() return None when unique_by is set, routing through
+// the non-basic Collection path that checks actual T values.
+#[hegel::test]
+fn test_vec_unique_sampled_from_no_duplicates(tc: TestCase) {
+    let vec: Vec<i64> = tc.draw(gs::vecs(gs::sampled_from(vec![0_i64; 100])).unique(true));
+    // All elements are 0, so a unique vec can have at most 1 element.
+    assert!(vec.len() <= 1);
+}
+
 #[test]
 fn test_vec_unique_requires_partial_eq() {
     TempRustProject::new()


### PR DESCRIPTION
Extracted from https://github.com/hegeldev/hegel-rust/pull/228. AI written info: <details>
<summary>Details</summary>

`VecGenerator::as_basic()` was sending a list schema with `"unique": true` to the server, which enforced uniqueness on raw CBOR values (indices for `sampled_from`), not on actual parsed values. For `sampled_from(vec![0; 100])`, distinct indices 5 and 42 both map to value `0`, so the server's uniqueness check passes while the resulting vec contains duplicates.

The fix makes `as_basic()` return `None` when `unique_by` is set, forcing the non-basic `Collection` path where uniqueness is checked on actual `T` values after parsing. The `"unique": false` change is safe because the fast path only runs when `unique_by` is `None`.

A regression test `test_vec_unique_sampled_from_no_duplicates` in `tests/test_collections.rs` verifies that `vecs(sampled_from(vec![0; 100])).unique(true)` never produces a vec with more than 1 element (since all 100 elements are equal, a truly unique vec can hold at most one of them).
</details>