### PR TITLE
Add gs::nan_floats() generator for NaN-specific float generation

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
-RELEASE_TYPE: patch
+RELEASE_TYPE: minor
 
-This patch bumps the minimum supported protocol version to take into account recent changes to `one_of`.
+This release adds `gs::nan_floats()`, a generator for NaN `f64` values with varied sign bits and mantissa bit-patterns. This is a port of Hypothesis's `NanStrategy` and is useful for tests that need to distinguish between different NaN variants.

--- a/src/generators/mod.rs
+++ b/src/generators/mod.rs
@@ -49,7 +49,10 @@ pub use deferred::{DeferredGeneratorDefinition, deferred};
 pub use generators::BasicGenerator;
 pub use generators::{BoxedGenerator, Filtered, FlatMapped, Generator, Mapped};
 pub use misc::{BoolGenerator, JustGenerator, booleans, just, unit};
-pub use numeric::{Float, FloatGenerator, Integer, IntegerGenerator, floats, integers};
+pub use numeric::{
+    Float, FloatGenerator, Integer, IntegerGenerator, NanFloatGenerator, floats, integers,
+    nan_floats,
+};
 pub use strings::{
     BinaryGenerator, CharactersGenerator, DateGenerator, DateTimeGenerator, DomainGenerator,
     EmailGenerator, IpAddressGenerator, RegexGenerator, TextGenerator, TimeGenerator, UrlGenerator,

--- a/src/generators/numeric.rs
+++ b/src/generators/numeric.rs
@@ -254,3 +254,37 @@ pub fn floats<T: Float + serde::de::DeserializeOwned + serde::Serialize + Send +
         allow_infinity: None,
     }
 }
+
+/// Generator for NaN `f64` values. Created by [`nan_floats()`].
+///
+/// Port of Hypothesis's `NanStrategy`, the strategy that `filter_rewriting`
+/// substitutes for `floats().filter(math.isnan)`. Emits a mix of sign bits
+/// and mantissa bit-patterns so all four (positive/negative × math.nan /
+/// other-bit-pattern) variants are routinely reachable.
+pub struct NanFloatGenerator;
+
+impl Generator<f64> for NanFloatGenerator {
+    fn do_draw(&self, tc: &TestCase) -> f64 {
+        // Match hypothesis/strategies/_internal/numbers.py::NanStrategy:
+        // sign bit, then 52-bit mantissa. The base `nan_bits` already has
+        // the quiet bit set, so the ORed result is always a valid NaN.
+        let sign: bool = tc.draw_silent(super::booleans());
+        let mantissa: i64 = tc.draw_silent(
+            super::integers::<i64>()
+                .min_value(0)
+                .max_value((1i64 << 52) - 1),
+        );
+        let sign_bit = u64::from(sign) << 63;
+        let nan_bits = f64::NAN.to_bits();
+        f64::from_bits(sign_bit | nan_bits | (mantissa as u64))
+    }
+}
+
+/// Generate NaN `f64` values with a mix of sign and mantissa bit-patterns.
+///
+/// Intended for tests that need to distinguish NaN variants (e.g. finding
+/// a negative NaN or a NaN whose bit-pattern differs from `f64::NAN`'s).
+/// For generic floats use [`floats()`].
+pub fn nan_floats() -> NanFloatGenerator {
+    NanFloatGenerator
+}

--- a/tests/test_floats.rs
+++ b/tests/test_floats.rs
@@ -156,3 +156,40 @@ mod f64_tests {
     use super::*;
     float_tests!(f64);
 }
+
+mod nan_float_tests {
+    use super::*;
+
+    #[test]
+    fn always_nan() {
+        assert_all_examples(gs::nan_floats(), |n: &f64| n.is_nan());
+    }
+
+    #[test]
+    fn can_find_positive_quiet_nan() {
+        find_any(gs::nan_floats(), |n: &f64| {
+            n.is_sign_positive() && n.abs().to_bits() == f64::NAN.to_bits()
+        });
+    }
+
+    #[test]
+    fn can_find_negative_quiet_nan() {
+        find_any(gs::nan_floats(), |n: &f64| {
+            n.is_sign_negative() && n.abs().to_bits() == f64::NAN.to_bits()
+        });
+    }
+
+    #[test]
+    fn can_find_positive_signaling_nan() {
+        find_any(gs::nan_floats(), |n: &f64| {
+            n.is_sign_positive() && n.abs().to_bits() != f64::NAN.to_bits()
+        });
+    }
+
+    #[test]
+    fn can_find_negative_signaling_nan() {
+        find_any(gs::nan_floats(), |n: &f64| {
+            n.is_sign_negative() && n.abs().to_bits() != f64::NAN.to_bits()
+        });
+    }
+}


### PR DESCRIPTION
Extracted from https://github.com/hegeldev/hegel-rust/pull/228. AI written info: <details>
<summary>Details</summary>

Adds a `NanFloatGenerator` struct and `gs::nan_floats()` factory function to `src/generators/numeric.rs`, exported via `src/generators/mod.rs`.

This is a port of Hypothesis's `NanStrategy`: it draws a sign bit (boolean) and a 52-bit mantissa (integer in `[0, 2^52 - 1]`), then ORs them together with `f64::NAN.to_bits()` (which has the quiet bit set). The result is always a valid NaN, and all four variants (positive/negative × quiet/signaling) are routinely reachable within a small number of draws.

**Why this is useful**: `gs::floats()` with default settings can generate NaN, but only rarely — the probability of hitting a specific bit-pattern variant is low. `nan_floats()` is intended for tests that specifically need NaN values and want to distinguish variants (e.g. finding a negative NaN or a NaN with a non-standard mantissa).

**Tests added** in `tests/test_floats.rs`:
- `always_nan`: property test asserting all values from `nan_floats()` are NaN
- `can_find_positive_quiet_nan`, `can_find_negative_quiet_nan`, `can_find_positive_signaling_nan`, `can_find_negative_signaling_nan`: four find-any tests covering all (sign × mantissa-pattern) variants
</details>