### PR TITLE
Forbid unchecked signed-integer abs() via clippy.toml

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,17 @@
+# Disallow signed-integer `abs()` on its own. The plain `abs()` panics on
+# T::MIN (its absolute value is not representable in the same signed type),
+# and we keep getting bitten by it — most recently when bumping hegel-core
+# happened to surface `i64::MIN` from `find_any` and turned a flaky-looking
+# test into a panic.
+#
+# To opt out at a specific call site, add an `#[expect(clippy::disallowed_methods, reason = "...")]`
+# attribute on the enclosing item or expression. Don't disable this list
+# wholesale — every callsite should articulate why the input cannot be MIN.
+disallowed-methods = [
+    { path = "i8::abs", reason = "i8::abs panics on i8::MIN; use unsigned_abs / wrapping_abs / saturating_abs / checked_abs (or #[expect(clippy::disallowed_methods, reason = \"...\")] if you have proven the input is never MIN)" },
+    { path = "i16::abs", reason = "i16::abs panics on i16::MIN; use unsigned_abs / wrapping_abs / saturating_abs / checked_abs (or #[expect(clippy::disallowed_methods, reason = \"...\")] if you have proven the input is never MIN)" },
+    { path = "i32::abs", reason = "i32::abs panics on i32::MIN; use unsigned_abs / wrapping_abs / saturating_abs / checked_abs (or #[expect(clippy::disallowed_methods, reason = \"...\")] if you have proven the input is never MIN)" },
+    { path = "i64::abs", reason = "i64::abs panics on i64::MIN; use unsigned_abs / wrapping_abs / saturating_abs / checked_abs (or #[expect(clippy::disallowed_methods, reason = \"...\")] if you have proven the input is never MIN)" },
+    { path = "i128::abs", reason = "i128::abs panics on i128::MIN; use unsigned_abs / wrapping_abs / saturating_abs / checked_abs (or #[expect(clippy::disallowed_methods, reason = \"...\")] if you have proven the input is never MIN)" },
+    { path = "isize::abs", reason = "isize::abs panics on isize::MIN; use unsigned_abs / wrapping_abs / saturating_abs / checked_abs (or #[expect(clippy::disallowed_methods, reason = \"...\")] if you have proven the input is never MIN)" },
+]

--- a/tests/test_collections.rs
+++ b/tests/test_collections.rs
@@ -174,15 +174,8 @@ fn test_hashset_with_min_and_max_size(tc: TestCase) {
 
 #[hegel::test]
 fn test_hashset_with_mapped_elements(tc: TestCase) {
-    // Exclude i32::MIN to avoid overflow when taking abs
-    let set: HashSet<i32> = tc.draw(
-        gs::hashsets(
-            gs::integers::<i32>()
-                .min_value(i32::MIN + 1)
-                .map(|x| x.abs()),
-        )
-        .max_size(10),
-    );
+    let set: HashSet<i32> =
+        tc.draw(gs::hashsets(gs::integers::<i32>().map(|x| x.saturating_abs())).max_size(10));
     assert!(set.iter().all(|&x| x >= 0));
 }
 

--- a/tests/test_find_quality/integers.rs
+++ b/tests/test_find_quality/integers.rs
@@ -10,7 +10,7 @@ fn test_can_produce_zero() {
 
 #[test]
 fn test_can_produce_large_magnitude_integers() {
-    find_any(gs::integers::<i64>(), |&x| x.abs() > 1000);
+    find_any(gs::integers::<i64>(), |&x| x.unsigned_abs() > 1000);
 }
 
 #[test]
@@ -35,12 +35,21 @@ fn test_integers_are_sometimes_zero() {
 
 #[test]
 fn test_integers_are_often_small() {
-    find_any(gs::integers::<i64>(), |&x| x.abs() <= 100);
+    find_any(gs::integers::<i64>(), |&x| x.unsigned_abs() <= 100);
 }
 
+// Expected to fail until https://github.com/HypothesisWorks/hypothesis/issues/4722
+// is fixed: hegel-core's unbounded-i64 distribution heavily biases toward
+// near-MIN/MAX values and rarely produces values in 50..=255 within
+// `find_any`'s 1000-attempt budget. Previously this test passed only because
+// the now-forbidden `i64::abs()` panicked on `i64::MIN`, which incidentally
+// triggered hegel-core's shrinking-style exploration of smaller magnitudes.
 #[test]
+#[should_panic(expected = "Could not find any examples satisfying the condition")]
 fn test_integers_are_often_small_but_not_that_small() {
-    find_any(gs::integers::<i64>(), |&x| (50..=255).contains(&x.abs()));
+    find_any(gs::integers::<i64>(), |&x| {
+        x.checked_abs().is_some_and(|a| (50..=255).contains(&a))
+    });
 }
 
 #[test]


### PR DESCRIPTION
The use of `abs` in our tests keeps biting us and causing flaky tests. This forbids the use of abs in favour of checked and unsigned abs methods - anything we're doing is likely to experience the full range of integers at some point, and we should just never fail in that case.

Along the way, this found a Hypothesis distribution bug, where it turns out we were relying on overflow in abs to pass one of our tests: https://github.com/HypothesisWorks/hypothesis/issues/4722

<details>
<summary>AI-generated implementation notes</summary>

## Summary

- New `clippy.toml` adds `disallowed-methods` entries for `{i8,i16,i32,i64,i128,isize}::abs`, with reasons that point developers at `unsigned_abs / wrapping_abs / saturating_abs / checked_abs` and the `#[expect(clippy::disallowed_methods, reason = "...")]` opt-out. The lint fires under the existing `cargo clippy --all-features --all-targets -- -D warnings` in `just check-clippy`, so it's already wired into CI for both the main workspace and the conformance workspace.
- Fixed the four `.abs()` callsites the lint flagged:
  - `tests/test_find_quality/integers.rs:13,38`: switched to `unsigned_abs()` (semantics unchanged for non-MIN values; predicates compare to literal magnitudes).
  - `tests/test_find_quality/integers.rs:43`: this is the test from the upstream report. Switched to `checked_abs()`. The test only passed before because `abs()` on `i64::MIN` panicked, which incidentally triggered hegel-core's shrinking-style exploration of smaller magnitudes. Without that, hegel-core's unbounded-i64 distribution rarely produces values in `50..=255` within `find_any`'s 1000-attempt budget. Marked `#[should_panic(expected = "Could not find any examples satisfying the condition")]` with a comment pointing at HypothesisWorks/hypothesis#4722. When that upstream issue is fixed, `should_panic` will start failing and we'll know to lift the marker.
  - `tests/test_collections.rs:182`: replaced the `min_value(i32::MIN+1).map(|x| x.abs())` workaround with `map(|x| x.saturating_abs())`. The `min_value` constraint existed only to dodge the panic; `saturating_abs(i32::MIN)` returns `i32::MAX`, which still satisfies the test's "all elements >= 0" assertion.

## Test plan

- [x] `just check-lint` (format + clippy + nocov-style) passes.
- [x] `just check` (lint + tests + all-features tests) passes.
- [x] Confirmed the lint catches probe `.abs()` calls in both the main workspace and `tests/conformance/rust/` workspace.
- [x] `test_integers_are_often_small_but_not_that_small` reports as `... should panic ... ok`, verifying the `should_panic` marker matches the panic message produced by `find_any`'s "Could not find any examples..." path.

</details>