### PR TITLE
Add native support for bytes type

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,8 +1,3 @@
 RELEASE_TYPE: patch
 
 The native backend (`--features native`) now supports byte-string generators.
-The `binary` schema (`min_size` / `max_size` bounds) is interpreted natively,
-and the shrinker has bytes-specific passes (`shrink_bytes` for shortening
-and lowering, `redistribute_bytes_pairs` for moving length between adjacent
-bytes nodes). Tests that draw bytes via Hypothesis schemas can now replay
-under `--features native`, including `tests/rand/randoms.rs::test_randoms_fill`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,8 @@
+RELEASE_TYPE: patch
+
+The native backend (`--features native`) now supports byte-string generators.
+The `binary` schema (`min_size` / `max_size` bounds) is interpreted natively,
+and the shrinker has bytes-specific passes (`shrink_bytes` for shortening
+and lowering, `redistribute_bytes_pairs` for moving length between adjacent
+bytes nodes). Tests that draw bytes via Hypothesis schemas can now replay
+under `--features native`, including `tests/rand/randoms.rs::test_randoms_fill`.

--- a/src/native/core/choices.rs
+++ b/src/native/core/choices.rs
@@ -555,7 +555,7 @@ pub enum ChoiceValue {
 }
 
 /// Bit-exact equality for floats keeps `-0.0` distinct from `0.0` and
-/// preserves NaN payloads; integers, booleans and bytes use natural equality.
+/// preserves NaN payloads; other choice types use natural equality.
 impl PartialEq for ChoiceValue {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {

--- a/src/native/core/choices.rs
+++ b/src/native/core/choices.rs
@@ -177,6 +177,97 @@ impl BooleanChoice {
     }
 }
 
+/// A bytes choice with bounded length.
+///
+/// Ordered by shortlex: shorter sequences are simpler, then lexicographic
+/// on the bytes themselves.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BytesChoice {
+    pub min_size: usize,
+    pub max_size: usize,
+}
+
+impl BytesChoice {
+    /// The simplest (most "shrunk") value: `min_size` zero bytes.
+    pub fn simplest(&self) -> Vec<u8> {
+        vec![0u8; self.min_size]
+    }
+
+    /// The second-simplest value, used for punning when types change.
+    /// If `min_size > 0`: the simplest except the last byte is 1.
+    /// Else if `max_size > 0`: a single `0x01` byte.
+    /// Else: the simplest (empty).
+    pub fn unit(&self) -> Vec<u8> {
+        if self.min_size > 0 {
+            let mut v = vec![0u8; self.min_size];
+            *v.last_mut().unwrap() = 1;
+            v
+        } else if self.max_size > 0 {
+            vec![1u8]
+        } else {
+            self.simplest()
+        }
+    }
+
+    pub fn validate(&self, value: &[u8]) -> bool {
+        self.min_size <= value.len() && value.len() <= self.max_size
+    }
+
+    /// Shortlex sort key: `(length, bytes)`.
+    pub fn sort_key(&self, value: &[u8]) -> (usize, Vec<u8>) {
+        (value.len(), value.to_vec())
+    }
+
+    /// Hypothesis: `core.py::BytesChoice.max_index`.
+    pub fn max_index(&self) -> crate::native::bignum::BigUint {
+        self.to_index(&vec![0xffu8; self.max_size])
+    }
+
+    /// Hypothesis: `core.py::BytesChoice.to_index`. Indexes byte sequences in
+    /// shortlex order over `[min_size, max_size]`: all length-`min_size`
+    /// sequences first, then length `min_size + 1`, and so on; within each
+    /// length, lexicographic on the bytes.
+    pub fn to_index(&self, value: &[u8]) -> crate::native::bignum::BigUint {
+        use crate::native::bignum::{BigUint, Zero};
+        let base = BigUint::from(256u32);
+        let mut offset = BigUint::zero();
+        for length in self.min_size..value.len() {
+            offset += base.pow(length as u32);
+        }
+        let mut position = BigUint::zero();
+        for &b in value {
+            position = position * &base + BigUint::from(b);
+        }
+        offset + position
+    }
+
+    /// Inverse of [`to_index`]. Returns `None` if the index is past the
+    /// last representable sequence.
+    #[allow(clippy::wrong_self_convention)]
+    pub fn from_index(&self, index: crate::native::bignum::BigUint) -> Option<Vec<u8>> {
+        use crate::native::bignum::BigUint;
+        let base = BigUint::from(256u32);
+        let mut remaining = index;
+        for length in self.min_size..=self.max_size {
+            let bucket = base.pow(length as u32);
+            if remaining < bucket {
+                let mut result: Vec<u8> = Vec::with_capacity(length);
+                for _ in 0..length {
+                    let b: u8 = (&remaining % &base)
+                        .try_into()
+                        .expect("byte < 256 fits in u8");
+                    result.push(b);
+                    remaining /= &base;
+                }
+                result.reverse();
+                return Some(result);
+            }
+            remaining -= bucket;
+        }
+        None
+    }
+}
+
 /// A float choice with bounded range.
 #[derive(Clone, Debug)]
 pub struct FloatChoice {
@@ -451,6 +542,7 @@ pub enum ChoiceKind {
     Integer(IntegerChoice),
     Boolean(BooleanChoice),
     Float(FloatChoice),
+    Bytes(BytesChoice),
 }
 
 /// The value produced by a choice.
@@ -459,16 +551,18 @@ pub enum ChoiceValue {
     Integer(i128),
     Boolean(bool),
     Float(f64),
+    Bytes(Vec<u8>),
 }
 
 /// Bit-exact equality for floats keeps `-0.0` distinct from `0.0` and
-/// preserves NaN payloads; integers and booleans use natural equality.
+/// preserves NaN payloads; integers, booleans and bytes use natural equality.
 impl PartialEq for ChoiceValue {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (ChoiceValue::Integer(a), ChoiceValue::Integer(b)) => a == b,
             (ChoiceValue::Boolean(a), ChoiceValue::Boolean(b)) => a == b,
             (ChoiceValue::Float(a), ChoiceValue::Float(b)) => a.to_bits() == b.to_bits(),
+            (ChoiceValue::Bytes(a), ChoiceValue::Bytes(b)) => a == b,
             _ => false,
         }
     }
@@ -483,6 +577,7 @@ impl std::hash::Hash for ChoiceValue {
             ChoiceValue::Integer(n) => n.hash(state),
             ChoiceValue::Boolean(b) => b.hash(state),
             ChoiceValue::Float(f) => f.to_bits().hash(state),
+            ChoiceValue::Bytes(v) => v.hash(state),
         }
     }
 }
@@ -494,6 +589,7 @@ impl ChoiceKind {
             ChoiceKind::Integer(ic) => ChoiceValue::Integer(ic.simplest()),
             ChoiceKind::Boolean(bc) => ChoiceValue::Boolean(bc.simplest()),
             ChoiceKind::Float(fc) => ChoiceValue::Float(fc.simplest()),
+            ChoiceKind::Bytes(bc) => ChoiceValue::Bytes(bc.simplest()),
         }
     }
 
@@ -505,6 +601,7 @@ impl ChoiceKind {
             ChoiceKind::Integer(ic) => ic.max_index(),
             ChoiceKind::Boolean(bc) => bc.max_index(),
             ChoiceKind::Float(fc) => fc.max_index(),
+            ChoiceKind::Bytes(bc) => bc.max_index(),
         }
     }
 
@@ -516,6 +613,7 @@ impl ChoiceKind {
             (ChoiceKind::Integer(ic), ChoiceValue::Integer(v)) => ic.to_index(*v),
             (ChoiceKind::Boolean(bc), ChoiceValue::Boolean(v)) => bc.to_index(*v),
             (ChoiceKind::Float(fc), ChoiceValue::Float(v)) => fc.to_index(*v),
+            (ChoiceKind::Bytes(bc), ChoiceValue::Bytes(v)) => bc.to_index(v),
             _ => panic!("ChoiceKind::to_index: kind/value mismatch"),
         }
     }
@@ -529,6 +627,7 @@ impl ChoiceKind {
             ChoiceKind::Integer(ic) => ic.from_index(index).map(ChoiceValue::Integer),
             ChoiceKind::Boolean(bc) => bc.from_index(index).map(ChoiceValue::Boolean),
             ChoiceKind::Float(fc) => fc.from_index(index).map(ChoiceValue::Float),
+            ChoiceKind::Bytes(bc) => bc.from_index(index).map(ChoiceValue::Bytes),
         }
     }
 
@@ -538,6 +637,7 @@ impl ChoiceKind {
             (ChoiceKind::Integer(ic), ChoiceValue::Integer(v)) => ic.validate(*v),
             (ChoiceKind::Boolean(_), ChoiceValue::Boolean(_)) => true,
             (ChoiceKind::Float(fc), ChoiceValue::Float(v)) => fc.validate(*v),
+            (ChoiceKind::Bytes(bc), ChoiceValue::Bytes(v)) => bc.validate(v),
             _ => false,
         }
     }
@@ -553,6 +653,7 @@ impl ChoiceKind {
             }
             ChoiceKind::Boolean(_) => BigUint::from(2u32),
             ChoiceKind::Float(fc) => fc.max_index() + BigUint::from(1u32),
+            ChoiceKind::Bytes(bc) => bc.max_index() + BigUint::from(1u32),
         }
     }
 
@@ -566,6 +667,9 @@ impl ChoiceKind {
             ChoiceKind::Boolean(_) => ChoiceValue::Boolean(rng.random::<bool>()),
             ChoiceKind::Float(fc) => {
                 ChoiceValue::Float(crate::native::core::state::biased_float_sample(fc, rng))
+            }
+            ChoiceKind::Bytes(bc) => {
+                ChoiceValue::Bytes(crate::native::core::state::biased_bytes_sample(bc, rng))
             }
         }
     }
@@ -600,6 +704,19 @@ impl ChoiceKind {
             ChoiceKind::Float(_) => {
                 unreachable!("FloatChoice max_children always exceeds u64::MAX cap")
             }
+            // For `BytesChoice` only the `max_size == 0` corner has a
+            // sensible enumeration (one empty value). Any non-zero
+            // `max_size` technically fits the `u64::MAX` cap up to
+            // `max_size = 7` (`Σ 256^k` through `k = 7` stays just under
+            // `2^64`), but the 256-way fan-out makes materialising the list
+            // pointless for any caller that would actually want it.
+            ChoiceKind::Bytes(bc) => {
+                if bc.max_size == 0 {
+                    Some(vec![ChoiceValue::Bytes(Vec::new())])
+                } else {
+                    None
+                }
+            }
         }
     }
 }
@@ -625,24 +742,42 @@ impl ChoiceNode {
         match (&self.kind, &self.value) {
             (ChoiceKind::Integer(ic), ChoiceValue::Integer(v)) => {
                 let (abs, neg) = ic.sort_key(*v);
-                NodeSortKey(abs, neg)
+                NodeSortKey::Scalar(abs, neg)
             }
-            (ChoiceKind::Boolean(_), ChoiceValue::Boolean(v)) => NodeSortKey(u128::from(*v), false),
+            (ChoiceKind::Boolean(_), ChoiceValue::Boolean(v)) => {
+                NodeSortKey::Scalar(u128::from(*v), false)
+            }
             (ChoiceKind::Float(fc), ChoiceValue::Float(v)) => {
                 let (mag, neg) = fc.sort_key(*v);
                 // `u64` widens losslessly into the `u128` magnitude slot used
                 // for integer sort keys: float and integer choices end up in a
                 // single totally-ordered space without losing precision.
-                NodeSortKey(u128::from(mag), neg)
+                NodeSortKey::Scalar(u128::from(mag), neg)
+            }
+            (ChoiceKind::Bytes(bc), ChoiceValue::Bytes(v)) => {
+                let (len, bytes) = bc.sort_key(v);
+                NodeSortKey::Sequence(len, bytes.into_iter().map(u32::from).collect())
             }
             _ => unreachable!("mismatched choice kind and value"),
         }
     }
 }
 
-/// Comparable key for ordering choice nodes during shrinking: (magnitude, sign).
+/// Comparable key for ordering choice nodes during shrinking.
+///
+/// Scalar kinds (integer, boolean, float) compare on a fixed `(magnitude,
+/// sign)` pair; sequence kinds (bytes) compare shortlex on `(length,
+/// elements)`. Per-element keys are stored as `u32` so a future string
+/// choice kind (with codepoint-key elements up to `0x10FFFF`) can join the
+/// same shape without changing this type. Variants are never mixed at a
+/// given node position; `Scalar < Sequence` by derived enum order is a
+/// total-ordering fall-through for the sort key of an entire
+/// sequence-of-nodes that contains both shapes.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct NodeSortKey(pub u128, pub bool);
+pub enum NodeSortKey {
+    Scalar(u128, bool),
+    Sequence(usize, Vec<u32>),
+}
 
 /// Shortlex sort key for a sequence of choice nodes.
 /// Shorter sequences are simpler; among equal lengths, smaller values win.

--- a/src/native/core/mod.rs
+++ b/src/native/core/mod.rs
@@ -9,7 +9,8 @@ pub(crate) mod choices;
 pub(crate) mod float_index;
 pub(crate) mod state;
 pub use choices::{
-    ChoiceKind, ChoiceNode, ChoiceValue, FloatChoice, NodeSortKey, Status, StopTest, sort_key,
+    BytesChoice, ChoiceKind, ChoiceNode, ChoiceValue, FloatChoice, NodeSortKey, Status, StopTest,
+    sort_key,
 };
 pub use float_index::{float_to_index, index_to_float};
 pub use state::{ManyState, NativeTestCase, NativeVariables, Span};

--- a/src/native/core/state.rs
+++ b/src/native/core/state.rs
@@ -8,7 +8,7 @@ use rand::RngExt;
 use rand::rngs::SmallRng;
 
 use super::choices::{
-    BooleanChoice, ChoiceKind, ChoiceNode, ChoiceValue, FloatChoice, IntegerChoice,
+    BooleanChoice, BytesChoice, ChoiceKind, ChoiceNode, ChoiceValue, FloatChoice, IntegerChoice,
     InterestingOrigin, Status, StopTest,
 };
 use super::float_index::lex_to_float;
@@ -95,6 +95,27 @@ static GLOBAL_CONSTANTS_INTEGERS: LazyLock<Vec<i128>> = LazyLock::new(|| {
     base.dedup();
     base
 });
+
+/// Geometric-distribution length draw for variable-length collections.
+///
+/// Drawing length uniformly from `[min_size, max_size]` produces huge
+/// values when `max_size` is large. This matches Hypothesis's `many()`
+/// distribution: length clusters around a small `average_size` derived
+/// from `min(max(min_size * 2, min_size + 5), 0.5 * (min_size + max_size))`.
+///
+/// Hypothesis: `conjecture/providers.py::HypothesisProvider.draw_bytes`
+/// (and `draw_string`).
+fn many_draw_length(rng: &mut SmallRng, min_size: usize, max_size: usize) -> usize {
+    if min_size == max_size {
+        return min_size;
+    }
+    let many = ManyState::new(min_size, Some(max_size));
+    let mut len = min_size;
+    while len < max_size && rng.random::<f64>() < many.p_continue {
+        len += 1;
+    }
+    len
+}
 
 /// Boundary-biased uniform sample for integers.
 ///
@@ -267,6 +288,28 @@ pub(crate) fn biased_float_sample(fc: &FloatChoice, rng: &mut SmallRng) -> f64 {
         }
     };
     if fc.validate(f) { f } else { fc.simplest() }
+}
+
+/// Boundary-biased sample for bytes. Draws the simplest (`min_size` zeros),
+/// the all-zeros minimum-plus-one length, or a single-`0xff` byte with
+/// probability proportional to `BOUNDARY_PROBABILITY × |nasty|`, falling
+/// back to a length drawn from [`many_draw_length`] with uniformly random
+/// byte values.
+pub(crate) fn biased_bytes_sample(bc: &BytesChoice, rng: &mut SmallRng) -> Vec<u8> {
+    let mut nasty: Vec<Vec<u8>> = vec![bc.simplest()];
+    if bc.min_size == 0 && bc.max_size > 0 {
+        nasty.push(vec![0u8]);
+    }
+    if bc.min_size <= 1 && bc.max_size >= 1 {
+        nasty.push(vec![0xffu8]);
+    }
+    let nasty_threshold = nasty.len() as f64 * BOUNDARY_PROBABILITY;
+    if rng.random::<f64>() < nasty_threshold {
+        let idx = rng.random_range(0..nasty.len());
+        return nasty[idx].clone();
+    }
+    let len = many_draw_length(rng, bc.min_size, bc.max_size);
+    (0..len).map(|_| rng.random::<u8>()).collect()
 }
 
 /// A pool of variable IDs for stateful testing.
@@ -503,6 +546,7 @@ pub trait DataObserver: Send {
     fn draw_boolean(&mut self, _value: bool, _was_forced: bool) {}
     fn draw_integer(&mut self, _value: i128, _was_forced: bool) {}
     fn draw_float(&mut self, _value: f64, _was_forced: bool) {}
+    fn draw_bytes(&mut self, _value: &[u8], _was_forced: bool) {}
     fn conclude_test(&mut self, _status: Status, _origin: Option<InterestingOrigin>) {}
 }
 
@@ -844,6 +888,39 @@ impl NativeTestCase {
 
         if let Some(ref mut obs) = self.observer {
             obs.draw_float(v, was_forced);
+        }
+
+        Ok(v)
+    }
+
+    /// Draw a bytes value with length in `[min_size, max_size]`.
+    pub fn draw_bytes(&mut self, min_size: usize, max_size: usize) -> Result<Vec<u8>, StopTest> {
+        assert!(
+            min_size <= max_size,
+            "min_size ({min_size}) must be <= max_size ({max_size})"
+        );
+        let kind = BytesChoice { min_size, max_size };
+
+        let (value, was_forced) = self.resolve_choice(
+            &ChoiceKind::Bytes(kind.clone()),
+            || ChoiceValue::Bytes(kind.simplest()),
+            || ChoiceValue::Bytes(kind.unit()),
+            |v| matches!(v, ChoiceValue::Bytes(b) if kind.validate(b)),
+            |rng| ChoiceValue::Bytes(biased_bytes_sample(&kind, rng)),
+        )?;
+
+        let ChoiceValue::Bytes(v) = value else {
+            unreachable!("kind/value invariant violated: outer match guaranteed this variant")
+        };
+
+        self.nodes.push(ChoiceNode {
+            kind: ChoiceKind::Bytes(kind),
+            value: ChoiceValue::Bytes(v.clone()),
+            was_forced,
+        });
+
+        if let Some(ref mut obs) = self.observer {
+            obs.draw_bytes(&v, was_forced);
         }
 
         Ok(v)

--- a/src/native/core/state.rs
+++ b/src/native/core/state.rs
@@ -26,28 +26,33 @@ pub struct ManyState {
 
 impl ManyState {
     pub fn new(min_size: usize, max_size: Option<usize>) -> Self {
-        let max_f = max_size.map_or(f64::INFINITY, |n| n as f64);
-        let min_f = min_size as f64;
-        let average = f64::min(f64::max(min_f * 2.0, min_f + 5.0), 0.5 * (min_f + max_f));
-        let desired_extra = average - min_f;
-        let max_extra = max_f - min_f;
-
-        let p_continue = if desired_extra >= max_extra {
-            0.99
-        } else if max_f.is_infinite() {
-            1.0 - 1.0 / (1.0 + desired_extra)
-        } else {
-            1.0 - 1.0 / (2.0 + desired_extra)
-        };
-
         ManyState {
             min_size,
-            max_size: max_f,
-            p_continue,
+            max_size: max_size.map_or(f64::INFINITY, |n| n as f64),
+            p_continue: length_p_continue(min_size, max_size),
             count: 0,
             rejections: 0,
             force_stop: false,
         }
+    }
+}
+
+/// Probability of extending a length draw beyond its current size. Port of
+/// Hypothesis's `many()`: length clusters around an `average_size` derived
+/// from `min(max(min_size * 2, min_size + 5), 0.5 * (min_size + max_size))`.
+pub(crate) fn length_p_continue(min_size: usize, max_size: Option<usize>) -> f64 {
+    let max_f = max_size.map_or(f64::INFINITY, |n| n as f64);
+    let min_f = min_size as f64;
+    let average = f64::min(f64::max(min_f * 2.0, min_f + 5.0), 0.5 * (min_f + max_f));
+    let desired_extra = average - min_f;
+    let max_extra = max_f - min_f;
+
+    if desired_extra >= max_extra {
+        0.99
+    } else if max_f.is_infinite() {
+        1.0 - 1.0 / (1.0 + desired_extra)
+    } else {
+        1.0 - 1.0 / (2.0 + desired_extra)
     }
 }
 
@@ -99,9 +104,8 @@ static GLOBAL_CONSTANTS_INTEGERS: LazyLock<Vec<i128>> = LazyLock::new(|| {
 /// Geometric-distribution length draw for variable-length collections.
 ///
 /// Drawing length uniformly from `[min_size, max_size]` produces huge
-/// values when `max_size` is large. This matches Hypothesis's `many()`
-/// distribution: length clusters around a small `average_size` derived
-/// from `min(max(min_size * 2, min_size + 5), 0.5 * (min_size + max_size))`.
+/// values when `max_size` is large; instead, the size follows a geometric
+/// variate with stop probability derived from [`length_p_continue`].
 ///
 /// Hypothesis: `conjecture/providers.py::HypothesisProvider.draw_bytes`
 /// (and `draw_string`).
@@ -109,12 +113,15 @@ fn many_draw_length(rng: &mut SmallRng, min_size: usize, max_size: usize) -> usi
     if min_size == max_size {
         return min_size;
     }
-    let many = ManyState::new(min_size, Some(max_size));
-    let mut len = min_size;
-    while len < max_size && rng.random::<f64>() < many.p_continue {
-        len += 1;
-    }
-    len
+    let p_continue = length_p_continue(min_size, Some(max_size));
+    // Geometric variate: `extra ~ floor(log(U) / log(p_continue))` for
+    // `U ~ Uniform(0, 1)`. `rng.random::<f64>()` returns `[0, 1)`, so `U`
+    // can be exactly `0` — that yields `-inf / log(p) = +inf` which
+    // saturates to `usize::MAX` via the float cast; the final `.min` clamps.
+    let u: f64 = rng.random();
+    let extra = (u.ln() / p_continue.ln()).floor();
+    assert!(extra >= 0.0);
+    min_size.saturating_add(extra as usize).min(max_size)
 }
 
 /// Boundary-biased uniform sample for integers.

--- a/src/native/data_tree.rs
+++ b/src/native/data_tree.rs
@@ -24,6 +24,7 @@ enum ChoiceValueKey {
     Integer(i128),
     Boolean(bool),
     Float(u64),
+    Bytes(Vec<u8>),
 }
 
 impl From<&ChoiceValue> for ChoiceValueKey {
@@ -32,6 +33,7 @@ impl From<&ChoiceValue> for ChoiceValueKey {
             ChoiceValue::Integer(n) => ChoiceValueKey::Integer(*n),
             ChoiceValue::Boolean(b) => ChoiceValueKey::Boolean(*b),
             ChoiceValue::Float(f) => ChoiceValueKey::Float(f.to_bits()),
+            ChoiceValue::Bytes(b) => ChoiceValueKey::Bytes(b.clone()),
         }
     }
 }

--- a/src/native/database.rs
+++ b/src/native/database.rs
@@ -203,12 +203,13 @@ pub(super) fn fnv_hex(s: &[u8]) -> String {
 /// Format:
 /// - 4-byte little-endian u32: number of choices
 /// - For each choice:
-///   - 1-byte type tag: 0=Integer, 1=Boolean, 2=Float
+///   - 1-byte type tag: 0=Integer, 1=Boolean, 2=Float, 3=Bytes
 ///   - Value bytes:
 ///     - Integer: 16 bytes (i128 little-endian)
 ///     - Boolean: 1 byte (0 or 1)
 ///     - Float: 8 bytes (the f64 bit pattern, little-endian, so `-0.0` and
 ///       NaN payloads round-trip unchanged)
+///     - Bytes: 4 bytes (u32 little-endian length) followed by the raw bytes
 ///
 /// Other [`ChoiceValue`] variants are not yet supported by the native
 /// backend and serializing them panics with `todo!()`.
@@ -229,6 +230,12 @@ pub fn serialize_choices(choices: &[ChoiceValue]) -> Vec<u8> {
             ChoiceValue::Float(v) => {
                 buf.push(2);
                 buf.extend_from_slice(&v.to_bits().to_le_bytes());
+            }
+            ChoiceValue::Bytes(v) => {
+                buf.push(3);
+                let len = v.len() as u32;
+                buf.extend_from_slice(&len.to_le_bytes());
+                buf.extend_from_slice(v);
             }
         }
     }
@@ -279,6 +286,19 @@ pub fn deserialize_choices(bytes: &[u8]) -> Option<Vec<ChoiceValue>> {
                 let bits = u64::from_le_bytes(bytes[pos..pos + 8].try_into().ok()?);
                 choices.push(ChoiceValue::Float(f64::from_bits(bits)));
                 pos += 8;
+            }
+            3 => {
+                pos += 1;
+                if pos + 4 > bytes.len() {
+                    return None;
+                }
+                let len = u32::from_le_bytes(bytes[pos..pos + 4].try_into().ok()?) as usize;
+                pos += 4;
+                if pos + len > bytes.len() {
+                    return None;
+                }
+                choices.push(ChoiceValue::Bytes(bytes[pos..pos + len].to_vec()));
+                pos += len;
             }
             _ => return None,
         }

--- a/src/native/schema/bytes.rs
+++ b/src/native/schema/bytes.rs
@@ -1,0 +1,22 @@
+// Bytes schema interpreter.
+
+use crate::cbor_utils::{as_u64, map_get};
+use crate::native::core::{NativeTestCase, StopTest};
+use ciborium::Value;
+
+pub(super) fn interpret_binary(
+    ntc: &mut NativeTestCase,
+    schema: &Value,
+) -> Result<Value, StopTest> {
+    let min_size = map_get(schema, "min_size").and_then(as_u64).unwrap_or(0) as usize;
+    // Unbounded `max_size` falls back to a generous ceiling — Hypothesis's
+    // server backend also truncates generation at some finite cap, and
+    // matching that keeps shrinker and cache behaviour sensible.
+    let max_size = map_get(schema, "max_size")
+        .and_then(as_u64)
+        .map(|n| n as usize)
+        .unwrap_or(100);
+
+    let bytes = ntc.draw_bytes(min_size, max_size)?;
+    Ok(Value::Bytes(bytes))
+}

--- a/src/native/schema/mod.rs
+++ b/src/native/schema/mod.rs
@@ -6,11 +6,13 @@
 // Split into submodules:
 //   numeric     — interpret_integer, interpret_boolean, interpret_constant
 //   float       — interpret_float
-//   text        — interpret_string, interpret_binary, StringAlphabet helpers
+//   bytes       — interpret_binary
+//   text        — interpret_string, StringAlphabet helpers
 //   regex       — interpret_regex, generate_hir_string
 //   collections — interpret_list, interpret_dict, interpret_tuple, interpret_one_of, interpret_sampled_from
 //   special     — date, time, datetime, ipv4, ipv6, domain, email, url
 
+mod bytes;
 mod collections;
 mod float;
 mod numeric;
@@ -38,28 +40,29 @@ pub(crate) fn interpret_schema(
     // Record spans for leaf schemas (no recursive interpret_schema calls).
     let is_leaf = matches!(
         schema_type,
-        "integer" | "boolean" | "float" | "sampled_from"
+        "integer" | "boolean" | "float" | "binary" | "sampled_from"
     );
     let span_start = if is_leaf { ntc.nodes.len() } else { 0 };
 
-    // Native backs integer + boolean + float leaves, plus the compound
-    // schemas (tuple/list/dict/one_of/sampled_from) that recurse into them.
-    // Schemas backed by string/binary/regex/datetime/etc. leaves panic with
-    // todo!() until those schema interpreters land in a follow-up PR.
+    // Native backs integer + boolean + float + binary leaves, plus the
+    // compound schemas (tuple/list/dict/one_of/sampled_from) that recurse
+    // into them. Schemas backed by string/regex/datetime/etc. leaves panic
+    // with todo!() until those schema interpreters land in a follow-up PR.
     let result = match schema_type {
         "integer" => numeric::interpret_integer(ntc, schema),
         "boolean" => numeric::interpret_boolean(ntc),
         "constant" => numeric::interpret_constant(schema),
         "null" => Ok(Value::Null),
         "float" => float::interpret_float(ntc, schema),
+        "binary" => bytes::interpret_binary(ntc, schema),
         "tuple" => collections::interpret_tuple(ntc, schema),
         "one_of" => collections::interpret_one_of(ntc, schema),
         "sampled_from" => collections::interpret_sampled_from(ntc, schema),
         "list" => collections::interpret_list(ntc, schema),
         "dict" => collections::interpret_dict(ntc, schema),
 
-        "string" | "binary" | "regex" | "email" | "url" | "domain" | "ip_address" | "uuid"
-        | "ipv4" | "ipv6" | "date" | "time" | "datetime" => {
+        "string" | "regex" | "email" | "url" | "domain" | "ip_address" | "uuid" | "ipv4"
+        | "ipv6" | "date" | "time" | "datetime" => {
             todo!("schema {:?} not yet supported in native mode", schema_type)
         }
 

--- a/src/native/shrinker/bytes.rs
+++ b/src/native/shrinker/bytes.rs
@@ -1,0 +1,212 @@
+// Bytes shrink passes: `shrink_bytes` reduces individual `BytesChoice`
+// nodes toward shorter / lex-smaller values, and `redistribute_bytes_pairs`
+// rebalances length between adjacent bytes nodes for sum-of-length style
+// predicates.
+
+use std::collections::HashMap;
+
+use crate::native::core::{BytesChoice, ChoiceKind, ChoiceValue};
+
+use super::{Shrinker, bin_search_down};
+
+impl<'a> Shrinker<'a> {
+    pub(super) fn shrink_bytes(&mut self) {
+        let mut i = 0;
+        while i < self.current_nodes.len() {
+            let (min_size, current) = match (
+                self.current_nodes[i].kind.clone(),
+                self.current_nodes[i].value.clone(),
+            ) {
+                (ChoiceKind::Bytes(bc), ChoiceValue::Bytes(v)) => (bc.min_size, v),
+                _ => {
+                    i += 1;
+                    continue;
+                }
+            };
+
+            // Try the simplest (min_size zeros) first.
+            let simplest = vec![0u8; min_size];
+            if simplest != current {
+                self.replace(&HashMap::from([(i, ChoiceValue::Bytes(simplest))]));
+            }
+
+            // Shorten via binary search.
+            let cur_len = self.current_byte_value(i).len();
+            if cur_len > min_size {
+                let captured = self.current_byte_value(i);
+                bin_search_down(min_size as i128, cur_len as i128, &mut |sz| {
+                    let sz = sz as usize;
+                    let cand = captured[..sz].to_vec();
+                    self.replace(&HashMap::from([(i, ChoiceValue::Bytes(cand))]))
+                });
+            }
+
+            // Linear scan small lengths (non-monotonic fallback).
+            let cur_len = self.current_byte_value(i).len();
+            let scan_end = (min_size + 8).min(cur_len);
+            for sz in min_size..scan_end {
+                let cur = self.current_byte_value(i);
+                if sz > cur.len() {
+                    break;
+                }
+                let cand = cur[..sz].to_vec();
+                self.replace(&HashMap::from([(i, ChoiceValue::Bytes(cand))]));
+            }
+
+            // Delete individual elements, from right to left.
+            let mut j = self.current_byte_value(i).len();
+            while j > 0 {
+                j -= 1;
+                let cur = self.current_byte_value(i);
+                if cur.len() <= min_size {
+                    continue;
+                }
+                let mut cand = cur.clone();
+                cand.remove(j);
+                self.replace(&HashMap::from([(i, ChoiceValue::Bytes(cand))]));
+            }
+
+            // Reduce each byte toward 0, from right to left.
+            let mut j = self.current_byte_value(i).len();
+            while j > 0 {
+                j -= 1;
+                let cur = self.current_byte_value(i);
+                if cur[j] == 0 {
+                    continue;
+                }
+                let hi = cur[j] as i128;
+                bin_search_down(0, hi, &mut |e| {
+                    let mut cand = self.current_byte_value(i);
+                    cand[j] = e as u8;
+                    self.replace(&HashMap::from([(i, ChoiceValue::Bytes(cand))]))
+                });
+            }
+
+            // Insertion-sort pass: swap adjacent out-of-order bytes.
+            let mut pos = 1;
+            loop {
+                let cur_len = self.current_byte_value(i).len();
+                if pos >= cur_len {
+                    break;
+                }
+                let mut j = pos;
+                while j > 0 {
+                    let cur = self.current_byte_value(i);
+                    if cur[j - 1] <= cur[j] {
+                        break;
+                    }
+                    let mut swapped = cur.clone();
+                    swapped.swap(j - 1, j);
+                    if self.replace(&HashMap::from([(i, ChoiceValue::Bytes(swapped))])) {
+                        j -= 1;
+                    } else {
+                        break;
+                    }
+                }
+                pos += 1;
+            }
+
+            i += 1;
+        }
+    }
+
+    fn current_byte_value(&self, i: usize) -> Vec<u8> {
+        match &self.current_nodes[i].value {
+            ChoiceValue::Bytes(v) => v.clone(),
+            _ => unreachable!("kind/value invariant violated: outer match guaranteed this variant"),
+        }
+    }
+
+    /// Try redistributing length between pairs of bytes values.
+    ///
+    /// For adjacent and skip-one-adjacent pairs of `BytesChoice` nodes,
+    /// try moving bytes from the earlier node's value to the later one's.
+    /// Useful for tests with a total-length constraint across two bytes
+    /// values, where the minimal counterexample has the first as short
+    /// as possible.
+    pub(super) fn redistribute_bytes_pairs(&mut self) {
+        for gap in 1..3usize {
+            let mut idx = 0;
+            loop {
+                let indices = self.bytes_indices();
+                if idx + gap >= indices.len() {
+                    break;
+                }
+                let i = indices[idx];
+                let j = indices[idx + gap];
+                self.redistribute_bytes_pair(i, j);
+                idx += 1;
+            }
+        }
+    }
+
+    fn bytes_indices(&self) -> Vec<usize> {
+        self.current_nodes
+            .iter()
+            .enumerate()
+            .filter_map(|(i, n)| match &n.kind {
+                ChoiceKind::Bytes(_) => Some(i),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn redistribute_bytes_pair(&mut self, i: usize, j: usize) {
+        let s = self.current_byte_value(i);
+        let t = self.current_byte_value(j);
+        let kind_j = match &self.current_nodes[j].kind {
+            ChoiceKind::Bytes(kj) => kj.clone(),
+            _ => unreachable!("kind/value invariant violated: outer match guaranteed this variant"),
+        };
+
+        if s.is_empty() {
+            return;
+        }
+
+        // Try moving everything from s to t.
+        let combined: Vec<u8> = s.iter().copied().chain(t.iter().copied()).collect();
+        if self.try_redistribute_bytes(i, j, Vec::new(), combined, &kind_j) {
+            return;
+        }
+
+        // Try moving the last byte of s to the start of t.
+        let (last, s_init) = s.split_last().unwrap();
+        let mut t_prepended = Vec::with_capacity(t.len() + 1);
+        t_prepended.push(*last);
+        t_prepended.extend_from_slice(&t);
+        if !self.try_redistribute_bytes(i, j, s_init.to_vec(), t_prepended, &kind_j) {
+            return;
+        }
+
+        // Binary search for the longest suffix of s that can be moved.
+        let s_len = s.len();
+        bin_search_down(1, s_len as i128, &mut |n| {
+            let n = n as usize;
+            let new_s = s[..s_len - n].to_vec();
+            let mut new_t = s[s_len - n..].to_vec();
+            new_t.extend_from_slice(&t);
+            self.try_redistribute_bytes(i, j, new_s, new_t, &kind_j)
+        });
+    }
+
+    fn try_redistribute_bytes(
+        &mut self,
+        i: usize,
+        j: usize,
+        new_s: Vec<u8>,
+        new_t: Vec<u8>,
+        kind_j: &BytesChoice,
+    ) -> bool {
+        if !kind_j.validate(&new_t) {
+            return false;
+        }
+        self.replace(&HashMap::from([
+            (i, ChoiceValue::Bytes(new_s)),
+            (j, ChoiceValue::Bytes(new_t)),
+        ]))
+    }
+}
+
+#[cfg(test)]
+#[path = "../../../tests/embedded/native/shrinker_bytes_tests.rs"]
+mod tests;

--- a/src/native/shrinker/floats.rs
+++ b/src/native/shrinker/floats.rs
@@ -356,7 +356,7 @@ fn can_choose_for_redistribute(node: &ChoiceNode) -> bool {
 fn is_float_or_integer(k: &ChoiceKind) -> bool {
     match k {
         ChoiceKind::Float(_) | ChoiceKind::Integer(_) => true,
-        ChoiceKind::Boolean(_) => false,
+        ChoiceKind::Boolean(_) | ChoiceKind::Bytes(_) => false,
     }
 }
 

--- a/src/native/shrinker/mod.rs
+++ b/src/native/shrinker/mod.rs
@@ -9,7 +9,9 @@
 //                redistribute_integers, shrink_duplicates
 //   sequence   — sort_values, swap_adjacent_blocks
 //   floats     — shrink_floats, redistribute_numeric_pairs
+//   bytes      — shrink_bytes, redistribute_bytes_pairs
 
+mod bytes;
 mod deletion;
 mod floats;
 mod index_passes;
@@ -187,6 +189,8 @@ impl<'a> Shrinker<'a> {
             self.swap_adjacent_blocks();
             self.shrink_floats();
             self.redistribute_numeric_pairs();
+            self.shrink_bytes();
+            self.redistribute_bytes_pairs();
             self.lower_and_bump();
             self.try_shortening_via_increment();
             self.mutate_and_shrink();

--- a/tests/embedded/native/choices_tests.rs
+++ b/tests/embedded/native/choices_tests.rs
@@ -280,3 +280,99 @@ fn float_choice_to_from_index_round_trip_for_infinity_and_nan() {
         }
     }
 }
+
+// ── BytesChoice ────────────────────────────────────────────────────────
+
+#[test]
+fn bytes_choice_simplest_is_min_size_zeros() {
+    let bc = BytesChoice {
+        min_size: 3,
+        max_size: 10,
+    };
+    assert_eq!(bc.simplest(), vec![0, 0, 0]);
+}
+
+#[test]
+fn bytes_choice_unit_with_zero_min_zero_max_falls_back_to_simplest() {
+    // min == 0 && max == 0: the unit() helper has no representable
+    // "second-simplest" — it returns the simplest (empty) by definition.
+    let bc = BytesChoice {
+        min_size: 0,
+        max_size: 0,
+    };
+    assert_eq!(bc.unit(), Vec::<u8>::new());
+}
+
+#[test]
+fn bytes_choice_unit_with_zero_min_nonzero_max_is_single_one() {
+    let bc = BytesChoice {
+        min_size: 0,
+        max_size: 5,
+    };
+    assert_eq!(bc.unit(), vec![1u8]);
+}
+
+#[test]
+fn bytes_choice_unit_with_nonzero_min_is_zeros_with_trailing_one() {
+    let bc = BytesChoice {
+        min_size: 3,
+        max_size: 10,
+    };
+    assert_eq!(bc.unit(), vec![0, 0, 1]);
+}
+
+#[test]
+fn bytes_choice_index_round_trip_across_lengths() {
+    let bc = BytesChoice {
+        min_size: 0,
+        max_size: 3,
+    };
+    for v in [
+        Vec::<u8>::new(),
+        vec![0u8],
+        vec![1u8],
+        vec![0xffu8],
+        vec![0u8, 0u8],
+        vec![0u8, 1u8],
+        vec![1u8, 2u8, 3u8],
+        vec![0xff, 0xff, 0xff],
+    ] {
+        let idx = bc.to_index(&v);
+        assert_eq!(bc.from_index(idx), Some(v));
+    }
+}
+
+#[test]
+fn bytes_choice_from_index_past_max_returns_none() {
+    // Sequences of length 0..=1 over 256 bytes give 1 + 256 = 257 options.
+    let bc = BytesChoice {
+        min_size: 0,
+        max_size: 1,
+    };
+    assert!(
+        bc.from_index(crate::native::bignum::BigUint::from(1000u32))
+            .is_none()
+    );
+}
+
+#[test]
+fn bytes_choice_kind_enumerate_zero_max_size_returns_single_empty() {
+    let kind = ChoiceKind::Bytes(BytesChoice {
+        min_size: 0,
+        max_size: 0,
+    });
+    assert_eq!(
+        kind.enumerate(u64::MAX),
+        Some(vec![ChoiceValue::Bytes(Vec::new())])
+    );
+}
+
+#[test]
+fn bytes_choice_kind_enumerate_positive_max_returns_none() {
+    // Once max_size > 0, the total cardinality (`Σ 256^k`) exceeds the cap.
+    let kind = ChoiceKind::Bytes(BytesChoice {
+        min_size: 0,
+        max_size: 4,
+    });
+    assert!(kind.enumerate(u64::MAX).is_none());
+}

--- a/tests/embedded/native/database_tests.rs
+++ b/tests/embedded/native/database_tests.rs
@@ -185,3 +185,34 @@ fn deserialize_returns_none_on_truncated_float_body() {
     bytes.extend_from_slice(&[0u8; 4]); // only 4 of 8 needed bytes
     assert!(deserialize_choices(&bytes).is_none());
 }
+
+#[test]
+fn round_trip_bytes_choices() {
+    let choices = vec![
+        ChoiceValue::Bytes(Vec::new()),
+        ChoiceValue::Bytes(vec![0u8]),
+        ChoiceValue::Bytes(vec![0xff, 0x00, 0x80, 0x7f]),
+        ChoiceValue::Bytes(vec![1; 1024]),
+    ];
+    let bytes = serialize_choices(&choices);
+    assert_eq!(deserialize_choices(&bytes), Some(choices));
+}
+
+#[test]
+fn deserialize_returns_none_on_truncated_bytes_length() {
+    // count = 1, type tag 3 (Bytes), but fewer than 4 bytes for the length.
+    let mut bytes = 1u32.to_le_bytes().to_vec();
+    bytes.push(3);
+    bytes.extend_from_slice(&[0u8; 2]); // only 2 of 4 needed bytes
+    assert!(deserialize_choices(&bytes).is_none());
+}
+
+#[test]
+fn deserialize_returns_none_on_truncated_bytes_body() {
+    // count = 1, type tag 3 (Bytes), length 5, but only 2 bytes follow.
+    let mut bytes = 1u32.to_le_bytes().to_vec();
+    bytes.push(3);
+    bytes.extend_from_slice(&5u32.to_le_bytes()); // claim 5 bytes
+    bytes.extend_from_slice(&[0u8; 2]);
+    assert!(deserialize_choices(&bytes).is_none());
+}

--- a/tests/embedded/native/shrinker_bytes_tests.rs
+++ b/tests/embedded/native/shrinker_bytes_tests.rs
@@ -69,6 +69,42 @@ fn shrink_bytes_linear_scan_breaks_when_replace_shortens_below_sz() {
 }
 
 #[test]
+fn redistribute_bytes_pair_partial_move_triggers_bin_search() {
+    // Reach the binary-search arm of `redistribute_bytes_pairs` that scans
+    // for the longest suffix of `s` movable into `t`. The full-move step
+    // must fail (so the early `return` after `combined` does not fire) and
+    // the single-byte step must succeed (otherwise the second `return`
+    // exits before bin_search).
+    //
+    // Predicate: accept iff `nodes[1]` has at most 3 bytes. Full-move
+    // builds `t = [1,2,3,4,5]` (rejected); single-byte move builds
+    // `t = [3,4,5]` (accepted). bin_search then probes for the longest
+    // movable suffix, which executes the loop body and `replace` call.
+    let initial = vec![
+        bytes_node(vec![1, 2, 3], 0, 10),
+        bytes_node(vec![4, 5], 0, 10),
+    ];
+    let mut shrinker = Shrinker::with_probe(
+        Box::new(|run| match run {
+            crate::native::shrinker::ShrinkRun::Full(nodes) => {
+                let t_ok = matches!(
+                    nodes.get(1).map(|n| &n.value),
+                    Some(ChoiceValue::Bytes(b)) if b.len() <= 3
+                );
+                (t_ok, nodes.to_vec())
+            }
+            crate::native::shrinker::ShrinkRun::Probe { .. } => (false, Vec::new()),
+        }),
+        initial,
+    );
+    shrinker.redistribute_bytes_pairs();
+    match &shrinker.current_nodes[1].value {
+        ChoiceValue::Bytes(b) => assert!(b.len() <= 3, "t exceeded 3 bytes: {b:?}"),
+        _ => unreachable!(),
+    }
+}
+
+#[test]
 fn redistribute_bytes_pair_moves_entire_value_when_accepted() {
     // Adjacent `BytesChoice` pair: the accepting test_fn lets the first
     // step (move everything from `s` to `t`) succeed, exercising the early

--- a/tests/embedded/native/shrinker_bytes_tests.rs
+++ b/tests/embedded/native/shrinker_bytes_tests.rs
@@ -1,0 +1,91 @@
+use super::*;
+use crate::native::core::ChoiceNode;
+use crate::native::shrinker::Shrinker;
+
+fn bytes_node(value: Vec<u8>, min_size: usize, max_size: usize) -> ChoiceNode {
+    ChoiceNode {
+        kind: ChoiceKind::Bytes(BytesChoice { min_size, max_size }),
+        value: ChoiceValue::Bytes(value),
+        was_forced: false,
+    }
+}
+
+fn accepting_shrinker(nodes: Vec<ChoiceNode>) -> Shrinker<'static> {
+    Shrinker::with_probe(
+        Box::new(|run| match run {
+            crate::native::shrinker::ShrinkRun::Full(nodes) => (true, nodes.to_vec()),
+            crate::native::shrinker::ShrinkRun::Probe { .. } => (false, Vec::new()),
+        }),
+        nodes,
+    )
+}
+
+#[test]
+fn shrink_bytes_collapses_accepting_run_to_simplest() {
+    // An always-accepting test_fn drives the shrinker from a 4-byte value to
+    // the simplest (single zero) — exercising the simplest replace and the
+    // surrounding loop structure.
+    let initial = vec![bytes_node(vec![3, 1, 4, 1], 1, 10)];
+    let mut shrinker = accepting_shrinker(initial);
+    shrinker.shrink_bytes();
+    let v = match &shrinker.current_nodes[0].value {
+        ChoiceValue::Bytes(v) => v.clone(),
+        _ => unreachable!(),
+    };
+    assert_eq!(v, vec![0u8]);
+}
+
+#[test]
+fn shrink_bytes_linear_scan_breaks_when_replace_shortens_below_sz() {
+    // The linear-scan fallback's `sz > cur.len()` guard only fires when a
+    // mid-loop `replace` shortens the current value below the next index.
+    //
+    // Setup: an 8-byte value whose only accepted shape is the singleton
+    // `[7]`. `simplest` (an empty vec) is rejected; `bin_search_down`
+    // probes mid points of `min_size..cur_len = 0..8` — `f(0)`, `f(4)`,
+    // `f(6)`, `f(7)` — and never tries `sz == 1`, so the linear scan still
+    // sees the full 8-byte value. Scan iteration `sz == 1` then accepts
+    // and replaces `cur` with `[7]`, and `sz == 2` immediately hits the
+    // break (`2 > cur.len() == 1`).
+    let initial = vec![bytes_node(vec![7, 0, 0, 0, 0, 0, 0, 0], 0, 16)];
+    let mut shrinker = Shrinker::with_probe(
+        Box::new(|run| match run {
+            crate::native::shrinker::ShrinkRun::Full(nodes) => {
+                let is_singleton_seven = matches!(
+                    nodes.first().map(|n| &n.value),
+                    Some(ChoiceValue::Bytes(b)) if b.as_slice() == [7]
+                );
+                (is_singleton_seven, nodes.to_vec())
+            }
+            crate::native::shrinker::ShrinkRun::Probe { .. } => (false, Vec::new()),
+        }),
+        initial,
+    );
+    shrinker.shrink_bytes();
+    match &shrinker.current_nodes[0].value {
+        ChoiceValue::Bytes(v) => assert_eq!(v, &vec![7u8]),
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn redistribute_bytes_pair_moves_entire_value_when_accepted() {
+    // Adjacent `BytesChoice` pair: the accepting test_fn lets the first
+    // step (move everything from `s` to `t`) succeed, exercising the early
+    // `return` after that branch's success path.
+    let initial = vec![
+        bytes_node(vec![1, 2, 3], 0, 10),
+        bytes_node(vec![4, 5], 0, 10),
+    ];
+    let mut shrinker = accepting_shrinker(initial);
+    shrinker.redistribute_bytes_pairs();
+    let (a, b) = match (
+        &shrinker.current_nodes[0].value,
+        &shrinker.current_nodes[1].value,
+    ) {
+        (ChoiceValue::Bytes(a), ChoiceValue::Bytes(b)) => (a.clone(), b.clone()),
+        _ => unreachable!(),
+    };
+    assert!(a.is_empty(), "first node not emptied: {a:?}");
+    assert_eq!(b, vec![1, 2, 3, 4, 5]);
+}

--- a/tests/embedded/native/shrinker_floats_tests.rs
+++ b/tests/embedded/native/shrinker_floats_tests.rs
@@ -36,6 +36,38 @@ fn int_node(value: i128, min: i128, max: i128) -> ChoiceNode {
 }
 
 #[test]
+fn redistribute_pair_below_shrink_target_uses_raise_left_direction() {
+    // `v_i` starts negative (below its shrink target of `0.0`), so
+    // `redistribute_pair` picks `Direction::RaiseLeftLowerRight`: raise the
+    // first node toward 0, lower the second. The integration tests in
+    // `tests/test_shrink_quality/mixed_types.rs` only exercise the
+    // `LowerLeftRaiseRight` direction (both sides positive); without a
+    // deterministic case here this branch's coverage depends on the
+    // boundary-biased random sampler happening to draw a negative value.
+    let initial = vec![
+        float_node(-3.0, -100.0, 100.0),
+        float_node(5.0, -100.0, 100.0),
+    ];
+    let mut shrinker = Shrinker::with_probe(
+        Box::new(|run| match run {
+            crate::native::shrinker::ShrinkRun::Full(nodes) => (true, nodes.to_vec()),
+            crate::native::shrinker::ShrinkRun::Probe { .. } => (false, Vec::new()),
+        }),
+        initial,
+    );
+    shrinker.redistribute_numeric_pairs();
+    let (a, b) = match (
+        &shrinker.current_nodes[0].value,
+        &shrinker.current_nodes[1].value,
+    ) {
+        (ChoiceValue::Float(a), ChoiceValue::Float(b)) => (*a, *b),
+        _ => unreachable!(),
+    };
+    assert!(a > -3.0, "v_i did not move up from -3.0 (got {a})");
+    assert!(b < 5.0, "v_j did not move down from 5.0 (got {b})");
+}
+
+#[test]
 fn redistribute_pair_bails_when_int_candidate_leaves_validate_range() {
     let initial = vec![float_node(3.0, -100.0, 100.0), int_node(2, 1, 10)];
     let mut shrinker = Shrinker::with_probe(

--- a/tests/embedded/native/state_tests.rs
+++ b/tests/embedded/native/state_tests.rs
@@ -527,6 +527,36 @@ fn draw_float_notifies_observer() {
     assert_eq!(recorded, Some((2.5_f64.to_bits(), false)));
 }
 
+#[test]
+fn data_observer_draw_bytes_default_is_no_op() {
+    let mut obs = NoopObserver;
+    obs.draw_bytes(&[1, 2, 3], false); // must not panic
+}
+
+#[test]
+fn draw_bytes_notifies_observer() {
+    use std::sync::{Arc, Mutex};
+    type Captured = Arc<Mutex<Option<(Vec<u8>, bool)>>>;
+    struct BytesObserver {
+        captured: Captured,
+    }
+    impl DataObserver for BytesObserver {
+        fn draw_bytes(&mut self, value: &[u8], was_forced: bool) {
+            *self.captured.lock().unwrap() = Some((value.to_vec(), was_forced));
+        }
+    }
+    let captured: Captured = Arc::new(Mutex::new(None));
+    let choices = vec![ChoiceValue::Bytes(vec![1, 2, 3])];
+    let obs = Box::new(BytesObserver {
+        captured: captured.clone(),
+    });
+    let mut tc = NativeTestCase::for_choices(&choices, None, Some(obs));
+    let v = tc.draw_bytes(0, 10).ok().unwrap();
+    assert_eq!(v, vec![1, 2, 3]);
+    let recorded = captured.lock().unwrap().take();
+    assert_eq!(recorded, Some((vec![1u8, 2, 3], false)));
+}
+
 // ── NativeTestCase::stop_span extends parent labels (line 798) ────────────
 //
 // When stop_span is called with discard=false and there is a parent span

--- a/tests/rand/randoms.rs
+++ b/tests/rand/randoms.rs
@@ -1,5 +1,3 @@
-use crate::not_supported_on_native;
-
 use hegel::TestCase;
 use hegel::extras::rand as rand_gs;
 use hegel::generators as gs;
@@ -36,10 +34,6 @@ fn test_randoms_choose(tc: TestCase) {
     assert!(items.contains(picked));
 }
 
-// `rng.fill` draws from `gs::binary` under the hood (see
-// `src/extras/rand/generators.rs::try_fill_bytes`), which the native
-// backend hasn't shipped yet.  Gate to the server backend until then.
-#[not_supported_on_native]
 #[hegel::test]
 fn test_randoms_fill(tc: TestCase) {
     let mut rng = tc.draw(rand_gs::randoms());

--- a/tests/test_collections.rs
+++ b/tests/test_collections.rs
@@ -238,7 +238,6 @@ fn test_hashmap_with_mapped_keys(tc: TestCase) {
     assert!(map.keys().all(|&k| k % 2 == 0));
 }
 
-#[not_supported_on_native]
 #[hegel::test]
 fn test_binary_with_max_size(tc: TestCase) {
     let data = tc.draw(gs::binary().max_size(50));

--- a/tests/test_derive.rs
+++ b/tests/test_derive.rs
@@ -337,7 +337,13 @@ fn test_derive_complex_enum_generates_all_variants() {
     });
 }
 
-#[not_supported_on_native]
+// Flaky on native: the `should_panic` expectation requires the engine
+// to draw `OptionVariant(Some(String))` at least once across the 15
+// cases that `check_can_generate_examples` runs (only then does the
+// not-yet-implemented `string` schema fire). At ~1/6 per case, the
+// failure rate is small but non-zero. Re-ungate once the string
+// schema is implemented natively.
+#[cfg(not(feature = "native"))]
 #[test]
 fn test_derive_enum_with_nested_types() {
     check_can_generate_examples(gs::default::<WithNestedTypes>());

--- a/tests/test_derive.rs
+++ b/tests/test_derive.rs
@@ -337,7 +337,11 @@ fn test_derive_complex_enum_generates_all_variants() {
     });
 }
 
-#[not_supported_on_native]
+// Flaky on native: the test expects the engine to eventually draw the
+// `OptionVariant(Some(String))` branch and panic on the unsupported
+// `string` schema, but whether that happens within the 100-case run
+// depends on RNG state, which shifts under coverage instrumentation.
+#[cfg(not(feature = "native"))]
 #[test]
 fn test_derive_enum_with_nested_types() {
     check_can_generate_examples(gs::default::<WithNestedTypes>());

--- a/tests/test_derive.rs
+++ b/tests/test_derive.rs
@@ -337,11 +337,7 @@ fn test_derive_complex_enum_generates_all_variants() {
     });
 }
 
-// Flaky on native: the test expects the engine to eventually draw the
-// `OptionVariant(Some(String))` branch and panic on the unsupported
-// `string` schema, but whether that happens within the 100-case run
-// depends on RNG state, which shifts under coverage instrumentation.
-#[cfg(not(feature = "native"))]
+#[not_supported_on_native]
 #[test]
 fn test_derive_enum_with_nested_types() {
     check_can_generate_examples(gs::default::<WithNestedTypes>());

--- a/tests/test_hegel_test.rs
+++ b/tests/test_hegel_test.rs
@@ -118,7 +118,6 @@ mod testdecorators {
         );
     }
 
-    #[not_supported_on_native]
     #[test]
     fn test_bytes_addition_is_commutative() {
         find_any(

--- a/tests/test_quality.rs
+++ b/tests/test_quality.rs
@@ -1071,7 +1071,6 @@ mod collective_minimization {
         check_collective_minimization(gs::text());
     }
 
-    #[not_supported_on_native]
     #[test]
     fn test_can_collectively_minimize_binary() {
         check_collective_minimization(gs::binary());

--- a/tests/test_shrink_quality/bytes.rs
+++ b/tests/test_shrink_quality/bytes.rs
@@ -5,7 +5,6 @@ use std::collections::HashMap;
 use crate::common::utils::{Minimal, minimal};
 use hegel::generators as gs;
 
-#[not_supported_on_native]
 #[test]
 fn test_redistribute_bytes_respects_max_size() {
     // redistribute_bytes must skip transfers that exceed max_size, and
@@ -30,7 +29,6 @@ fn test_redistribute_bytes_respects_max_size() {
     assert_eq!(b, vec![0u8; 8]);
 }
 
-#[not_supported_on_native]
 #[test]
 fn test_bytes_sorts_when_order_matters() {
     // Bytes shrinking attempts to sort bytes; when sorting would violate
@@ -54,7 +52,6 @@ fn test_bytes_sorts_when_order_matters() {
     assert_eq!(v0, vec![0u8, 1, 0]);
 }
 
-#[not_supported_on_native]
 #[test]
 fn test_bytes_redistribution_moves_all() {
     // min_size=3 on v0 prevents the value shrinker from emptying it; the
@@ -96,7 +93,6 @@ fn test_bytes_increment_shortens_sequence() {
     assert!(v1.is_empty());
 }
 
-#[not_supported_on_native]
 #[test]
 fn test_lower_and_bump_stale_kind_after_replace() {
     // Regression: `lower_and_bump` must validate values against the

--- a/tests/test_shrink_quality/composite.rs
+++ b/tests/test_shrink_quality/composite.rs
@@ -109,7 +109,6 @@ fn test_one_of_shrinks_branch_selector() {
     assert_eq!(result, BoolOrFloat::Bool(true));
 }
 
-#[not_supported_on_native]
 #[test]
 fn test_early_exit_via_flag_with_preceding_draws() {
     let g = hegel::compose!(|tc| {


### PR DESCRIPTION
<details>
<summary>LLM-generated implementation notes</summary>

This PR was extracted from `DRMacIver/native` by Claude Code following the `landing-native-chunk` skill.

## What this adds

- `BytesChoice { min_size, max_size }` in `src/native/core/choices.rs`, with `simplest`, `unit`, `validate`, `sort_key`, and index round-trip (BigUint shortlex). Refactored `NodeSortKey` to an enum (`Scalar` vs `Sequence`) so byte-string nodes can sort by `(len, lex)`.
- `draw_bytes` on `NativeTestCase`, with `biased_bytes_sample` and a many-state-driven length draw mirroring the float chunk's structure.
- `interpret_binary` schema interpreter (`src/native/schema/bytes.rs`); wired into the schema dispatch — `binary` schemas no longer `todo!()` under native.
- Database tag `3` for `Bytes` in the choice serialization format: 4-byte LE length followed by raw bytes, with bounds-checked deserialization.
- `Bytes(Vec<u8>)` arm added to `ChoiceValueKey` in `data_tree.rs`.
- Two shrinker passes in `src/native/shrinker/bytes.rs`: `shrink_bytes` (simplest, binary-search shorten, linear-scan fallback, delete, reduce-toward-0, insertion-sort) and `redistribute_bytes_pairs` (move bytes between adjacent `BytesChoice` pairs). Wired into the shrink loop after the float passes.
- `is_float_or_integer` in the float shrinker now has a `Bytes` arm returning `false`.

## What this lets through

`#[not_supported_on_native]` is dropped from every test that was gated only because of a `binary` schema draw — including `tests/rand/randoms.rs::test_randoms_fill`, and several places in `tests/test_quality.rs`, `tests/test_collections.rs`, `tests/test_hegel_test.rs`, `tests/test_shrink_quality/bytes.rs`, `tests/test_shrink_quality/composite.rs`.

## What this doesn't add

No new public API (no `gs::bytes()` generator). This is purely engine-level: server-mode tests that draw bytes from Hypothesis can now replay under `--features native`. A `bytes()` generator can land in a follow-up.

## Test plan

- [x] `just check` passes (clippy + fmt + native test suite + server test suite + doctests)
- [x] `just check-coverage` clean (0 uncovered code lines)
- [x] 3 stability runs of `cargo test --features native`: 0 failures each
- [x] `cargo test` (server suite): 0 failures
- [ ] Watch CI on the open PR

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)