### PR TITLE
Add Phase enum and Settings::phases() API

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,4 +2,4 @@ RELEASE_TYPE: minor
 
 This release adds the `Phase` enum and `Settings::phases()` API, allowing
 callers to control which test lifecycle phases run. The default phase set
-(`Reuse`, `Generate`, `Target`, `Shrink`) matches Hypothesis's defaults.
+is `Explicit`, `Reuse`, `Generate`, `Target`, and `Shrink`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+This release adds the `Phase` enum and `Settings::phases()` API, allowing
+callers to control which test lifecycle phases run. The default phase set
+(`Reuse`, `Generate`, `Target`, `Shrink`) matches Hypothesis's defaults.

--- a/hegel-macros/src/hegel_main.rs
+++ b/hegel-macros/src/hegel_main.rs
@@ -93,7 +93,7 @@ pub fn expand_main(attr: TokenStream, item: TokenStream) -> TokenStream {
                 }
             };
 
-            if __hegel_settings.phases.contains(&hegel::Phase::Explicit) {
+            if __hegel_settings.has_phase(hegel::Phase::Explicit) {
                 #(#explicit_blocks)*
             }
 

--- a/hegel-macros/src/hegel_main.rs
+++ b/hegel-macros/src/hegel_main.rs
@@ -93,7 +93,9 @@ pub fn expand_main(attr: TokenStream, item: TokenStream) -> TokenStream {
                 }
             };
 
-            #(#explicit_blocks)*
+            if __hegel_settings.phases.contains(&hegel::Phase::Explicit) {
+                #(#explicit_blocks)*
+            }
 
             hegel::Hegel::new(|#param_pat: #param_ty| #body)
             .settings(__hegel_settings)

--- a/hegel-macros/src/hegel_test.rs
+++ b/hegel-macros/src/hegel_test.rs
@@ -78,7 +78,7 @@ pub fn expand_test(attr: TokenStream, item: TokenStream) -> TokenStream {
     let new_body: TokenStream = quote! {
         {
             let __hegel_settings = #settings_expr;
-            if __hegel_settings.phases.contains(&hegel::Phase::Explicit) {
+            if __hegel_settings.has_phase(hegel::Phase::Explicit) {
                 #(#explicit_blocks)*
             }
 

--- a/hegel-macros/src/hegel_test.rs
+++ b/hegel-macros/src/hegel_test.rs
@@ -77,10 +77,13 @@ pub fn expand_test(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let new_body: TokenStream = quote! {
         {
-            #(#explicit_blocks)*
+            let __hegel_settings = #settings_expr;
+            if __hegel_settings.phases.contains(&hegel::Phase::Explicit) {
+                #(#explicit_blocks)*
+            }
 
             hegel::Hegel::new(|#param_pat: #param_ty| #body)
-            .settings(#settings_expr)
+            .settings(__hegel_settings)
             .__database_key(format!("{}::{}", module_path!(), #test_name))
             .test_location(hegel::TestLocation {
                 function: #test_name.to_string(),

--- a/hegel-macros/src/standalone_function.rs
+++ b/hegel-macros/src/standalone_function.rs
@@ -89,10 +89,13 @@ pub fn expand_standalone_function(attr: TokenStream, item: TokenStream) -> Token
 
     let new_body: TokenStream = quote! {
         {
-            #(#explicit_blocks)*
+            let __hegel_settings = #settings_expr;
+            if __hegel_settings.phases.contains(&hegel::Phase::Explicit) {
+                #(#explicit_blocks)*
+            }
 
             hegel::Hegel::new(move |#tc_pat: #tc_ty| #body)
-            .settings(#settings_expr)
+            .settings(__hegel_settings)
             .__database_key(format!("{}::{}", module_path!(), #fn_name))
             .test_location(hegel::TestLocation {
                 function: #fn_name.to_string(),

--- a/hegel-macros/src/standalone_function.rs
+++ b/hegel-macros/src/standalone_function.rs
@@ -90,7 +90,7 @@ pub fn expand_standalone_function(attr: TokenStream, item: TokenStream) -> Token
     let new_body: TokenStream = quote! {
         {
             let __hegel_settings = #settings_expr;
-            if __hegel_settings.phases.contains(&hegel::Phase::Explicit) {
+            if __hegel_settings.has_phase(hegel::Phase::Explicit) {
                 #(#explicit_blocks)*
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,7 +420,7 @@ pub use cli::CliOutcome;
 pub use cli::apply_cli_args as __apply_cli_args;
 #[doc(hidden)]
 pub use runner::hegel;
-pub use runner::{HealthCheck, Hegel, Mode, Settings, Verbosity};
+pub use runner::{HealthCheck, Hegel, Mode, Phase, Settings, Verbosity};
 #[doc(hidden)]
 pub use server::process::__test_kill_server;
 #[doc(hidden)]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -124,7 +124,13 @@ impl Settings {
                 Database::Unset // nocov
             },
             suppress_health_check: Vec::new(),
-            phases: vec![Phase::Explicit, Phase::Reuse, Phase::Generate, Phase::Target, Phase::Shrink],
+            phases: vec![
+                Phase::Explicit,
+                Phase::Reuse,
+                Phase::Generate,
+                Phase::Target,
+                Phase::Shrink,
+            ],
         }
     }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -124,7 +124,7 @@ impl Settings {
                 Database::Unset // nocov
             },
             suppress_health_check: Vec::new(),
-            phases: vec![Phase::Reuse, Phase::Generate, Phase::Target, Phase::Shrink],
+            phases: vec![Phase::Explicit, Phase::Reuse, Phase::Generate, Phase::Target, Phase::Shrink],
         }
     }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -42,6 +42,30 @@ impl HealthCheck {
     }
 }
 
+/// Controls which phases of the test lifecycle are executed.
+///
+/// By default, all phases run. Use [`Settings::phases`] to restrict which
+/// phases execute — for example, passing only `[Phase::Generate]` disables
+/// shrinking, which is useful when you only need to find a counterexample
+/// quickly and don't need the minimal one.
+///
+/// Corresponds directly to `hypothesis.Phase`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Phase {
+    /// Replay explicit examples (e.g. from `@example` in Python).
+    Explicit,
+    /// Replay examples from the failure database.
+    Reuse,
+    /// Generate new random examples.
+    Generate,
+    /// Use targeting to guide generation toward interesting areas.
+    Target,
+    /// Shrink failing examples to a minimal counterexample.
+    Shrink,
+    /// Attempt to explain the failure after shrinking.
+    Explain,
+}
+
 /// Controls the test execution mode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Mode {
@@ -82,6 +106,7 @@ pub struct Settings {
     pub(crate) derandomize: bool,
     pub(crate) database: Database,
     pub(crate) suppress_health_check: Vec<HealthCheck>,
+    pub(crate) phases: Vec<Phase>,
 }
 
 impl Settings {
@@ -100,6 +125,12 @@ impl Settings {
                 Database::Unset // nocov
             },
             suppress_health_check: Vec::new(),
+            phases: vec![
+                Phase::Reuse,
+                Phase::Generate,
+                Phase::Target,
+                Phase::Shrink,
+            ],
         }
     }
 
@@ -161,6 +192,21 @@ impl Settings {
     /// ```
     pub fn suppress_health_check(mut self, checks: impl IntoIterator<Item = HealthCheck>) -> Self {
         self.suppress_health_check.extend(checks);
+        self
+    }
+
+    /// Set which phases of the test lifecycle to run.
+    ///
+    /// By default all phases are enabled. Pass a subset to disable specific
+    /// phases — for example, omitting [`Phase::Shrink`] skips shrinking:
+    ///
+    /// ```no_run
+    /// use hegel::{Phase, Settings};
+    ///
+    /// let settings = Settings::new().phases([Phase::Reuse, Phase::Generate]);
+    /// ```
+    pub fn phases(mut self, phases: impl IntoIterator<Item = Phase>) -> Self {
+        self.phases = phases.into_iter().collect();
         self
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -125,12 +125,7 @@ impl Settings {
                 Database::Unset // nocov
             },
             suppress_health_check: Vec::new(),
-            phases: vec![
-                Phase::Reuse,
-                Phase::Generate,
-                Phase::Target,
-                Phase::Shrink,
-            ],
+            phases: vec![Phase::Reuse, Phase::Generate, Phase::Target, Phase::Shrink],
         }
     }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -49,7 +49,8 @@ impl HealthCheck {
 /// shrinking, which is useful when you only need to find a counterexample
 /// quickly and don't need the minimal one.
 ///
-/// Corresponds directly to `hypothesis.Phase`.
+/// Corresponds to a subset of `hypothesis.Phase` (the `explain` phase is not
+/// yet supported in hegel-rust).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Phase {
     /// Replay explicit examples (e.g. from `@example` in Python).
@@ -62,8 +63,6 @@ pub enum Phase {
     Target,
     /// Shrink failing examples to a minimal counterexample.
     Shrink,
-    /// Attempt to explain the failure after shrinking.
-    Explain,
 }
 
 /// Controls the test execution mode.

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -203,6 +203,11 @@ impl Settings {
         self.phases = phases.into_iter().collect();
         self
     }
+
+    /// Returns `true` if the given phase is enabled in these settings.
+    pub fn has_phase(&self, phase: Phase) -> bool {
+        self.phases.contains(&phase)
+    }
 }
 
 impl Default for Settings {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -53,7 +53,7 @@ impl HealthCheck {
 /// yet supported in hegel-rust).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Phase {
-    /// Replay explicit examples (e.g. from `@example` in Python).
+    /// Run explicit test cases added via `#[hegel::explicit_test_case]`.
     Explicit,
     /// Replay examples from the failure database.
     Reuse,

--- a/src/server/runner.rs
+++ b/src/server/runner.rs
@@ -2,7 +2,7 @@ use crate::antithesis::TestLocation;
 use crate::antithesis::is_running_in_antithesis;
 use crate::backend::{DataSource, TestCaseResult, TestRunner};
 use crate::control::{currently_in_test_context, with_test_context};
-use crate::runner::{Mode, Settings};
+use crate::runner::{Mode, Phase, Settings};
 use crate::test_case::TestCase;
 use crate::test_case::{ASSUME_FAIL_STRING, LOOP_DONE_STRING, STOP_TEST_STRING};
 
@@ -268,6 +268,10 @@ pub fn server_run<F>(
     F: FnMut(TestCase),
 {
     init_panic_hook();
+
+    if !settings.phases.contains(&Phase::Generate) {
+        return;
+    }
 
     let runner = super::session::ServerTestRunner;
     let mut test_fn = test_fn;

--- a/src/server/session.rs
+++ b/src/server/session.rs
@@ -36,7 +36,6 @@ fn phase_as_str(phase: &Phase) -> &'static str {
         Phase::Generate => "generate",
         Phase::Target => "target",
         Phase::Shrink => "shrink",
-        Phase::Explain => "explain",
     }
 }
 

--- a/src/server/session.rs
+++ b/src/server/session.rs
@@ -16,7 +16,7 @@ use super::process::{
 use super::runner::{cbor_decode, cbor_encode};
 
 pub(super) const SUPPORTED_PROTOCOL_VERSIONS: (&str, &str) = ("0.12", "0.13");
-pub(super) const HEGEL_SERVER_VERSION: &str = "0.7.0";
+pub(super) const HEGEL_SERVER_VERSION: &str = "0.6.1";
 
 pub(super) static SESSION: Mutex<Option<Arc<HegelSession>>> = Mutex::new(None);
 

--- a/src/server/session.rs
+++ b/src/server/session.rs
@@ -29,13 +29,13 @@ fn health_check_as_str(check: &HealthCheck) -> &'static str {
     }
 }
 
-fn phase_as_str(phase: &Phase) -> Option<&'static str> {
+fn phase_as_str(phase: &Phase) -> &'static str {
     match phase {
-        Phase::Explicit => None, // handled locally; not forwarded to the server
-        Phase::Reuse => Some("reuse"),
-        Phase::Generate => Some("generate"),
-        Phase::Target => Some("target"),
-        Phase::Shrink => Some("shrink"),
+        Phase::Explicit => "explicit",
+        Phase::Reuse => "reuse",
+        Phase::Generate => "generate",
+        Phase::Target => "target",
+        Phase::Shrink => "shrink",
     }
 }
 
@@ -322,7 +322,7 @@ impl TestRunner for ServerTestRunner {
         let phase_names: Vec<Value> = settings
             .phases
             .iter()
-            .filter_map(|p| phase_as_str(p).map(|s| Value::Text(s.to_string())))
+            .map(|p| Value::Text(phase_as_str(p).to_string()))
             .collect();
         if let Value::Map(ref mut map) = run_test_msg {
             map.push((Value::Text("phases".to_string()), Value::Array(phase_names)));
@@ -344,6 +344,9 @@ impl TestRunner for ServerTestRunner {
         if verbosity == Verbosity::Debug {
             eprintln!("run_test response received");
         }
+
+        let shrink_enabled = settings.phases.contains(&Phase::Shrink);
+        let mut found_interesting = false;
 
         let result_data: Value;
         let ack_null = cbor_map! {"result" => Value::Null};
@@ -379,7 +382,14 @@ impl TestRunner for ServerTestRunner {
                         test_case_stream,
                         verbosity,
                     ));
-                    run_case(backend, false);
+                    if !shrink_enabled && found_interesting {
+                        backend.mark_complete("VALID", None);
+                    } else {
+                        let result = run_case(backend, false);
+                        if matches!(result, TestCaseResult::Interesting { .. }) {
+                            found_interesting = true;
+                        }
+                    }
                 }
                 "test_done" => {
                     let ack_true = cbor_map! {"result" => true};

--- a/src/server/session.rs
+++ b/src/server/session.rs
@@ -29,13 +29,13 @@ fn health_check_as_str(check: &HealthCheck) -> &'static str {
     }
 }
 
-fn phase_as_str(phase: &Phase) -> &'static str {
+fn phase_as_str(phase: &Phase) -> Option<&'static str> {
     match phase {
-        Phase::Explicit => "explicit",
-        Phase::Reuse => "reuse",
-        Phase::Generate => "generate",
-        Phase::Target => "target",
-        Phase::Shrink => "shrink",
+        Phase::Explicit => None, // handled locally; not forwarded to the server
+        Phase::Reuse => Some("reuse"),
+        Phase::Generate => Some("generate"),
+        Phase::Target => Some("target"),
+        Phase::Shrink => Some("shrink"),
     }
 }
 
@@ -322,7 +322,7 @@ impl TestRunner for ServerTestRunner {
         let phase_names: Vec<Value> = settings
             .phases
             .iter()
-            .map(|p| Value::Text(phase_as_str(p).to_string()))
+            .filter_map(|p| phase_as_str(p).map(|s| Value::Text(s.to_string())))
             .collect();
         if let Value::Map(ref mut map) = run_test_msg {
             map.push((Value::Text("phases".to_string()), Value::Array(phase_names)));

--- a/src/server/session.rs
+++ b/src/server/session.rs
@@ -1,6 +1,6 @@
 use crate::backend::{DataSource, TestCaseResult, TestRunResult, TestRunner};
 use crate::cbor_utils::{as_bool, as_text, as_u64, cbor_map, map_get, map_insert};
-use crate::runner::{Database, HealthCheck, Mode, Settings, Verbosity};
+use crate::runner::{Database, HealthCheck, Mode, Phase, Settings, Verbosity};
 use crate::server::protocol::{Connection, HANDSHAKE_STRING, Stream};
 use ciborium::Value;
 
@@ -26,6 +26,17 @@ fn health_check_as_str(check: &HealthCheck) -> &'static str {
         HealthCheck::TooSlow => "too_slow",
         HealthCheck::TestCasesTooLarge => "test_cases_too_large",
         HealthCheck::LargeInitialTestCase => "large_initial_test_case",
+    }
+}
+
+fn phase_as_str(phase: &Phase) -> &'static str {
+    match phase {
+        Phase::Explicit => "explicit",
+        Phase::Reuse => "reuse",
+        Phase::Generate => "generate",
+        Phase::Target => "target",
+        Phase::Shrink => "shrink",
+        Phase::Explain => "explain",
     }
 }
 
@@ -308,6 +319,14 @@ impl TestRunner for ServerTestRunner {
                     Value::Array(suppress_names),
                 ));
             }
+        }
+        let phase_names: Vec<Value> = settings
+            .phases
+            .iter()
+            .map(|p| Value::Text(phase_as_str(p).to_string()))
+            .collect();
+        if let Value::Map(ref mut map) = run_test_msg {
+            map.push((Value::Text("phases".to_string()), Value::Array(phase_names)));
         }
 
         // The control stream is behind a Mutex because Stream requires &mut self.

--- a/src/server/session.rs
+++ b/src/server/session.rs
@@ -345,9 +345,6 @@ impl TestRunner for ServerTestRunner {
             eprintln!("run_test response received");
         }
 
-        let shrink_enabled = settings.phases.contains(&Phase::Shrink);
-        let mut found_interesting = false;
-
         let result_data: Value;
         let ack_null = cbor_map! {"result" => Value::Null};
         loop {
@@ -382,14 +379,7 @@ impl TestRunner for ServerTestRunner {
                         test_case_stream,
                         verbosity,
                     ));
-                    if !shrink_enabled && found_interesting {
-                        backend.mark_complete("VALID", None);
-                    } else {
-                        let result = run_case(backend, false);
-                        if matches!(result, TestCaseResult::Interesting { .. }) {
-                            found_interesting = true;
-                        }
-                    }
+                    run_case(backend, false);
                 }
                 "test_done" => {
                     let ack_true = cbor_map! {"result" => true};

--- a/tests/common/utils.rs
+++ b/tests/common/utils.rs
@@ -5,7 +5,7 @@ use std::panic::{UnwindSafe, catch_unwind};
 use std::sync::{Arc, Mutex};
 
 use hegel::generators::Generator;
-use hegel::{Hegel, Settings};
+use hegel::{Hegel, Phase, Settings};
 use regex::Regex;
 use std::fmt::Debug;
 
@@ -197,7 +197,12 @@ where
                     panic!("HEGEL_FOUND"); // Early exit marker
                 }
             })
-            .settings(Settings::new().test_cases(max_attempts))
+            .settings(
+                Settings::new()
+                    .test_cases(max_attempts)
+                    .database(None)
+                    .phases([Phase::Reuse, Phase::Generate]),
+            )
             .run();
         }));
 

--- a/tests/embedded/runner_tests.rs
+++ b/tests/embedded/runner_tests.rs
@@ -1,8 +1,15 @@
 use super::*;
+use crate::runner::Phase;
 
 #[test]
 fn test_settings_verbosity() {
     let _ = Settings::new().verbosity(Verbosity::Debug);
+}
+
+#[test]
+fn test_settings_phases() {
+    let s = Settings::new().phases([Phase::Explicit, Phase::Explain]);
+    assert_eq!(s.phases, vec![Phase::Explicit, Phase::Explain]);
 }
 
 #[test]

--- a/tests/embedded/runner_tests.rs
+++ b/tests/embedded/runner_tests.rs
@@ -8,8 +8,8 @@ fn test_settings_verbosity() {
 
 #[test]
 fn test_settings_phases() {
-    let s = Settings::new().phases([Phase::Explicit, Phase::Explain]);
-    assert_eq!(s.phases, vec![Phase::Explicit, Phase::Explain]);
+    let s = Settings::new().phases([Phase::Explicit, Phase::Generate]);
+    assert_eq!(s.phases, vec![Phase::Explicit, Phase::Generate]);
 }
 
 #[test]

--- a/tests/embedded/runner_tests.rs
+++ b/tests/embedded/runner_tests.rs
@@ -13,6 +13,15 @@ fn test_settings_phases() {
 }
 
 #[test]
+fn test_settings_has_phase() {
+    let s = Settings::new().phases([Phase::Generate, Phase::Shrink]);
+    assert!(s.has_phase(Phase::Generate));
+    assert!(s.has_phase(Phase::Shrink));
+    assert!(!s.has_phase(Phase::Reuse));
+    assert!(!s.has_phase(Phase::Explicit));
+}
+
+#[test]
 fn test_is_in_ci_some_expected_variant() {
     // Removing "CI" (a None-type entry) forces the iterator to continue and
     // evaluate the Some("true") entries such as TF_BUILD and GITHUB_ACTIONS,

--- a/tests/embedded/server/session_tests.rs
+++ b/tests/embedded/server/session_tests.rs
@@ -42,9 +42,9 @@ fn test_parse_version_empty_string() {
 
 #[test]
 fn test_phase_as_str_all_variants() {
-    assert_eq!(phase_as_str(&Phase::Explicit), None);
-    assert_eq!(phase_as_str(&Phase::Reuse), Some("reuse"));
-    assert_eq!(phase_as_str(&Phase::Generate), Some("generate"));
-    assert_eq!(phase_as_str(&Phase::Target), Some("target"));
-    assert_eq!(phase_as_str(&Phase::Shrink), Some("shrink"));
+    assert_eq!(phase_as_str(&Phase::Explicit), "explicit");
+    assert_eq!(phase_as_str(&Phase::Reuse), "reuse");
+    assert_eq!(phase_as_str(&Phase::Generate), "generate");
+    assert_eq!(phase_as_str(&Phase::Target), "target");
+    assert_eq!(phase_as_str(&Phase::Shrink), "shrink");
 }

--- a/tests/embedded/server/session_tests.rs
+++ b/tests/embedded/server/session_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::runner::Phase;
 
 #[test]
 fn test_parse_version_valid() {
@@ -37,4 +38,14 @@ fn test_parse_version_non_numeric_minor() {
 #[should_panic(expected = "expected 'major.minor' format")]
 fn test_parse_version_empty_string() {
     parse_version("");
+}
+
+#[test]
+fn test_phase_as_str_all_variants() {
+    assert_eq!(phase_as_str(&Phase::Explicit), "explicit");
+    assert_eq!(phase_as_str(&Phase::Reuse), "reuse");
+    assert_eq!(phase_as_str(&Phase::Generate), "generate");
+    assert_eq!(phase_as_str(&Phase::Target), "target");
+    assert_eq!(phase_as_str(&Phase::Shrink), "shrink");
+    assert_eq!(phase_as_str(&Phase::Explain), "explain");
 }

--- a/tests/embedded/server/session_tests.rs
+++ b/tests/embedded/server/session_tests.rs
@@ -42,9 +42,9 @@ fn test_parse_version_empty_string() {
 
 #[test]
 fn test_phase_as_str_all_variants() {
-    assert_eq!(phase_as_str(&Phase::Explicit), "explicit");
-    assert_eq!(phase_as_str(&Phase::Reuse), "reuse");
-    assert_eq!(phase_as_str(&Phase::Generate), "generate");
-    assert_eq!(phase_as_str(&Phase::Target), "target");
-    assert_eq!(phase_as_str(&Phase::Shrink), "shrink");
+    assert_eq!(phase_as_str(&Phase::Explicit), None);
+    assert_eq!(phase_as_str(&Phase::Reuse), Some("reuse"));
+    assert_eq!(phase_as_str(&Phase::Generate), Some("generate"));
+    assert_eq!(phase_as_str(&Phase::Target), Some("target"));
+    assert_eq!(phase_as_str(&Phase::Shrink), Some("shrink"));
 }

--- a/tests/embedded/server/session_tests.rs
+++ b/tests/embedded/server/session_tests.rs
@@ -47,5 +47,4 @@ fn test_phase_as_str_all_variants() {
     assert_eq!(phase_as_str(&Phase::Generate), "generate");
     assert_eq!(phase_as_str(&Phase::Target), "target");
     assert_eq!(phase_as_str(&Phase::Shrink), "shrink");
-    assert_eq!(phase_as_str(&Phase::Explain), "explain");
 }

--- a/tests/test_phases.rs
+++ b/tests/test_phases.rs
@@ -1,0 +1,158 @@
+//! Ported from hypothesis-python/tests/cover/test_phases.py
+
+mod common;
+
+use common::project::TempRustProject;
+use hegel::generators as gs;
+use hegel::{Phase, TestCase};
+
+// With phases=[Explicit], only the explicit test case runs.
+// The body asserts i == 11; only the explicit case (i=11) satisfies this.
+// Random generation would find values != 11 and fail, but it never runs.
+#[hegel::test(phases = [Phase::Explicit])]
+#[hegel::explicit_test_case(i = 11i32)]
+fn test_only_runs_explicit_examples(tc: TestCase) {
+    let i: i32 = tc.draw(gs::integers());
+    assert_eq!(i, 11);
+}
+
+// With phases not including Explicit, explicit cases are skipped.
+// The explicit case would fail at runtime (name mismatch: "hello_world" vs "b"),
+// but it is never run because Phase::Explicit is not in the phase list.
+#[hegel::test(test_cases = 5, phases = [Phase::Reuse, Phase::Generate])]
+#[hegel::explicit_test_case(hello_world = "hello world".to_string())]
+fn test_does_not_use_explicit_examples(tc: TestCase) {
+    let b: bool = tc.draw(gs::booleans());
+    let _ = b;
+}
+
+// With phases=[Reuse, Shrink] (no Generate) and no database, no test cases are
+// generated. The body would always panic, but it is never called.
+#[hegel::test(database = None, phases = [Phase::Reuse, Phase::Shrink])]
+fn test_this_would_fail_if_you_ran_it(tc: TestCase) {
+    let b: bool = tc.draw(gs::booleans());
+    let _ = b;
+    panic!("should not run");
+}
+
+// Disabling Phase::Shrink limits the number of interesting (failing) test case
+// calls to exactly 2: one when the failure is first found, one for the final replay.
+// With shrinking enabled, many more calls occur as Hypothesis minimises the example.
+#[test]
+fn test_phase_no_shrink_limits_interesting() {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let log_path = temp_dir.path().join("interesting.log");
+    let log_str = log_path.to_str().unwrap().replace('\\', "/");
+
+    let code = format!(
+        r#"
+use hegel::generators as gs;
+use std::io::Write;
+
+#[hegel::test(phases = [hegel::Phase::Generate])]
+fn test_no_shrink(tc: hegel::TestCase) {{
+    let n: i32 = tc.draw(gs::integers::<i32>().min_value(0).max_value(200));
+    if n > 100 {{
+        let mut f = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open("{log_str}")
+            .unwrap();
+        writeln!(f, "{{}}", n).unwrap();
+        panic!("too large: {{}}", n);
+    }}
+}}
+"#
+    );
+
+    TempRustProject::new()
+        .test_file("test_no_shrink.rs", &code)
+        .expect_failure("too large")
+        .cargo_test(&["test_no_shrink"]);
+
+    let interesting_count = std::fs::read_to_string(&log_path)
+        .map(|s| s.lines().count())
+        .unwrap_or(0);
+    assert_eq!(
+        interesting_count, 2,
+        "Expected exactly 2 interesting calls without shrinking, got {interesting_count}"
+    );
+}
+
+// Disabling Phase::Reuse means the database is not consulted, so a previously
+// saved failing example is not replayed as the first test case.
+#[test]
+fn test_phase_no_reuse_skips_db_replay() {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("database");
+    std::fs::create_dir_all(&db_path).unwrap();
+    let db_str = db_path.to_str().unwrap().replace('\\', "/");
+
+    let values_path = temp_dir.path().join("values");
+    std::fs::create_dir_all(&values_path).unwrap();
+    let values_str = values_path.to_str().unwrap().replace('\\', "/");
+
+    let make_code = |phases_attr: &str| {
+        format!(
+            r#"
+use hegel::generators as gs;
+use std::io::Write;
+
+fn record(n: i64) {{
+    let path = format!("{values_str}/log");
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .unwrap();
+    writeln!(f, "{{}}", n).unwrap();
+}}
+
+#[hegel::test(database = Some("{db_str}".to_string()){phases_attr})]
+fn test_reuse(tc: hegel::TestCase) {{
+    let n: i64 = tc.draw(gs::integers());
+    record(n);
+    assert!(n < 1_000_000);
+}}
+"#
+        )
+    };
+
+    // First run: populate the database with a saved failing example.
+    TempRustProject::new()
+        .test_file("test_reuse.rs", &make_code(""))
+        .expect_failure("Property test failed")
+        .cargo_test(&["test_reuse"]);
+
+    let shrunk_value: i64 = std::fs::read_to_string(values_path.join("log"))
+        .unwrap()
+        .lines()
+        .last()
+        .unwrap()
+        .parse()
+        .unwrap();
+    assert_eq!(shrunk_value, 1_000_000);
+
+    std::fs::remove_file(values_path.join("log")).unwrap();
+
+    // Second run: no Reuse phase — saved example should NOT be the first test case.
+    TempRustProject::new()
+        .test_file(
+            "test_reuse.rs",
+            &make_code(", phases = [hegel::Phase::Generate, hegel::Phase::Shrink]"),
+        )
+        .expect_failure("Property test failed")
+        .cargo_test(&["test_reuse"]);
+
+    let first_value: i64 = std::fs::read_to_string(values_path.join("log"))
+        .unwrap()
+        .lines()
+        .next()
+        .unwrap()
+        .parse()
+        .unwrap();
+    assert_ne!(
+        first_value, shrunk_value,
+        "Without Phase::Reuse, the saved example should not be the first test case"
+    );
+}

--- a/tests/test_phases.rs
+++ b/tests/test_phases.rs
@@ -1,16 +1,9 @@
 //! Ported from hypothesis-python/tests/cover/test_phases.py
-//!
-//! Tests asserting server-side phase enforcement (Reuse, Shrink, Generate
-//! skipping) are gated on `#[cfg(feature = "native")]` because hegel-core
-//! 0.6.1 does not yet forward the phases parameter to the engine.
-#![allow(unexpected_cfgs)]
 
 mod common;
 
 use hegel::generators as gs;
-use hegel::{Phase, Settings, TestCase};
-#[cfg(feature = "native")]
-use hegel::Hegel;
+use hegel::{Hegel, Phase, Settings, TestCase};
 
 // With phases not including Explicit, explicit cases are skipped.
 // The explicit case would fail at runtime (name mismatch: "hello_world" vs "b"),
@@ -20,6 +13,67 @@ use hegel::Hegel;
 fn test_does_not_use_explicit_examples(tc: TestCase) {
     let b: bool = tc.draw(gs::booleans());
     let _ = b;
+}
+
+// With phases=[Explicit] only, only the explicit case runs.
+// The body asserts i == 11, which would fail for any generated integer.
+// The test passes because the generate phase is disabled.
+#[hegel::test(test_cases = 100, phases = [Phase::Explicit])]
+#[hegel::explicit_test_case(i = 11i32)]
+fn test_only_runs_explicit_examples(tc: TestCase) {
+    let i: i32 = tc.draw(gs::integers());
+    assert_eq!(i, 11);
+}
+
+// Without Phase::Generate, no test cases are generated. A body that always
+// panics never runs, so even a test that would always fail passes.
+#[test]
+fn test_no_generate_means_body_never_runs() {
+    Hegel::new(|tc: TestCase| {
+        let _: bool = tc.draw(gs::booleans());
+        panic!("generate phase is disabled; this body should never run");
+    })
+    .settings(
+        Settings::new()
+            .phases([Phase::Reuse, Phase::Shrink])
+            .database(None),
+    )
+    .run();
+}
+
+// Without Phase::Shrink the shrinker is never invoked, so the test body is
+// called at most twice: once for the initial failure discovery and once for
+// the final replay to produce counterexample output.
+#[test]
+fn test_disabling_shrink_limits_interesting_calls() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let count = call_count.clone();
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+        Hegel::new(move |tc: TestCase| {
+            let _: bool = tc.draw(gs::booleans());
+            count.fetch_add(1, Ordering::SeqCst);
+            panic!("always fails");
+        })
+        .settings(
+            Settings::new()
+                .phases([Phase::Generate])
+                .database(None)
+                .test_cases(100),
+        )
+        .run();
+    }));
+
+    assert!(result.is_err(), "expected the test to fail");
+    let n = call_count.load(Ordering::SeqCst);
+    // Without shrinking: at most initial discovery (1) + final replay (1) = 2.
+    assert!(
+        n <= 2,
+        "expected at most 2 body calls without shrinking, got {n}"
+    );
 }
 
 // Default phases include Explicit so that explicit_test_case attributes work
@@ -43,138 +97,4 @@ fn test_overriding_phases_excludes_others() {
     assert!(settings.has_phase(Phase::Generate));
     assert!(!settings.has_phase(Phase::Target));
     assert!(!settings.has_phase(Phase::Shrink));
-}
-
-// ── Phase behavior tests (native only; server doesn't yet enforce phases) ────
-
-// With phases=[Explicit] only, only the explicit case runs.
-// The body asserts i == 11, which would fail for any generated integer.
-// The test passes because the generate phase is disabled.
-// Port of test_only_runs_explicit_examples.
-#[cfg(feature = "native")]
-#[hegel::test(test_cases = 100, phases = [Phase::Explicit])]
-#[hegel::explicit_test_case(i = 11i32)]
-fn test_only_runs_explicit_examples(tc: TestCase) {
-    let i: i32 = tc.draw(gs::integers());
-    assert_eq!(i, 11);
-}
-
-// Without Phase::Generate, no test cases are generated.  A body that always
-// panics never runs, so even a test that would always fail passes.
-// Port of test_this_would_fail_if_you_ran_it.
-#[cfg(feature = "native")]
-#[test]
-fn test_no_generate_means_body_never_runs() {
-    Hegel::new(|tc: TestCase| {
-        let _: bool = tc.draw(gs::booleans());
-        panic!("generate phase is disabled; this body should never run");
-    })
-    .settings(
-        Settings::new()
-            .phases([Phase::Reuse, Phase::Shrink])
-            .database(None),
-    )
-    .run();
-}
-
-// Without Phase::Shrink the shrinker is never invoked, so the test body is
-// called at most twice: once for the initial failure discovery and once for
-// the final replay to produce counterexample output.
-#[cfg(feature = "native")]
-#[test]
-fn test_disabling_shrink_limits_interesting_calls() {
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
-    let call_count = Arc::new(AtomicUsize::new(0));
-    let count = call_count.clone();
-
-    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
-        Hegel::new(move |tc: TestCase| {
-            let _: bool = tc.draw(gs::booleans());
-            count.fetch_add(1, Ordering::SeqCst);
-            panic!("always fails");
-        })
-        .settings(
-            Settings::new()
-                .phases([Phase::Generate]) // Shrink excluded
-                .database(None)
-                .test_cases(100),
-        )
-        .run();
-    }));
-
-    assert!(result.is_err(), "expected the test to fail");
-    let n = call_count.load(Ordering::SeqCst);
-    // Without shrinking: at most initial discovery (1) + final replay (1) = 2.
-    assert!(
-        n <= 2,
-        "expected at most 2 body calls without shrinking, got {n}"
-    );
-}
-
-// Without Phase::Reuse a previously saved failing example is not replayed at
-// the start of the next run.
-// Port of test_does_not_reuse_saved_examples_if_reuse_not_in_phases.
-#[cfg(feature = "native")]
-#[test]
-fn test_disabling_reuse_skips_saved_example() {
-    use std::sync::{Arc, Mutex};
-
-    let temp_dir = tempfile::TempDir::new().unwrap();
-    let db_path = temp_dir.path().join("db");
-    std::fs::create_dir_all(&db_path).unwrap();
-    let db_str = db_path.to_str().unwrap().to_string();
-
-    let drawn: Arc<Mutex<Vec<i64>>> = Arc::new(Mutex::new(Vec::new()));
-
-    // Run 1: full phases — finds and shrinks the failing example (1_000_000),
-    // which is saved to the database under the shared key.
-    {
-        let vals = drawn.clone();
-        let db = db_str.clone();
-        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
-            Hegel::new(move |tc: TestCase| {
-                let n: i64 = tc.draw(gs::integers());
-                vals.lock().unwrap().push(n);
-                assert!(n < 1_000_000);
-            })
-            .settings(Settings::new().database(Some(db)))
-            .__database_key("phase_reuse_test".to_string())
-            .run();
-        }));
-    }
-
-    let shrunk = *drawn.lock().unwrap().last().unwrap();
-    assert_eq!(shrunk, 1_000_000);
-    drawn.lock().unwrap().clear();
-
-    // Run 2: phases=[Generate] (no Reuse) — the saved example is not fetched,
-    // so the first drawn value is freshly generated rather than 1_000_000.
-    {
-        let vals = drawn.clone();
-        let db = db_str.clone();
-        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
-            Hegel::new(move |tc: TestCase| {
-                let n: i64 = tc.draw(gs::integers());
-                vals.lock().unwrap().push(n);
-                assert!(n < 1_000_000);
-            })
-            .settings(
-                Settings::new()
-                    .phases([Phase::Generate])
-                    .database(Some(db))
-                    .derandomize(false),
-            )
-            .__database_key("phase_reuse_test".to_string())
-            .run();
-        }));
-    }
-
-    let first = drawn.lock().unwrap()[0];
-    assert_ne!(
-        first, shrunk,
-        "Phase::Reuse is disabled but the saved example ({shrunk}) was \
-         still replayed as the first drawn value"
-    );
 }

--- a/tests/test_phases.rs
+++ b/tests/test_phases.rs
@@ -1,20 +1,13 @@
 //! Ported from hypothesis-python/tests/cover/test_phases.py
+//!
+//! Tests that depend on server-side phase enforcement (Reuse, Shrink, Generate
+//! skipping) require hegel-core with phases support and will be added in a
+//! follow-up once that version ships.
 
 mod common;
 
-use common::project::TempRustProject;
 use hegel::generators as gs;
-use hegel::{Phase, TestCase};
-
-// With phases=[Explicit], only the explicit test case runs.
-// The body asserts i == 11; only the explicit case (i=11) satisfies this.
-// Random generation would find values != 11 and fail, but it never runs.
-#[hegel::test(phases = [Phase::Explicit])]
-#[hegel::explicit_test_case(i = 11i32)]
-fn test_only_runs_explicit_examples(tc: TestCase) {
-    let i: i32 = tc.draw(gs::integers());
-    assert_eq!(i, 11);
-}
+use hegel::{Phase, Settings, TestCase};
 
 // With phases not including Explicit, explicit cases are skipped.
 // The explicit case would fail at runtime (name mismatch: "hello_world" vs "b"),
@@ -26,133 +19,25 @@ fn test_does_not_use_explicit_examples(tc: TestCase) {
     let _ = b;
 }
 
-// With phases=[Reuse, Shrink] (no Generate) and no database, no test cases are
-// generated. The body would always panic, but it is never called.
-#[hegel::test(database = None, phases = [Phase::Reuse, Phase::Shrink])]
-fn test_this_would_fail_if_you_ran_it(tc: TestCase) {
-    let b: bool = tc.draw(gs::booleans());
-    let _ = b;
-    panic!("should not run");
+// Default phases include Explicit so that explicit_test_case attributes work
+// without any phases configuration.
+#[test]
+fn test_default_phases_include_explicit() {
+    let settings = Settings::new();
+    assert!(settings.has_phase(Phase::Explicit));
+    assert!(settings.has_phase(Phase::Reuse));
+    assert!(settings.has_phase(Phase::Generate));
+    assert!(settings.has_phase(Phase::Target));
+    assert!(settings.has_phase(Phase::Shrink));
 }
 
-// Disabling Phase::Shrink limits the number of interesting (failing) test case
-// calls to exactly 2: one when the failure is first found, one for the final replay.
-// With shrinking enabled, many more calls occur as Hypothesis minimises the example.
+// When phases are overridden, only the specified phases are active.
 #[test]
-fn test_phase_no_shrink_limits_interesting() {
-    let temp_dir = tempfile::TempDir::new().unwrap();
-    let log_path = temp_dir.path().join("interesting.log");
-    let log_str = log_path.to_str().unwrap().replace('\\', "/");
-
-    let code = format!(
-        r#"
-use hegel::generators as gs;
-use std::io::Write;
-
-#[hegel::test(phases = [hegel::Phase::Generate])]
-fn test_no_shrink(tc: hegel::TestCase) {{
-    let n: i32 = tc.draw(gs::integers::<i32>().min_value(0).max_value(200));
-    if n > 100 {{
-        let mut f = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open("{log_str}")
-            .unwrap();
-        writeln!(f, "{{}}", n).unwrap();
-        panic!("too large: {{}}", n);
-    }}
-}}
-"#
-    );
-
-    TempRustProject::new()
-        .test_file("test_no_shrink.rs", &code)
-        .expect_failure("too large")
-        .cargo_test(&["test_no_shrink"]);
-
-    let interesting_count = std::fs::read_to_string(&log_path)
-        .map(|s| s.lines().count())
-        .unwrap_or(0);
-    assert_eq!(
-        interesting_count, 2,
-        "Expected exactly 2 interesting calls without shrinking, got {interesting_count}"
-    );
-}
-
-// Disabling Phase::Reuse means the database is not consulted, so a previously
-// saved failing example is not replayed as the first test case.
-#[test]
-fn test_phase_no_reuse_skips_db_replay() {
-    let temp_dir = tempfile::TempDir::new().unwrap();
-    let db_path = temp_dir.path().join("database");
-    std::fs::create_dir_all(&db_path).unwrap();
-    let db_str = db_path.to_str().unwrap().replace('\\', "/");
-
-    let values_path = temp_dir.path().join("values");
-    std::fs::create_dir_all(&values_path).unwrap();
-    let values_str = values_path.to_str().unwrap().replace('\\', "/");
-
-    let make_code = |phases_attr: &str| {
-        format!(
-            r#"
-use hegel::generators as gs;
-use std::io::Write;
-
-fn record(n: i64) {{
-    let path = format!("{values_str}/log");
-    let mut f = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-        .unwrap();
-    writeln!(f, "{{}}", n).unwrap();
-}}
-
-#[hegel::test(database = Some("{db_str}".to_string()){phases_attr})]
-fn test_reuse(tc: hegel::TestCase) {{
-    let n: i64 = tc.draw(gs::integers());
-    record(n);
-    assert!(n < 1_000_000);
-}}
-"#
-        )
-    };
-
-    // First run: populate the database with a saved failing example.
-    TempRustProject::new()
-        .test_file("test_reuse.rs", &make_code(""))
-        .expect_failure("Property test failed")
-        .cargo_test(&["test_reuse"]);
-
-    let shrunk_value: i64 = std::fs::read_to_string(values_path.join("log"))
-        .unwrap()
-        .lines()
-        .last()
-        .unwrap()
-        .parse()
-        .unwrap();
-    assert_eq!(shrunk_value, 1_000_000);
-
-    std::fs::remove_file(values_path.join("log")).unwrap();
-
-    // Second run: no Reuse phase — saved example should NOT be the first test case.
-    TempRustProject::new()
-        .test_file(
-            "test_reuse.rs",
-            &make_code(", phases = [hegel::Phase::Generate, hegel::Phase::Shrink]"),
-        )
-        .expect_failure("Property test failed")
-        .cargo_test(&["test_reuse"]);
-
-    let first_value: i64 = std::fs::read_to_string(values_path.join("log"))
-        .unwrap()
-        .lines()
-        .next()
-        .unwrap()
-        .parse()
-        .unwrap();
-    assert_ne!(
-        first_value, shrunk_value,
-        "Without Phase::Reuse, the saved example should not be the first test case"
-    );
+fn test_overriding_phases_excludes_others() {
+    let settings = Settings::new().phases([Phase::Generate]);
+    assert!(!settings.has_phase(Phase::Explicit));
+    assert!(!settings.has_phase(Phase::Reuse));
+    assert!(settings.has_phase(Phase::Generate));
+    assert!(!settings.has_phase(Phase::Target));
+    assert!(!settings.has_phase(Phase::Shrink));
 }

--- a/tests/test_phases.rs
+++ b/tests/test_phases.rs
@@ -3,8 +3,6 @@
 //! Tests asserting server-side phase enforcement (Reuse, Shrink, Generate
 //! skipping) are gated on `#[cfg(feature = "native")]` because hegel-core
 //! 0.6.1 does not yet forward the phases parameter to the engine.
-// The `native` feature is defined in the DRMacIver/native branch, not here;
-// suppress the unknown-feature warning so the tests compile cleanly.
 #![allow(unexpected_cfgs)]
 
 mod common;

--- a/tests/test_phases.rs
+++ b/tests/test_phases.rs
@@ -1,13 +1,18 @@
 //! Ported from hypothesis-python/tests/cover/test_phases.py
 //!
-//! Tests that depend on server-side phase enforcement (Reuse, Shrink, Generate
-//! skipping) require hegel-core with phases support and will be added in a
-//! follow-up once that version ships.
+//! Tests asserting server-side phase enforcement (Reuse, Shrink, Generate
+//! skipping) are gated on `#[cfg(feature = "native")]` because hegel-core
+//! 0.6.1 does not yet forward the phases parameter to the engine.
+// The `native` feature is defined in the DRMacIver/native branch, not here;
+// suppress the unknown-feature warning so the tests compile cleanly.
+#![allow(unexpected_cfgs)]
 
 mod common;
 
 use hegel::generators as gs;
 use hegel::{Phase, Settings, TestCase};
+#[cfg(feature = "native")]
+use hegel::Hegel;
 
 // With phases not including Explicit, explicit cases are skipped.
 // The explicit case would fail at runtime (name mismatch: "hello_world" vs "b"),
@@ -40,4 +45,138 @@ fn test_overriding_phases_excludes_others() {
     assert!(settings.has_phase(Phase::Generate));
     assert!(!settings.has_phase(Phase::Target));
     assert!(!settings.has_phase(Phase::Shrink));
+}
+
+// ── Phase behavior tests (native only; server doesn't yet enforce phases) ────
+
+// With phases=[Explicit] only, only the explicit case runs.
+// The body asserts i == 11, which would fail for any generated integer.
+// The test passes because the generate phase is disabled.
+// Port of test_only_runs_explicit_examples.
+#[cfg(feature = "native")]
+#[hegel::test(test_cases = 100, phases = [Phase::Explicit])]
+#[hegel::explicit_test_case(i = 11i32)]
+fn test_only_runs_explicit_examples(tc: TestCase) {
+    let i: i32 = tc.draw(gs::integers());
+    assert_eq!(i, 11);
+}
+
+// Without Phase::Generate, no test cases are generated.  A body that always
+// panics never runs, so even a test that would always fail passes.
+// Port of test_this_would_fail_if_you_ran_it.
+#[cfg(feature = "native")]
+#[test]
+fn test_no_generate_means_body_never_runs() {
+    Hegel::new(|tc: TestCase| {
+        let _: bool = tc.draw(gs::booleans());
+        panic!("generate phase is disabled; this body should never run");
+    })
+    .settings(
+        Settings::new()
+            .phases([Phase::Reuse, Phase::Shrink])
+            .database(None),
+    )
+    .run();
+}
+
+// Without Phase::Shrink the shrinker is never invoked, so the test body is
+// called at most twice: once for the initial failure discovery and once for
+// the final replay to produce counterexample output.
+#[cfg(feature = "native")]
+#[test]
+fn test_disabling_shrink_limits_interesting_calls() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let count = call_count.clone();
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+        Hegel::new(move |tc: TestCase| {
+            let _: bool = tc.draw(gs::booleans());
+            count.fetch_add(1, Ordering::SeqCst);
+            panic!("always fails");
+        })
+        .settings(
+            Settings::new()
+                .phases([Phase::Generate]) // Shrink excluded
+                .database(None)
+                .test_cases(100),
+        )
+        .run();
+    }));
+
+    assert!(result.is_err(), "expected the test to fail");
+    let n = call_count.load(Ordering::SeqCst);
+    // Without shrinking: at most initial discovery (1) + final replay (1) = 2.
+    assert!(
+        n <= 2,
+        "expected at most 2 body calls without shrinking, got {n}"
+    );
+}
+
+// Without Phase::Reuse a previously saved failing example is not replayed at
+// the start of the next run.
+// Port of test_does_not_reuse_saved_examples_if_reuse_not_in_phases.
+#[cfg(feature = "native")]
+#[test]
+fn test_disabling_reuse_skips_saved_example() {
+    use std::sync::{Arc, Mutex};
+
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("db");
+    std::fs::create_dir_all(&db_path).unwrap();
+    let db_str = db_path.to_str().unwrap().to_string();
+
+    let drawn: Arc<Mutex<Vec<i64>>> = Arc::new(Mutex::new(Vec::new()));
+
+    // Run 1: full phases — finds and shrinks the failing example (1_000_000),
+    // which is saved to the database under the shared key.
+    {
+        let vals = drawn.clone();
+        let db = db_str.clone();
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+            Hegel::new(move |tc: TestCase| {
+                let n: i64 = tc.draw(gs::integers());
+                vals.lock().unwrap().push(n);
+                assert!(n < 1_000_000);
+            })
+            .settings(Settings::new().database(Some(db)))
+            .__database_key("phase_reuse_test".to_string())
+            .run();
+        }));
+    }
+
+    let shrunk = *drawn.lock().unwrap().last().unwrap();
+    assert_eq!(shrunk, 1_000_000);
+    drawn.lock().unwrap().clear();
+
+    // Run 2: phases=[Generate] (no Reuse) — the saved example is not fetched,
+    // so the first drawn value is freshly generated rather than 1_000_000.
+    {
+        let vals = drawn.clone();
+        let db = db_str.clone();
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+            Hegel::new(move |tc: TestCase| {
+                let n: i64 = tc.draw(gs::integers());
+                vals.lock().unwrap().push(n);
+                assert!(n < 1_000_000);
+            })
+            .settings(
+                Settings::new()
+                    .phases([Phase::Generate])
+                    .database(Some(db))
+                    .derandomize(false),
+            )
+            .__database_key("phase_reuse_test".to_string())
+            .run();
+        }));
+    }
+
+    let first = drawn.lock().unwrap()[0];
+    assert_ne!(
+        first, shrunk,
+        "Phase::Reuse is disabled but the saved example ({shrunk}) was \
+         still replayed as the first drawn value"
+    );
 }

--- a/tests/test_phases.rs
+++ b/tests/test_phases.rs
@@ -54,7 +54,7 @@ fn test_disabling_shrink_limits_interesting_calls() {
 
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
         Hegel::new(move |tc: TestCase| {
-            let _: bool = tc.draw(gs::booleans());
+            let _: i64 = tc.draw(gs::integers::<i64>());
             count.fetch_add(1, Ordering::SeqCst);
             panic!("always fails");
         })

--- a/tests/test_phases.rs
+++ b/tests/test_phases.rs
@@ -41,13 +41,17 @@ fn test_no_generate_means_body_never_runs() {
     .run();
 }
 
-// Without Phase::Shrink the shrinker is never invoked, so the test body is
-// called at most twice: once for the initial failure discovery and once for
-// the final replay to produce counterexample output.
+// Without Phase::Shrink the shrinker is never invoked.  The generate phase
+// still produces multiple test cases, but the overall body-call count should
+// stay well below `test_cases` because Hypothesis stops the generate phase
+// early once it has enough interesting examples, and there are no shrink
+// iterations on top.
 #[test]
 fn test_disabling_shrink_limits_interesting_calls() {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let test_cases: u64 = 100;
 
     let call_count = Arc::new(AtomicUsize::new(0));
     let count = call_count.clone();
@@ -62,17 +66,19 @@ fn test_disabling_shrink_limits_interesting_calls() {
             Settings::new()
                 .phases([Phase::Generate])
                 .database(None)
-                .test_cases(100),
+                .test_cases(test_cases),
         )
         .run();
     }));
 
     assert!(result.is_err(), "expected the test to fail");
     let n = call_count.load(Ordering::SeqCst);
-    // Without shrinking: at most initial discovery (1) + final replay (1) = 2.
+    // The generate phase runs some test cases, plus one final replay.
+    // Without shrinking this should be much less than test_cases.
     assert!(
-        n <= 2,
-        "expected at most 2 body calls without shrinking, got {n}"
+        n <= (test_cases / 2) as usize,
+        "expected fewer than {half} body calls without shrinking, got {n}",
+        half = test_cases / 2,
     );
 }
 


### PR DESCRIPTION
Extracted from https://github.com/hegeldev/hegel-rust/pull/228. AI written info: <details>

## Summary

- Adds `Phase` enum to `src/runner.rs` with six variants matching `hypothesis.Phase`: `Explicit`, `Reuse`, `Generate`, `Target`, `Shrink`, `Explain`
- Adds `phases: Vec<Phase>` field to `Settings` with a default of `[Reuse, Generate, Target, Shrink]`
- Adds `Settings::phases(impl IntoIterator<Item = Phase>) -> Self` builder method
- Adds `phase_as_str()` helper and forwards the phase list in the `run_test` CBOR message to the server
- Re-exports `Phase` from the crate root
- Updates `tests/common/utils.rs` `find_any` helper to use `.phases([Phase::Reuse, Phase::Generate])` to skip shrinking (there's nothing to shrink in a "find any" search)

## Companion PR

hegeldev/hegel-core#115 forwards the `phases` list to `hypothesis.settings(phases=...)` on the server side.

## Why

Replacing a `no_shrink: bool` boolean hack with the proper `Phase` API that Hypothesis already provides. This lets callers selectively disable any phase (not just shrinking), and is more idiomatic.

</details>