### PR TITLE
Report each distinct failing test case

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,38 @@
+RELEASE_TYPE: patch
+
+This patch makes Hegel surface every distinct failing test case from a
+run, rather than collapsing multi-bug runs down to whichever failure
+fired last. Previously the runner would print only one diagnostic and
+re-raise with one message, even when Hypothesis had actually found
+several unrelated bugs in the same run. That could even hide unrelated
+panics — e.g. an overflow in a test predicate would get silently
+overwritten by a later assertion failure.
+
+When the run produces multiple distinct failures, Hegel now prints:
+
+```
+Hegel found N failing test cases:
+<diagnostic for failure 1>
+<diagnostic for failure 2>
+...
+```
+
+followed by a `Property-based test failed with N distinct failures.`
+panic. Single-failure runs are unchanged: the diagnostic and
+`Property test failed: <msg>` panic look exactly as before.
+
+This patch also adds a `report_multiple_failures` setting (default
+`true`) which controls the behaviour:
+
+```rust
+use hegel::Settings;
+
+let settings = Settings::new().report_multiple_failures(false);
+```
+
+When set to `false`, Hegel asks the server to collapse multi-bug runs
+to a single failing example — useful when one root-cause bug shows up
+as several superficially-distinct failures and the extra reports are
+noise. The setting maps to Hypothesis's `report_multiple_bugs`. It
+takes effect when paired with hegel-core 0.9.0 or later (older
+versions silently ignore the field and use the Hypothesis default).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,11 +2,7 @@ RELEASE_TYPE: patch
 
 This patch makes Hegel surface every distinct failing test case from a
 run, rather than collapsing multi-bug runs down to whichever failure
-fired last. Previously the runner would print only one diagnostic and
-re-raise with one message, even when Hypothesis had actually found
-several unrelated bugs in the same run. That could even hide unrelated
-panics — e.g. an overflow in a test predicate would get silently
-overwritten by a later assertion failure.
+fired last.
 
 When the run produces multiple distinct failures, Hegel now prints:
 
@@ -16,23 +12,3 @@ Hegel found N failing test cases:
 <diagnostic for failure 2>
 ...
 ```
-
-followed by a `Property-based test failed with N distinct failures.`
-panic. Single-failure runs are unchanged: the diagnostic and
-`Property test failed: <msg>` panic look exactly as before.
-
-This patch also adds a `report_multiple_failures` setting (default
-`true`) which controls the behaviour:
-
-```rust
-use hegel::Settings;
-
-let settings = Settings::new().report_multiple_failures(false);
-```
-
-When set to `false`, Hegel asks the server to collapse multi-bug runs
-to a single failing example — useful when one root-cause bug shows up
-as several superficially-distinct failures and the extra reports are
-noise. The setting maps to Hypothesis's `report_multiple_bugs`. It
-takes effect when paired with hegel-core 0.9.0 or later (older
-versions silently ignore the field and use the Hypothesis default).

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -38,17 +38,17 @@
       },
       "locked": {
         "dir": "nix",
-        "lastModified": 1778498440,
-        "narHash": "sha256-pyqXb1oTQ6NATvs/fgsGCPMcbEKyl0tveX1CEB7MTVg=",
-        "ref": "refs/tags/v0.8.2",
-        "rev": "5d5e6f78d7af745cff7c657c98480ef4472e3b40",
-        "revCount": 689,
+        "lastModified": 1778671529,
+        "narHash": "sha256-wjYqIoWjlNupckJ97pfNcSl2y2yz9x/fDLTv1L1wEek=",
+        "ref": "refs/tags/v0.9.0",
+        "rev": "a04305b618557c73a836be23c037f5f723bdacdd",
+        "revCount": 693,
         "type": "git",
         "url": "https://github.com/hegeldev/hegel-core"
       },
       "original": {
         "dir": "nix",
-        "ref": "refs/tags/v0.8.2",
+        "ref": "refs/tags/v0.9.0",
         "type": "git",
         "url": "https://github.com/hegeldev/hegel-core"
       }

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     # note: this version is automatically bumped when we update hegel-core, do not update manually
-    hegel.url = "git+https://github.com/hegeldev/hegel-core?dir=nix&ref=refs/tags/v0.8.2"; # git+https instead of github so that we can use the ref parameter
+    hegel.url = "git+https://github.com/hegeldev/hegel-core?dir=nix&ref=refs/tags/v0.9.0"; # git+https instead of github so that we can use the ref parameter
     flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
   };
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -81,6 +81,25 @@ pub trait DataSource: Send + Sync {
     fn test_aborted(&self) -> bool;
 }
 
+/// A single failing test case discovered by a [`TestRunner`].
+#[derive(Debug, Clone)]
+pub struct Failure {
+    /// The raw panic message from the failing test (the string passed to `panic!`).
+    /// Used as-is for the legacy single-failure outer panic message.
+    pub panic_message: String,
+    /// Pre-rendered multi-line diagnostic — `thread '...' panicked at file:line:`
+    /// followed by the panic message and (when captured) the stack backtrace.
+    /// Same format that was previously printed inline by the runner on final replay.
+    pub diagnostic: String,
+    /// Opaque per-bug origin tag — currently `"Panic at file:line:col"` from
+    /// the captured panic site (with `<unknown>` for the location when
+    /// `take_panic_info` returns nothing).  Passed through
+    /// `DataSource::mark_complete` so Hypothesis can group test cases by
+    /// which bug they trigger and shrink each origin to its own minimal
+    /// counterexample.
+    pub origin: String,
+}
+
 /// Result of running a single test case.
 #[derive(Debug)]
 pub enum TestCaseResult {
@@ -91,10 +110,7 @@ pub enum TestCaseResult {
     /// Test case was rejected because the backend ran out of data.
     Overrun,
     /// Test case found a bug.
-    Interesting {
-        /// The panic message from the failing test.
-        panic_message: String,
-    },
+    Interesting(Failure),
 }
 
 /// Result of a full test run.
@@ -102,8 +118,11 @@ pub enum TestCaseResult {
 pub struct TestRunResult {
     /// Whether all test cases passed.
     pub passed: bool,
-    /// If a test case failed, the message from the minimal failing example.
-    pub failure_message: Option<String>,
+    /// One entry per distinct failing example surfaced by the run.  Empty when
+    /// `passed` is `true`.  For the multi-bug case (Hypothesis emits one final
+    /// replay per `BaseExceptionGroup` origin), each origin contributes one
+    /// entry, ordered as the backend replayed them.
+    pub failures: Vec<Failure>,
 }
 
 /// Drives the test execution lifecycle.

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -106,6 +106,7 @@ pub struct Settings {
     pub(crate) database: Database,
     pub(crate) suppress_health_check: Vec<HealthCheck>,
     pub(crate) phases: Vec<Phase>,
+    pub(crate) report_multiple_failures: bool,
 }
 
 impl Settings {
@@ -131,6 +132,7 @@ impl Settings {
                 Phase::Target,
                 Phase::Shrink,
             ],
+            report_multiple_failures: true,
         }
     }
 
@@ -213,6 +215,22 @@ impl Settings {
     /// Returns `true` if the given phase is enabled in these settings.
     pub fn has_phase(&self, phase: Phase) -> bool {
         self.phases.contains(&phase)
+    }
+
+    /// Control whether multi-bug runs report every distinct failing example
+    /// or collapse to just the first one.
+    ///
+    /// When `true` (the default), each distinct origin Hegel finds is surfaced
+    /// as its own diagnostic, and the final panic message reports the count of
+    /// distinct failures.  Setting this to `false` makes Hegel collapse a
+    /// multi-bug run to one example — useful when you have a flaky predicate
+    /// that triggers several superficially-distinct failures whose root cause
+    /// is the same, and the extra reports are just noise.
+    ///
+    /// Maps to Hypothesis's `report_multiple_bugs` setting.
+    pub fn report_multiple_failures(mut self, report_multiple_failures: bool) -> Self {
+        self.report_multiple_failures = report_multiple_failures;
+        self
     }
 }
 

--- a/src/server/runner.rs
+++ b/src/server/runner.rs
@@ -1,6 +1,6 @@
 use crate::antithesis::TestLocation;
 use crate::antithesis::is_running_in_antithesis;
-use crate::backend::{DataSource, TestCaseResult, TestRunner};
+use crate::backend::{DataSource, Failure, TestCaseResult, TestRunner};
 use crate::control::{currently_in_test_context, with_test_context};
 use crate::runner::{Mode, Phase, Settings};
 use crate::test_case::TestCase;
@@ -153,6 +153,40 @@ pub(super) fn init_panic_hook() {
     });
 }
 
+/// Format the diagnostic block that previously printed inline on final replay.
+/// Mirrors the default Rust panic-handler output: `thread '...' panicked at file:line:`
+/// followed by the message and (when captured) the stack backtrace.
+fn render_diagnostic(
+    thread_name: &str,
+    thread_id: &str,
+    location: &str,
+    msg: &str,
+    backtrace: &Backtrace,
+) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "thread '{}' ({}) panicked at {}:\n",
+        thread_name, thread_id, location
+    ));
+    out.push_str(msg);
+    out.push('\n');
+    // nocov start
+    if backtrace.status() == BacktraceStatus::Captured {
+        let is_full = std::env::var("RUST_BACKTRACE")
+            .map(|v| v == "full")
+            .unwrap_or(false);
+        let formatted = format_backtrace(backtrace, is_full);
+        out.push_str(&format!("stack backtrace:\n{}\n", formatted));
+        if !is_full {
+            out.push_str(
+                "note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.\n",
+            );
+        }
+    }
+    // nocov end
+    out
+}
+
 fn run_test_case(
     data_source: Box<dyn DataSource>,
     test_fn: &mut dyn FnMut(TestCase),
@@ -163,21 +197,20 @@ fn run_test_case(
 
     let result = with_test_context(|| catch_unwind(AssertUnwindSafe(|| test_fn(tc.clone()))));
 
-    let (tc_result, origin) = match &result {
-        Ok(()) => (TestCaseResult::Valid, None),
+    let tc_result = match &result {
+        Ok(()) => TestCaseResult::Valid,
         Err(e) => {
             let msg = panic_message(e);
             if msg == ASSUME_FAIL_STRING {
-                (TestCaseResult::Invalid, None)
+                TestCaseResult::Invalid
             } else if msg == STOP_TEST_STRING {
-                (TestCaseResult::Overrun, None)
+                TestCaseResult::Overrun
             } else if msg == LOOP_DONE_STRING {
                 // `TestCase::repeat` returns `!`, so it exits via this
                 // sentinel panic when its loop completes normally. Treat it
                 // the same as a no-panic return.
-                (TestCaseResult::Valid, None)
+                TestCaseResult::Valid
             } else {
-                // Take panic info - we need location for origin, and print details on final
                 let (thread_name, thread_id, location, backtrace) = take_panic_info()
                     .unwrap_or_else(|| {
                         // nocov start
@@ -190,34 +223,13 @@ fn run_test_case(
                         // nocov end
                     });
 
-                if is_final {
-                    eprintln!(
-                        "thread '{}' ({}) panicked at {}:",
-                        thread_name, thread_id, location
-                    );
-                    eprintln!("{}", msg);
-
-                    // nocov start
-                    if backtrace.status() == BacktraceStatus::Captured {
-                        let is_full = std::env::var("RUST_BACKTRACE")
-                            .map(|v| v == "full")
-                            .unwrap_or(false);
-                        let formatted = format_backtrace(&backtrace, is_full);
-                        eprintln!("stack backtrace:\n{}", formatted);
-                        if !is_full {
-                            eprintln!(
-                                "note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace."
-                            );
-                        }
-                    }
-                    // nocov end
-                }
-
-                let origin = format!("Panic at {}", location);
-                (
-                    TestCaseResult::Interesting { panic_message: msg },
-                    Some(origin),
-                )
+                let diagnostic =
+                    render_diagnostic(&thread_name, &thread_id, &location, &msg, &backtrace);
+                TestCaseResult::Interesting(Failure {
+                    panic_message: msg,
+                    diagnostic,
+                    origin: format!("Panic at {}", location),
+                })
             }
         }
     };
@@ -225,14 +237,15 @@ fn run_test_case(
     // Send mark_complete via the data source.
     // Skip if test was aborted (StopTest) - the data source already closed.
     if !tc.test_aborted() {
-        let status = match &tc_result {
-            TestCaseResult::Valid => "VALID",
-            TestCaseResult::Invalid | TestCaseResult::Overrun => "INVALID",
-            TestCaseResult::Interesting { .. } => "INTERESTING",
+        let (status, origin) = match &tc_result {
+            TestCaseResult::Valid => ("VALID", None),
+            TestCaseResult::Invalid | TestCaseResult::Overrun => ("INVALID", None),
+            TestCaseResult::Interesting(f) => ("INTERESTING", Some(f.origin.as_str())),
         };
-        tc.mark_complete(status, origin.as_deref());
+        tc.mark_complete(status, origin);
     }
 
+    let _ = is_final;
     tc_result
 }
 
@@ -280,7 +293,7 @@ pub fn server_run<F>(
     let mode = settings.mode;
     let result = runner.run(settings, database_key, &mut |backend, is_final| {
         let tc_result = run_test_case(backend, &mut test_fn, is_final, mode);
-        if matches!(&tc_result, TestCaseResult::Interesting { .. }) {
+        if matches!(&tc_result, TestCaseResult::Interesting(_)) {
             got_interesting.store(true, Ordering::SeqCst);
         }
         tc_result
@@ -306,8 +319,32 @@ pub fn server_run<F>(
     // test_location is only consumed inside the is_running_in_antithesis() block above.
     let _ = test_location;
 
-    if test_failed {
-        let msg = result.failure_message.as_deref().unwrap_or("unknown");
-        panic!("Property test failed: {}", msg);
+    if !test_failed {
+        return;
+    }
+
+    match result.failures.as_slice() {
+        // `test_failed` was set but no Failure surfaced — e.g. an aborted
+        // mid-draw test case or a backend that reported failure without
+        // attaching a Failure.  Preserve the legacy generic panic.
+        [] => panic!("Property test failed: unknown"),
+        // Single-failure path: keep the original output shape so test
+        // harnesses that pattern-match on `"Property test failed: <msg>"`
+        // (e.g. `Minimal::run` in `tests/common/utils.rs`) keep working.
+        [failure] => {
+            eprint!("{}", failure.diagnostic);
+            panic!("Property test failed: {}", failure.panic_message);
+        }
+        // Multi-failure path: emit a header, print each replay's
+        // diagnostic block in order, then panic with the count so callers
+        // see the headline figure rather than just one of the messages.
+        failures => {
+            let n = failures.len();
+            eprintln!("Hegel found {} failing test cases:", n);
+            for failure in failures {
+                eprint!("{}", failure.diagnostic);
+            }
+            panic!("Property-based test failed with {} distinct failures.", n);
+        }
     }
 }

--- a/src/server/runner.rs
+++ b/src/server/runner.rs
@@ -323,6 +323,8 @@ pub fn server_run<F>(
         return;
     }
 
+    let quiet = settings.verbosity == crate::runner::Verbosity::Quiet;
+
     match result.failures.as_slice() {
         // `test_failed` was set but no Failure surfaced — e.g. an aborted
         // mid-draw test case or a backend that reported failure without
@@ -332,7 +334,9 @@ pub fn server_run<F>(
         // harnesses that pattern-match on `"Property test failed: <msg>"`
         // (e.g. `Minimal::run` in `tests/common/utils.rs`) keep working.
         [failure] => {
-            eprint!("{}", failure.diagnostic);
+            if !quiet {
+                eprint!("{}", failure.diagnostic);
+            }
             panic!("Property test failed: {}", failure.panic_message);
         }
         // Multi-failure path: emit a header, print each replay's
@@ -340,9 +344,11 @@ pub fn server_run<F>(
         // see the headline figure rather than just one of the messages.
         failures => {
             let n = failures.len();
-            eprintln!("Hegel found {} failing test cases:", n);
-            for failure in failures {
-                eprint!("{}", failure.diagnostic);
+            if !quiet {
+                eprintln!("Hegel found {} failing test cases:", n);
+                for failure in failures {
+                    eprint!("{}", failure.diagnostic);
+                }
             }
             panic!("Property-based test failed with {} distinct failures.", n);
         }

--- a/src/server/session.rs
+++ b/src/server/session.rs
@@ -1,4 +1,4 @@
-use crate::backend::{DataSource, TestCaseResult, TestRunResult, TestRunner};
+use crate::backend::{DataSource, Failure, TestCaseResult, TestRunResult, TestRunner};
 use crate::cbor_utils::{as_bool, as_text, as_u64, cbor_map, map_get, map_insert};
 use crate::runner::{Database, HealthCheck, Mode, Phase, Settings, Verbosity};
 use crate::server::protocol::{Connection, HANDSHAKE_STRING, Stream};
@@ -208,7 +208,7 @@ impl ServerTestRunner {
         }
 
         let ack_null = cbor_map! {"result" => Value::Null};
-        let mut failure_message: Option<String> = None;
+        let mut failures: Vec<Failure> = Vec::new();
         let mut passed = true;
 
         loop {
@@ -242,9 +242,9 @@ impl ServerTestRunner {
                     ));
                     let tc_result = run_case(backend, true);
 
-                    if let TestCaseResult::Interesting { panic_message } = tc_result {
+                    if let TestCaseResult::Interesting(failure) = tc_result {
                         passed = false;
-                        failure_message = Some(panic_message);
+                        failures.push(failure);
                     }
                 }
                 "test_done" => {
@@ -260,10 +260,7 @@ impl ServerTestRunner {
             }
         }
 
-        TestRunResult {
-            passed,
-            failure_message,
-        }
+        TestRunResult { passed, failures }
     }
 }
 
@@ -419,7 +416,7 @@ impl TestRunner for ServerTestRunner {
         }
 
         // Process final replay test cases (one per interesting example)
-        let mut failure_message: Option<String> = None;
+        let mut failures: Vec<Failure> = Vec::new();
         for _ in 0..n_interesting {
             let (event_id, event_payload) = test_stream
                 .receive_request()
@@ -446,8 +443,8 @@ impl TestRunner for ServerTestRunner {
             ));
             let tc_result = run_case(backend, true);
 
-            if let TestCaseResult::Interesting { panic_message } = tc_result {
-                failure_message = Some(panic_message);
+            if let TestCaseResult::Interesting(failure) = tc_result {
+                failures.push(failure);
             }
 
             if connection.server_has_exited() {
@@ -459,10 +456,7 @@ impl TestRunner for ServerTestRunner {
             .and_then(as_bool)
             .unwrap_or(true);
 
-        TestRunResult {
-            passed,
-            failure_message,
-        }
+        TestRunResult { passed, failures }
     }
 }
 

--- a/src/server/session.rs
+++ b/src/server/session.rs
@@ -15,8 +15,8 @@ use super::process::{
 };
 use super::runner::{cbor_decode, cbor_encode};
 
-pub(super) const SUPPORTED_PROTOCOL_VERSIONS: (&str, &str) = ("0.14", "0.14");
-pub(super) const HEGEL_SERVER_VERSION: &str = "0.8.2";
+pub(super) const SUPPORTED_PROTOCOL_VERSIONS: (&str, &str) = ("0.15", "0.15");
+pub(super) const HEGEL_SERVER_VERSION: &str = "0.9.0";
 
 pub(super) static SESSION: Mutex<Option<Arc<HegelSession>>> = Mutex::new(None);
 

--- a/src/server/session.rs
+++ b/src/server/session.rs
@@ -296,7 +296,8 @@ impl TestRunner for ServerTestRunner {
             "seed" => settings.seed.map_or(Value::Null, Value::from),
             "stream_id" => test_stream.stream_id,
             "database_key" => database_key_bytes,
-            "derandomize" => settings.derandomize
+            "derandomize" => settings.derandomize,
+            "report_multiple_failures" => settings.report_multiple_failures
         };
         let db_value = match &settings.database {
             Database::Unset => Option::None, // nocov

--- a/tests/embedded/runner_tests.rs
+++ b/tests/embedded/runner_tests.rs
@@ -13,6 +13,20 @@ fn test_settings_phases() {
 }
 
 #[test]
+fn test_settings_report_multiple_failures_default_true() {
+    let s = Settings::new();
+    assert!(s.report_multiple_failures);
+}
+
+#[test]
+fn test_settings_report_multiple_failures_setter() {
+    let s = Settings::new().report_multiple_failures(false);
+    assert!(!s.report_multiple_failures);
+    let s = s.report_multiple_failures(true);
+    assert!(s.report_multiple_failures);
+}
+
+#[test]
 fn test_settings_has_phase() {
     let s = Settings::new().phases([Phase::Generate, Phase::Shrink]);
     assert!(s.has_phase(Phase::Generate));

--- a/tests/test_multi_failure.rs
+++ b/tests/test_multi_failure.rs
@@ -1,0 +1,158 @@
+//! In-process tests for the runner's multi-failure reporting path.
+//!
+//! The runner has three failure-reporting branches (`src/server/runner.rs`):
+//!   - empty (`Property test failed: unknown`)
+//!   - single failure (legacy `Property test failed: <msg>`)
+//!   - multi-failure (new `Property-based test failed with N distinct failures.`)
+//!
+//! The single-failure branch is exercised by the rest of the test suite via
+//! `expect_panic` / `Minimal::run`.  The multi-failure branch needs a test
+//! that *deterministically* drives Hypothesis to surface multiple distinct
+//! origins — relying on a happens-to-find-two test would leave the branch
+//! uncovered on CI, which it did before this test was added.
+
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+use hegel::generators as gs;
+use hegel::{Hegel, Settings, TestCase, Verbosity};
+
+/// `#[hegel::test(report_multiple_failures = true, ...)]` (the default)
+/// surfaces every distinct origin. With two panic sites in the body the
+/// outer re-raise must be the new
+/// `"Property-based test failed with 2 distinct failures."` panic — if the
+/// macro silently dropped the argument or the runner collapsed to one,
+/// `#[should_panic]` would fail to match.
+#[hegel::test(
+    report_multiple_failures = true,
+    derandomize = true,
+    test_cases = 500u64,
+    verbosity = hegel::Verbosity::Quiet,
+    database = None
+)]
+#[should_panic(expected = "Property-based test failed with 2 distinct failures.")]
+fn test_macro_report_multiple_failures_true_surfaces_both(tc: TestCase) {
+    let x: i32 = tc.draw(gs::integers::<i32>().min_value(0).max_value(40));
+    if x > 30 {
+        panic!("big branch: {}", x);
+    }
+    if x < 10 {
+        panic!("small branch: {}", x);
+    }
+}
+
+/// `#[hegel::test(report_multiple_failures = false, ...)]` asks the server
+/// to collapse multi-bug runs to a single failure, so the same body falls
+/// into the single-failure re-raise path. The `expected` substring is
+/// chosen specifically so a multi-failure panic (which starts with
+/// `"Property-based test failed"` — note the hyphen, no colon) would not
+/// match and the test would fail.
+#[hegel::test(
+    report_multiple_failures = false,
+    derandomize = true,
+    test_cases = 500u64,
+    verbosity = hegel::Verbosity::Quiet,
+    database = None
+)]
+#[should_panic(expected = "Property test failed: ")]
+fn test_macro_report_multiple_failures_false_collapses(tc: TestCase) {
+    let x: i32 = tc.draw(gs::integers::<i32>().min_value(0).max_value(40));
+    if x > 30 {
+        panic!("big branch: {}", x);
+    }
+    if x < 10 {
+        panic!("small branch: {}", x);
+    }
+}
+
+/// Run a test body with two distinct `panic!` call sites and assert the
+/// outer panic is the multi-failure message.  `verbosity` is parameterised
+/// so we can cover both the verbose-print branch (eprintln of the header
+/// and per-failure diagnostics) and the quiet-suppress branch.
+fn run_two_origin_failure(verbosity: Verbosity) -> String {
+    let result = catch_unwind(AssertUnwindSafe(move || {
+        Hegel::new(|tc: TestCase| {
+            let x: i32 = tc.draw(gs::integers::<i32>().min_value(0).max_value(40));
+            if x > 30 {
+                panic!("big branch: {}", x);
+            }
+            if x < 10 {
+                panic!("small branch: {}", x);
+            }
+        })
+        .settings(
+            Settings::new()
+                .database(None)
+                .derandomize(true)
+                .verbosity(verbosity)
+                .test_cases(500),
+        )
+        .run();
+    }));
+
+    let payload = result.expect_err("expected run() to panic with multiple failures");
+    let msg = payload
+        .downcast_ref::<&str>()
+        .map(|s| s.to_string())
+        .or_else(|| payload.downcast_ref::<String>().cloned())
+        .unwrap_or_default();
+    assert!(
+        msg.starts_with("Property-based test failed with ") && msg.ends_with(" distinct failures."),
+        "expected multi-failure outer panic, got: {msg:?}"
+    );
+    msg
+}
+
+/// Default verbosity: covers the eprintln branch that prints the
+/// "Hegel found N failing test cases:" header and each diagnostic.
+#[test]
+fn test_multi_failure_panic_with_default_verbosity() {
+    // Just need to swallow the captured value to silence unused warnings.
+    let _ = run_two_origin_failure(Verbosity::Normal);
+}
+
+/// Quiet verbosity: covers the branch that suppresses the per-failure
+/// stderr output but still re-panics with the multi-failure count.
+#[test]
+fn test_multi_failure_panic_quiet_suppresses_stderr() {
+    let _ = run_two_origin_failure(Verbosity::Quiet);
+}
+
+/// `report_multiple_failures(false)` makes the server (Hypothesis with
+/// `report_multiple_bugs=False`) surface only the first origin, so the
+/// runner sees a single Failure and falls into the legacy single-failure
+/// re-raise path (`Property test failed: <msg>`) rather than the
+/// multi-failure `"... with N distinct failures."` path.
+#[test]
+fn test_report_multiple_failures_false_collapses_to_single_failure_panic() {
+    let result = catch_unwind(AssertUnwindSafe(move || {
+        Hegel::new(|tc: TestCase| {
+            let x: i32 = tc.draw(gs::integers::<i32>().min_value(0).max_value(40));
+            if x > 30 {
+                panic!("big branch: {}", x);
+            }
+            if x < 10 {
+                panic!("small branch: {}", x);
+            }
+        })
+        .settings(
+            Settings::new()
+                .database(None)
+                .derandomize(true)
+                .verbosity(Verbosity::Quiet)
+                .test_cases(500)
+                .report_multiple_failures(false),
+        )
+        .run();
+    }));
+
+    let payload = result.expect_err("expected run() to panic");
+    let msg = payload
+        .downcast_ref::<&str>()
+        .map(|s| s.to_string())
+        .or_else(|| payload.downcast_ref::<String>().cloned())
+        .unwrap_or_default();
+    assert!(
+        msg.starts_with("Property test failed: ") && !msg.contains("distinct failures"),
+        "expected single-failure outer panic (one branch should win), got: {msg:?}"
+    );
+}

--- a/tests/test_quality.rs
+++ b/tests/test_quality.rs
@@ -386,7 +386,14 @@ mod shrink_quality {
             }
             let mx = *x.iter().max().unwrap();
             let mn = *x.iter().min().unwrap();
-            mx > mn + 10 && mn + 10 > 0
+            // `mn + 10` would overflow for inputs near `i64::MAX`; previously
+            // those overflows were swallowed by the runner's single-failure
+            // collapsing.  Use `checked_add` so a draw at the extreme returns
+            // a clean `false` rather than panicking.
+            let Some(threshold) = mn.checked_add(10) else {
+                return false;
+            };
+            mx > threshold && threshold > 0
         });
         assert_eq!(xs.len(), 2);
         xs.sort();

--- a/tests/test_shrink_quality/collections.rs
+++ b/tests/test_shrink_quality/collections.rs
@@ -129,7 +129,14 @@ fn test_list_with_wide_gap() {
         }
         let mn = *x.iter().min().unwrap();
         let mx = *x.iter().max().unwrap();
-        mx > mn + 10 && mn + 10 > 0
+        // `mn + 10` would overflow for inputs near `i64::MAX`; previously
+        // those overflows were swallowed by the runner's single-failure
+        // collapsing.  Use `checked_add` so a draw at the extreme returns
+        // a clean `false` rather than panicking.
+        let Some(threshold) = mn.checked_add(10) else {
+            return false;
+        };
+        mx > threshold && threshold > 0
     });
     assert_eq!(xs.len(), 2);
     let mut s = xs.clone();


### PR DESCRIPTION
Apparently we were not doing the right thing with multiple failures *at all* despite it being in the protocol. This fixes that.