### PR TITLE
Add tc.target() for targeted property-based testing

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,17 @@
+RELEASE_TYPE: patch
+
+This patch adds `tc.target(score, label)` for targeted property-based testing. Call it inside a test body to feed an observation back to the engine, which uses the score to guide generation toward higher-scoring inputs.
+
+```rust
+use hegel::generators as gs;
+
+#[hegel::test]
+fn my_test(tc: hegel::TestCase) {
+    let n: u64 = tc.draw(gs::integers::<u64>().max_value(1000));
+    let m: u64 = tc.draw(gs::integers::<u64>().max_value(1000));
+    tc.target((n + m) as f64, "");
+    assert!(n + m < 2000);
+}
+```
+
+The label distinguishes multiple simultaneous targeting goals; pass `""` for a single unlabeled score.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 RELEASE_TYPE: patch
 
-This patch adds `tc.target(score, label)` for targeted property-based testing. Call it inside a test body to feed an observation back to the engine, which uses the score to guide generation toward higher-scoring inputs.
+This patch adds `tc.target(score)` and `tc.target_labelled(score, label)` for targeted property-based testing. Call them inside a test body to feed an observation back to the engine, which uses the score to guide generation toward higher-scoring inputs.
 
 ```rust
 use hegel::generators as gs;
@@ -9,9 +9,9 @@ use hegel::generators as gs;
 fn my_test(tc: hegel::TestCase) {
     let n: u64 = tc.draw(gs::integers::<u64>().max_value(1000));
     let m: u64 = tc.draw(gs::integers::<u64>().max_value(1000));
-    tc.target((n + m) as f64, "");
+    tc.target((n + m) as f64);
     assert!(n + m < 2000);
 }
 ```
 
-The label distinguishes multiple simultaneous targeting goals; pass `""` for a single unlabeled score.
+Inside a `#[hegel::test]`, `#[hegel::main]`, or `#[hegel::standalone_function]` body — and inside a `hegel::rewrite_draws!` closure — `tc.target(expr)` is rewritten to `tc.target_labelled(expr, "expr")`, where the label is the source text of `expr`. That way separate targeting expressions get separate labels by default, and the engine optimises each independently. Call `tc.target_labelled(score, "...")` directly when you want to choose the label yourself.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,4 +14,4 @@ fn my_test(tc: hegel::TestCase) {
 }
 ```
 
-Inside a `#[hegel::test]`, `#[hegel::main]`, or `#[hegel::standalone_function]` body — and inside a `hegel::rewrite_draws!` closure — `tc.target(expr)` is rewritten to `tc.target_labelled(expr, "expr")`, where the label is the source text of `expr`. That way separate targeting expressions get separate labels by default, and the engine optimises each independently. Call `tc.target_labelled(score, "...")` directly when you want to choose the label yourself.
+Inside a `#[hegel::test]`, `#[hegel::main]`, or `#[hegel::standalone_function]` body, `tc.target(expr)` is rewritten to `tc.target_labelled(expr, "expr")`, where the label is the source text of `expr`. That way separate targeting expressions get separate labels by default, and the engine optimises each independently. Call `tc.target_labelled(score, "...")` directly when you want to choose the label yourself.

--- a/hegel-macros/src/common.rs
+++ b/hegel-macros/src/common.rs
@@ -201,6 +201,10 @@ impl VisitMut for DrawRewriter {
 ///
 /// Uses a two-pass approach so that if a name is used in a repeatable context
 /// anywhere (nested block or closure), every use of that name becomes repeatable.
+///
+/// Also rewrites `<test_case_ident>.target(score)` calls into
+/// `<test_case_ident>.target_labelled(score, "score-source")`, so each
+/// targeted expression gets a distinct label by default.
 pub fn rewrite_draws_in_block(body: &mut syn::Block, test_case_ident: &str) {
     let mut collector = DrawNameCollector {
         test_case_ident: test_case_ident.to_string(),
@@ -217,6 +221,45 @@ pub fn rewrite_draws_in_block(body: &mut syn::Block, test_case_ident: &str) {
     };
     for stmt in &mut body.stmts {
         rewriter.visit_stmt_mut(stmt);
+    }
+
+    let mut target_rewriter = TargetRewriter {
+        test_case_ident: test_case_ident.to_string(),
+    };
+    for stmt in &mut body.stmts {
+        target_rewriter.visit_stmt_mut(stmt);
+    }
+}
+
+struct TargetRewriter {
+    test_case_ident: String,
+}
+
+impl VisitMut for TargetRewriter {
+    fn visit_item_fn_mut(&mut self, _node: &mut syn::ItemFn) {}
+
+    fn visit_expr_method_call_mut(&mut self, node: &mut syn::ExprMethodCall) {
+        syn::visit_mut::visit_expr_method_call_mut(self, node);
+
+        if node.method != "target" || node.args.len() != 1 {
+            return;
+        }
+        let is_tc = match &*node.receiver {
+            Expr::Path(path) => path.path.is_ident(&self.test_case_ident),
+            _ => false,
+        };
+        if !is_tc {
+            return;
+        }
+
+        let span = node.method.span();
+        let arg = &node.args[0];
+        let expr_source = quote! { #arg }.to_string();
+        node.method = Ident::new("target_labelled", span);
+        node.args.push(Expr::Lit(syn::ExprLit {
+            attrs: vec![],
+            lit: syn::Lit::Str(syn::LitStr::new(&expr_source, span)),
+        }));
     }
 }
 
@@ -353,3 +396,7 @@ pub fn build_explicit_blocks(
         })
         .collect()
 }
+
+#[cfg(test)]
+#[path = "../tests/embedded/common_tests.rs"]
+mod tests;

--- a/hegel-macros/tests/embedded/common_tests.rs
+++ b/hegel-macros/tests/embedded/common_tests.rs
@@ -1,0 +1,101 @@
+use super::*;
+use quote::quote;
+
+fn rewrite(input: proc_macro2::TokenStream) -> String {
+    let mut block: syn::Block = syn::parse2(quote! { { #input } }).unwrap();
+    rewrite_draws_in_block(&mut block, "tc");
+    quote! { #block }.to_string()
+}
+
+#[test]
+fn test_target_call_is_rewritten_with_source_label() {
+    let out = rewrite(quote! {
+        tc.target(n as f64);
+    });
+    assert!(
+        out.contains("target_labelled"),
+        "expected method renamed to target_labelled, got: {out}"
+    );
+    assert!(
+        out.contains("\"n as f64\""),
+        "expected label to be the source of the score expression, got: {out}"
+    );
+}
+
+#[test]
+fn test_target_rewrite_uses_full_expression_source() {
+    let out = rewrite(quote! {
+        tc.target((m + n) as f64 / 2.0);
+    });
+    assert!(
+        out.contains("\"(m + n) as f64 / 2.0\""),
+        "expected literal expression in label, got: {out}"
+    );
+}
+
+#[test]
+fn test_target_labelled_call_is_left_alone() {
+    let out = rewrite(quote! {
+        tc.target_labelled(score, "explicit");
+    });
+    assert!(
+        !out.contains("target_labelled (score , \"explicit\" , \""),
+        "target_labelled must not be rewritten further, got: {out}"
+    );
+    assert!(
+        out.contains("target_labelled (score , \"explicit\")"),
+        "target_labelled call should be unchanged, got: {out}"
+    );
+}
+
+#[test]
+fn test_target_with_two_args_is_left_alone() {
+    let out = rewrite(quote! {
+        tc.target(score, ignored);
+    });
+    assert!(
+        out.contains("tc . target (score , ignored)"),
+        "two-arg target call must not be rewritten, got: {out}"
+    );
+}
+
+#[test]
+fn test_target_on_other_receiver_is_left_alone() {
+    let out = rewrite(quote! {
+        other.target(123.0);
+    });
+    assert!(
+        out.contains("other . target (123.0)"),
+        "non-tc receiver must not be rewritten, got: {out}"
+    );
+    assert!(
+        !out.contains("target_labelled"),
+        "non-tc receiver must not pick up target_labelled, got: {out}"
+    );
+}
+
+#[test]
+fn test_target_in_nested_block_is_rewritten() {
+    let out = rewrite(quote! {
+        for _ in 0..3 {
+            tc.target(score);
+        }
+    });
+    assert!(
+        out.contains("target_labelled (score , \"score\")"),
+        "target inside nested block should be rewritten, got: {out}"
+    );
+}
+
+#[test]
+fn test_target_inside_nested_fn_is_left_alone() {
+    let out = rewrite(quote! {
+        fn helper(tc: &TestCase) {
+            tc.target(n as f64);
+        }
+    });
+    assert!(
+        !out.contains("target_labelled"),
+        "rewriting must not descend into nested fn items, got: {out}"
+    );
+}

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -68,6 +68,12 @@ pub trait DataSource: Send + Sync {
     /// If `consume` is true, the variable is removed from the pool.
     fn pool_generate(&self, pool_id: i128, consume: bool) -> Result<i128, DataSourceError>;
 
+    /// Record a targeting observation for the current test case.
+    ///
+    /// The score is used by the backend to guide generation toward
+    /// higher-scoring inputs. No-op if the test has been aborted.
+    fn target_observation(&self, score: f64, label: &str);
+
     /// Signal that the test case is complete.
     fn mark_complete(&self, status: &str, origin: Option<&str>);
 

--- a/src/explicit_test_case.rs
+++ b/src/explicit_test_case.rs
@@ -129,6 +129,11 @@ impl ExplicitTestCase {
         panic!("{}", ASSUME_FAIL_STRING);
     }
 
+    pub fn target(&self, _score: f64, _label: impl Into<String>) {
+        // No-op for explicit test cases: targeting is only meaningful
+        // when the engine can act on the score during generation.
+    }
+
     #[doc(hidden)]
     pub fn start_span(&self, _label: u64) {
         panic!("start_span is not supported in explicit test cases");

--- a/src/explicit_test_case.rs
+++ b/src/explicit_test_case.rs
@@ -129,9 +129,13 @@ impl ExplicitTestCase {
         panic!("{}", ASSUME_FAIL_STRING);
     }
 
-    pub fn target(&self, _score: f64, _label: impl Into<String>) {
+    pub fn target(&self, _score: f64) {
         // No-op for explicit test cases: targeting is only meaningful
         // when the engine can act on the score during generation.
+    }
+
+    pub fn target_labelled(&self, _score: f64, _label: impl Into<String>) {
+        // No-op for explicit test cases: see `target`.
     }
 
     #[doc(hidden)]

--- a/src/server/data_source.rs
+++ b/src/server/data_source.rs
@@ -212,6 +212,16 @@ impl DataSource for ServerDataSource {
         }
     }
 
+    fn target_observation(&self, score: f64, label: &str) {
+        let _ = self.send_request(
+            "target",
+            &cbor_map! {
+                "value" => score,
+                "label" => label.to_string()
+            },
+        );
+    }
+
     fn mark_complete(&self, status: &str, origin: Option<&str>) {
         let origin_value = match origin {
             Some(s) => Value::Text(s.to_string()),

--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -389,12 +389,11 @@ impl TestCase {
     ///
     /// Call this inside a test body to guide generation toward inputs that
     /// maximise `score`. Inside a `#[hegel::test]`, `#[hegel::main]`, or
-    /// `#[hegel::standalone_function]` body (or a `hegel::rewrite_draws!`
-    /// closure), `tc.target(expr)` is rewritten to call
-    /// [`target_labelled`](Self::target_labelled) with the source text of
-    /// `expr` as the label, so different targeting expressions are tracked
-    /// separately by default. Outside that rewrite, `tc.target(score)` uses
-    /// the empty label.
+    /// `#[hegel::standalone_function]` body, `tc.target(expr)` is rewritten
+    /// to call [`target_labelled`](Self::target_labelled) with the source
+    /// text of `expr` as the label, so different targeting expressions are
+    /// tracked separately by default. Outside that rewrite, `tc.target(score)`
+    /// uses the empty label.
     ///
     /// Has no effect during replays or if the test case has been aborted.
     ///

--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -385,6 +385,30 @@ impl TestCase {
         (local.on_draw)(&format!("{:indent$}{}", "", message, indent = indent));
     }
 
+    /// Record a targeting observation to help the engine find extreme inputs.
+    ///
+    /// Call this inside a test body to guide generation toward inputs that
+    /// maximise `score`. The label distinguishes multiple simultaneous
+    /// targeting goals; pass `""` for a single unlabeled score.
+    ///
+    /// Has no effect during replays or if the test case has been aborted.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use hegel::generators as gs;
+    ///
+    /// #[hegel::test]
+    /// fn my_test(tc: hegel::TestCase) {
+    ///     let n: u32 = tc.draw(gs::integers::<u32>());
+    ///     tc.target(n as f64, "");
+    /// }
+    /// ```
+    pub fn target(&self, score: f64, label: impl Into<String>) {
+        let label = label.into();
+        self.with_data_source(|ds| ds.target_observation(score, &label));
+    }
+
     /// Run `body` in a loop that should runs "logically infinitely" or until
     /// error. Roughly equivalent to a `loop` but with better interaction with
     /// the test runner: This loop will never exit until the test case completes.

--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -388,8 +388,13 @@ impl TestCase {
     /// Record a targeting observation to help the engine find extreme inputs.
     ///
     /// Call this inside a test body to guide generation toward inputs that
-    /// maximise `score`. The label distinguishes multiple simultaneous
-    /// targeting goals; pass `""` for a single unlabeled score.
+    /// maximise `score`. Inside a `#[hegel::test]`, `#[hegel::main]`, or
+    /// `#[hegel::standalone_function]` body (or a `hegel::rewrite_draws!`
+    /// closure), `tc.target(expr)` is rewritten to call
+    /// [`target_labelled`](Self::target_labelled) with the source text of
+    /// `expr` as the label, so different targeting expressions are tracked
+    /// separately by default. Outside that rewrite, `tc.target(score)` uses
+    /// the empty label.
     ///
     /// Has no effect during replays or if the test case has been aborted.
     ///
@@ -401,10 +406,23 @@ impl TestCase {
     /// #[hegel::test]
     /// fn my_test(tc: hegel::TestCase) {
     ///     let n: u32 = tc.draw(gs::integers::<u32>());
-    ///     tc.target(n as f64, "");
+    ///     tc.target(n as f64);
     /// }
     /// ```
-    pub fn target(&self, score: f64, label: impl Into<String>) {
+    pub fn target(&self, score: f64) {
+        self.target_labelled(score, "");
+    }
+
+    /// Record a targeting observation under an explicit label.
+    ///
+    /// The label distinguishes multiple simultaneous targeting goals.
+    /// Use this directly when you want a specific label string;
+    /// [`target`](Self::target) is the usual entry point and will be
+    /// rewritten to call this with the source expression as the label
+    /// inside a `#[hegel::test]` body.
+    ///
+    /// Has no effect during replays or if the test case has been aborted.
+    pub fn target_labelled(&self, score: f64, label: impl Into<String>) {
         let label = label.into();
         self.with_data_source(|ds| ds.target_observation(score, &label));
     }

--- a/tests/test_explicit_test_case.rs
+++ b/tests/test_explicit_test_case.rs
@@ -260,6 +260,13 @@ fn test_explicit_reject_panics() {
 }
 
 #[test]
+fn test_explicit_target_is_noop() {
+    let etc = hegel::ExplicitTestCase::new();
+    etc.target(42.0, "label");
+    etc.target(0.0, "");
+}
+
+#[test]
 fn test_explicit_start_span_panics() {
     expect_panic(
         || {

--- a/tests/test_explicit_test_case.rs
+++ b/tests/test_explicit_test_case.rs
@@ -262,8 +262,9 @@ fn test_explicit_reject_panics() {
 #[test]
 fn test_explicit_target_is_noop() {
     let etc = hegel::ExplicitTestCase::new();
-    etc.target(42.0, "label");
-    etc.target(0.0, "");
+    etc.target(42.0);
+    etc.target_labelled(42.0, "label");
+    etc.target_labelled(0.0, "");
 }
 
 #[test]

--- a/tests/test_targeting.rs
+++ b/tests/test_targeting.rs
@@ -1,46 +1,10 @@
 //! Tests for `tc.target()`, the public targeted property-based testing API.
-//!
-//! Ports the Hypothesis test_targeting suites:
-//! - hypothesis-python/tests/cover/test_targeting.py
-//! - hypothesis-python/tests/nocover/test_targeting.py
-//! - resources/pbtkit/tests/test_targeting.py
-//!
-//! Tests not ported (and why):
-//! - `test_disallowed_inputs_to_target` — hegel-rust's API is typed (`f64`,
-//!   `Into<String>`), so invalid types (non-float score, non-string label) are
-//!   compile-time errors rather than runtime `InvalidArgument` exceptions.
-//!   NaN and infinity are valid `f64` values in Rust and pass through silently.
-//! - `test_cannot_target_outside_test` — hegel-rust has no free
-//!   `hegel::target()` function; targeting is only possible via `tc.target()`
-//!   inside a test closure, so this case is statically unreachable.
-//! - `test_cannot_target_same_label_twice` / `test_cannot_target_default_label_twice`
-//!   — hegel-rust silently overwrites duplicate labels rather than raising.
-//! - `test_target_returns_value` — `tc.target()` returns `()`, not the score.
-//! - `test_reports_target_results` — requires capture of pytest's stdout output
-//!   format; no portable Rust counterpart via the public API.
-//! - `test_targeting_can_be_disabled` — exercises `phases=[Phase.generate,
-//!   Phase.target]` vs `phases=[Phase.generate]` and asserts targeting achieves
-//!   higher scores; flaky and depends on targeting being effective, so left for
-//!   a dedicated targeting-quality test pass.
-//! - `test_targeting_skips_non_integer` — exercises `tc.weighted()`, not
-//!   `tc.target()`.
-//!
-//! The pbtkit "stdout via capsys" assertions in
-//! `test_can_target_a_score_upwards_to_interesting`,
-//! `test_targeting_when_most_do_not_benefit`, and
-//! `test_can_target_a_score_downwards` are not ported (no Rust capsys
-//! equivalent); each test still asserts the panic from the targeted assertion
-//! failure.
 
 mod common;
 
 use common::utils::expect_panic;
 use hegel::generators as gs;
 use hegel::{Hegel, Settings};
-
-// ============================================================
-// API surface tests (cover/test_targeting.py)
-// ============================================================
 
 /// `tc.target(observation, label)` compiles and runs without panicking.
 #[test]
@@ -92,7 +56,7 @@ fn test_multiple_target_calls() {
     .run();
 }
 
-/// Stress-test with many distinct target labels (mirrors `test_respects_max_pool_size`).
+/// Stress-test with many distinct target labels.
 #[test]
 fn test_respects_max_pool_size() {
     Hegel::new(|tc| {
@@ -109,13 +73,7 @@ fn test_respects_max_pool_size() {
     .run();
 }
 
-// ============================================================
-// Behavioural tests (pbtkit/test_targeting.py)
-// ============================================================
-
 /// Targeting must not call the test body more times than `max_examples`.
-/// Ported from `test_max_examples_is_not_exceeded` (parametrized 1..100);
-/// a representative subset `[1, 5, 25, 99]` is checked here.
 #[test]
 fn test_max_examples_is_not_exceeded() {
     let m: u64 = 10000;
@@ -137,7 +95,6 @@ fn test_max_examples_is_not_exceeded() {
 }
 
 /// Targeting with a 2D quadratic score drives the optimizer to (500, 500).
-/// Ported from `test_finds_a_local_maximum` (parametrized over 100 seeds).
 #[test]
 fn test_finds_a_local_maximum() {
     expect_panic(
@@ -157,7 +114,6 @@ fn test_finds_a_local_maximum() {
 }
 
 /// Targeting can drive a sum score to its maximum and trigger an assertion failure.
-/// Ported from `test_can_target_a_score_upwards_to_interesting` (stdout check omitted).
 #[test]
 fn test_can_target_a_score_upwards_to_interesting() {
     expect_panic(
@@ -177,7 +133,6 @@ fn test_can_target_a_score_upwards_to_interesting() {
 }
 
 /// Targeting drives the maximum observed sum to 2000 without any assertion failure.
-/// Ported from `test_can_target_a_score_upwards_without_failing`.
 #[test]
 fn test_can_target_a_score_upwards_without_failing() {
     let mut max_score: u64 = 0;
@@ -197,7 +152,6 @@ fn test_can_target_a_score_upwards_without_failing() {
 
 /// When most test cases yield the same score on the first two draws, targeting
 /// still drives the third draw to its maximum.
-/// Ported from `test_targeting_when_most_do_not_benefit` (stdout check omitted).
 #[test]
 fn test_targeting_when_most_do_not_benefit() {
     let big: u64 = 10000;
@@ -231,7 +185,6 @@ fn test_targeting_adjust_avoids_negative_values() {
 }
 
 /// Targeting can drive a score downwards and find a case where the sum is 0.
-/// Ported from `test_can_target_a_score_downwards` (stdout check omitted).
 #[test]
 fn test_can_target_a_score_downwards() {
     expect_panic(

--- a/tests/test_targeting.rs
+++ b/tests/test_targeting.rs
@@ -6,42 +6,42 @@ use common::utils::expect_panic;
 use hegel::generators as gs;
 use hegel::{Hegel, Settings};
 
-/// `tc.target(observation, label)` compiles and runs without panicking.
+/// `tc.target_labelled(observation, label)` compiles and runs without panicking.
 #[test]
 fn test_allowed_inputs_to_target() {
     Hegel::new(|tc| {
         let observation: f64 = tc.draw(gs::floats::<f64>().allow_nan(false).allow_infinity(false));
         let label: String = tc.draw(gs::text());
-        tc.target(observation, label);
+        tc.target_labelled(observation, label);
     })
     .settings(Settings::new().test_cases(100).database(None))
     .run();
 }
 
-/// `tc.target(observation, label)` works for a restricted set of labels.
+/// `tc.target_labelled(observation, label)` works for a restricted set of labels.
 #[test]
 fn test_allowed_inputs_to_target_fewer_labels() {
     Hegel::new(|tc| {
         let observation: f64 = tc.draw(gs::floats::<f64>().min_value(1.0).allow_infinity(false));
         let label: &str = tc.draw(gs::sampled_from(vec!["a", "few", "labels"]));
-        tc.target(observation, label);
+        tc.target_labelled(observation, label);
     })
     .settings(Settings::new().test_cases(100).database(None))
     .run();
 }
 
-/// `tc.target(observation, "")` works with the empty default label.
+/// `tc.target(observation)` works with the empty default label.
 #[test]
 fn test_target_without_label() {
     Hegel::new(|tc| {
         let observation: f64 = tc.draw(gs::floats::<f64>().min_value(1.0).max_value(10.0));
-        tc.target(observation, "");
+        tc.target(observation);
     })
     .settings(Settings::new().test_cases(100).database(None))
     .run();
 }
 
-/// Multiple `tc.target()` calls with different labels all execute without error.
+/// Multiple `tc.target_labelled()` calls with different labels all execute without error.
 #[test]
 fn test_multiple_target_calls() {
     Hegel::new(|tc| {
@@ -49,7 +49,7 @@ fn test_multiple_target_calls() {
         for i in 0..n {
             let observation: f64 =
                 tc.draw(gs::floats::<f64>().allow_nan(false).allow_infinity(false));
-            tc.target(observation, i.to_string());
+            tc.target_labelled(observation, i.to_string());
         }
     })
     .settings(Settings::new().test_cases(100).database(None))
@@ -66,7 +66,7 @@ fn test_respects_max_pool_size() {
                 .max_size(20),
         );
         for (i, obs) in observations.iter().enumerate() {
-            tc.target(*obs, i.to_string());
+            tc.target_labelled(*obs, i.to_string());
         }
     })
     .settings(Settings::new().test_cases(100).database(None))
@@ -82,7 +82,7 @@ fn test_max_examples_is_not_exceeded() {
         Hegel::new(|tc| {
             calls += 1;
             let n: u64 = tc.draw(gs::integers::<u64>().max_value(m));
-            tc.target((n * (m - n)) as f64, "");
+            tc.target((n * (m - n)) as f64);
         })
         .settings(
             Settings::new()
@@ -103,7 +103,7 @@ fn test_finds_a_local_maximum() {
                 let m: u64 = tc.draw(gs::integers::<u64>().max_value(1000));
                 let n: u64 = tc.draw(gs::integers::<u64>().max_value(1000));
                 let score = -(((m as i64) - 500).pow(2) + ((n as i64) - 500).pow(2));
-                tc.target(score as f64, "");
+                tc.target(score as f64);
                 assert!(m != 500 || n != 500);
             })
             .settings(Settings::new().test_cases(200).database(None))
@@ -122,7 +122,7 @@ fn test_can_target_a_score_upwards_to_interesting() {
                 let n: u64 = tc.draw(gs::integers::<u64>().max_value(1000));
                 let m: u64 = tc.draw(gs::integers::<u64>().max_value(1000));
                 let score = n + m;
-                tc.target(score as f64, "");
+                tc.target(score as f64);
                 assert!(score < 2000);
             })
             .settings(Settings::new().test_cases(1000).database(None))
@@ -140,7 +140,7 @@ fn test_can_target_a_score_upwards_without_failing() {
         let n: u64 = tc.draw(gs::integers::<u64>().max_value(1000));
         let m: u64 = tc.draw(gs::integers::<u64>().max_value(1000));
         let score = n + m;
-        tc.target(score as f64, "");
+        tc.target(score as f64);
         if score > max_score {
             max_score = score;
         }
@@ -161,7 +161,7 @@ fn test_targeting_when_most_do_not_benefit() {
                 tc.draw(gs::integers::<u64>().max_value(1000));
                 tc.draw(gs::integers::<u64>().max_value(1000));
                 let score: u64 = tc.draw(gs::integers::<u64>().max_value(big));
-                tc.target(score as f64, "");
+                tc.target(score as f64);
                 assert!(score < big);
             })
             .settings(Settings::new().test_cases(1000).database(None))
@@ -178,7 +178,7 @@ fn test_targeting_when_most_do_not_benefit() {
 fn test_targeting_adjust_avoids_negative_values() {
     Hegel::new(|tc| {
         let n: u64 = tc.draw(gs::integers::<u64>().max_value(0));
-        tc.target(n as f64, "");
+        tc.target(n as f64);
     })
     .settings(Settings::new().test_cases(200).database(None))
     .run();
@@ -193,7 +193,7 @@ fn test_can_target_a_score_downwards() {
                 let n: u64 = tc.draw(gs::integers::<u64>().max_value(1000));
                 let m: u64 = tc.draw(gs::integers::<u64>().max_value(1000));
                 let score = n + m;
-                tc.target(-(score as f64), "");
+                tc.target(-(score as f64));
                 assert!(score > 0);
             })
             .settings(Settings::new().test_cases(1000).database(None))
@@ -201,4 +201,15 @@ fn test_can_target_a_score_downwards() {
         },
         "Property test failed",
     );
+}
+
+/// Sanity check that `#[hegel::test]` accepts the rewritten `tc.target(expr)`
+/// form. The rewrite of `tc.target(expr)` to `tc.target_labelled(expr, "expr")`
+/// is verified directly by the unit tests in `hegel-macros`.
+#[hegel::test(test_cases = 5)]
+fn test_target_rewrite_compiles_in_hegel_test(tc: hegel::TestCase) {
+    let n: i32 = tc.draw(gs::integers::<i32>().min_value(0).max_value(100));
+    tc.target(n as f64);
+    tc.target((n * 2) as f64);
+    tc.target_labelled(n as f64, "explicit");
 }

--- a/tests/test_targeting.rs
+++ b/tests/test_targeting.rs
@@ -1,0 +1,251 @@
+//! Tests for `tc.target()`, the public targeted property-based testing API.
+//!
+//! Ports the Hypothesis test_targeting suites:
+//! - hypothesis-python/tests/cover/test_targeting.py
+//! - hypothesis-python/tests/nocover/test_targeting.py
+//! - resources/pbtkit/tests/test_targeting.py
+//!
+//! Tests not ported (and why):
+//! - `test_disallowed_inputs_to_target` — hegel-rust's API is typed (`f64`,
+//!   `Into<String>`), so invalid types (non-float score, non-string label) are
+//!   compile-time errors rather than runtime `InvalidArgument` exceptions.
+//!   NaN and infinity are valid `f64` values in Rust and pass through silently.
+//! - `test_cannot_target_outside_test` — hegel-rust has no free
+//!   `hegel::target()` function; targeting is only possible via `tc.target()`
+//!   inside a test closure, so this case is statically unreachable.
+//! - `test_cannot_target_same_label_twice` / `test_cannot_target_default_label_twice`
+//!   — hegel-rust silently overwrites duplicate labels rather than raising.
+//! - `test_target_returns_value` — `tc.target()` returns `()`, not the score.
+//! - `test_reports_target_results` — requires capture of pytest's stdout output
+//!   format; no portable Rust counterpart via the public API.
+//! - `test_targeting_can_be_disabled` — exercises `phases=[Phase.generate,
+//!   Phase.target]` vs `phases=[Phase.generate]` and asserts targeting achieves
+//!   higher scores; flaky and depends on targeting being effective, so left for
+//!   a dedicated targeting-quality test pass.
+//! - `test_targeting_skips_non_integer` — exercises `tc.weighted()`, not
+//!   `tc.target()`.
+//!
+//! The pbtkit "stdout via capsys" assertions in
+//! `test_can_target_a_score_upwards_to_interesting`,
+//! `test_targeting_when_most_do_not_benefit`, and
+//! `test_can_target_a_score_downwards` are not ported (no Rust capsys
+//! equivalent); each test still asserts the panic from the targeted assertion
+//! failure.
+
+mod common;
+
+use common::utils::expect_panic;
+use hegel::generators as gs;
+use hegel::{Hegel, Settings};
+
+// ============================================================
+// API surface tests (cover/test_targeting.py)
+// ============================================================
+
+/// `tc.target(observation, label)` compiles and runs without panicking.
+#[test]
+fn test_allowed_inputs_to_target() {
+    Hegel::new(|tc| {
+        let observation: f64 = tc.draw(gs::floats::<f64>().allow_nan(false).allow_infinity(false));
+        let label: String = tc.draw(gs::text());
+        tc.target(observation, label);
+    })
+    .settings(Settings::new().test_cases(100).database(None))
+    .run();
+}
+
+/// `tc.target(observation, label)` works for a restricted set of labels.
+#[test]
+fn test_allowed_inputs_to_target_fewer_labels() {
+    Hegel::new(|tc| {
+        let observation: f64 = tc.draw(gs::floats::<f64>().min_value(1.0).allow_infinity(false));
+        let label: &str = tc.draw(gs::sampled_from(vec!["a", "few", "labels"]));
+        tc.target(observation, label);
+    })
+    .settings(Settings::new().test_cases(100).database(None))
+    .run();
+}
+
+/// `tc.target(observation, "")` works with the empty default label.
+#[test]
+fn test_target_without_label() {
+    Hegel::new(|tc| {
+        let observation: f64 = tc.draw(gs::floats::<f64>().min_value(1.0).max_value(10.0));
+        tc.target(observation, "");
+    })
+    .settings(Settings::new().test_cases(100).database(None))
+    .run();
+}
+
+/// Multiple `tc.target()` calls with different labels all execute without error.
+#[test]
+fn test_multiple_target_calls() {
+    Hegel::new(|tc| {
+        let n: usize = tc.draw(gs::integers::<usize>().min_value(1).max_value(20));
+        for i in 0..n {
+            let observation: f64 =
+                tc.draw(gs::floats::<f64>().allow_nan(false).allow_infinity(false));
+            tc.target(observation, i.to_string());
+        }
+    })
+    .settings(Settings::new().test_cases(100).database(None))
+    .run();
+}
+
+/// Stress-test with many distinct target labels (mirrors `test_respects_max_pool_size`).
+#[test]
+fn test_respects_max_pool_size() {
+    Hegel::new(|tc| {
+        let observations: Vec<f64> = tc.draw(
+            gs::vecs(gs::floats::<f64>().allow_nan(false).allow_infinity(false))
+                .min_size(11)
+                .max_size(20),
+        );
+        for (i, obs) in observations.iter().enumerate() {
+            tc.target(*obs, i.to_string());
+        }
+    })
+    .settings(Settings::new().test_cases(100).database(None))
+    .run();
+}
+
+// ============================================================
+// Behavioural tests (pbtkit/test_targeting.py)
+// ============================================================
+
+/// Targeting must not call the test body more times than `max_examples`.
+/// Ported from `test_max_examples_is_not_exceeded` (parametrized 1..100);
+/// a representative subset `[1, 5, 25, 99]` is checked here.
+#[test]
+fn test_max_examples_is_not_exceeded() {
+    let m: u64 = 10000;
+    for max_examples in [1usize, 5, 25, 99] {
+        let mut calls: usize = 0;
+        Hegel::new(|tc| {
+            calls += 1;
+            let n: u64 = tc.draw(gs::integers::<u64>().max_value(m));
+            tc.target((n * (m - n)) as f64, "");
+        })
+        .settings(
+            Settings::new()
+                .test_cases(max_examples as u64)
+                .database(None),
+        )
+        .run();
+        assert_eq!(calls, max_examples, "max_examples = {max_examples}");
+    }
+}
+
+/// Targeting with a 2D quadratic score drives the optimizer to (500, 500).
+/// Ported from `test_finds_a_local_maximum` (parametrized over 100 seeds).
+#[test]
+fn test_finds_a_local_maximum() {
+    expect_panic(
+        || {
+            Hegel::new(|tc| {
+                let m: u64 = tc.draw(gs::integers::<u64>().max_value(1000));
+                let n: u64 = tc.draw(gs::integers::<u64>().max_value(1000));
+                let score = -(((m as i64) - 500).pow(2) + ((n as i64) - 500).pow(2));
+                tc.target(score as f64, "");
+                assert!(m != 500 || n != 500);
+            })
+            .settings(Settings::new().test_cases(200).database(None))
+            .run();
+        },
+        "Property test failed",
+    );
+}
+
+/// Targeting can drive a sum score to its maximum and trigger an assertion failure.
+/// Ported from `test_can_target_a_score_upwards_to_interesting` (stdout check omitted).
+#[test]
+fn test_can_target_a_score_upwards_to_interesting() {
+    expect_panic(
+        || {
+            Hegel::new(|tc| {
+                let n: u64 = tc.draw(gs::integers::<u64>().max_value(1000));
+                let m: u64 = tc.draw(gs::integers::<u64>().max_value(1000));
+                let score = n + m;
+                tc.target(score as f64, "");
+                assert!(score < 2000);
+            })
+            .settings(Settings::new().test_cases(1000).database(None))
+            .run();
+        },
+        "Property test failed",
+    );
+}
+
+/// Targeting drives the maximum observed sum to 2000 without any assertion failure.
+/// Ported from `test_can_target_a_score_upwards_without_failing`.
+#[test]
+fn test_can_target_a_score_upwards_without_failing() {
+    let mut max_score: u64 = 0;
+    Hegel::new(|tc| {
+        let n: u64 = tc.draw(gs::integers::<u64>().max_value(1000));
+        let m: u64 = tc.draw(gs::integers::<u64>().max_value(1000));
+        let score = n + m;
+        tc.target(score as f64, "");
+        if score > max_score {
+            max_score = score;
+        }
+    })
+    .settings(Settings::new().test_cases(1000).database(None))
+    .run();
+    assert_eq!(max_score, 2000);
+}
+
+/// When most test cases yield the same score on the first two draws, targeting
+/// still drives the third draw to its maximum.
+/// Ported from `test_targeting_when_most_do_not_benefit` (stdout check omitted).
+#[test]
+fn test_targeting_when_most_do_not_benefit() {
+    let big: u64 = 10000;
+    expect_panic(
+        move || {
+            Hegel::new(move |tc| {
+                tc.draw(gs::integers::<u64>().max_value(1000));
+                tc.draw(gs::integers::<u64>().max_value(1000));
+                let score: u64 = tc.draw(gs::integers::<u64>().max_value(big));
+                tc.target(score as f64, "");
+                assert!(score < big);
+            })
+            .settings(Settings::new().test_cases(1000).database(None))
+            .run();
+        },
+        "Property test failed",
+    );
+}
+
+/// Targeting with `choice(0)` (always 0) must not produce a negative value.
+/// The targeting optimizer checks for `step=-1` on value 0; the guard must fire
+/// and return `False` rather than producing a negative choice.
+#[test]
+fn test_targeting_adjust_avoids_negative_values() {
+    Hegel::new(|tc| {
+        let n: u64 = tc.draw(gs::integers::<u64>().max_value(0));
+        tc.target(n as f64, "");
+    })
+    .settings(Settings::new().test_cases(200).database(None))
+    .run();
+}
+
+/// Targeting can drive a score downwards and find a case where the sum is 0.
+/// Ported from `test_can_target_a_score_downwards` (stdout check omitted).
+#[test]
+fn test_can_target_a_score_downwards() {
+    expect_panic(
+        || {
+            Hegel::new(|tc| {
+                let n: u64 = tc.draw(gs::integers::<u64>().max_value(1000));
+                let m: u64 = tc.draw(gs::integers::<u64>().max_value(1000));
+                let score = n + m;
+                tc.target(-(score as f64), "");
+                assert!(score > 0);
+            })
+            .settings(Settings::new().test_cases(1000).database(None))
+            .run();
+        },
+        "Property test failed",
+    );
+}


### PR DESCRIPTION
Adds public `TestCase::target(score, label)` for the server backend; ports the upstream `test_targeting.py` suites.

<details>
<summary>Implementation details</summary>

- `DataSource::target_observation(score: f64, label: &str)` added to the trait.
- `ServerDataSource::target_observation` sends `{command: "target", value: score, label: label}` to hegel-core (server-side targeting hill-climber uses the score to guide generation).
- `TestCase::target(score, label: impl Into<String>)` is the public method.
- `ExplicitTestCase::target` is a no-op (targeting only matters when the engine can act on the score).

## Tests
- `tests/test_targeting.rs` (12 tests) — combines the upstream cover, nocover, and pbtkit `test_targeting.py` suites into one file:
  - API surface: `test_allowed_inputs_to_target`, `test_allowed_inputs_to_target_fewer_labels`, `test_target_without_label`, `test_multiple_target_calls`, `test_respects_max_pool_size`.
  - Behaviour: `test_max_examples_is_not_exceeded`, `test_finds_a_local_maximum`, `test_can_target_a_score_upwards_to_interesting`, `test_can_target_a_score_upwards_without_failing`, `test_targeting_when_most_do_not_benefit`, `test_targeting_adjust_avoids_negative_values`, `test_can_target_a_score_downwards`.
- `tests/test_explicit_test_case.rs` gains `test_explicit_target_is_noop`.

The file header documents which upstream tests are intentionally not ported and why (e.g. typed API removes runtime InvalidArgument cases; no free `hegel::target()` function; tc.target returns `()`; etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>