### PR TITLE
claude: add serde_json extras

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,9 @@ rand = ["dep:rand"]
 antithesis = ["dep:serde_json"]
 chrono = ["dep:chrono"]
 jiff = ["dep:jiff"]
+serde_json = ["dep:serde_json"]
+# Enables the serde_json/raw_value feature. Enables generators for serde_json::value::RawValue.
+serde_json_raw_value = ["serde_json", "serde_json/raw_value"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,28 @@
+RELEASE_TYPE: patch
+
+This patch adds generators for the [`serde_json`](https://docs.rs/serde_json) crate behind the new `serde_json` feature flag.
+
+`hegel::extras::serde_json` provides generators for:
+
+* `numbers()` — generates `serde_json::Number`.
+* `values()` — generates `serde_json::Value`.
+* `raw_values()` - generates `Box<serde_json::value::RawValue>`. Requires the `serde_json_raw_value` feature flag.
+
+And default generators for:
+
+* `serde_json::Number`
+* `serde_json::Value`
+* `serde_json::Map<String, Value>`
+
+For example:
+
+```rust
+use hegel::extras::serde_json as json_gs;
+
+#[hegel::test]
+fn my_test(tc: hegel::TestCase) {
+    let v = tc.draw(json_gs::values());
+    let s = serde_json::to_string(&v).unwrap();
+    let _: serde_json::Value = serde_json::from_str(&s).unwrap();
+}
+```

--- a/src/extras/mod.rs
+++ b/src/extras/mod.rs
@@ -6,3 +6,6 @@ pub mod jiff;
 
 #[cfg(feature = "rand")]
 pub mod rand;
+
+#[cfg(feature = "serde_json")]
+pub mod serde_json;

--- a/src/extras/serde_json/default.rs
+++ b/src/extras/serde_json/default.rs
@@ -1,0 +1,45 @@
+use std::collections::HashMap;
+
+use serde_json::{Map, Number, Value};
+
+use crate::generators::{self as gs, BoxedGenerator, DefaultGenerator, Generator};
+
+use super::{NumberGenerator, ValueGenerator, numbers, values};
+
+impl DefaultGenerator for Number {
+    type Generator = NumberGenerator;
+    fn default_generator() -> Self::Generator {
+        numbers()
+    }
+}
+
+impl DefaultGenerator for Value {
+    type Generator = ValueGenerator;
+    fn default_generator() -> Self::Generator {
+        values()
+    }
+}
+
+// `serde_json::Map<K, V>` is generic in its type signature, but every public
+// constructor and trait impl is hardcoded to `Map<String, Value>`. There's no
+// way to construct any other instantiation through the crate's public API,
+// so this impl covers the full usable space.
+impl DefaultGenerator for Map<String, Value> {
+    type Generator = BoxedGenerator<'static, Map<String, Value>>;
+    fn default_generator() -> Self::Generator {
+        gs::hashmaps(
+            <String as DefaultGenerator>::default_generator(),
+            <Value as DefaultGenerator>::default_generator(),
+        )
+        .map(|m: HashMap<String, Value>| m.into_iter().collect::<Map<String, Value>>())
+        .boxed()
+    }
+}
+
+#[cfg(feature = "serde_json_raw_value")]
+impl DefaultGenerator for Box<serde_json::value::RawValue> {
+    type Generator = super::RawValueGenerator;
+    fn default_generator() -> Self::Generator {
+        super::raw_values()
+    }
+}

--- a/src/extras/serde_json/generators.rs
+++ b/src/extras/serde_json/generators.rs
@@ -1,0 +1,147 @@
+use std::collections::HashMap;
+
+use serde_json::{Number, Value};
+
+use crate::generators::{self as gs, BoxedGenerator, DefaultGenerator, Generator};
+
+/// Generator for [`serde_json::Number`] values. Created by [`numbers()`].
+///
+/// Produces `Number` values backed by an `i64`, `u64`, or finite `f64`.
+/// JSON numbers cannot represent NaN or infinity, so the float branch is
+/// constrained to finite values.
+pub struct NumberGenerator {
+    inner: BoxedGenerator<'static, Number>,
+}
+
+impl Generator<Number> for NumberGenerator {
+    fn do_draw(&self, tc: &crate::TestCase) -> Number {
+        self.inner.do_draw(tc)
+    }
+
+    fn as_basic(&self) -> Option<gs::BasicGenerator<'_, Number>> {
+        self.inner.as_basic()
+    }
+}
+
+/// Generate [`serde_json::Number`] values.
+///
+/// See [`NumberGenerator`] for details.
+///
+/// # Example
+///
+/// ```no_run
+/// use hegel::extras::serde_json as json_gs;
+///
+/// #[hegel::test]
+/// fn my_test(tc: hegel::TestCase) {
+///     let n = tc.draw(json_gs::numbers());
+///     assert!(n.as_i64().is_some() || n.as_u64().is_some() || n.as_f64().is_some());
+/// }
+/// ```
+pub fn numbers() -> NumberGenerator {
+    let inner = gs::one_of([
+        gs::integers::<i64>().map(Number::from).boxed(),
+        gs::integers::<u64>().map(Number::from).boxed(),
+        gs::floats::<f64>()
+            .allow_nan(false)
+            .allow_infinity(false)
+            .map(|f| Number::from_f64(f).unwrap())
+            .boxed(),
+    ])
+    .boxed();
+    NumberGenerator { inner }
+}
+
+/// Generator for [`serde_json::Value`] values. Created by [`values()`].
+pub struct ValueGenerator {
+    inner: BoxedGenerator<'static, Value>,
+}
+
+impl Generator<Value> for ValueGenerator {
+    fn do_draw(&self, tc: &crate::TestCase) -> Value {
+        self.inner.do_draw(tc)
+    }
+}
+
+/// Generate [`serde_json::Value`] values.
+///
+/// See [`ValueGenerator`] for details.
+///
+/// # Example
+///
+/// ```no_run
+/// use hegel::extras::serde_json as json_gs;
+///
+/// #[hegel::test]
+/// fn my_test(tc: hegel::TestCase) {
+///     let v = tc.draw(json_gs::values());
+///     // round-trip through serde_json
+///     let s = serde_json::to_string(&v).unwrap();
+///     let _: serde_json::Value = serde_json::from_str(&s).unwrap();
+/// }
+/// ```
+pub fn values() -> ValueGenerator {
+    let def = gs::deferred::<Value>();
+    let handle = def.generator();
+
+    let recursive = gs::one_of([
+        gs::just(Value::Null).boxed(),
+        gs::booleans().map(Value::Bool).boxed(),
+        numbers().map(Value::Number).boxed(),
+        <String as DefaultGenerator>::default_generator()
+            .map(Value::String)
+            .boxed(),
+        gs::vecs(handle.clone()).map(Value::Array).boxed(),
+        gs::hashmaps(
+            <String as DefaultGenerator>::default_generator(),
+            handle.clone(),
+        )
+        .map(|m: HashMap<String, Value>| Value::Object(m.into_iter().collect()))
+        .boxed(),
+    ])
+    .boxed();
+
+    def.set(recursive);
+
+    ValueGenerator { inner: handle }
+}
+
+/// Generator for [`Box<RawValue>`](serde_json::value::RawValue) values.
+/// Created by [`raw_values()`].
+///
+/// The generated values are guaranteed to be valid json.
+#[cfg(feature = "serde_json_raw_value")]
+pub struct RawValueGenerator {
+    inner: BoxedGenerator<'static, Box<serde_json::value::RawValue>>,
+}
+
+#[cfg(feature = "serde_json_raw_value")]
+impl Generator<Box<serde_json::value::RawValue>> for RawValueGenerator {
+    fn do_draw(&self, tc: &crate::TestCase) -> Box<serde_json::value::RawValue> {
+        self.inner.do_draw(tc)
+    }
+}
+
+/// Generate [`Box<RawValue>`](serde_json::value::RawValue) values.
+///
+/// # Example
+///
+/// ```no_run
+/// use hegel::extras::serde_json as json_gs;
+///
+/// #[hegel::test]
+/// fn my_test(tc: hegel::TestCase) {
+///     let r = tc.draw(json_gs::raw_values());
+///     // The generated value is always valid JSON.
+///     let _: serde_json::Value = serde_json::from_str(r.get()).unwrap();
+/// }
+/// ```
+#[cfg(feature = "serde_json_raw_value")]
+pub fn raw_values() -> RawValueGenerator {
+    let inner = values()
+        .map(|v| {
+            serde_json::value::RawValue::from_string(serde_json::to_string(&v).unwrap()).unwrap()
+        })
+        .boxed();
+    RawValueGenerator { inner }
+}

--- a/src/extras/serde_json/mod.rs
+++ b/src/extras/serde_json/mod.rs
@@ -1,0 +1,8 @@
+//! Generators for the [`serde_json`] crate.
+//!
+//! Available behind the `serde_json` feature flag.
+
+mod default;
+mod generators;
+
+pub use generators::*;

--- a/tests/serde_json/main.rs
+++ b/tests/serde_json/main.rs
@@ -1,0 +1,10 @@
+#![cfg(feature = "serde_json")]
+
+#[path = "../common/mod.rs"]
+mod common;
+
+mod number;
+mod value;
+
+#[cfg(feature = "serde_json_raw_value")]
+mod raw_value;

--- a/tests/serde_json/number.rs
+++ b/tests/serde_json/number.rs
@@ -1,0 +1,34 @@
+use crate::common::utils::{assert_all_examples, check_can_generate_examples};
+use hegel::extras::serde_json as json_gs;
+use hegel::generators as gs;
+use serde_json::Number;
+
+#[test]
+fn test_serde_json_numbers_default() {
+    check_can_generate_examples(json_gs::numbers());
+}
+
+#[test]
+fn test_serde_json_numbers_are_finite() {
+    // Every drawn Number must be representable: it has a valid i64, u64,
+    // or finite f64 view.
+    assert_all_examples(json_gs::numbers(), |n| {
+        n.as_i64().is_some() || n.as_u64().is_some() || n.as_f64().is_some_and(|f| f.is_finite())
+    });
+}
+
+#[test]
+fn test_serde_json_numbers_in_vec() {
+    assert_all_examples(gs::vecs(json_gs::numbers()).max_size(5), |v| {
+        v.iter().all(|n| {
+            n.as_i64().is_some()
+                || n.as_u64().is_some()
+                || n.as_f64().is_some_and(|f| f.is_finite())
+        })
+    });
+}
+
+#[test]
+fn test_serde_json_number_default_generator() {
+    check_can_generate_examples(gs::default::<Number>());
+}

--- a/tests/serde_json/raw_value.rs
+++ b/tests/serde_json/raw_value.rs
@@ -1,0 +1,31 @@
+use crate::common::utils::{assert_all_examples, check_can_generate_examples};
+use hegel::extras::serde_json as json_gs;
+use hegel::generators as gs;
+use serde_json::Value;
+use serde_json::value::RawValue;
+
+#[test]
+fn test_serde_json_raw_values_default() {
+    check_can_generate_examples(json_gs::raw_values());
+}
+
+#[test]
+fn test_serde_json_raw_values_are_valid_json() {
+    // The text inside a generated RawValue must always parse as valid JSON.
+    assert_all_examples(json_gs::raw_values(), |r| {
+        serde_json::from_str::<Value>(r.get()).is_ok()
+    });
+}
+
+#[test]
+fn test_serde_json_raw_values_in_vec() {
+    assert_all_examples(gs::vecs(json_gs::raw_values()).max_size(3), |v| {
+        v.iter()
+            .all(|r| serde_json::from_str::<Value>(r.get()).is_ok())
+    });
+}
+
+#[test]
+fn test_serde_json_raw_value_default_generator() {
+    check_can_generate_examples(gs::default::<Box<RawValue>>());
+}

--- a/tests/serde_json/value.rs
+++ b/tests/serde_json/value.rs
@@ -1,0 +1,47 @@
+use crate::common::utils::{assert_all_examples, check_can_generate_examples};
+use hegel::extras::serde_json as json_gs;
+use hegel::generators as gs;
+use serde_json::{Map, Value};
+
+#[test]
+fn test_serde_json_values_default() {
+    check_can_generate_examples(json_gs::values());
+}
+
+#[test]
+fn test_serde_json_values_serialize_to_valid_json() {
+    // Every drawn Value must serialize to text that re-parses as JSON.
+    // Note: serde_json's float parser does not always preserve f64 precision
+    // exactly for very large numbers, so we don't assert structural equality.
+    assert_all_examples(json_gs::values(), |v| {
+        let s = serde_json::to_string(v).unwrap();
+        serde_json::from_str::<Value>(&s).is_ok()
+    });
+}
+
+#[test]
+fn test_serde_json_values_in_vec() {
+    assert_all_examples(gs::vecs(json_gs::values()).max_size(3), |v| {
+        v.iter()
+            .all(|val| serde_json::to_string(val).is_ok_and(|s| !s.is_empty()))
+    });
+}
+
+#[test]
+fn test_serde_json_value_default_generator() {
+    check_can_generate_examples(gs::default::<Value>());
+}
+
+#[test]
+fn test_serde_json_map_default_generator() {
+    check_can_generate_examples(gs::default::<Map<String, Value>>());
+}
+
+#[test]
+fn test_serde_json_map_default_serializes_to_valid_json() {
+    assert_all_examples(gs::default::<Map<String, Value>>(), |m| {
+        let v = Value::Object(m.clone());
+        let s = serde_json::to_string(&v).unwrap();
+        serde_json::from_str::<Value>(&s).is_ok()
+    });
+}


### PR DESCRIPTION
Closes https://github.com/hegeldev/hegel-rust/issues/223.

<details><summary>Claude-written description</summary>

Adds a new feature-gated `hegel::extras::serde_json` module with generators for the `serde_json` crate.

Two new feature flags:

- `serde_json` — enables the dep and the module. Exposes `numbers()` (generates `serde_json::Number` backed by `i64`/`u64`/finite `f64`) and `values()` (recursively generates arbitrary `serde_json::Value`).
- `serde_json_raw_value` — extends `serde_json` with the upstream `raw_value` feature and exposes `raw_values()`, a generator for `Box<serde_json::value::RawValue>` whose output is guaranteed to be valid JSON. Gated separately so users who don't need `RawValue` don't pay for the upstream feature.

`gs::default::<T>()` is wired up for `serde_json::Number`, `serde_json::Value`, `serde_json::Map<String, Value>`, and (under `serde_json_raw_value`) `Box<serde_json::value::RawValue>`. The `Map` impl only covers `Map<String, Value>` because every public constructor on `serde_json::Map` is hardcoded to that instantiation.

The recursive `values()` definition uses `gs::deferred()` to tie the knot, so generated values can include nested arrays and objects of arbitrary depth (bounded by Hypothesis's per-draw size budget at each `vecs`/`hashmaps` layer).

No builder methods on the new generators in this initial cut (e.g. no `numbers().min_value(...)`); can be added in a follow-up if there's demand. Consistent with how `chrono`'s `Days`/`Months`/`IsoWeek` are exposed via `DefaultGenerator` only, there's also no public `maps()` factory — `gs::default::<Map<String, Value>>()` covers it.

`RELEASE_TYPE: patch`, since the change is purely additive (per the changelog skill, hegel-rust is zerover so additive features are still patches).

</details>
