### PR TITLE
claude: change gs::default to return T::Generator

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,19 @@
+RELEASE_TYPE: minor
+
+This release changes `gs::default::<T>()` to return the concrete generator for `T` instead of a weakly typed `BoxedGenerator` (https://github.com/hegeldev/hegel-rust/issues/246).
+
+This has the following implications:
+
+```rust
+#[derive(DefaultGenerator)]
+struct Person { name: String, age: u32 }
+
+// before
+let p: Person = tc.draw(gs::default());
+// after
+let p = tc.draw(gs::default::<Person>());
+
+// writing the following is now possible, where it would have errored before
+gs::default::<Person>().age(gs::integers::<u32>())
+gs::default::<u32>().min_value(0).max_value(100)
+```

--- a/src/generators/default.rs
+++ b/src/generators/default.rs
@@ -44,8 +44,8 @@ pub trait DefaultGenerator: Sized {
 ///         .age(gs::integers().min_value(0).max_value(120)));
 /// }
 /// ```
-pub fn default<T: DefaultGenerator>() -> BoxedGenerator<'static, T> {
-    T::default_generator().boxed()
+pub fn default<T: DefaultGenerator>() -> T::Generator {
+    T::default_generator()
 }
 
 impl DefaultGenerator for bool {

--- a/tests/test_default.rs
+++ b/tests/test_default.rs
@@ -3,8 +3,8 @@
 mod common;
 
 use common::not_supported_on_native;
-use common::utils::check_can_generate_examples;
-use hegel::TestCase;
+use common::project::TempRustProject;
+use common::utils::{assert_all_examples, check_can_generate_examples};
 use hegel::generators as gs;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -107,10 +107,28 @@ fn test_default_nested() {
     check_can_generate_examples(gs::default::<[Option<i32>; 4]>());
 }
 
-#[hegel::test]
-fn test_default_can_infer_through_draw(tc: TestCase) {
-    // This doesn't test anything much at runtime. We are checking
-    // that the type checker can infer the type parameter to default
-    // rather than forcing us to write this as gs::default::<i32>
+#[not_supported_on_native]
+#[test]
+fn test_default_supports_primitive_builder() {
+    let g = gs::default::<u32>().min_value(10).max_value(20);
+    assert_all_examples(g, |n: &u32| *n >= 10 && *n <= 20);
+}
+
+// see https://github.com/hegeldev/hegel-rust/issues/246 for context
+#[test]
+fn test_default_cant_infer_through_draw() {
+    TempRustProject::new()
+        .main_file(
+            r#"
+use hegel::generators as gs;
+
+fn _check(tc: &hegel::TestCase) {
     let _: i32 = tc.draw(gs::default());
+}
+
+fn main() {}
+"#,
+        )
+        .expect_failure("type annotations needed")
+        .cargo_run(&[]);
 }

--- a/tests/test_default.rs
+++ b/tests/test_default.rs
@@ -107,7 +107,6 @@ fn test_default_nested() {
     check_can_generate_examples(gs::default::<[Option<i32>; 4]>());
 }
 
-#[not_supported_on_native]
 #[test]
 fn test_default_supports_primitive_builder() {
     let g = gs::default::<u32>().min_value(10).max_value(20);

--- a/tests/test_derive.rs
+++ b/tests/test_derive.rs
@@ -169,6 +169,12 @@ fn test_derive_struct_with_filtered_field() {
 }
 
 #[test]
+fn test_default_supports_struct_builder() {
+    let g = gs::default::<Point>().x(gs::just(42));
+    assert_all_examples(g, |p: &Point| p.x == 42);
+}
+
+#[test]
 fn test_derive_unit_enum() {
     check_can_generate_examples(gs::default::<Color>());
 }
@@ -219,6 +225,16 @@ fn test_derive_tuple_variant_generates_both() {
 fn test_derive_enum_variant_generator_named_fields() {
     let g = Shape::default_generator()
         .circle(|g| g.radius(gs::floats().min_value(1.0).max_value(10.0)));
+    assert_all_examples(g, |s: &Shape| match s {
+        Shape::Circle { radius } => *radius >= 1.0 && *radius <= 10.0,
+        Shape::Rectangle { .. } => true,
+    });
+}
+
+#[test]
+fn test_default_supports_enum_variant_builder() {
+    let g =
+        gs::default::<Shape>().circle(|g| g.radius(gs::floats().min_value(1.0).max_value(10.0)));
     assert_all_examples(g, |s: &Shape| match s {
         Shape::Circle { radius } => *radius >= 1.0 && *radius <= 10.0,
         Shape::Rectangle { .. } => true,
@@ -362,19 +378,19 @@ fn test_derive_enum_with_filter() {
 
 #[hegel::test]
 fn test_derive_struct_in_hegel_test(tc: hegel::TestCase) {
-    let _: Point = tc.draw(gs::default());
+    let _ = tc.draw(gs::default::<Point>());
 }
 
 #[hegel::test]
 fn test_derive_enum_in_hegel_test(tc: hegel::TestCase) {
-    let c: Color = tc.draw(gs::default());
+    let c = tc.draw(gs::default::<Color>());
     assert!(matches!(c, Color::Red | Color::Green | Color::Blue));
 }
 
 #[not_supported_on_native]
 #[hegel::test]
 fn test_derive_nested_structs(tc: hegel::TestCase) {
-    let _: WithNested = tc.draw(gs::default());
+    let _ = tc.draw(gs::default::<WithNested>());
 }
 
 #[not_supported_on_native]
@@ -387,9 +403,9 @@ fn test_derive_nested_struct_with_custom_inner() {
 
 #[test]
 fn test_derive_struct_generator_is_send_sync() {
-    fn assert_send_sync<T: Send + Sync>() {}
+    fn assert_send_sync<T: Send + Sync>(_: &T) {}
     let g = gs::default::<Point>();
-    assert_send_sync::<hegel::generators::BoxedGenerator<'static, Point>>();
+    assert_send_sync(&g);
     check_can_generate_examples(g);
 }
 


### PR DESCRIPTION
Closes https://github.com/hegeldev/hegel-rust/issues/246.

<details><summary>Claude-written description</summary>

Fixes [#246](https://github.com/hegeldev/hegel-rust/issues/246).

`gs::default::<T>()` now returns the concrete `T::Generator` rather than `BoxedGenerator<'static, T>`. The documented builder pattern through `gs::default` now actually works:

```rust
gs::default::<Person>().age(gs::integers::<u32>().min_value(0).max_value(120))
gs::default::<Shape>().circle(|g| g.radius(gs::floats().min_value(1.0)))
gs::default::<u32>().min_value(0).max_value(100)
```

Per the discussion on #246 this is a deliberate reversal of the boxing decision made in #57. The tradeoff is that Rust can no longer reverse-resolve `T` through the associated type `T::Generator`, so the turbofish is now required at the call site:

```rust
// before
let p: Person = tc.draw(gs::default());
// after
let p = tc.draw(gs::default::<Person>());
```

### Tests

Three new green tests exercise the builder chain through `gs::default::<T>()` for primitives, structs, and enum variants. The `test_default_can_infer_through_draw` test is replaced by `test_default_cant_infer_through_draw`, a `TempRustProject`-based compile-failure test that locks in the new contract — if anyone re-introduces boxing in a future refactor, this test starts failing and forces a reconsideration.

Three existing tests that relied on LHS-only inference (`let p: Person = tc.draw(gs::default());`) were updated to use the turbofish form.

### Self-review

The `code-reviewer` subagent caught that `test_derive_struct_generator_is_send_sync` was using a free-standing `assert_send_sync::<BoxedGenerator<…>>()` that didn't actually constrain the value returned by `gs::default::<Point>()`. After this diff that mismatch became more glaring (the value is now `PointGenerator<'static>`, not `BoxedGenerator`). Fixed by switching to `assert_send_sync(&g)` so the bound is tied to `g`'s real type.

</details>
