### PR TITLE
Add native floats: choice kind, schema, shrinker passes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-RELEASE_TYPE: minor
+RELEASE_TYPE: patch
 
 The native backend (`--features native`) now supports floating-point
 generators: `gs::floats::<f32>()` and `gs::floats::<f64>()` work on native,

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,13 @@
+RELEASE_TYPE: minor
+
+The native backend (`--features native`) now supports floating-point
+generators: `gs::floats::<f32>()` and `gs::floats::<f64>()` work on native,
+along with their `min_value` / `max_value` / `exclude_min` / `exclude_max` /
+`allow_nan` / `allow_infinity` bounds and the float-specific shrink passes.
+
+`gs::floats()` also now rejects empty-range `exclude_min` / `exclude_max`
+combinations (`min_value = +inf` with `exclude_min`, `max_value = -inf` with
+`exclude_max`, single-point ranges with either exclude flag) with an
+`InvalidArgument` panic at generator construction. Previously the server
+backend's Hypothesis layer caught these at draw time; both backends now
+agree at builder time.

--- a/src/generators/numeric.rs
+++ b/src/generators/numeric.rs
@@ -195,6 +195,34 @@ impl<T: Float + serde::Serialize> FloatGenerator<T> {
                      values between min_value=0.0 and max_value=-0.0"
                 );
             }
+            // After exclude_min/exclude_max, the closed-open / open-closed /
+            // open-open ranges over [min, min] (and the `-0.0`/`0.0` pair
+            // that compares equal under sign-aware ordering) are empty.
+            let min_f = min.to_f64();
+            let max_f = max.to_f64();
+            let zero_pair = min_f == 0.0 && max_f == 0.0;
+            if (min_f == max_f || zero_pair) && (self.exclude_min || self.exclude_max) {
+                panic!(
+                    "InvalidArgument: exclude_min/exclude_max leave no \
+                     {width}-bit floating-point values in [{min_f}, {max_f}]"
+                );
+            }
+        }
+
+        // exclude_min=true with min_value=+inf (or exclude_max=true with
+        // max_value=-inf) demands the next representable value beyond an
+        // unbounded endpoint, which doesn't exist.
+        if self.exclude_min && self.min.is_some_and(|v| v.to_f64() == f64::INFINITY) {
+            panic!(
+                "InvalidArgument: exclude_min=true with min_value=+inf leaves \
+                 no {width}-bit floating-point values"
+            );
+        }
+        if self.exclude_max && self.max.is_some_and(|v| v.to_f64() == f64::NEG_INFINITY) {
+            panic!(
+                "InvalidArgument: exclude_max=true with max_value=-inf leaves \
+                 no {width}-bit floating-point values"
+            );
         }
 
         let allow_nan = self.allow_nan.unwrap_or(!has_min && !has_max);

--- a/src/native/core/choices.rs
+++ b/src/native/core/choices.rs
@@ -1,5 +1,7 @@
 // Choice types: the recorded decisions a test case makes.
 
+use crate::native::floats::sign_aware_lte;
+
 /// An integer choice with bounded range.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct IntegerChoice {
@@ -175,18 +177,314 @@ impl BooleanChoice {
     }
 }
 
+/// A float choice with bounded range.
+#[derive(Clone, Debug)]
+pub struct FloatChoice {
+    pub min_value: f64,
+    pub max_value: f64,
+    pub allow_nan: bool,
+    pub allow_infinity: bool,
+}
+
+/// Bit-exact equality so a `FloatChoice` recorded with `-0.0` doesn't compare
+/// equal to one recorded with `0.0`, and distinct NaN payloads stay distinct.
+impl PartialEq for FloatChoice {
+    fn eq(&self, other: &Self) -> bool {
+        self.min_value.to_bits() == other.min_value.to_bits()
+            && self.max_value.to_bits() == other.max_value.to_bits()
+            && self.allow_nan == other.allow_nan
+            && self.allow_infinity == other.allow_infinity
+    }
+}
+
+impl Eq for FloatChoice {}
+
+impl FloatChoice {
+    /// The simplest (lowest-sort-key) valid float for this choice.
+    pub fn simplest(&self) -> f64 {
+        use super::float_index::{float_to_index, index_to_float};
+
+        if self.validate(0.0) {
+            return 0.0;
+        }
+
+        let mut best: Option<f64> = None;
+        let mut best_key: (u64, bool) = (u64::MAX, true);
+
+        // Update best if v is valid and has a smaller sort key.
+        macro_rules! try_candidate {
+            ($v:expr) => {{
+                let v: f64 = $v;
+                if !v.is_nan() && self.validate(v) {
+                    let is_neg = v.is_sign_negative();
+                    let mag = if is_neg { -v } else { v };
+                    let key = (float_to_index(mag), is_neg);
+                    if key < best_key {
+                        best = Some(v);
+                        best_key = key;
+                    }
+                }
+            }};
+        }
+
+        // Check boundaries first.
+        if self.min_value.is_finite() {
+            try_candidate!(self.min_value);
+        }
+        if self.max_value.is_finite() {
+            try_candidate!(self.max_value);
+        }
+
+        // Smallest valid non-negative integer in range.
+        if self.max_value >= 0.0 {
+            let lo_int = self.min_value.max(0.0).ceil() as i64;
+            try_candidate!(lo_int as f64);
+        }
+        // Largest valid non-positive integer in range.
+        if self.min_value <= 0.0 {
+            let hi_int = self.max_value.min(0.0).floor() as i64;
+            try_candidate!(hi_int as f64);
+        }
+
+        // Simple non-integer fractions at each exponent level.
+        for exp_enc in 0u64..64 {
+            let base_idx = (1u64 << 63) | (exp_enc << 52);
+            if (base_idx, false) >= best_key {
+                break;
+            }
+            for mantissa_enc in 0u64..8 {
+                let idx = base_idx | mantissa_enc;
+                if (idx, false) >= best_key {
+                    break;
+                }
+                let v = index_to_float(idx);
+                try_candidate!(v);
+                try_candidate!(-v);
+            }
+        }
+
+        if let Some(v) = best {
+            return v;
+        }
+        if self.allow_infinity && self.validate(f64::INFINITY) {
+            return f64::INFINITY;
+        }
+        if self.allow_infinity && self.validate(f64::NEG_INFINITY) {
+            return f64::NEG_INFINITY;
+        }
+        if self.allow_nan {
+            return f64::NAN;
+        }
+        panic!("FloatChoice::simplest: no valid float for this choice")
+    }
+
+    /// Second-simplest valid float (for type punning during replay).
+    pub fn unit(&self) -> f64 {
+        use super::float_index::{float_to_index, index_to_float};
+
+        let s = self.simplest();
+        if s.is_nan() {
+            return s;
+        }
+        let base = float_to_index(s.abs());
+        let is_neg = s.is_sign_negative();
+        for offset in 1u64..4 {
+            let v_mag = index_to_float(base + offset);
+            let v = if is_neg { -v_mag } else { v_mag };
+            if !v.is_nan() && self.validate(v) {
+                return v;
+            }
+        }
+        s
+    }
+
+    pub fn validate(&self, v: f64) -> bool {
+        if v.is_nan() {
+            return self.allow_nan;
+        }
+        if v.is_infinite() {
+            if !self.allow_infinity {
+                return false;
+            }
+            if v == f64::NEG_INFINITY && self.min_value > f64::NEG_INFINITY {
+                return false;
+            }
+            if v == f64::INFINITY && self.max_value < f64::INFINITY {
+                return false;
+            }
+            return true;
+        }
+        sign_aware_lte(self.min_value, v) && sign_aware_lte(v, self.max_value)
+    }
+
+    /// Sort key for shrinking. Returns `(magnitude_index, is_negative)`.
+    /// NaN sorts last (u64::MAX, false).
+    pub fn sort_key(&self, v: f64) -> (u64, bool) {
+        use super::float_index::float_to_index;
+        if v.is_nan() {
+            return (u64::MAX, false);
+        }
+        let is_neg = v.is_sign_negative();
+        let mag = if is_neg { -v } else { v };
+        (float_to_index(mag), is_neg)
+    }
+
+    /// Hypothesis: `core.py::FloatChoice.max_index`. Largest valid index for
+    /// [`from_index`]. Indexes the full finite range (both signs) followed
+    /// by `+inf`, `-inf`, then all NaN payloads.
+    pub fn max_index(&self) -> crate::native::bignum::BigUint {
+        use crate::native::bignum::BigUint;
+        // 2^52 NaN payloads (one bit forced to 1) × 2 signs = 2^53 NaN slots.
+        max_finite_global_rank() + BigUint::from(2u32) + BigUint::from(1u64 << 53)
+    }
+
+    /// Hypothesis: `core.py::FloatChoice.to_index`.
+    ///
+    /// Implementation note: a direct port of Hypothesis's
+    /// `to_index = _float_to_index(value) - _float_to_index(simplest)` over
+    /// the raw-index ordering would underflow whenever `value` is below
+    /// `simplest` in raw-index terms (which can happen because `simplest`
+    /// prefers nearby integers — `65673.0` for the range `[65672.5, 65673.0]`
+    /// — even though their raw lex indices put `65672.5` first). The dense
+    /// ordering used by the shrinker is `(float_to_index(|v|), is_neg)`, so
+    /// we build the index directly from that and subtract the rank of
+    /// `simplest`.
+    pub fn to_index(&self, value: f64) -> crate::native::bignum::BigUint {
+        float_global_rank(value) - float_global_rank(self.simplest())
+    }
+
+    /// Hypothesis: `core.py::FloatChoice.from_index`.
+    #[allow(clippy::wrong_self_convention)]
+    pub fn from_index(&self, index: crate::native::bignum::BigUint) -> Option<f64> {
+        let raw = float_global_rank(self.simplest()) + index;
+        let value = float_from_global_rank(raw)?;
+        if self.validate(value) {
+            Some(value)
+        } else {
+            None
+        }
+    }
+}
+
+/// Dense rank of `v` under the float sort order: finite floats indexed by
+/// `(float_to_index(|v|), is_neg)`, then `+inf`, `-inf`, then NaN payloads.
+fn float_global_rank(v: f64) -> crate::native::bignum::BigUint {
+    use super::float_index::float_to_index;
+    use crate::native::bignum::BigUint;
+
+    if v.is_nan() {
+        // NaN payload (one bit always forced to 1, see `from_index` below).
+        let bits = v.to_bits();
+        let nan_offset = bits & ((1u64 << 52) - 1);
+        let sign = bits >> 63;
+        return max_finite_global_rank()
+            + BigUint::from(3u32)
+            + BigUint::from(nan_offset) * BigUint::from(2u32)
+            + BigUint::from(sign);
+    }
+    if v.is_infinite() {
+        return if v > 0.0 {
+            max_finite_global_rank() + BigUint::from(1u32)
+        } else {
+            max_finite_global_rank() + BigUint::from(2u32)
+        };
+    }
+    let is_neg = v.is_sign_negative();
+    let mag = if is_neg { -v } else { v };
+    let mag_idx = float_to_index(mag);
+    BigUint::from(mag_idx) * BigUint::from(2u32) + BigUint::from(u32::from(is_neg))
+}
+
+/// Inverse of [`float_global_rank`]. Returns `None` if `rank` falls in the
+/// NaN-payload region for a sign+offset combination that would not be a
+/// valid NaN bit pattern.
+fn float_from_global_rank(rank: crate::native::bignum::BigUint) -> Option<f64> {
+    use super::float_index::index_to_float;
+    use crate::native::bignum::BigUint;
+
+    let max_finite = max_finite_global_rank();
+    if rank > max_finite {
+        let offset = &rank - &max_finite;
+        if offset == BigUint::from(1u32) {
+            return Some(f64::INFINITY);
+        }
+        if offset == BigUint::from(2u32) {
+            return Some(f64::NEG_INFINITY);
+        }
+        let nan_rel = offset - BigUint::from(3u32);
+        let sign: u64 = (&nan_rel % BigUint::from(2u32))
+            .try_into()
+            .expect("mod 2 fits in u64");
+        let mantissa_base: u64 = (nan_rel / BigUint::from(2u32)).try_into().ok()?;
+        // Force bit 51 to 1 so the mantissa is non-zero (matches Hypothesis).
+        let mantissa = mantissa_base | (1u64 << 51);
+        let bits = (sign << 63) | (0x7FFu64 << 52) | mantissa;
+        let v = f64::from_bits(bits);
+        return if v.is_nan() { Some(v) } else { None };
+    }
+    let is_neg_u: u64 = (&rank % BigUint::from(2u32))
+        .try_into()
+        .expect("mod 2 fits in u64");
+    let mag_big = rank / BigUint::from(2u32);
+    let mag_idx: u64 = (&mag_big).try_into().ok()?;
+    let mag = index_to_float(mag_idx);
+    Some(if is_neg_u == 1 { -mag } else { mag })
+}
+
+/// Largest dense rank used by any finite float. The maximum lex index over
+/// any finite float is `(1<<63) | (2046<<52) | mantissa_max` — bit 63 set
+/// (non-simple), encoded exponent 2046 (the last non-NaN/inf slot), and
+/// every fractional bit set. (Note: this is *not* `float_to_index(f64::MAX)`,
+/// because the lex ordering ranks fractions like `0.5` — encoded
+/// exponent 1024 — *higher* than huge integers like `f64::MAX`, which has
+/// encoded exponent 1023.) The `+1` is the negative-sign slot for that lex
+/// index, since `float_global_rank` packs sign into the low bit.
+fn max_finite_global_rank() -> crate::native::bignum::BigUint {
+    use crate::native::bignum::BigUint;
+    let max_finite_lex = (1u64 << 63) | (2046u64 << 52) | ((1u64 << 52) - 1);
+    BigUint::from(max_finite_lex) * BigUint::from(2u32) + BigUint::from(1u32)
+}
+
 /// The kind of choice made at a particular point.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ChoiceKind {
     Integer(IntegerChoice),
     Boolean(BooleanChoice),
+    Float(FloatChoice),
 }
 
 /// The value produced by a choice.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug)]
 pub enum ChoiceValue {
     Integer(i128),
     Boolean(bool),
+    Float(f64),
+}
+
+/// Bit-exact equality for floats keeps `-0.0` distinct from `0.0` and
+/// preserves NaN payloads; integers and booleans use natural equality.
+impl PartialEq for ChoiceValue {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (ChoiceValue::Integer(a), ChoiceValue::Integer(b)) => a == b,
+            (ChoiceValue::Boolean(a), ChoiceValue::Boolean(b)) => a == b,
+            (ChoiceValue::Float(a), ChoiceValue::Float(b)) => a.to_bits() == b.to_bits(),
+            _ => false,
+        }
+    }
+}
+
+impl Eq for ChoiceValue {}
+
+impl std::hash::Hash for ChoiceValue {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(self).hash(state);
+        match self {
+            ChoiceValue::Integer(n) => n.hash(state),
+            ChoiceValue::Boolean(b) => b.hash(state),
+            ChoiceValue::Float(f) => f.to_bits().hash(state),
+        }
+    }
 }
 
 impl ChoiceKind {
@@ -195,6 +493,7 @@ impl ChoiceKind {
         match self {
             ChoiceKind::Integer(ic) => ChoiceValue::Integer(ic.simplest()),
             ChoiceKind::Boolean(bc) => ChoiceValue::Boolean(bc.simplest()),
+            ChoiceKind::Float(fc) => ChoiceValue::Float(fc.simplest()),
         }
     }
 
@@ -205,6 +504,7 @@ impl ChoiceKind {
         match self {
             ChoiceKind::Integer(ic) => ic.max_index(),
             ChoiceKind::Boolean(bc) => bc.max_index(),
+            ChoiceKind::Float(fc) => fc.max_index(),
         }
     }
 
@@ -215,6 +515,7 @@ impl ChoiceKind {
         match (self, value) {
             (ChoiceKind::Integer(ic), ChoiceValue::Integer(v)) => ic.to_index(*v),
             (ChoiceKind::Boolean(bc), ChoiceValue::Boolean(v)) => bc.to_index(*v),
+            (ChoiceKind::Float(fc), ChoiceValue::Float(v)) => fc.to_index(*v),
             _ => panic!("ChoiceKind::to_index: kind/value mismatch"),
         }
     }
@@ -227,6 +528,7 @@ impl ChoiceKind {
         match self {
             ChoiceKind::Integer(ic) => ic.from_index(index).map(ChoiceValue::Integer),
             ChoiceKind::Boolean(bc) => bc.from_index(index).map(ChoiceValue::Boolean),
+            ChoiceKind::Float(fc) => fc.from_index(index).map(ChoiceValue::Float),
         }
     }
 
@@ -235,6 +537,7 @@ impl ChoiceKind {
         match (self, value) {
             (ChoiceKind::Integer(ic), ChoiceValue::Integer(v)) => ic.validate(*v),
             (ChoiceKind::Boolean(_), ChoiceValue::Boolean(_)) => true,
+            (ChoiceKind::Float(fc), ChoiceValue::Float(v)) => fc.validate(*v),
             _ => false,
         }
     }
@@ -249,6 +552,7 @@ impl ChoiceKind {
                 BigUint::from(diff) + BigUint::from(1u32)
             }
             ChoiceKind::Boolean(_) => BigUint::from(2u32),
+            ChoiceKind::Float(fc) => fc.max_index() + BigUint::from(1u32),
         }
     }
 
@@ -260,6 +564,9 @@ impl ChoiceKind {
                 ChoiceValue::Integer(crate::native::core::state::biased_integer_sample(ic, rng))
             }
             ChoiceKind::Boolean(_) => ChoiceValue::Boolean(rng.random::<bool>()),
+            ChoiceKind::Float(fc) => {
+                ChoiceValue::Float(crate::native::core::state::biased_float_sample(fc, rng))
+            }
         }
     }
 
@@ -287,6 +594,12 @@ impl ChoiceKind {
                 ChoiceValue::Boolean(false),
                 ChoiceValue::Boolean(true),
             ]),
+            // `max_children` for a `FloatChoice` is at least `2^53` (the NaN
+            // payload count), which always exceeds the `cap: u64` early-return
+            // threshold above. No caller can ever land here.
+            ChoiceKind::Float(_) => {
+                unreachable!("FloatChoice max_children always exceeds u64::MAX cap")
+            }
         }
     }
 }
@@ -315,6 +628,13 @@ impl ChoiceNode {
                 NodeSortKey(abs, neg)
             }
             (ChoiceKind::Boolean(_), ChoiceValue::Boolean(v)) => NodeSortKey(u128::from(*v), false),
+            (ChoiceKind::Float(fc), ChoiceValue::Float(v)) => {
+                let (mag, neg) = fc.sort_key(*v);
+                // `u64` widens losslessly into the `u128` magnitude slot used
+                // for integer sort keys: float and integer choices end up in a
+                // single totally-ordered space without losing precision.
+                NodeSortKey(u128::from(mag), neg)
+            }
             _ => unreachable!("mismatched choice kind and value"),
         }
     }

--- a/src/native/core/float_index.rs
+++ b/src/native/core/float_index.rs
@@ -1,0 +1,119 @@
+// Hypothesis float lex ordering.
+//
+// Maps non-negative floats to dense lexicographic indices where:
+// - Small non-negative integers (0, 1, 2, ...) have the smallest indices
+// - Non-integer fractions with "simpler" denominators come next
+// - Large or irrational-looking floats come last
+//
+// Port of hypothesis/internal/conjecture/floats.py.
+
+/// Encode a biased exponent to a Hypothesis lex rank.
+/// Exponents closer to 1023 (values near 1.0) rank first.
+pub fn encode_exponent(biased_exp: u64) -> u64 {
+    if biased_exp == 2047 {
+        return 2047; // inf/NaN exponent: rank last
+    }
+    if biased_exp >= 1023 {
+        biased_exp - 1023
+    } else {
+        2046 - biased_exp
+    }
+}
+
+/// Decode a lex rank back to a biased exponent.
+pub fn decode_exponent(enc: u64) -> u64 {
+    if enc == 2047 {
+        return 2047;
+    }
+    if enc <= 1023 { enc + 1023 } else { 2046 - enc }
+}
+
+/// Reverse the lowest `n` bits of `v`.
+pub fn reverse_bits_n(v: u64, n: u64) -> u64 {
+    v.reverse_bits() >> (64 - n)
+}
+
+/// Adjust mantissa bits so that low-denominator fractions have smaller indices.
+///
+/// For values in [1, 2) (unbiased_exp=0), reverses all 52 fractional bits so
+/// that 1.5 (mantissa=2^51, reversed=1) is simpler than 1.1 (mantissa=complex).
+/// For values in [2, 4) (unbiased_exp=1), only the lower 51 fractional bits are
+/// reversed. For large exponents (>= 52), no change needed (no fractional part).
+pub fn update_mantissa(unbiased_exp: i64, mantissa: u64) -> u64 {
+    if unbiased_exp <= 0 {
+        reverse_bits_n(mantissa, 52)
+    } else if unbiased_exp <= 51 {
+        let n_frac = (52 - unbiased_exp) as u64;
+        let frac_mask = (1u64 << n_frac) - 1;
+        let frac = mantissa & frac_mask;
+        (mantissa ^ frac) | reverse_bits_n(frac, n_frac)
+    } else {
+        mantissa
+    }
+}
+
+/// True if `v` is a non-negative integer representable in 56 bits.
+/// These are mapped directly to their integer value in the lex ordering.
+fn is_simple_float(v: f64) -> bool {
+    if v.is_sign_negative() || !v.is_finite() {
+        return false;
+    }
+    let i = v as u64;
+    i as f64 == v && i < (1u64 << 56)
+}
+
+/// Map a non-negative (finite or infinite) float to its Hypothesis lex index.
+///
+/// Port of Hypothesis's `float_to_lex`. Integer floats 0, 1, 2, ... map to
+/// 0, 1, 2, ... Non-integer floats map to values with bit 63 set.
+pub fn float_to_index(v: f64) -> u64 {
+    debug_assert!(
+        !v.is_sign_negative(),
+        "float_to_index called on negative: {v}"
+    );
+    debug_assert!(!v.is_nan(), "float_to_index called on NaN");
+    if is_simple_float(v) {
+        return v as u64;
+    }
+    let bits = v.to_bits();
+    let biased_exp = (bits >> 52) & 0x7FF;
+    let mantissa = bits & ((1u64 << 52) - 1);
+    let unbiased_exp = biased_exp as i64 - 1023;
+    let mantissa_enc = update_mantissa(unbiased_exp, mantissa);
+    let exp_enc = encode_exponent(biased_exp);
+    (1u64 << 63) | (exp_enc << 52) | mantissa_enc
+}
+
+/// Map a Hypothesis lex index back to a non-negative float.
+///
+/// Port of Hypothesis's `lex_to_float`. Inverse of `float_to_index`.
+pub fn index_to_float(i: u64) -> f64 {
+    if i >> 63 == 0 {
+        let integral = i & ((1u64 << 56) - 1);
+        return integral as f64;
+    }
+    let exp_enc = (i >> 52) & 0x7FF;
+    let biased_exp = decode_exponent(exp_enc);
+    let mantissa_enc = i & ((1u64 << 52) - 1);
+    let unbiased_exp = biased_exp as i64 - 1023;
+    // update_mantissa is its own inverse (bit reversal is self-inverse).
+    let mantissa = update_mantissa(unbiased_exp, mantissa_enc);
+    f64::from_bits((biased_exp << 52) | mantissa)
+}
+
+/// Convert a lexicographically ordered u64 to a float covering the full
+/// float space. Used for random float generation: feeding uniformly random
+/// `u64` bit patterns through this gives a distribution that covers the
+/// whole representable space.
+pub fn lex_to_float(bits: u64) -> f64 {
+    let bits = if bits >> 63 != 0 {
+        bits ^ (1u64 << 63)
+    } else {
+        bits ^ u64::MAX
+    };
+    f64::from_bits(bits)
+}
+
+#[cfg(test)]
+#[path = "../../../tests/embedded/native/float_index_tests.rs"]
+mod tests;

--- a/src/native/core/mod.rs
+++ b/src/native/core/mod.rs
@@ -1,12 +1,17 @@
 // Core types for the native Hypothesis-style test engine.
 //
 // Split into submodules:
-//   choices    — choice types (ChoiceKind, ChoiceNode, ChoiceValue, etc.)
-//   state      — NativeTestCase, ManyState, NativeVariables, Span
+//   choices     — choice types (ChoiceKind, ChoiceNode, ChoiceValue, etc.)
+//   float_index — Hypothesis float lex ordering (float_to_index, index_to_float)
+//   state       — NativeTestCase, ManyState, NativeVariables, Span
 
 pub(crate) mod choices;
+pub(crate) mod float_index;
 pub(crate) mod state;
-pub use choices::{ChoiceKind, ChoiceNode, ChoiceValue, NodeSortKey, Status, StopTest, sort_key};
+pub use choices::{
+    ChoiceKind, ChoiceNode, ChoiceValue, FloatChoice, NodeSortKey, Status, StopTest, sort_key,
+};
+pub use float_index::{float_to_index, index_to_float};
 pub use state::{ManyState, NativeTestCase, NativeVariables, Span};
 
 /// Maximum number of choices a single test case can make.

--- a/src/native/core/state.rs
+++ b/src/native/core/state.rs
@@ -8,9 +8,10 @@ use rand::RngExt;
 use rand::rngs::SmallRng;
 
 use super::choices::{
-    BooleanChoice, ChoiceKind, ChoiceNode, ChoiceValue, IntegerChoice, InterestingOrigin, Status,
-    StopTest,
+    BooleanChoice, ChoiceKind, ChoiceNode, ChoiceValue, FloatChoice, IntegerChoice,
+    InterestingOrigin, Status, StopTest,
 };
+use super::float_index::lex_to_float;
 use super::{BOUNDARY_PROBABILITY, BUFFER_SIZE};
 
 /// State for a variable-length collection (port of Hypothesis's `many` class).
@@ -189,6 +190,83 @@ pub(crate) fn biased_integer_sample(ic: &IntegerChoice, rng: &mut SmallRng) -> i
     } else {
         rng.random_range(ic.min_value..=ic.max_value)
     }
+}
+
+/// Float counterpart of [`biased_integer_sample`]: draws boundary / "nasty"
+/// values (`0.0`, `-0.0`, `±1.0`, `±MAX`, `±INFINITY`, `MIN_POSITIVE`, NaN,
+/// plus the user's `min_value`/`max_value`) with probability proportional to
+/// `BOUNDARY_PROBABILITY × |nasty|`, falling back to a uniform-ish lex draw
+/// otherwise. Shared with the data-tree walk so novel-prefix exploration
+/// hits the same boundary distribution as fresh draws.
+pub(crate) fn biased_float_sample(fc: &FloatChoice, rng: &mut SmallRng) -> f64 {
+    let bounded = fc.min_value.is_finite() && fc.max_value.is_finite();
+    let half_bounded = !bounded && (fc.min_value.is_finite() || fc.max_value.is_finite());
+
+    let candidates = [
+        fc.min_value,
+        fc.max_value,
+        0.0,
+        -0.0_f64,
+        1.0,
+        -1.0,
+        f64::INFINITY,
+        f64::NEG_INFINITY,
+        f64::NAN,
+        f64::MIN_POSITIVE,
+        f64::MAX,
+        -f64::MAX,
+    ];
+    let nasty: Vec<f64> = candidates
+        .iter()
+        .copied()
+        .filter(|&v| fc.validate(v))
+        .collect();
+    let nasty_threshold = nasty.len() as f64 * BOUNDARY_PROBABILITY;
+
+    if rng.random::<f64>() < nasty_threshold {
+        let idx = rng.random_range(0..nasty.len());
+        return nasty[idx];
+    }
+    let f = if bounded {
+        let r: f64 = rng.random();
+        let v = fc.min_value + r * (fc.max_value - fc.min_value);
+        v.max(fc.min_value).min(fc.max_value)
+    } else if half_bounded {
+        let use_inf = fc.allow_infinity && rng.random::<f64>() < 0.05;
+        if use_inf {
+            if fc.max_value == f64::INFINITY {
+                f64::INFINITY
+            } else {
+                f64::NEG_INFINITY
+            }
+        } else {
+            loop {
+                let bits: u64 = rng.random();
+                let mag = lex_to_float(bits).abs();
+                if mag.is_finite() {
+                    break if fc.min_value.is_finite() {
+                        fc.min_value + mag
+                    } else {
+                        fc.max_value - mag
+                    };
+                }
+            }
+        }
+    } else if fc.allow_nan && rng.random::<f64>() < 0.01 {
+        let exponent: u64 = 0x7FF << 52;
+        let sign: u64 = (rng.random::<u64>() >> 63) << 63;
+        let mantissa: u64 = (rng.random::<u64>() & ((1u64 << 52) - 1)).max(1);
+        f64::from_bits(sign | exponent | mantissa)
+    } else {
+        loop {
+            let bits: u64 = rng.random();
+            let v = lex_to_float(bits);
+            if !v.is_nan() {
+                break v;
+            }
+        }
+    };
+    if fc.validate(f) { f } else { fc.simplest() }
 }
 
 /// A pool of variable IDs for stateful testing.
@@ -424,6 +502,7 @@ impl std::ops::Index<i64> for Spans {
 pub trait DataObserver: Send {
     fn draw_boolean(&mut self, _value: bool, _was_forced: bool) {}
     fn draw_integer(&mut self, _value: i128, _was_forced: bool) {}
+    fn draw_float(&mut self, _value: f64, _was_forced: bool) {}
     fn conclude_test(&mut self, _status: Status, _origin: Option<InterestingOrigin>) {}
 }
 
@@ -723,6 +802,48 @@ impl NativeTestCase {
 
         if let Some(ref mut obs) = self.observer {
             obs.draw_integer(v, was_forced);
+        }
+
+        Ok(v)
+    }
+
+    /// Draw a floating-point value in `[min_value, max_value]`. NaN is drawn
+    /// only when `allow_nan` is set; ±∞ only when `allow_infinity` is set and
+    /// the relevant endpoint is unbounded.
+    pub fn draw_float(
+        &mut self,
+        min_value: f64,
+        max_value: f64,
+        allow_nan: bool,
+        allow_infinity: bool,
+    ) -> Result<f64, StopTest> {
+        let kind = FloatChoice {
+            min_value,
+            max_value,
+            allow_nan,
+            allow_infinity,
+        };
+
+        let (value, was_forced) = self.resolve_choice(
+            &ChoiceKind::Float(kind.clone()),
+            || ChoiceValue::Float(kind.simplest()),
+            || ChoiceValue::Float(kind.unit()),
+            |v| matches!(v, ChoiceValue::Float(f) if kind.validate(*f)),
+            |rng| ChoiceValue::Float(biased_float_sample(&kind, rng)),
+        )?;
+
+        let ChoiceValue::Float(v) = value else {
+            unreachable!("kind/value invariant violated: outer match guaranteed this variant")
+        };
+
+        self.nodes.push(ChoiceNode {
+            kind: ChoiceKind::Float(kind),
+            value: ChoiceValue::Float(v),
+            was_forced,
+        });
+
+        if let Some(ref mut obs) = self.observer {
+            obs.draw_float(v, was_forced);
         }
 
         Ok(v)

--- a/src/native/data_tree.rs
+++ b/src/native/data_tree.rs
@@ -16,12 +16,14 @@ use rand::seq::SliceRandom;
 use crate::native::bignum::BigUint;
 use crate::native::core::{ChoiceKind, ChoiceNode, ChoiceValue, Status};
 
-/// Hashable choice-value key. Mirrors `super::det_tree::ChoiceValueKey`;
-/// kept private so the tree node type can stay unexported.
+/// Hashable choice-value key. `f64` is keyed by its bit pattern so `-0.0`
+/// stays distinct from `0.0` and individual NaN payloads are tracked
+/// separately — both matter for novel-prefix exhaustion accounting.
 #[derive(Clone, PartialEq, Eq, Hash)]
 enum ChoiceValueKey {
     Integer(i128),
     Boolean(bool),
+    Float(u64),
 }
 
 impl From<&ChoiceValue> for ChoiceValueKey {
@@ -29,6 +31,7 @@ impl From<&ChoiceValue> for ChoiceValueKey {
         match v {
             ChoiceValue::Integer(n) => ChoiceValueKey::Integer(*n),
             ChoiceValue::Boolean(b) => ChoiceValueKey::Boolean(*b),
+            ChoiceValue::Float(f) => ChoiceValueKey::Float(f.to_bits()),
         }
     }
 }

--- a/src/native/database.rs
+++ b/src/native/database.rs
@@ -203,13 +203,15 @@ pub(super) fn fnv_hex(s: &[u8]) -> String {
 /// Format:
 /// - 4-byte little-endian u32: number of choices
 /// - For each choice:
-///   - 1-byte type tag: 0=Integer, 1=Boolean
+///   - 1-byte type tag: 0=Integer, 1=Boolean, 2=Float
 ///   - Value bytes:
 ///     - Integer: 16 bytes (i128 little-endian)
 ///     - Boolean: 1 byte (0 or 1)
+///     - Float: 8 bytes (the f64 bit pattern, little-endian, so `-0.0` and
+///       NaN payloads round-trip unchanged)
 ///
-/// Minimal-native only supports integer and boolean choice nodes;
-/// attempting to serialize any other variant panics with `todo!()`.
+/// Other [`ChoiceValue`] variants are not yet supported by the native
+/// backend and serializing them panics with `todo!()`.
 pub fn serialize_choices(choices: &[ChoiceValue]) -> Vec<u8> {
     let mut buf = Vec::with_capacity(4 + choices.len() * 17);
     let count = choices.len() as u32;
@@ -223,6 +225,10 @@ pub fn serialize_choices(choices: &[ChoiceValue]) -> Vec<u8> {
             ChoiceValue::Boolean(v) => {
                 buf.push(1);
                 buf.push(*v as u8);
+            }
+            ChoiceValue::Float(v) => {
+                buf.push(2);
+                buf.extend_from_slice(&v.to_bits().to_le_bytes());
             }
         }
     }
@@ -264,6 +270,15 @@ pub fn deserialize_choices(bytes: &[u8]) -> Option<Vec<ChoiceValue>> {
                 }
                 choices.push(ChoiceValue::Boolean(bytes[pos] != 0));
                 pos += 1;
+            }
+            2 => {
+                pos += 1;
+                if pos + 8 > bytes.len() {
+                    return None;
+                }
+                let bits = u64::from_le_bytes(bytes[pos..pos + 8].try_into().ok()?);
+                choices.push(ChoiceValue::Float(f64::from_bits(bits)));
+                pos += 8;
             }
             _ => return None,
         }

--- a/src/native/floats.rs
+++ b/src/native/floats.rs
@@ -1,0 +1,21 @@
+// Float-specialised helpers used by the native engine.
+
+/// Less-than-or-equal that orders `-0.0` strictly below `0.0`.
+///
+/// Mirrors Hypothesis's `sign_aware_lte` from `internal/floats.py`.
+/// The native float draw uses this to honour user-supplied bounds that
+/// straddle `-0.0`/`0.0`: with the standard `<=` the two compare equal,
+/// so a bound of `0.0` would silently admit `-0.0`.
+pub fn sign_aware_lte(x: f64, y: f64) -> bool {
+    if x == 0.0 && y == 0.0 {
+        let sx = if x.is_sign_negative() { -1.0_f64 } else { 1.0 };
+        let sy = if y.is_sign_negative() { -1.0_f64 } else { 1.0 };
+        sx <= sy
+    } else {
+        x <= y
+    }
+}
+
+#[cfg(test)]
+#[path = "../../tests/embedded/native/floats_tests.rs"]
+mod tests;

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -11,6 +11,7 @@ pub mod core;
 pub mod data_source;
 pub mod data_tree;
 pub mod database;
+pub mod floats;
 pub mod schema;
 pub mod shrinker;
 pub mod test_runner;

--- a/src/native/schema/float.rs
+++ b/src/native/schema/float.rs
@@ -1,0 +1,96 @@
+// Float schema interpreter.
+
+use crate::cbor_utils::{as_bool, as_u64, map_get};
+use crate::native::core::{NativeTestCase, StopTest};
+use ciborium::Value;
+
+pub(super) fn interpret_float(ntc: &mut NativeTestCase, schema: &Value) -> Result<Value, StopTest> {
+    let width: u64 = map_get(schema, "width").and_then(as_u64).unwrap_or(64);
+    // `width=64` is backed by `f64` and `width=32` by `f64` rounded to
+    // `f32` precision (no `f16` Rust type yet). The schema is constructed
+    // by Rust generators, so any other value is a Rust-side bug — fail
+    // loud at the boundary rather than silently treating it as f64.
+    if width != 32 && width != 64 {
+        panic!("unsupported float width: {width} — Hegel supports widths 32 and 64");
+    }
+    let min_value = map_get(schema, "min_value")
+        .map(cbor_to_f64)
+        .unwrap_or(f64::NEG_INFINITY);
+    let max_value = map_get(schema, "max_value")
+        .map(cbor_to_f64)
+        .unwrap_or(f64::INFINITY);
+    let allow_nan = map_get(schema, "allow_nan")
+        .and_then(as_bool)
+        .unwrap_or(true);
+    let allow_infinity = map_get(schema, "allow_infinity")
+        .and_then(as_bool)
+        .unwrap_or(true);
+    let exclude_min = map_get(schema, "exclude_min")
+        .and_then(as_bool)
+        .unwrap_or(false);
+    let exclude_max = map_get(schema, "exclude_max")
+        .and_then(as_bool)
+        .unwrap_or(false);
+
+    // Adjust bounds by one ULP for exclusive boundaries.
+    // For f32 schemas (width=32), use f32-precision next_up/next_down so that
+    // the adjusted bound is representable as f32 (preventing round-to-boundary bugs).
+    let min_value = if exclude_min && min_value.is_finite() {
+        if width == 32 {
+            (min_value as f32).next_up() as f64
+        } else {
+            min_value.next_up()
+        }
+    } else {
+        min_value
+    };
+    let max_value = if exclude_max && max_value.is_finite() {
+        if width == 32 {
+            (max_value as f32).next_down() as f64
+        } else {
+            max_value.next_down()
+        }
+    } else {
+        max_value
+    };
+
+    // For f32 schemas with infinity disallowed, clamp the unbounded end(s) to
+    // the f32 finite range. Otherwise `draw_float` can produce large f64 values
+    // that round to ±f32::INFINITY when the client deserializes as f32 — and
+    // since the draw used f64 bounds, the engine would not recognise the result
+    // as violating `allow_infinity=false`. Mirrors Hypothesis, which applies
+    // `float_of(x, width)` post-generation and rejects f32 overflows
+    // (`strategies/_internal/numbers.py::floats`).
+    let (min_value, max_value) = if width == 32 && !allow_infinity {
+        (
+            min_value.max(f32::MIN as f64),
+            max_value.min(f32::MAX as f64),
+        )
+    } else {
+        (min_value, max_value)
+    };
+
+    let v = ntc.draw_float(min_value, max_value, allow_nan, allow_infinity)?;
+    // Round the drawn f64 to f32 precision when the user asked for f32.
+    // This matches what the client's deserializer will do and keeps
+    // shrinking / replay stable (the same bit pattern round-trips).
+    let v = if width == 32 && v.is_finite() {
+        (v as f32) as f64
+    } else {
+        v
+    };
+    Ok(Value::Float(v))
+}
+
+/// Extract an f64 from a CBOR value (Float or Integer).
+fn cbor_to_f64(value: &Value) -> f64 {
+    match value {
+        Value::Float(f) => *f,
+        Value::Integer(i) => i128::from(*i) as f64,
+        _ => panic!("Expected CBOR float/integer, got {:?}", value),
+    }
+}
+
+#[cfg(test)]
+#[path = "../../../tests/embedded/native/schema/float_tests.rs"]
+mod tests;

--- a/src/native/schema/mod.rs
+++ b/src/native/schema/mod.rs
@@ -12,6 +12,7 @@
 //   special     — date, time, datetime, ipv4, ipv6, domain, email, url
 
 mod collections;
+mod float;
 mod numeric;
 
 use crate::cbor_utils::map_get;
@@ -35,26 +36,30 @@ pub(crate) fn interpret_schema(
         .expect("Schema must have a \"type\" field");
 
     // Record spans for leaf schemas (no recursive interpret_schema calls).
-    let is_leaf = matches!(schema_type, "integer" | "boolean" | "sampled_from");
+    let is_leaf = matches!(
+        schema_type,
+        "integer" | "boolean" | "float" | "sampled_from"
+    );
     let span_start = if is_leaf { ntc.nodes.len() } else { 0 };
 
-    // Minimal native: integer + boolean leaves, plus the compound schemas
-    // (tuple/list/dict/one_of/sampled_from) that recurse into them. Schemas
-    // backed by float/string/binary/regex/datetime/etc. leaves panic with
+    // Native backs integer + boolean + float leaves, plus the compound
+    // schemas (tuple/list/dict/one_of/sampled_from) that recurse into them.
+    // Schemas backed by string/binary/regex/datetime/etc. leaves panic with
     // todo!() until those schema interpreters land in a follow-up PR.
     let result = match schema_type {
         "integer" => numeric::interpret_integer(ntc, schema),
         "boolean" => numeric::interpret_boolean(ntc),
         "constant" => numeric::interpret_constant(schema),
         "null" => Ok(Value::Null),
+        "float" => float::interpret_float(ntc, schema),
         "tuple" => collections::interpret_tuple(ntc, schema),
         "one_of" => collections::interpret_one_of(ntc, schema),
         "sampled_from" => collections::interpret_sampled_from(ntc, schema),
         "list" => collections::interpret_list(ntc, schema),
         "dict" => collections::interpret_dict(ntc, schema),
 
-        "string" | "binary" | "float" | "regex" | "email" | "url" | "domain" | "ip_address"
-        | "uuid" | "ipv4" | "ipv6" | "date" | "time" | "datetime" => {
+        "string" | "binary" | "regex" | "email" | "url" | "domain" | "ip_address" | "uuid"
+        | "ipv4" | "ipv6" | "date" | "time" | "datetime" => {
             todo!("schema {:?} not yet supported in native mode", schema_type)
         }
 

--- a/src/native/shrinker/floats.rs
+++ b/src/native/shrinker/floats.rs
@@ -1,0 +1,507 @@
+// Float shrink passes: `shrink_floats` reduces individual float choices toward
+// the simplest value under Hypothesis's lex ordering, and
+// `redistribute_numeric_pairs` rebalances adjacent (float, float),
+// (float, integer), and (integer, float) pairs so sum-style predicates like
+// `a + b > 1000` can collapse to their joint minimum.
+
+use std::collections::HashMap;
+
+use crate::native::core::choices::IntegerChoice;
+use crate::native::core::{
+    ChoiceKind, ChoiceNode, ChoiceValue, FloatChoice, float_to_index, index_to_float, sort_key,
+};
+
+use super::{ShrinkRun, Shrinker, bin_search_down, find_integer};
+
+/// Largest `f64` for which `n + 1.0 != n` holds — i.e., `2^53`.  Above
+/// this magnitude consecutive integers stop being individually
+/// representable as `f64`, so any "redistribute" that bumps a float by
+/// 1 silently reads as a shrink without actually changing the value.
+/// Mirrors `hypothesis.internal.floats.MAX_PRECISE_INTEGER`.
+const MAX_PRECISE_INTEGER: f64 = (1u64 << 53) as f64;
+
+/// Decompose a positive finite float into `(m, n)` with `value == m / n`.
+///
+/// Mirrors Python's `float.as_integer_ratio`. Returns `None` for values whose
+/// numerator or denominator doesn't fit in `u128`: subnormals (denominator
+/// `2^1074`) and huge normals (numerator > `2^127`) both overflow. Callers
+/// skip the integer-ratio shrink step for those.
+pub(super) fn as_integer_ratio(v: f64) -> Option<(u128, u128)> {
+    debug_assert!(v.is_finite() && v > 0.0);
+    let bits = v.to_bits();
+    let biased_exp = ((bits >> 52) & 0x7FF) as i32;
+    let mantissa_bits = bits & ((1u64 << 52) - 1);
+    let (mut num, mut exp) = if biased_exp == 0 {
+        (u128::from(mantissa_bits), -1074i32)
+    } else {
+        (
+            u128::from((1u64 << 52) | mantissa_bits),
+            biased_exp - 1023 - 52,
+        )
+    };
+    let trailing = num.trailing_zeros() as i32;
+    num >>= trailing;
+    exp += trailing;
+    if exp >= 0 {
+        let shifted = num.checked_shl(exp as u32)?;
+        Some((shifted, 1))
+    } else {
+        let n = 1u128.checked_shl((-exp) as u32)?;
+        Some((num, n))
+    }
+}
+
+impl<'a> Shrinker<'a> {
+    /// Shrink float choices toward simpler values using Hypothesis lex ordering.
+    ///
+    /// Steps per float node:
+    /// 1. Try replacing with simplest().
+    /// 2. From ±inf, try ±f64::MAX (and -inf → +inf). Needed because the
+    ///    later integer search saturates well below f64::MAX (i128::MAX as
+    ///    f64 ≪ f64::MAX) and the lex-index bisection never lands on MAX's
+    ///    all-ones mantissa.
+    /// 3. If sign-negative, try negating (positive is simpler).
+    /// 4. Binary search on absolute-value lex index from 0 toward current value.
+    ///    Searching from 0 ensures we can find "nice" integer floats (like 2.0)
+    ///    even when they have smaller lex indices than the boundary values.
+    /// 5. Integer-ratio reduction: decompose v = k + r/n and shrink k toward
+    ///    zero while holding the fractional remainder r/n fixed. Catches
+    ///    shrinks like 2.5 → 1.5 under predicates that constrain the
+    ///    fractional part.
+    pub(super) fn shrink_floats(&mut self) {
+        let mut i = 0;
+        while i < self.current_nodes.len() {
+            let node = &self.current_nodes[i];
+            if let (ChoiceKind::Float(fc), ChoiceValue::Float(v)) = (&node.kind, &node.value) {
+                let v = *v;
+                let fc = fc.clone();
+
+                // Step 1: Try simplest.
+                let s = fc.simplest();
+                if ChoiceValue::Float(s) != ChoiceValue::Float(v) {
+                    self.replace(&HashMap::from([(i, ChoiceValue::Float(s))]));
+                }
+
+                let v = self.float_at(i);
+
+                // Step 2: Special-value transitions out of ±inf.
+                if v.is_infinite() {
+                    if v < 0.0 && fc.validate(f64::INFINITY) {
+                        self.replace(&HashMap::from([(i, ChoiceValue::Float(f64::INFINITY))]));
+                    }
+                    let v = self.float_at(i);
+                    if v.is_infinite() {
+                        let cand = if v > 0.0 { f64::MAX } else { -f64::MAX };
+                        if fc.validate(cand) {
+                            self.replace(&HashMap::from([(i, ChoiceValue::Float(cand))]));
+                        }
+                    }
+                }
+
+                let v = self.float_at(i);
+
+                // NaN canonicalization. Mirrors Python's
+                // `Float.short_circuit`, which considers
+                // `[sys.float_info.max, inf, nan]` when current is NaN so
+                // that unconstrained predicates escape to a finite value and
+                // `is_nan`-style predicates converge on the positive
+                // canonical NaN (`0x7ff8_0000_0000_0000`, smallest mantissa
+                // in lex order). The non-NaN candidates go through
+                // `replace`/`consider` unchanged; the canonical-NaN
+                // fallback has to bypass `consider`'s sort-key shortcut,
+                // since all NaN bit patterns share
+                // `sort_index = (u64::MAX, false)` and `consider` would
+                // otherwise return true without rewriting `current_nodes[i]`.
+                if v.is_nan() {
+                    let mut stepped = false;
+                    for cand in [f64::MAX, f64::INFINITY] {
+                        if fc.validate(cand)
+                            && self.replace(&HashMap::from([(i, ChoiceValue::Float(cand))]))
+                        {
+                            stepped = true;
+                            break;
+                        }
+                    }
+                    if !stepped && v.to_bits() != f64::NAN.to_bits() && fc.validate(f64::NAN) {
+                        let mut attempt: Vec<ChoiceNode> = self.current_nodes.clone();
+                        attempt[i] = attempt[i].with_value(ChoiceValue::Float(f64::NAN));
+                        let (is_interesting, actual_nodes) =
+                            (self.test_fn)(ShrinkRun::Full(&attempt));
+                        // Accept as a lateral move: all NaN bit patterns
+                        // share sort_key so `<` alone would reject, but
+                        // guard against a (hypothetical) test that
+                        // produces a strictly worse sequence.
+                        if is_interesting
+                            && sort_key(&actual_nodes) <= sort_key(&self.current_nodes)
+                        {
+                            self.current_nodes = actual_nodes;
+                        }
+                    }
+                }
+
+                let v = self.float_at(i);
+
+                // Skip NaN — can't binary search on NaN.
+                if v.is_nan() {
+                    i += 1;
+                    continue;
+                }
+
+                // Step 3: Try negating if sign-negative (positive is simpler).
+                if v.is_sign_negative() {
+                    let neg = -v;
+                    if fc.validate(neg) {
+                        self.replace(&HashMap::from([(i, ChoiceValue::Float(neg))]));
+                    }
+                }
+
+                // After negation, v is still finite non-NaN: simplest/negation only
+                // produce finite non-NaN candidates, and a failed replace leaves the
+                // (finite non-NaN) value in place.
+                let v = self.float_at(i);
+
+                // Step 4a: When current is a non-integer, explicitly search the
+                // integer-float range.  In our ordering, integer floats 0, 1, 2, …
+                // have indices 0, 1, 2, … (much smaller than any non-integer).
+                // The existing binary search below misses them because it jumps
+                // past small indices when hi is near 2^63.
+                let v_abs = v.abs();
+                let current_idx = float_to_index(v_abs);
+                let is_neg = v.is_sign_negative();
+                if current_idx >= (1u64 << 63) {
+                    // Compute the integer magnitude range valid for fc. The bounds
+                    // below keep candidates strictly inside [fc.min_value,
+                    // fc.max_value], so fc.validate is guaranteed to hold.
+                    let (int_lo, int_hi) = if is_neg {
+                        // Negative float: candidate = -(n as f64). v < 0 implies
+                        // fc.min_value < 0, so the `hi` expression is well-defined.
+                        let lo = if fc.max_value <= 0.0 {
+                            (-fc.max_value).ceil() as i128
+                        } else {
+                            0
+                        };
+                        let hi = (-fc.min_value).floor() as i128;
+                        (lo, hi)
+                    } else {
+                        let lo = fc.min_value.max(0.0).ceil() as i128;
+                        let hi = fc.max_value.min(f64::MAX).floor() as i128;
+                        (lo, hi)
+                    };
+                    if int_lo >= 0 && int_lo <= int_hi {
+                        let i_capture = i;
+                        let is_neg_capture = is_neg;
+                        bin_search_down(int_lo, int_hi, &mut |n| {
+                            let candidate = if is_neg_capture {
+                                -(n as f64)
+                            } else {
+                                n as f64
+                            };
+                            self.replace(&HashMap::from([(
+                                i_capture,
+                                ChoiceValue::Float(candidate),
+                            )]))
+                        });
+                    }
+                }
+
+                // Step 4b: Binary search on absolute-value lex index toward 0.
+                // Integer replacement above only produces finite non-NaN values.
+                let v = self.float_at(i);
+                let v_abs = v.abs();
+                let current_idx = float_to_index(v_abs);
+                let is_neg = v.is_sign_negative();
+                if current_idx > 0 {
+                    bin_search_down(0, current_idx as i128, &mut |idx| {
+                        let candidate_mag = index_to_float(idx as u64);
+                        let candidate = if is_neg {
+                            -candidate_mag
+                        } else {
+                            candidate_mag
+                        };
+                        if fc.validate(candidate) {
+                            self.replace(&HashMap::from([(i, ChoiceValue::Float(candidate))]))
+                        } else {
+                            false
+                        }
+                    });
+                }
+
+                // Step 5: Integer-ratio numeric reduction.
+                //
+                // Port of Hypothesis `conjecture/shrinking/floats.py::Float.run_step`
+                // tail: decompose v = m/n exactly and binary-search the integer
+                // part k of `divmod(m, n)` toward zero, keeping the fractional
+                // remainder r/n fixed. Catches shrinks like 2.5 → 1.5 under
+                // `fract(x) == 0.5` where neither the integer-range search
+                // (Step 4a) nor the lex-index bisection (Step 4b) visit 1.5:
+                // integer candidates have fract 0, and lex-bisection midpoints
+                // are powers of 2 whose decoded values sit near 1.0 without
+                // preserving the fractional half.
+                //
+                // Uses strict `sort_key`-reduction as the accept predicate so a
+                // candidate that is merely interesting but lex-larger than
+                // current (e.g. 0.5 vs 2.5: both satisfy fract==0.5, but
+                // float_to_index(0.5) > float_to_index(2.5)) does not
+                // short-circuit `bin_search_down` at k=0 and skip lex-smaller
+                // values at larger k (1.5 at k=1).
+                let v = self.float_at(i);
+                if v.is_finite() && v != 0.0 {
+                    let is_neg = v.is_sign_negative();
+                    if let Some((m, n)) = as_integer_ratio(v.abs()) {
+                        let k_init = m / n;
+                        let r = m % n;
+                        if k_init > 0 {
+                            bin_search_down(0, k_init as i128, &mut |k| {
+                                let num_sum = (k as u128) * n + r;
+                                let candidate_abs = (num_sum as f64) / (n as f64);
+                                let candidate = if is_neg {
+                                    -candidate_abs
+                                } else {
+                                    candidate_abs
+                                };
+                                if !fc.validate(candidate) {
+                                    return false;
+                                }
+                                let prev_key = sort_key(&self.current_nodes);
+                                self.replace(&HashMap::from([(i, ChoiceValue::Float(candidate))]));
+                                sort_key(&self.current_nodes) < prev_key
+                            });
+                        }
+                    }
+                }
+            }
+            i += 1;
+        }
+    }
+
+    fn float_at(&self, i: usize) -> f64 {
+        match self.current_nodes[i].value {
+            ChoiceValue::Float(f) => f,
+            _ => unreachable!("kind/value invariant violated: outer match guaranteed this variant"),
+        }
+    }
+
+    /// Redistribute magnitude across nearby numeric pairs.
+    ///
+    /// Port of Hypothesis's `redistribute_numeric_pairs`. For sum-style
+    /// constraints (`a + b > 1000`), shrinking `a` toward 0 alone breaks
+    /// the predicate; the pair only collapses to its minimum when `a` is
+    /// reduced and `b` is raised by the same amount in lockstep. Walks pairs
+    /// `(i, j)` where `j - i` is small (cap 4 to avoid quadratic scans), at
+    /// least one side is a non-trivial Float, and probes
+    /// `(v_i - k, v_j + k)` (or `(v_i + k, v_j - k)` if `v_i` is below its
+    /// shrink target). Maximises `k` via `find_integer`.
+    ///
+    /// Pure Integer-Integer pairs are already handled by
+    /// [`Shrinker::redistribute_integers`] — this pass complements it by
+    /// covering Float-Float, Float-Integer, and Integer-Float pairs that
+    /// the integer-only pass skips.
+    pub(super) fn redistribute_numeric_pairs(&mut self) {
+        let len = self.current_nodes.len();
+        for i in 0..len {
+            for gap in 1..=4 {
+                if i + gap >= self.current_nodes.len() {
+                    break;
+                }
+                let j = i + gap;
+                if !is_float_or_integer(&self.current_nodes[i].kind)
+                    || !is_float_or_integer(&self.current_nodes[j].kind)
+                {
+                    continue;
+                }
+                // Skip pure Int-Int — covered by redistribute_integers.
+                if matches!(
+                    (&self.current_nodes[i].kind, &self.current_nodes[j].kind),
+                    (ChoiceKind::Integer(_), ChoiceKind::Integer(_))
+                ) {
+                    continue;
+                }
+                // MAX_PRECISE_INTEGER guard (shrinker.py:1356-1358): for
+                // a Float node, skip if the value is non-finite or has
+                // `|v| >= 2^53`.  Above that magnitude `f + 1 == f` so
+                // the redistribute math reads as a shrink without
+                // actually reducing the value — we'd waste calls and
+                // possibly accept lossy "no-op" candidates.
+                if !can_choose_for_redistribute(&self.current_nodes[i])
+                    || !can_choose_for_redistribute(&self.current_nodes[j])
+                {
+                    continue;
+                }
+                if is_trivial(&self.current_nodes[i]) {
+                    continue;
+                }
+                redistribute_pair(self, i, j);
+            }
+        }
+    }
+}
+
+/// `node.constraints["shrink_towards"]` for floats is fixed at 0 in
+/// upstream and we don't carry it in [`FloatChoice`]; the only
+/// node-level filter `redistribute_numeric_pairs` needs is the
+/// MAX_PRECISE_INTEGER / NaN / inf check from `shrinker.py:1356-1358`.
+fn can_choose_for_redistribute(node: &ChoiceNode) -> bool {
+    // Caller (`redistribute_numeric_pairs`) has already filtered out
+    // non-numeric kinds via `is_float_or_integer`, so anything outside
+    // matched-(Int, Int) / (Float, Float) is unreachable here.
+    match (&node.kind, &node.value) {
+        (ChoiceKind::Float(_), ChoiceValue::Float(f)) => {
+            f.is_finite() && f.abs() < MAX_PRECISE_INTEGER
+        }
+        (ChoiceKind::Integer(_), ChoiceValue::Integer(_)) => true,
+        _ => unreachable!("filtered by is_float_or_integer; ChoiceNode invariant otherwise"),
+    }
+}
+
+fn is_float_or_integer(k: &ChoiceKind) -> bool {
+    match k {
+        ChoiceKind::Float(_) | ChoiceKind::Integer(_) => true,
+        ChoiceKind::Boolean(_) => false,
+    }
+}
+
+fn is_trivial(node: &ChoiceNode) -> bool {
+    // Only called by `redistribute_numeric_pairs` after the
+    // `is_float_or_integer` filter, so Booleans cannot appear.
+    match (&node.kind, &node.value) {
+        (ChoiceKind::Integer(ic), ChoiceValue::Integer(v)) => *v == ic.simplest(),
+        (ChoiceKind::Float(fc), ChoiceValue::Float(v)) => !v.is_finite() || *v == fc.simplest(),
+        _ => unreachable!("filtered by is_float_or_integer; ChoiceNode invariant otherwise"),
+    }
+}
+
+/// Direction the integer-pair search moves `node[i]` in.
+///
+/// `v_i` is reduced toward its shrink target (0 for floats, simplest() for
+/// integers); the matching adjustment to `v_j` raises it. If `v_i` is
+/// already below its shrink target, both deltas flip sign.
+fn redistribute_pair(shrinker: &mut Shrinker<'_>, i: usize, j: usize) {
+    // Snapshot the original values; find_integer will probe larger and
+    // larger `k` and the kept candidate updates current_nodes in place.
+    // Caller has already filtered to Integer/Float pairs via
+    // `is_float_or_integer`, and `is_trivial` rejects non-finite floats, so
+    // every branch outside (Int, Int) / (Float finite, Float finite) is
+    // unreachable here.
+    let (v_i, kind_i) = match (
+        &shrinker.current_nodes[i].kind,
+        &shrinker.current_nodes[i].value,
+    ) {
+        (ChoiceKind::Integer(ic), ChoiceValue::Integer(n)) => {
+            (NumericValue::Integer(*n), NumericKind::Integer(ic.clone()))
+        }
+        (ChoiceKind::Float(fc), ChoiceValue::Float(f)) => {
+            (NumericValue::Float(*f), NumericKind::Float(fc.clone()))
+        }
+        _ => unreachable!("redistribute_pair gated on is_float_or_integer + is_trivial"),
+    };
+    let (v_j, kind_j) = match (
+        &shrinker.current_nodes[j].kind,
+        &shrinker.current_nodes[j].value,
+    ) {
+        (ChoiceKind::Integer(ic), ChoiceValue::Integer(n)) => {
+            (NumericValue::Integer(*n), NumericKind::Integer(ic.clone()))
+        }
+        (ChoiceKind::Float(fc), ChoiceValue::Float(f)) => {
+            (NumericValue::Float(*f), NumericKind::Float(fc.clone()))
+        }
+        _ => unreachable!("redistribute_pair gated on is_float_or_integer + is_trivial"),
+    };
+
+    let target_i = shrink_target(&kind_i);
+    let dir = if v_i.as_f64() >= target_i {
+        Direction::LowerLeftRaiseRight
+    } else {
+        Direction::RaiseLeftLowerRight
+    };
+
+    // Upstream `shrinker.py:1404-1405` guards against `cand_j` crossing
+    // `MAX_PRECISE_INTEGER` here. We don't need that: the sort-key check
+    // in `consider`/`replace` rejects any candidate whose `|cand_i|` grows
+    // beyond the prior accept, which always trips well before `cand_j`
+    // reaches `2^53`.
+    find_integer(|k| {
+        let (cand_i, cand_j) = apply_delta(&v_i, &v_j, k as i128, dir);
+        let Some(val_i) = build_value(&kind_i, cand_i) else {
+            return false;
+        };
+        let Some(val_j) = build_value(&kind_j, cand_j) else {
+            return false;
+        };
+        shrinker.replace(&HashMap::from([(i, val_i), (j, val_j)]))
+    });
+}
+
+#[derive(Clone, Copy)]
+enum Direction {
+    /// v_i above shrink target: subtract k from v_i, add k to v_j.
+    LowerLeftRaiseRight,
+    /// v_i below shrink target: add k to v_i, subtract k from v_j.
+    RaiseLeftLowerRight,
+}
+
+#[derive(Clone, Copy)]
+enum NumericValue {
+    Integer(i128),
+    Float(f64),
+}
+
+impl NumericValue {
+    fn as_f64(self) -> f64 {
+        match self {
+            NumericValue::Integer(n) => n as f64,
+            NumericValue::Float(f) => f,
+        }
+    }
+}
+
+#[derive(Clone)]
+enum NumericKind {
+    Integer(IntegerChoice),
+    Float(FloatChoice),
+}
+
+fn shrink_target(kind: &NumericKind) -> f64 {
+    match kind {
+        NumericKind::Integer(ic) => ic.simplest() as f64,
+        NumericKind::Float(_) => 0.0,
+    }
+}
+
+fn apply_delta(
+    v_i: &NumericValue,
+    v_j: &NumericValue,
+    k: i128,
+    dir: Direction,
+) -> (NumericValue, NumericValue) {
+    let signed_k_i = match dir {
+        Direction::LowerLeftRaiseRight => -k,
+        Direction::RaiseLeftLowerRight => k,
+    };
+    let signed_k_j = -signed_k_i;
+    (add_int(v_i, signed_k_i), add_int(v_j, signed_k_j))
+}
+
+fn add_int(v: &NumericValue, k: i128) -> NumericValue {
+    match v {
+        NumericValue::Integer(n) => NumericValue::Integer(n.saturating_add(k)),
+        NumericValue::Float(f) => NumericValue::Float(*f + k as f64),
+    }
+}
+
+fn build_value(kind: &NumericKind, candidate: NumericValue) -> Option<ChoiceValue> {
+    // `apply_delta` preserves the variant of each input, so only the
+    // matching kind/value combinations are reachable from `redistribute_pair`.
+    match (kind, candidate) {
+        (NumericKind::Integer(ic), NumericValue::Integer(n)) => {
+            ic.validate(n).then_some(ChoiceValue::Integer(n))
+        }
+        (NumericKind::Float(fc), NumericValue::Float(f)) => {
+            fc.validate(f).then_some(ChoiceValue::Float(f))
+        }
+        _ => unreachable!("apply_delta preserves variant; kind and value cannot disagree"),
+    }
+}
+
+#[cfg(test)]
+#[path = "../../../tests/embedded/native/shrinker_floats_tests.rs"]
+mod tests;

--- a/src/native/shrinker/mod.rs
+++ b/src/native/shrinker/mod.rs
@@ -8,11 +8,10 @@
 //   integers   — zero_choices, swap_integer_sign, binary_search_integer_towards_zero,
 //                redistribute_integers, shrink_duplicates
 //   sequence   — sort_values, swap_adjacent_blocks
-//   floats     — shrink_floats
-//   bytes      — shrink_bytes
-//   strings    — shrink_strings
+//   floats     — shrink_floats, redistribute_numeric_pairs
 
 mod deletion;
+mod floats;
 mod index_passes;
 mod integers;
 mod mutation;
@@ -186,6 +185,8 @@ impl<'a> Shrinker<'a> {
             self.shrink_duplicates();
             self.sort_values();
             self.swap_adjacent_blocks();
+            self.shrink_floats();
+            self.redistribute_numeric_pairs();
             self.lower_and_bump();
             self.try_shortening_via_increment();
             self.mutate_and_shrink();

--- a/tests/embedded/native/choices_tests.rs
+++ b/tests/embedded/native/choices_tests.rs
@@ -161,3 +161,122 @@ fn integer_full_i128_range_is_two_pow_128() {
 fn boolean_is_always_two() {
     assert_eq!((ChoiceKind::Boolean(BooleanChoice)).max_children(), bu(2));
 }
+
+// ── FloatChoice ──────────────────────────────────────────────────────────
+
+fn fc(min: f64, max: f64, allow_nan: bool, allow_infinity: bool) -> FloatChoice {
+    FloatChoice {
+        min_value: min,
+        max_value: max,
+        allow_nan,
+        allow_infinity,
+    }
+}
+
+#[test]
+fn float_choice_simplest_picks_zero_when_in_range() {
+    assert_eq!(fc(-1.0, 1.0, false, false).simplest(), 0.0);
+    assert_eq!(fc(0.0, 10.0, false, false).simplest(), 0.0);
+}
+
+#[test]
+fn float_choice_simplest_picks_closest_endpoint_when_zero_excluded() {
+    // [1.5, 10.0]: simplest is the nearest integer above 1.5, which is 2.0.
+    assert_eq!(fc(1.5, 10.0, false, false).simplest(), 2.0);
+    // [-5.0, -1.5]: simplest is the nearest integer below -1.5, which is -2.0.
+    assert_eq!(fc(-5.0, -1.5, false, false).simplest(), -2.0);
+}
+
+#[test]
+fn float_choice_simplest_finds_simple_fraction_in_tight_range() {
+    // [1.4, 1.6] contains no integer, so the search falls through to the
+    // exponent/mantissa loop that scans "simple fractions". `1.5` has the
+    // smallest lex index in that loop, becomes the running best, and the
+    // next mantissa probe trips the inner-loop early break.
+    assert_eq!(fc(1.4, 1.6, false, false).simplest(), 1.5);
+}
+
+#[test]
+fn float_choice_simplest_falls_back_to_infinity_when_no_finite_values() {
+    // Empty finite range, but +inf allowed.
+    let fc = fc(f64::INFINITY, f64::INFINITY, false, true);
+    assert_eq!(fc.simplest(), f64::INFINITY);
+    let fc = fc_neg();
+    assert_eq!(fc.simplest(), f64::NEG_INFINITY);
+}
+
+fn fc_neg() -> FloatChoice {
+    fc(f64::NEG_INFINITY, f64::NEG_INFINITY, false, true)
+}
+
+#[test]
+fn float_choice_simplest_falls_back_to_nan_when_only_nan_allowed() {
+    // Empty finite range, no infinities, but NaN allowed.
+    let fc = FloatChoice {
+        min_value: f64::INFINITY,
+        max_value: f64::NEG_INFINITY,
+        allow_nan: true,
+        allow_infinity: false,
+    };
+    assert!(fc.simplest().is_nan());
+}
+
+#[test]
+#[should_panic(expected = "FloatChoice::simplest: no valid float")]
+fn float_choice_simplest_panics_when_nothing_valid() {
+    let fc = FloatChoice {
+        min_value: f64::INFINITY,
+        max_value: f64::NEG_INFINITY,
+        allow_nan: false,
+        allow_infinity: false,
+    };
+    let _ = fc.simplest();
+}
+
+#[test]
+fn float_choice_unit_falls_through_to_simplest_on_nan_start() {
+    // When simplest() returns NaN, unit() short-circuits to that NaN.
+    let fc = FloatChoice {
+        min_value: f64::INFINITY,
+        max_value: f64::NEG_INFINITY,
+        allow_nan: true,
+        allow_infinity: false,
+    };
+    assert!(fc.unit().is_nan());
+}
+
+#[test]
+fn float_choice_enumerate_returns_none() {
+    // The float space is too large to enumerate under any reasonable cap.
+    let kind = ChoiceKind::Float(fc(0.0, 1.0, false, false));
+    assert!(kind.enumerate(u64::MAX).is_none());
+}
+
+#[test]
+fn float_choice_to_from_index_round_trip() {
+    let kind = ChoiceKind::Float(fc(-10.0, 10.0, false, false));
+    for v in [0.0_f64, 1.0, 2.0, -1.0, -2.0, 0.5, -0.5, 4.25] {
+        let idx = kind.to_index(&ChoiceValue::Float(v));
+        let back = kind.from_index(idx).unwrap();
+        assert_eq!(back, ChoiceValue::Float(v));
+    }
+}
+
+#[test]
+fn float_choice_to_from_index_round_trip_for_infinity_and_nan() {
+    let fc = FloatChoice {
+        min_value: f64::NEG_INFINITY,
+        max_value: f64::INFINITY,
+        allow_nan: true,
+        allow_infinity: true,
+    };
+    for v in [f64::INFINITY, f64::NEG_INFINITY, f64::NAN] {
+        let idx = fc.to_index(v);
+        let back = fc.from_index(idx).expect("rank is valid");
+        if v.is_nan() {
+            assert!(back.is_nan());
+        } else {
+            assert_eq!(back, v);
+        }
+    }
+}

--- a/tests/embedded/native/database_tests.rs
+++ b/tests/embedded/native/database_tests.rs
@@ -150,3 +150,38 @@ fn deserialize_returns_none_on_unknown_type_tag() {
     bytes.push(42); // unknown type tag
     assert!(deserialize_choices(&bytes).is_none());
 }
+
+#[test]
+fn round_trip_float_choices_preserves_bit_pattern() {
+    let choices = vec![
+        ChoiceValue::Float(0.0),
+        ChoiceValue::Float(-0.0),
+        ChoiceValue::Float(1.5),
+        ChoiceValue::Float(-1.5),
+        ChoiceValue::Float(f64::INFINITY),
+        ChoiceValue::Float(f64::NEG_INFINITY),
+        ChoiceValue::Float(f64::NAN),
+        ChoiceValue::Float(f64::MAX),
+        ChoiceValue::Float(f64::MIN_POSITIVE),
+    ];
+    let bytes = serialize_choices(&choices);
+    let round_tripped = deserialize_choices(&bytes).unwrap();
+    assert_eq!(round_tripped.len(), choices.len());
+    for (got, want) in round_tripped.iter().zip(choices.iter()) {
+        match (got, want) {
+            (ChoiceValue::Float(g), ChoiceValue::Float(w)) => {
+                assert_eq!(g.to_bits(), w.to_bits(), "bit pattern mismatch");
+            }
+            _ => panic!("non-float variant produced"),
+        }
+    }
+}
+
+#[test]
+fn deserialize_returns_none_on_truncated_float_body() {
+    // count = 1, type tag 2 (Float), but fewer than 8 bytes follow.
+    let mut bytes = 1u32.to_le_bytes().to_vec();
+    bytes.push(2); // type tag = Float
+    bytes.extend_from_slice(&[0u8; 4]); // only 4 of 8 needed bytes
+    assert!(deserialize_choices(&bytes).is_none());
+}

--- a/tests/embedded/native/float_index_tests.rs
+++ b/tests/embedded/native/float_index_tests.rs
@@ -1,0 +1,189 @@
+use super::*;
+
+// ── encode_exponent ─────────────────────────────────────────────────────────
+
+#[test]
+fn encode_exponent_max_stays_max() {
+    assert_eq!(encode_exponent(2047), 2047);
+}
+
+#[test]
+fn encode_exponent_positive_exponents() {
+    // biased_exp >= 1023 (unbiased >= 0) → biased_exp - 1023
+    assert_eq!(encode_exponent(1023), 0);
+    assert_eq!(encode_exponent(1024), 1);
+    assert_eq!(encode_exponent(2046), 1023);
+}
+
+#[test]
+fn encode_exponent_negative_exponents() {
+    // biased_exp < 1023 (unbiased < 0) → 2046 - biased_exp
+    assert_eq!(encode_exponent(0), 2046);
+    assert_eq!(encode_exponent(1022), 1024);
+    assert_eq!(encode_exponent(1), 2045);
+}
+
+// ── decode_exponent ─────────────────────────────────────────────────────────
+
+#[test]
+fn decode_exponent_max_stays_max() {
+    assert_eq!(decode_exponent(2047), 2047);
+}
+
+#[test]
+fn decode_exponent_both_branches() {
+    // enc <= 1023 → enc + 1023
+    assert_eq!(decode_exponent(0), 1023);
+    assert_eq!(decode_exponent(1023), 2046);
+    // enc > 1023 → 2046 - enc
+    assert_eq!(decode_exponent(1024), 1022);
+    assert_eq!(decode_exponent(2046), 0);
+}
+
+#[test]
+fn encode_decode_round_trip() {
+    for biased in [0u64, 1, 500, 1022, 1023, 1024, 1500, 2046, 2047] {
+        assert_eq!(decode_exponent(encode_exponent(biased)), biased);
+    }
+}
+
+// ── update_mantissa ─────────────────────────────────────────────────────────
+
+#[test]
+fn update_mantissa_nonpositive_reverses_all_52_bits() {
+    // unbiased_exp <= 0 → full 52-bit reversal
+    assert_eq!(update_mantissa(0, 0), 0);
+    // Bit 0 swaps with bit 51
+    assert_eq!(update_mantissa(0, 1), 1u64 << 51);
+    assert_eq!(update_mantissa(0, 1u64 << 51), 1);
+    // Same logic for unbiased_exp < 0
+    assert_eq!(update_mantissa(-1, 1), 1u64 << 51);
+    assert_eq!(update_mantissa(-5, 0b1010), (0b0101) << 48);
+}
+
+#[test]
+fn update_mantissa_partial_reversal() {
+    // unbiased_exp in [1, 51] reverses the low (52 - unbiased_exp) bits
+    // exp = 51 → n_frac = 1, reverse lowest 1 bit (no-op for a single bit)
+    assert_eq!(update_mantissa(51, 1), 1);
+    // exp = 50 → n_frac = 2. mantissa=0b10 → frac=0b10 → reversed=0b01
+    assert_eq!(update_mantissa(50, 0b10), 0b01);
+    // High bits above the fractional window are preserved
+    // exp = 40 → n_frac = 12. mantissa = (1<<15) | 1 keeps bit 15, moves bit 0 to bit 11.
+    let mantissa = (1u64 << 15) | 1;
+    assert_eq!(update_mantissa(40, mantissa), (1u64 << 15) | (1u64 << 11));
+    // exp = 1 → n_frac = 51 (reverse all but the top fractional bit)
+    assert_eq!(update_mantissa(1, 1), 1u64 << 50);
+}
+
+#[test]
+fn update_mantissa_large_exponent_unchanged() {
+    // unbiased_exp >= 52 → mantissa returned as-is (no fractional bits)
+    assert_eq!(update_mantissa(52, 0xDEAD_BEEF), 0xDEAD_BEEF);
+    assert_eq!(update_mantissa(100, 0), 0);
+    assert_eq!(
+        update_mantissa(1023, 0x000F_FFFF_FFFF_FFFF),
+        0x000F_FFFF_FFFF_FFFF
+    );
+}
+
+#[test]
+fn update_mantissa_is_self_inverse() {
+    // Bit reversal is involutive: applying twice yields the original value.
+    for (exp, m) in [
+        (-10i64, 0x1_2345u64),
+        (0, 0x000F_FFFF_FFFF_FFFF),
+        (1, 0x7_A5A5),
+        (25, 0xABCD_1234),
+        (51, 1),
+        (52, 0xFF),
+        (100, 0x000F_FFFF_FFFF_FFFF),
+    ] {
+        assert_eq!(update_mantissa(exp, update_mantissa(exp, m)), m);
+    }
+}
+
+// ── float_to_index / index_to_float ─────────────────────────────────────────
+
+#[test]
+fn simple_integer_floats_map_to_themselves() {
+    // is_simple_float path: 0..2^56 integer floats map to their integer value.
+    for v in [0.0_f64, 1.0, 2.0, 42.0, 1_000_000.0, ((1u64 << 55) as f64)] {
+        assert_eq!(float_to_index(v), v as u64);
+        assert_eq!(index_to_float(v as u64), v);
+    }
+}
+
+#[test]
+fn non_integer_float_uses_tagged_encoding() {
+    // 0.5 is not simple → top bit must be set, and round-trip must hold.
+    let idx = float_to_index(0.5);
+    assert_ne!(idx & (1u64 << 63), 0);
+    assert_eq!(index_to_float(idx), 0.5);
+}
+
+#[test]
+fn large_integer_above_threshold_uses_nonsimple_path() {
+    // 2^56 fails `i < 2^56`, forcing the non-simple encoding.
+    let v = (1u64 << 56) as f64;
+    let idx = float_to_index(v);
+    assert_ne!(idx & (1u64 << 63), 0);
+    assert_eq!(index_to_float(idx), v);
+}
+
+#[test]
+fn infinity_uses_nonsimple_path() {
+    // is_simple_float returns false via the !is_finite branch.
+    let idx = float_to_index(f64::INFINITY);
+    assert_eq!(index_to_float(idx), f64::INFINITY);
+}
+
+#[test]
+fn float_index_round_trip_assorted_values() {
+    for v in [
+        0.0_f64,
+        1.0,
+        2.0,
+        0.5,
+        0.1,
+        2.5,
+        100.0,
+        1e100,
+        1e-100,
+        f64::MIN_POSITIVE,
+        f64::MAX,
+        f64::INFINITY,
+    ] {
+        let idx = float_to_index(v);
+        let back = index_to_float(idx);
+        assert_eq!(back.to_bits(), v.to_bits(), "round-trip failed for {v}");
+    }
+}
+
+#[test]
+fn integer_floats_are_lex_simpler_than_fractions() {
+    // Sanity-check: integer encodings (tag bit 0) precede fractional encodings (tag bit 1).
+    assert!(float_to_index(0.0) < float_to_index(1.0));
+    assert!(float_to_index(1.0) < float_to_index(2.0));
+    assert!(float_to_index(1_000_000.0) < float_to_index(0.5));
+}
+
+// ── lex_to_float ────────────────────────────────────────────────────────────
+
+#[test]
+fn lex_to_float_top_bit_set_clears_sign() {
+    // bits >> 63 != 0: XOR with (1 << 63) clears the top bit.
+    // 1<<63 → 0 → +0.0
+    assert_eq!(lex_to_float(1u64 << 63).to_bits(), 0);
+}
+
+#[test]
+fn lex_to_float_top_bit_clear_inverts_all_bits() {
+    // bits >> 63 == 0: XOR with u64::MAX flips every bit.
+    // 0 → u64::MAX → NaN (all-ones is a NaN bit pattern).
+    assert!(lex_to_float(0).is_nan());
+    // (u64::MAX >> 1) has top bit clear → flips to 1 << 63 → -0.0
+    let v = lex_to_float(u64::MAX >> 1);
+    assert_eq!(v, 0.0);
+    assert!(v.is_sign_negative());
+}

--- a/tests/embedded/native/floats_tests.rs
+++ b/tests/embedded/native/floats_tests.rs
@@ -1,0 +1,30 @@
+use super::*;
+
+#[test]
+fn sign_aware_lte_orders_negative_zero_below_positive_zero() {
+    assert!(sign_aware_lte(-0.0, 0.0));
+    assert!(!sign_aware_lte(0.0, -0.0));
+}
+
+#[test]
+fn sign_aware_lte_is_reflexive_on_zero_pair() {
+    assert!(sign_aware_lte(0.0, 0.0));
+    assert!(sign_aware_lte(-0.0, -0.0));
+}
+
+#[test]
+fn sign_aware_lte_agrees_with_lte_for_non_zero_pairs() {
+    let cases = [
+        (1.0, 2.0),
+        (2.0, 1.0),
+        (-1.0, 1.0),
+        (1.0, -1.0),
+        (f64::NEG_INFINITY, 0.0),
+        (0.0, f64::INFINITY),
+        (f64::NEG_INFINITY, f64::INFINITY),
+        (-1e-300, 1e-300),
+    ];
+    for (x, y) in cases {
+        assert_eq!(sign_aware_lte(x, y), x <= y, "{x} <= {y}");
+    }
+}

--- a/tests/embedded/native/schema/float_tests.rs
+++ b/tests/embedded/native/schema/float_tests.rs
@@ -1,0 +1,61 @@
+use super::*;
+
+#[test]
+fn cbor_to_f64_from_integer() {
+    assert_eq!(cbor_to_f64(&Value::Integer(42.into())), 42.0);
+}
+
+#[test]
+fn cbor_to_f64_from_negative_integer() {
+    assert_eq!(cbor_to_f64(&Value::Integer((-7i64).into())), -7.0);
+}
+
+#[test]
+#[should_panic(expected = "Expected CBOR float/integer")]
+fn cbor_to_f64_panics_on_non_numeric() {
+    let _ = cbor_to_f64(&Value::Bool(true));
+}
+
+// interpret_float must reject widths outside `{32, 64}`: Hypothesis only
+// supports `{16, 32, 64}` and we have no Rust `f16` to back width 16, so
+// the schema interpreter fails loud at the boundary rather than silently
+// treating unknown widths as f64.
+
+#[test]
+#[should_panic(expected = "unsupported float width")]
+fn interpret_float_rejects_width_16() {
+    use crate::cbor_utils::cbor_map;
+    use crate::native::core::NativeTestCase;
+    use rand::SeedableRng;
+    use rand::rngs::SmallRng;
+    let mut ntc = NativeTestCase::new_random(SmallRng::seed_from_u64(0));
+    let schema = cbor_map! { "type" => "float", "width" => 16 };
+    let _ = interpret_float(&mut ntc, &schema);
+}
+
+#[test]
+#[should_panic(expected = "unsupported float width")]
+fn interpret_float_rejects_width_128() {
+    use crate::cbor_utils::cbor_map;
+    use crate::native::core::NativeTestCase;
+    use rand::SeedableRng;
+    use rand::rngs::SmallRng;
+    let mut ntc = NativeTestCase::new_random(SmallRng::seed_from_u64(0));
+    let schema = cbor_map! { "type" => "float", "width" => 128 };
+    let _ = interpret_float(&mut ntc, &schema);
+}
+
+#[test]
+fn interpret_float_accepts_width_32_and_64() {
+    use crate::cbor_utils::cbor_map;
+    use crate::native::core::NativeTestCase;
+    use rand::SeedableRng;
+    use rand::rngs::SmallRng;
+    let mut ntc = NativeTestCase::new_random(SmallRng::seed_from_u64(0));
+    let schema_64 = cbor_map! { "type" => "float", "width" => 64 };
+    assert!(interpret_float(&mut ntc, &schema_64).is_ok());
+
+    let mut ntc = NativeTestCase::new_random(SmallRng::seed_from_u64(0));
+    let schema_32 = cbor_map! { "type" => "float", "width" => 32 };
+    assert!(interpret_float(&mut ntc, &schema_32).is_ok());
+}

--- a/tests/embedded/native/shrinker_floats_tests.rs
+++ b/tests/embedded/native/shrinker_floats_tests.rs
@@ -1,0 +1,135 @@
+use super::*;
+use crate::native::shrinker::Shrinker;
+
+// ── redistribute_pair: cand_j out-of-range ────────────────────────────────
+//
+// `find_integer` short-circuits via `return false` when `build_value` rejects
+// a candidate for either side. Walked organically the (Float, Int) and
+// (Int, Float) integration tests in `tests/test_shrink_quality/mixed_types.rs`
+// already hit the `cand_i` side; this test covers the `cand_j` side too by
+// constructing a Float-Int pair where `find_integer` raises the integer past
+// its `max_value`.
+
+fn float_node(value: f64, min: f64, max: f64) -> ChoiceNode {
+    ChoiceNode {
+        kind: ChoiceKind::Float(FloatChoice {
+            min_value: min,
+            max_value: max,
+            allow_nan: false,
+            allow_infinity: false,
+        }),
+        value: ChoiceValue::Float(value),
+        was_forced: false,
+    }
+}
+
+fn int_node(value: i128, min: i128, max: i128) -> ChoiceNode {
+    ChoiceNode {
+        kind: ChoiceKind::Integer(IntegerChoice {
+            min_value: min,
+            max_value: max,
+            shrink_towards: 0,
+        }),
+        value: ChoiceValue::Integer(value),
+        was_forced: false,
+    }
+}
+
+#[test]
+fn redistribute_pair_bails_when_int_candidate_leaves_validate_range() {
+    let initial = vec![float_node(3.0, -100.0, 100.0), int_node(2, 1, 10)];
+    let mut shrinker = Shrinker::with_probe(
+        Box::new(|run| match run {
+            crate::native::shrinker::ShrinkRun::Full(nodes) => (true, nodes.to_vec()),
+            crate::native::shrinker::ShrinkRun::Probe { .. } => (false, Vec::new()),
+        }),
+        initial,
+    );
+    shrinker.redistribute_numeric_pairs();
+    // Engine stayed within validate bounds despite the accepting test_fn.
+    match (
+        &shrinker.current_nodes[0].value,
+        &shrinker.current_nodes[1].value,
+    ) {
+        (ChoiceValue::Float(_), ChoiceValue::Integer(n)) => {
+            assert!((1..=10).contains(n));
+        }
+        _ => unreachable!(),
+    }
+}
+
+// ── shrink_floats: NaN canonicalization (stepped accept path) ─────────────
+//
+// When a Float node holds a NaN value, `shrink_floats` tries to replace it
+// with `f64::MAX` and then `f64::INFINITY`. If the test predicate accepts
+// one of those candidates, the loop sets `stepped = true` and breaks.
+//
+// Driving this directly with a constructed shrinker makes the path
+// deterministic — random integration tests hit it only when the boundary
+// sampler happens to find NaN before any other interesting value.
+
+#[test]
+fn shrink_floats_canonicalizes_nan_to_finite_when_predicate_admits() {
+    let initial = vec![ChoiceNode {
+        kind: ChoiceKind::Float(FloatChoice {
+            min_value: f64::NEG_INFINITY,
+            max_value: f64::INFINITY,
+            allow_nan: true,
+            allow_infinity: true,
+        }),
+        value: ChoiceValue::Float(f64::NAN),
+        was_forced: false,
+    }];
+    // Predicate: accept NaN, infinity, or `f64::MAX`. The canonicalization
+    // tries `f64::MAX` first and accepts it.
+    let mut shrinker = Shrinker::with_probe(
+        Box::new(|run: crate::native::shrinker::ShrinkRun<'_>| match run {
+            crate::native::shrinker::ShrinkRun::Full(nodes) => {
+                let interesting = nodes.iter().all(|n| match &n.value {
+                    ChoiceValue::Float(f) => f.is_nan() || f.is_infinite() || *f == f64::MAX,
+                    _ => false,
+                });
+                (interesting, nodes.to_vec())
+            }
+            crate::native::shrinker::ShrinkRun::Probe { .. } => (false, Vec::new()),
+        }),
+        initial,
+    );
+    shrinker.shrink_floats();
+    // After canonicalization the node holds `f64::MAX` (first accepted
+    // candidate in the iteration order) rather than the original NaN.
+    match shrinker.current_nodes[0].value {
+        ChoiceValue::Float(f) => assert_eq!(f, f64::MAX),
+        _ => unreachable!(),
+    }
+}
+
+// ── as_integer_ratio ──────────────────────────────────────────────────────
+
+#[test]
+fn as_integer_ratio_recovers_simple_terminating_decimal() {
+    // 0.5 = 1 / 2
+    assert_eq!(as_integer_ratio(0.5), Some((1, 2)));
+    // 1.5 = 3 / 2
+    assert_eq!(as_integer_ratio(1.5), Some((3, 2)));
+    // Integer values: denominator 1.
+    assert_eq!(as_integer_ratio(2.0), Some((2, 1)));
+    assert_eq!(as_integer_ratio(1024.0), Some((1024, 1)));
+}
+
+#[test]
+fn as_integer_ratio_subnormal_decomposes_with_huge_denominator() {
+    // The smallest positive subnormal has biased_exp == 0 and mantissa 1.
+    // Its denominator is 2^1074, which overflows u128 — we expect `None`
+    // back, but the early `biased_exp == 0` branch must still run to
+    // compute the numerator/exponent pair before the overflow check trips.
+    let smallest_subnormal = f64::from_bits(1);
+    assert_eq!(as_integer_ratio(smallest_subnormal), None);
+}
+
+#[test]
+fn as_integer_ratio_huge_value_overflows_to_none() {
+    // f64::MAX has a numerator that, after shifting, exceeds u128. The
+    // checked_shl on line 46 returns None.
+    assert_eq!(as_integer_ratio(f64::MAX), None);
+}

--- a/tests/embedded/native/state_tests.rs
+++ b/tests/embedded/native/state_tests.rs
@@ -351,35 +351,10 @@ fn stop_span_on_empty_stack_is_a_no_op() {
     assert!(tc.spans.is_empty());
 }
 
-// ── NativeResult::Conjecture path in as_result ────────────────────────────
-
-// ── Observer called in draw_float ─────────────────────────────────────────
+// ── DataObserver default method bodies ────────────────────────────────────
 //
-// The `observer` field on `NativeTestCase` is private, so post-draw the
-// test can't reach back into the boxed observer.  Instead the observer
-// holds an `Arc<Mutex<...>>` that the test side keeps a clone of —
-// after the draw, the lock contains exactly what the observer captured.
-
-// ── Observer called in draw_string ────────────────────────────────────────
-
-// ── Observer called in draw_float_forced ─────────────────────────────────
-
-// ── Observer called in draw_bytes_forced ─────────────────────────────────
-
-// ── N18.core_state: observer notified by draw_bytes (non-forced) ─────────
-//
-// `draw_bytes` (non-forced) ends with
-//     if let Some(ref mut obs) = self.observer { obs.draw_bytes(&v, was_forced); }
-// at state.rs:1290-1292. `draw_bytes_forced` has a separate notification
-// site; only that one was exercised. Replay via `for_choices` resolves the
-// draw with was_forced=false, so the non-forced notification fires.
-
-// ── Observer called in draw_string_forced ────────────────────────────────
-
-// ── DataObserver::draw_boolean default (line 453) ─────────────────────────
-//
-// The `data_observer_default_methods_are_no_ops` test above omitted
-// `draw_boolean`.  Call it to cover the default implementation.
+// Each default body is a no-op; calling it on a struct that doesn't override
+// the method exercises the default arm.
 
 #[test]
 fn data_observer_draw_boolean_default_is_no_op() {
@@ -391,6 +366,12 @@ fn data_observer_draw_boolean_default_is_no_op() {
 fn data_observer_draw_integer_default_is_no_op() {
     let mut obs = NoopObserver;
     obs.draw_integer(42, false); // must not panic
+}
+
+#[test]
+fn data_observer_draw_float_default_is_no_op() {
+    let mut obs = NoopObserver;
+    obs.draw_float(1.5, false); // must not panic
 }
 
 #[test]
@@ -520,6 +501,32 @@ fn draw_integer_notifies_observer() {
     assert_eq!(recorded, Some((99, false)));
 }
 
+// ── NativeTestCase::draw_float with observer ──────────────────────────────
+
+#[test]
+fn draw_float_notifies_observer() {
+    use std::sync::{Arc, Mutex};
+    struct FloatObserver {
+        captured: Arc<Mutex<Option<(u64, bool)>>>,
+    }
+    impl DataObserver for FloatObserver {
+        fn draw_float(&mut self, value: f64, was_forced: bool) {
+            // Capture the bit pattern so `-0.0` and NaN payloads compare exactly.
+            *self.captured.lock().unwrap() = Some((value.to_bits(), was_forced));
+        }
+    }
+    let captured = Arc::new(Mutex::new(None));
+    let choices = vec![ChoiceValue::Float(2.5)];
+    let obs = Box::new(FloatObserver {
+        captured: captured.clone(),
+    });
+    let mut tc = NativeTestCase::for_choices(&choices, None, Some(obs));
+    let v = tc.draw_float(0.0, 10.0, false, false).ok().unwrap();
+    assert_eq!(v, 2.5);
+    let recorded = captured.lock().unwrap().take();
+    assert_eq!(recorded, Some((2.5_f64.to_bits(), false)));
+}
+
 // ── NativeTestCase::stop_span extends parent labels (line 798) ────────────
 //
 // When stop_span is called with discard=false and there is a parent span
@@ -538,27 +545,35 @@ fn stop_span_extends_parent_label_stack() {
     // No panic means the label propagation path was executed.
 }
 
-// ── many_draw_length: min_size == max_size (line 65) ─────────────────────
-//
-// draw_string with min_size == max_size calls many_draw_length which takes
-// the early return path (line 65: return min_size).
+// ── draw_float on a fresh random NTC ─────────────────────────────────────
 
-// ── draw_float: half-bounded range (lines 1167-1187) ─────────────────────
-//
-// half_bounded = !bounded && (min.is_finite() || max.is_finite()).
-// Use (1.0, f64::INFINITY) so the range is half-bounded from below.
+#[test]
+fn draw_float_unbounded_with_nan_can_produce_nan() {
+    use rand::SeedableRng;
+    use rand::rngs::SmallRng;
+    // Fully unbounded with allow_nan=true exercises the random-generation
+    // branch including the NaN-emission arm.
+    for seed in 0..200u64 {
+        let mut tc = NativeTestCase::new_random(SmallRng::seed_from_u64(seed));
+        let v = tc
+            .draw_float(f64::NEG_INFINITY, f64::INFINITY, true, true)
+            .ok()
+            .unwrap();
+        if v.is_nan() {
+            return; // exercised
+        }
+    }
+    panic!("never produced NaN in 200 unbounded draws with allow_nan=true");
+}
 
-// ── draw_float: unbounded range with NaN (lines 1188-1199) ───────────────
-//
-// !bounded && !half_bounded = fully unbounded. allow_nan=true enables the
-// NaN generation branch.
-
-// ── draw_string: random generation body (lines 1339-1373) ─────────────────
-//
-// Calling draw_string on a fresh random NTC (no prefix) exercises the
-// random-generation closure.
-
-// ── draw_string: min_size==0 path (line 1319) ────────────────────────────
-//
-// The nasty-floats list for draw_string includes Vec::new() when min_size==0
-// and max_size > 0. Line 1319: `v.push(Vec::new())`.
+#[test]
+fn draw_float_half_bounded_below_explores_finite_range() {
+    use rand::SeedableRng;
+    use rand::rngs::SmallRng;
+    let mut tc = NativeTestCase::new_random(SmallRng::seed_from_u64(0));
+    let v = tc
+        .draw_float(1.0, f64::INFINITY, false, false)
+        .ok()
+        .unwrap();
+    assert!(v >= 1.0 && !v.is_nan());
+}

--- a/tests/test_find_quality/floats.rs
+++ b/tests/test_find_quality/floats.rs
@@ -36,13 +36,11 @@ fn test_can_find_nan_in_list() {
     );
 }
 
-#[cfg(not(feature = "native"))]
 #[test]
 fn test_can_find_positive_infinity() {
     find_any(gs::floats::<f64>(), |x: &f64| *x > 0.0 && x.is_infinite());
 }
 
-#[cfg(not(feature = "native"))]
 #[test]
 fn test_can_find_negative_infinity() {
     find_any(gs::floats::<f64>(), |x: &f64| *x < 0.0 && x.is_infinite());
@@ -128,7 +126,6 @@ fn test_can_find_float_that_does_not_round_trip_through_repr() {
     );
 }
 
-#[cfg(not(feature = "native"))]
 #[test]
 fn test_half_bounded_generates_zero() {
     find_any(
@@ -143,7 +140,6 @@ fn test_half_bounded_generates_zero() {
 
 // True properties that should NOT be falsified.
 
-#[cfg(not(feature = "native"))]
 #[test]
 fn test_is_float() {
     // Trivially true under Rust's static typing — drawing `f64` always
@@ -155,7 +151,6 @@ fn test_is_float() {
     .run();
 }
 
-#[cfg(not(feature = "native"))]
 #[test]
 fn test_negation_is_self_inverse() {
     Hegel::new(|tc| {
@@ -167,7 +162,6 @@ fn test_negation_is_self_inverse() {
     .run();
 }
 
-#[cfg(not(feature = "native"))]
 #[test]
 fn test_largest_range_has_no_infinities() {
     Hegel::new(|tc| {

--- a/tests/test_floats.rs
+++ b/tests/test_floats.rs
@@ -1,4 +1,3 @@
-#![cfg(not(feature = "native"))]
 mod common;
 
 use common::utils::{assert_all_examples, find_any};

--- a/tests/test_shrink_quality/floats.rs
+++ b/tests/test_shrink_quality/floats.rs
@@ -1,7 +1,6 @@
 use crate::common::utils::minimal;
 use hegel::generators as gs;
 
-#[cfg(not(feature = "native"))]
 #[test]
 fn test_shrinks_to_simple_float_above_0() {
     assert_eq!(
@@ -10,31 +9,26 @@ fn test_shrinks_to_simple_float_above_0() {
     );
 }
 
-#[cfg(not(feature = "native"))]
 #[test]
 fn test_can_shrink_in_variable_sized_context_1() {
     check_shrink_in_variable_sized_context(1);
 }
 
-#[cfg(not(feature = "native"))]
 #[test]
 fn test_can_shrink_in_variable_sized_context_2() {
     check_shrink_in_variable_sized_context(2);
 }
 
-#[cfg(not(feature = "native"))]
 #[test]
 fn test_can_shrink_in_variable_sized_context_3() {
     check_shrink_in_variable_sized_context(3);
 }
 
-#[cfg(not(feature = "native"))]
 #[test]
 fn test_can_shrink_in_variable_sized_context_8() {
     check_shrink_in_variable_sized_context(8);
 }
 
-#[cfg(not(feature = "native"))]
 #[test]
 fn test_can_shrink_in_variable_sized_context_10() {
     check_shrink_in_variable_sized_context(10);
@@ -50,14 +44,12 @@ fn check_shrink_in_variable_sized_context(n: usize) {
     assert!(x.contains(&1.0));
 }
 
-#[cfg(not(feature = "native"))]
 #[test]
 fn test_can_find_nan() {
     let x = minimal(gs::floats::<f64>(), |x: &f64| x.is_nan());
     assert!(x.is_nan());
 }
 
-#[cfg(not(feature = "native"))]
 #[test]
 fn test_can_find_nans() {
     let x = minimal(gs::vecs(gs::floats::<f64>()), |x: &Vec<f64>| {
@@ -67,5 +59,35 @@ fn test_can_find_nans() {
         assert!(x[0].is_nan());
     } else {
         assert!(x.len() >= 2 && x.len() <= 3);
+    }
+}
+
+#[test]
+fn test_negative_non_integer_shrinks_through_integer_range() {
+    // Restrict to negative non-integer floats so the shrinker stays in the
+    // non-simple lex region and the negative-bound integer-range step in
+    // `shrink_floats` actually fires.
+    let x = minimal(
+        gs::floats::<f64>()
+            .min_value(-1000.0)
+            .max_value(-0.1)
+            .allow_nan(false)
+            .allow_infinity(false),
+        |x: &f64| *x < 0.0 && x.fract() != 0.0,
+    );
+    assert!(x < 0.0 && x.fract() != 0.0);
+}
+
+#[test]
+fn test_nan_canonicalization_prefers_finite_when_predicate_admits() {
+    // Predicate accepts NaN or any infinite. When the shrinker lands on a
+    // NaN node, its NaN-canonicalization branch tries `f64::MAX` (rejected)
+    // then `f64::INFINITY` (accepted) and steps the choice over to it.
+    // Run a handful of seeds because which boundary value the random sampler
+    // discovers first is luck-of-the-draw — every seed that lands on NaN
+    // first walks the accept path.
+    for _ in 0..10 {
+        let x = minimal(gs::floats::<f64>(), |x: &f64| x.is_nan() || x.is_infinite());
+        assert!(x.is_nan() || x.is_infinite());
     }
 }

--- a/tests/test_shrink_quality/mixed_types.rs
+++ b/tests/test_shrink_quality/mixed_types.rs
@@ -110,3 +110,89 @@ fn test_one_of_slip() {
     );
     assert_eq!(result, 101);
 }
+
+/// Asserts a tight joint minimum for the sum-style predicate
+/// `i + f >= 100 && i != 1 && f != 1.0`. With those exclusions both sides
+/// are forced above their individual shrink targets, so the only way to
+/// reach the joint minimum is via `redistribute_numeric_pairs` walking both
+/// sides together.
+fn assert_tight_joint_minimum(i: i64, f: f64) {
+    assert!(
+        i != 1,
+        "integer at its shrink target — joint walk didn't fire"
+    );
+    assert!(
+        f != 1.0,
+        "float at its shrink target — joint walk didn't fire"
+    );
+    assert!(
+        (i as f64) + f >= 100.0,
+        "predicate fails for (i={i}, f={f})"
+    );
+    assert!(
+        (i as f64) + f < 101.0,
+        "joint sum {:.3} is more than one unit slack — pair didn't tighten",
+        (i as f64) + f
+    );
+}
+
+fn pair_predicate(i: i64, f: f64) -> bool {
+    (i as f64) + f >= 100.0 && i != 1 && f != 1.0
+}
+
+#[test]
+fn test_redistribute_int_float_pair() {
+    // A sum-style predicate where the per-kind simplest values are
+    // excluded: only the joint redistribute pass can find the minimum.
+    let (i, f) = minimal(
+        hegel::tuples!(
+            gs::integers::<i64>().min_value(1).max_value(10_000),
+            gs::floats::<f64>()
+                .min_value(0.5)
+                .max_value(1000.0)
+                .allow_nan(false)
+                .allow_infinity(false),
+        ),
+        |&(i, f): &(i64, f64)| pair_predicate(i, f),
+    );
+    assert_tight_joint_minimum(i, f);
+}
+
+#[test]
+fn test_redistribute_float_int_pair() {
+    // Mirror of the above with `(f64, i64)` ordering — exercises the
+    // (Float, Int) adjacency direction of `redistribute_numeric_pairs`.
+    let (f, i) = minimal(
+        hegel::tuples!(
+            gs::floats::<f64>()
+                .min_value(0.5)
+                .max_value(1000.0)
+                .allow_nan(false)
+                .allow_infinity(false),
+            gs::integers::<i64>().min_value(1).max_value(10_000),
+        ),
+        |&(f, i): &(f64, i64)| pair_predicate(i, f),
+    );
+    assert_tight_joint_minimum(i, f);
+}
+
+#[test]
+fn test_redistribute_pair_with_boolean_in_sequence() {
+    // A boolean adjacent to the (int, float) pair forces the
+    // `redistribute_numeric_pairs` walk to skip non-numeric kinds via
+    // `is_float_or_integer`.
+    let (b, i, f) = minimal(
+        hegel::tuples!(
+            gs::booleans(),
+            gs::integers::<i64>().min_value(1).max_value(10_000),
+            gs::floats::<f64>()
+                .min_value(0.5)
+                .max_value(1000.0)
+                .allow_nan(false)
+                .allow_infinity(false),
+        ),
+        |&(_, i, f): &(bool, i64, f64)| pair_predicate(i, f),
+    );
+    assert!(!b);
+    assert_tight_joint_minimum(i, f);
+}


### PR DESCRIPTION
Adds floating-point support to the native (in-process) backend, and improves validation for floating point numbers in server-based backends.

This is technically a breaking change but it just moves the error around - the same things are errors, but previously they failed at draw time, now they fail at construction time.

<details>
<summary>Extraction notes</summary>

**New / patched modules:**

- `src/native/core/choices.rs` — added `FloatChoice` struct and `Float` arms on `ChoiceKind` / `ChoiceValue` / `NodeSortKey`, with bit-exact `PartialEq` / `Hash` so `-0.0` and individual NaN payloads stay distinct.
- `src/native/core/float_index.rs` (new) — Hypothesis float lex ordering (`float_to_index`, `index_to_float`, `lex_to_float`).
- `src/native/floats.rs` (new) — `sign_aware_lte` only. Other helpers from the source branch (the `make_float_clamper` / `next_up_normal` / etc. cluster) are scaffolding for a Hypothesis test port and aren't reachable from the production engine, so they're dropped here.
- `src/native/core/state.rs` — `draw_float` (delegating to a new `biased_float_sample`) and an observer `draw_float` default no-op.
- `src/native/schema/float.rs` (new) — `interpret_float` dispatcher; rejects `width ∉ {32, 64}` at the boundary, applies f32 finite-range clamp for `allow_infinity = false`.
- `src/native/schema/mod.rs` — wires `"float"` into the schema dispatch, removes it from the `todo!()` arm.
- `src/native/data_tree.rs` — `ChoiceValueKey::Float(u64)` keyed by `f64::to_bits()` so `-0.0` and NaN payloads track separately in novel-prefix exhaustion accounting.
- `src/native/database.rs` — serialization tag 2 = Float, 8 bytes of bit pattern; defensive truncation check.
- `src/native/shrinker/mod.rs` — declares the new `floats` submodule and wires `shrink_floats` + `redistribute_numeric_pairs` into the main shrink loop.
- `src/native/shrinker/floats.rs` (new) — the two float shrink passes. `redistribute_numeric_pairs` covers (Float, Float), (Float, Int), and (Int, Float) adjacencies; pure (Int, Int) is left to the existing `redistribute_integers` pass.
- `src/generators/numeric.rs` — `gs::floats()::build_schema` now rejects empty-range `exclude_min` / `exclude_max` combinations at builder time (single-point ranges; `+inf` with `exclude_min`; `-inf` with `exclude_max`). Both backends agree at the boundary; previously native silently generated the boundary value.

**Dropped from the source branch:**

- `draw_float_forced` on `NativeTestCase` — no production caller (only used by Hypothesis-port tests not on main).
- The `make_float_clamper` / `next_up_normal` / `next_down_normal` / `FloatConstraints` cluster in `floats.rs` — same reason.
- `Float` arm of `ChoiceKind::enumerate` returning `None` — replaced with `unreachable!()` since float `max_children` always exceeds the `u64` cap.
- `MAX_PRECISE_INTEGER` defensive guard inside `find_integer`'s closure in `redistribute_pair` — Rust's `consider` / `replace` sort-key reduction already short-circuits well before any cand crosses `2^53`, so the upstream Python guard against arbitrary-precision overflow is dead in our port.
- Catch-all `_ => true` / `_ => false` arms in `is_trivial` / `is_float_or_integer` / `can_choose_for_redistribute` / `redistribute_pair`'s kind-value matches — replaced with explicit Boolean arms or `unreachable!()` so a future kind/value invariant violation surfaces immediately rather than being silently absorbed.

**Tests added:**

- `tests/embedded/native/float_index_tests.rs` — encode/decode exponent, mantissa-reversal round-trip, simple/non-simple/large-integer lex paths.
- `tests/embedded/native/floats_tests.rs` — `sign_aware_lte` over the `±0.0` boundary.
- `tests/embedded/native/schema/float_tests.rs` — width 16/128 rejection, width 32/64 acceptance.
- `tests/embedded/native/choices_tests.rs` — FloatChoice `simplest` / `unit` / `enumerate` / `to_index` / `from_index` round-trip including infinity and NaN.
- `tests/embedded/native/database_tests.rs` — float serialize/deserialize round-trip preserving bit pattern; truncated-body rejection.
- `tests/embedded/native/state_tests.rs` — `draw_float` observer notification, default observer no-op, unbounded NaN draw, half-bounded finite draw.
- `tests/embedded/native/shrinker_floats_tests.rs` — `as_integer_ratio` cases (terminating decimal, subnormal, huge); `redistribute_pair` short-circuit when `cand_j` leaves validate range; `shrink_floats` NaN canonicalization accept path.
- `tests/test_shrink_quality/mixed_types.rs` — three integration tests covering `redistribute_numeric_pairs` in (Int, Float), (Float, Int), and (Bool, Int, Float) orderings.
- `tests/test_shrink_quality/floats.rs` — two new tests: negative-non-integer shrink through the integer range; NaN canonicalization prefers a finite alternative.

**Ungated under native:**

- `tests/test_floats.rs` (whole file)
- `tests/test_find_quality/floats.rs` (six previously-gated tests)
- `tests/test_shrink_quality/floats.rs` (six previously-gated tests)

**Audit:**

- Walked through the `detecting-port-bullshit` skill catalogue. Findings fixed in this PR: agent-citation comments (`Refs: B3`, `Pre-B3`), pbtkit-as-authoritative doc comment on `lex_to_float`, `draw_float_forced` dead-end, defensive `MAX_PRECISE_INTEGER` guard with no live path, catch-all match arms hiding invariant violations.
- `just check` clean; `just check-coverage` 100% on new code with no `// nocov` additions and no ratchet bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
</details>