### PR TITLE
ci: drop --all-features from test-minimal-versions

### DIFF
--- a/justfile
+++ b/justfile
@@ -26,7 +26,9 @@ check-tests-minimal-versions:
 
     # --locked tells cargo not to update the lockfile. this makes sure we use the lockfile we just generated
     # and don't regenerate it for non-minimal versions.
-    HEGEL_RUNNING_TESTS_WITH_RUST_NIGHTLY=1 RUST_BACKTRACE=1 cargo test --locked --all-features
+    # Feature list matches `check-tests-all-features`: --all-features would enable `native`,
+    # which swaps the backend rather than adding capabilities.
+    HEGEL_RUNNING_TESTS_WITH_RUST_NIGHTLY=1 RUST_BACKTRACE=1 cargo test --locked --features rand,antithesis,chrono,jiff,serde_json,serde_json_raw_value
 
 format:
     cargo fmt


### PR DESCRIPTION
<!-- Human: please replace this comment with the PR description. -->

<details>
<summary>AI-generated implementation notes</summary>

`check-tests-minimal-versions` was running `cargo test --locked --all-features`, which enables the `native` feature. `native` swaps the backend rather than adding capabilities to the server one, so the minimal-versions matrix was never actually exercising the server-backend code path it's meant to validate. Additionally, several integration test binaries are gated off under `native` (they `#![cfg(all(feature = "X", not(feature = "native")))]`), so the additive features weren't being exercised either.

Failing job that prompted this fix: https://github.com/hegeldev/hegel-rust/actions/runs/25873787152/job/76035586277?pr=154

This is the same class of bug `4d864816` ("ci: exclude native from test-all-features") fixed for `check-tests-all-features`; `check-tests-minimal-versions` was missed at the time.

Fix: spell the feature set out explicitly, matching `check-tests-all-features`: `rand,antithesis,chrono,jiff,serde_json,serde_json_raw_value`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)