### PR TITLE
Add native support for targeted property-based testing

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+The native backend (`--features native`) now implements `Phase::Target`, so `tc.target()` and `tc.target_labelled()` drive a hill-climbing search for better-scoring inputs instead of panicking with `todo!()`.

--- a/src/native/data_source.rs
+++ b/src/native/data_source.rs
@@ -5,6 +5,7 @@
 // the engine so it can read back the recorded nodes / spans and, via
 // `mark_complete`, the test case outcome after the test body returns.
 
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -26,6 +27,10 @@ pub struct NativeTestCaseInner {
     /// in `run_lifecycle::run_test_case` guarantees won't happen — so the
     /// engine can safely unwrap when reading the outcome back.
     pub outcome: Option<TestCaseResult>,
+    /// `tc.target()` observations recorded during the test case, keyed by
+    /// label. Populated by [`DataSource::target_observation`]; read back by
+    /// the targeting phase via [`NativeDataSource::take_target_observations`].
+    pub target_observations: HashMap<String, f64>,
 }
 
 /// Shared handle to the per-test-case inner state.
@@ -43,7 +48,11 @@ impl NativeDataSource {
     /// state: choice nodes, spans, and the outcome reported by
     /// [`DataSource::mark_complete`].
     pub fn new(ntc: NativeTestCase) -> (Self, NativeTestCaseHandle) {
-        let inner = Arc::new(Mutex::new(NativeTestCaseInner { ntc, outcome: None }));
+        let inner = Arc::new(Mutex::new(NativeTestCaseInner {
+            ntc,
+            outcome: None,
+            target_observations: HashMap::new(),
+        }));
         let handle = Arc::clone(&inner);
         (
             NativeDataSource {
@@ -73,6 +82,19 @@ impl NativeDataSource {
             .spans
             .clone()
             .into_vec()
+    }
+
+    /// Drain the `tc.target()` observations the test body recorded.
+    ///
+    /// Used by the targeting phase in `test_runner` to read back per-label
+    /// scores after a test case completes.
+    pub fn take_target_observations(handle: &NativeTestCaseHandle) -> HashMap<String, f64> {
+        std::mem::take(
+            &mut handle
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .target_observations,
+        )
     }
 
     /// Read the outcome reported via [`DataSource::mark_complete`].
@@ -203,11 +225,26 @@ impl DataSource for NativeDataSource {
         })
     }
 
-    fn target_observation(&self, _score: f64, _label: &str) {
-        todo!(
-            "tc.target() is not yet supported by the native backend; \
-             Phase::Target will land in a follow-up PR"
-        );
+    fn target_observation(&self, score: f64, label: &str) {
+        // Mirror `ServerDataSource::target_observation` and upstream
+        // `hypothesis.control.target` (`control.py:354-356,372-376`): the
+        // observation must be finite and each label may be observed at
+        // most once per test case.
+        if !score.is_finite() {
+            panic!(
+                "tc.target({score}, label={label:?}) requires a finite score; \
+                 got non-finite value"
+            );
+        }
+        let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        if inner.target_observations.contains_key(label) {
+            panic!(
+                "tc.target({score}, label={label:?}) would overwrite previous \
+                 tc.target(_, label={label:?}); each label can be observed at \
+                 most once per test case"
+            );
+        }
+        inner.target_observations.insert(label.to_string(), score);
     }
 
     fn mark_complete(&self, result: &TestCaseResult) {

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -15,4 +15,5 @@ pub mod floats;
 pub mod intervalsets;
 pub mod schema;
 pub mod shrinker;
+pub mod targeting;
 pub mod test_runner;

--- a/src/native/shrinker/mod.rs
+++ b/src/native/shrinker/mod.rs
@@ -240,7 +240,7 @@ pub(super) fn bin_search_down(lo: i128, hi: i128, f: &mut impl FnMut(i128) -> bo
 /// Rust a predicate that accepts an unbounded range (e.g. a `lower_integers_together`
 /// pass over full-range `i128` nodes) would otherwise walk `hi` off the end
 /// of `usize`.
-pub(super) fn find_integer(mut f: impl FnMut(usize) -> bool) -> usize {
+pub(crate) fn find_integer(mut f: impl FnMut(usize) -> bool) -> usize {
     for i in 1..5 {
         if !f(i) {
             return i - 1;

--- a/src/native/targeting.rs
+++ b/src/native/targeting.rs
@@ -1,0 +1,424 @@
+// Targeted property-based search for the native runner.
+//
+// Records `tc.target()` observations during the generation phase, keeps
+// the best-scoring choice sequence seen for each label, and — when
+// `Phase::Target` is enabled and no bug has been found yet — hill-climbs
+// each label by perturbing climbable choices (integers, floats, booleans,
+// bytes) in the best-scoring sequence.
+//
+// Mirrors Hypothesis's `internal/conjecture/optimiser.py::Optimiser.hill_climb`
+// and the `optimise_targets` driver in `internal/conjecture/engine.py`. The
+// integer-search step uses the same linear/exponential/binary pattern as
+// `junkdrawer.find_integer`.
+
+use std::collections::{HashMap, HashSet};
+
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
+
+use crate::native::core::{
+    BUFFER_SIZE, ChoiceKind, ChoiceNode, ChoiceValue, NativeTestCase, Status,
+};
+use crate::native::shrinker::find_integer;
+use crate::native::test_runner::{EngineCtx, RunResult};
+
+/// Per-label best score and the choice sequence that produced it.
+pub(crate) struct TargetingState {
+    best_observed_targets: HashMap<String, f64>,
+    best_choices_for_target: HashMap<String, Vec<ChoiceValue>>,
+}
+
+impl TargetingState {
+    pub fn new() -> Self {
+        Self {
+            best_observed_targets: HashMap::new(),
+            best_choices_for_target: HashMap::new(),
+        }
+    }
+
+    /// Record the observations from a Valid run. The first observation for
+    /// each label always populates both maps; subsequent observations only
+    /// overwrite when the score strictly improves. The two maps therefore
+    /// share the same key set (relied on by [`hill_climb`]).
+    pub fn record(&mut self, choices: &[ChoiceValue], observations: &HashMap<String, f64>) {
+        for (label, &score) in observations {
+            let should_record = match self.best_observed_targets.get(label) {
+                None => true,
+                Some(&best) => score > best,
+            };
+            if should_record {
+                self.best_observed_targets.insert(label.clone(), score);
+                self.best_choices_for_target
+                    .insert(label.clone(), choices.to_vec());
+            }
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.best_observed_targets.is_empty()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn best_score(&self, label: &str) -> Option<f64> {
+        self.best_observed_targets.get(label).copied()
+    }
+}
+
+/// Schedule for firing `optimise_targets` during the generation loop.
+///
+/// Mirrors the threshold logic in
+/// `internal/conjecture/engine.py::generate_new_examples`: a first pass
+/// after ~10% of the budget (capped at 50 valid examples), then another
+/// pass every ~50% of the original budget thereafter. Re-entry lets the
+/// climber explore from fresh starting points if later random draws raise
+/// the best-observed score for some label after the first pass settled
+/// on a different starting sequence.
+pub(crate) struct TargetingSchedule {
+    step: u64,
+    next_at: u64,
+}
+
+impl TargetingSchedule {
+    pub fn new(max_examples: u64) -> Self {
+        let small_example_cap = (max_examples / 10).min(50);
+        let step = (max_examples / 2)
+            .max(small_example_cap.saturating_add(1))
+            .max(10);
+        Self {
+            step,
+            next_at: step,
+        }
+    }
+
+    /// Returns `true` if the caller should fire `optimise_targets` now.
+    /// Advances the next-firing threshold so each call to this method on
+    /// the same valid count returns `true` at most once.
+    pub fn should_fire(&mut self, valid_test_cases: u64) -> bool {
+        if valid_test_cases < self.next_at {
+            return false;
+        }
+        self.next_at = valid_test_cases.saturating_add(self.step);
+        true
+    }
+}
+
+/// Mutable state threaded through the hill-climber.
+pub(crate) struct OptimiseCtx<'a, 'b, 'c> {
+    pub engine: &'a mut EngineCtx<'b>,
+    pub interesting: &'a mut HashMap<String, Vec<ChoiceNode>>,
+    pub calls: &'a mut u64,
+    pub valid_test_cases: &'a mut u64,
+    pub max_valid: u64,
+    pub max_calls: u64,
+    pub rng: &'a mut SmallRng,
+    pub on_run: &'a mut (dyn FnMut(&RunResult) + 'c),
+}
+
+impl OptimiseCtx<'_, '_, '_> {
+    fn budget_exhausted(&self) -> bool {
+        !self.interesting.is_empty()
+            || *self.valid_test_cases >= self.max_valid
+            || *self.calls >= self.max_calls
+    }
+}
+
+/// Run a single trial and update bookkeeping. Returns the run result if it
+/// completed, or `None` if the budget was exhausted before this call.
+///
+/// Uses [`NativeTestCase::for_probe`] rather than `for_choices` so that
+/// perturbations which grow the realised choice sequence (e.g. raising
+/// an integer that controls a downstream loop count) can still draw the
+/// extra values from a fresh RNG instead of overrunning the prefix.
+/// Mirrors Hypothesis's `cached_test_function(choices, extend="full")`
+/// in `optimiser.py::attempt_replace`.
+fn run_trial(
+    targeting: &mut TargetingState,
+    ctx: &mut OptimiseCtx<'_, '_, '_>,
+    choices: &[ChoiceValue],
+) -> Option<RunResult> {
+    if ctx.budget_exhausted() {
+        return None;
+    }
+    let ntc = NativeTestCase::for_probe(choices, SmallRng::from_rng(ctx.rng), BUFFER_SIZE);
+    let run = ctx.engine.run(ntc);
+    *ctx.calls += 1;
+    (ctx.on_run)(&run);
+    if run.status >= Status::Valid {
+        *ctx.valid_test_cases += 1;
+        let actual_choices: Vec<ChoiceValue> = run.nodes.iter().map(|n| n.value.clone()).collect();
+        targeting.record(&actual_choices, &run.target_observations);
+    }
+    if run.status == Status::Interesting {
+        // `budget_exhausted` already short-circuited on `!interesting.is_empty()`
+        // above, so the map entry for this origin must be vacant — there's
+        // no prior result here whose sort_key we'd need to beat.
+        let origin = run.origin.clone().unwrap_or_default();
+        ctx.interesting.insert(origin, run.nodes.clone());
+    }
+    Some(run)
+}
+
+/// Hill-climb every target until no further improvements are found or the
+/// budget is exhausted. Mirrors `engine.py::optimise_targets`.
+pub(crate) fn optimise_targets(targeting: &mut TargetingState, ctx: &mut OptimiseCtx<'_, '_, '_>) {
+    let targets: Vec<String> = targeting.best_observed_targets.keys().cloned().collect();
+    let mut max_improvements: usize = 10;
+    loop {
+        let prev_calls = *ctx.calls;
+        let mut any_improvements = false;
+        for target in &targets {
+            let imps = hill_climb(targeting, ctx, target, max_improvements);
+            if imps > 0 {
+                any_improvements = true;
+            }
+        }
+        max_improvements = max_improvements.saturating_mul(2);
+        if !any_improvements || prev_calls == *ctx.calls {
+            return;
+        }
+    }
+}
+
+/// Walk the integer choices in `best_choices_for_target[target]` from the
+/// end backwards, hill-climbing each one in both directions. Mirrors
+/// `Optimiser._optimise_target`.
+fn hill_climb(
+    targeting: &mut TargetingState,
+    ctx: &mut OptimiseCtx<'_, '_, '_>,
+    target: &str,
+    max_improvements: usize,
+) -> usize {
+    // `record` keeps `best_choices_for_target` in sync with
+    // `best_observed_targets`, so any label our caller iterates from
+    // `best_observed_targets` must have a matching choice sequence here.
+    let start_choices = targeting
+        .best_choices_for_target
+        .get(target)
+        .cloned()
+        .expect("best_choices_for_target out of sync with best_observed_targets");
+    let trial = match run_trial(targeting, ctx, &start_choices) {
+        Some(t) => t,
+        None => return 0,
+    };
+    if trial.status < Status::Valid {
+        return 0;
+    }
+    let mut current_choices: Vec<ChoiceValue> =
+        trial.nodes.iter().map(|n| n.value.clone()).collect();
+    let mut current_nodes = trial.nodes;
+    let mut current_score = *trial
+        .target_observations
+        .get(target)
+        .unwrap_or(&f64::NEG_INFINITY);
+    let mut improvements: usize = 0;
+
+    let mut nodes_examined: HashSet<usize> = HashSet::new();
+    let mut i: isize = current_nodes.len() as isize - 1;
+    let mut prev_len = current_nodes.len();
+    while i >= 0 && improvements <= max_improvements {
+        // When `find_integer` lengthens or shortens `current_nodes`, `i`
+        // no longer indexes the same logical position. Reset to the new
+        // tail and start afresh — but keep `nodes_examined` populated so
+        // indices we already optimised in the pre-resize pass don't get
+        // redone. Mirrors `optimiser.py:95-97`.
+        if current_nodes.len() != prev_len {
+            i = current_nodes.len() as isize - 1;
+            prev_len = current_nodes.len();
+            continue;
+        }
+        let idx = i as usize;
+        if !nodes_examined.insert(idx) {
+            i -= 1;
+            continue;
+        }
+        let node = &current_nodes[idx];
+        if !node.was_forced && is_climbable(&node.value, &node.kind) {
+            let len_before = current_nodes.len();
+            // Hill-climb in the +1 direction. `find_integer` itself is the
+            // general `junkdrawer.find_integer` from `shrinker/mod.rs`: it
+            // probes deltas 1, 2, 3, 4, then 5, 10, 20, … with binary
+            // bisection in between, calling the closure once per probe.
+            // The closure threads through all the per-climb state; its
+            // return value (the largest accepted delta) is discarded —
+            // commit happens as a side effect inside `try_replace`, and
+            // the `improvements` counter it bumps is what drives the
+            // outer `while improvements <= max_improvements` loop.
+            find_integer(|k| {
+                try_replace(
+                    targeting,
+                    ctx,
+                    target,
+                    &mut current_choices,
+                    &mut current_nodes,
+                    &mut current_score,
+                    &mut improvements,
+                    idx,
+                    k as i128,
+                )
+            });
+            // If the +1 direction grew `current_nodes`, idx no longer points
+            // at the same logical position; trying -1 there almost always
+            // shrinks the sequence back below the new score, so skip.
+            // Mirrors the same guard in Hypothesis's `Optimiser.hill_climb`.
+            if idx < current_nodes.len() && current_nodes.len() == len_before {
+                find_integer(|k| {
+                    try_replace(
+                        targeting,
+                        ctx,
+                        target,
+                        &mut current_choices,
+                        &mut current_nodes,
+                        &mut current_score,
+                        &mut improvements,
+                        idx,
+                        -(k as i128),
+                    )
+                });
+            }
+        }
+        i -= 1;
+    }
+    improvements
+}
+
+/// Replace `current_choices[idx]` by stepping it `delta` units. Score
+/// acceptance mirrors `optimiser.py::consider_new_data` (lines 65-82): a
+/// strict score improvement commits the new state and bumps `improvements`;
+/// a tie commits iff the new node count doesn't grow but does *not* count
+/// as an improvement (lateral moves are the principal mechanism for
+/// escaping local maxima, but they shouldn't keep the climber spinning
+/// forever). Returns `true` iff the trial was committed.
+#[allow(clippy::too_many_arguments)]
+fn try_replace(
+    targeting: &mut TargetingState,
+    ctx: &mut OptimiseCtx<'_, '_, '_>,
+    target: &str,
+    current_choices: &mut Vec<ChoiceValue>,
+    current_nodes: &mut Vec<ChoiceNode>,
+    current_score: &mut f64,
+    improvements: &mut usize,
+    idx: usize,
+    delta: i128,
+) -> bool {
+    // Cap the perturbation magnitude to avoid driving an unbounded score
+    // up forever. Mirrors `optimiser.py::attempt_replace` line 122.
+    if delta.saturating_abs() > (1 << 20) {
+        return false;
+    }
+    let new_val = match step_choice(&current_nodes[idx], delta) {
+        Some(v) => v,
+        None => return false,
+    };
+    let mut trial_choices = current_choices.clone();
+    trial_choices[idx] = new_val;
+    let trial = match run_trial(targeting, ctx, &trial_choices) {
+        Some(t) => t,
+        None => return false,
+    };
+    if trial.status < Status::Valid {
+        return false;
+    }
+    let new_score = *trial
+        .target_observations
+        .get(target)
+        .unwrap_or(&f64::NEG_INFINITY);
+    if new_score < *current_score {
+        return false;
+    }
+    let strict = new_score > *current_score;
+    if !strict && trial.nodes.len() > current_nodes.len() {
+        return false;
+    }
+    *current_score = new_score;
+    *current_choices = trial.nodes.iter().map(|n| n.value.clone()).collect();
+    *current_nodes = trial.nodes;
+    if strict {
+        *improvements += 1;
+    }
+    true
+}
+
+/// Returns `true` iff `(value, kind)` is a node kind the hill-climber can
+/// step. Mirrors `optimiser.py:109`, which admits integer / float / bytes /
+/// boolean and skips strings (no sensible "larger" step).
+pub(crate) fn is_climbable(value: &ChoiceValue, kind: &ChoiceKind) -> bool {
+    matches!(
+        (value, kind),
+        (ChoiceValue::Integer(_), ChoiceKind::Integer(_))
+            | (ChoiceValue::Float(_), ChoiceKind::Float(_))
+            | (ChoiceValue::Boolean(_), ChoiceKind::Boolean(_))
+            | (ChoiceValue::Bytes(_), ChoiceKind::Bytes(_))
+    )
+}
+
+/// Step a choice node by `delta` and return the resulting value if it's
+/// representable and validates against the node's kind constraints, or
+/// `None` to signal "this trial isn't worth running." Mirrors
+/// `optimiser.py::Optimiser.attempt_replace` (lines 130-156) plus the
+/// `choice_permitted(new_choice, node.constraints)` post-check.
+pub(crate) fn step_choice(node: &ChoiceNode, delta: i128) -> Option<ChoiceValue> {
+    match (&node.value, &node.kind) {
+        (ChoiceValue::Integer(v), ChoiceKind::Integer(kind)) => {
+            let new = v.saturating_add(delta);
+            if !kind.validate(new) {
+                return None;
+            }
+            Some(ChoiceValue::Integer(new))
+        }
+        (ChoiceValue::Float(v), ChoiceKind::Float(kind)) => {
+            let new = v + delta as f64;
+            if !kind.validate(new) {
+                return None;
+            }
+            Some(ChoiceValue::Float(new))
+        }
+        (ChoiceValue::Boolean(b), ChoiceKind::Boolean(_)) => {
+            if delta.saturating_abs() > 1 {
+                return None;
+            }
+            let new = if delta == -1 {
+                false
+            } else if delta == 1 {
+                true
+            } else {
+                *b
+            };
+            Some(ChoiceValue::Boolean(new))
+        }
+        (ChoiceValue::Bytes(b), ChoiceKind::Bytes(kind)) => {
+            let mut v: i128 = 0;
+            for &byte in b {
+                v = (v << 8) | byte as i128;
+            }
+            let new_v = v.saturating_add(delta);
+            if new_v < 0 {
+                return None;
+            }
+            let mut new_bytes = Vec::new();
+            let mut x = new_v;
+            if x == 0 {
+                new_bytes.push(0u8);
+            }
+            while x > 0 {
+                new_bytes.push((x & 0xff) as u8);
+                x >>= 8;
+            }
+            new_bytes.reverse();
+            // Pad up to the original length so a shorter encoding doesn't
+            // collapse the byte string. Mirrors upstream's
+            // `max(len(node.value), bits_to_bytes(v.bit_length()))`.
+            while new_bytes.len() < b.len() {
+                new_bytes.insert(0, 0);
+            }
+            if !kind.validate(&new_bytes) {
+                return None;
+            }
+            Some(ChoiceValue::Bytes(new_bytes))
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+#[path = "../../tests/embedded/native/targeting_tests.rs"]
+mod tests;

--- a/src/native/test_runner.rs
+++ b/src/native/test_runner.rs
@@ -42,6 +42,9 @@ pub struct RunResult {
     pub spans: Vec<Span>,
     pub origin: Option<String>,
     pub failure: Option<Failure>,
+    /// `tc.target()` observations recorded during the test case, keyed by
+    /// label. Empty for tests that don't call `tc.target()`.
+    pub target_observations: HashMap<String, f64>,
 }
 
 const RANDOM_GENERATION_BATCH: u64 = 10;
@@ -54,7 +57,15 @@ const FILTER_TOO_MUCH_THRESHOLD: u64 = 200;
 
 /// Cumulative wall-clock threshold across the generation phase before
 /// TooSlow fires.
-const TOO_SLOW_THRESHOLD: std::time::Duration = std::time::Duration::from_secs(1);
+///
+/// Hypothesis computes its equivalent threshold as `max(1s, 5 × deadline)`,
+/// which works out to 1s when the user has the default `deadline=200ms` set
+/// but 30s when the user sets `deadline=None`. Hegel-Rust deliberately
+/// doesn't have a `deadline` setting at all (tight timing on tests tends to
+/// be more trouble than it's worth in this ecosystem), which puts every
+/// Hegel run in the "deadline=None" regime — so the matching Hypothesis
+/// behaviour is the 30s threshold, not the 1s one.
+const TOO_SLOW_THRESHOLD: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Health checks (TooSlow / FilterTooMuch) are evaluated only while the run
 /// has fewer than this many valid examples on record.
@@ -141,6 +152,9 @@ fn run_main(
     // is what makes a single test that fails with several distinct bugs
     // surface each one.
     let mut interesting: HashMap<String, Vec<ChoiceNode>> = HashMap::new();
+    let mut targeting = crate::native::targeting::TargetingState::new();
+    let mut target_schedule = crate::native::targeting::TargetingSchedule::new(max_examples);
+    let target_enabled = settings.phases.contains(&Phase::Target);
     let mut valid_test_cases: u64 = 0;
     let mut calls: u64 = 0;
     let mut test_is_trivial = false;
@@ -268,6 +282,11 @@ fn run_main(
             }
             if run.status >= Status::Valid {
                 valid_test_cases += 1;
+                if !run.target_observations.is_empty() {
+                    let choices: Vec<ChoiceValue> =
+                        run.nodes.iter().map(|n| n.value.clone()).collect();
+                    targeting.record(&choices, &run.target_observations);
+                }
             }
 
             if run.status == Status::Invalid {
@@ -312,6 +331,39 @@ fn run_main(
                 );
             }
             // nocov end
+
+            // Fire `optimise_targets` periodically once enough valid
+            // examples have accumulated; mirrors Hypothesis's interleaved
+            // call from `generate_new_examples`. Counts share the
+            // generation budget — targeting trials count toward
+            // `valid_test_cases` and `calls`, so `max_examples` remains a
+            // hard cap across both. Skipped once a bug has been found
+            // (matching `optimise_targets`'s own short-circuit).
+            if target_enabled
+                && interesting.is_empty()
+                && !targeting.is_empty()
+                && target_schedule.should_fire(valid_test_cases)
+            {
+                let mut on_run = |run: &RunResult| {
+                    crate::native::data_tree::record_tree(
+                        &mut tree_root,
+                        &run.nodes,
+                        run.status,
+                        &[],
+                    );
+                };
+                let mut opt_ctx = crate::native::targeting::OptimiseCtx {
+                    engine: &mut ctx,
+                    interesting: &mut interesting,
+                    calls: &mut calls,
+                    valid_test_cases: &mut valid_test_cases,
+                    max_valid: max_examples,
+                    max_calls: max_examples * 10,
+                    rng: &mut rng,
+                    on_run: &mut on_run,
+                };
+                crate::native::targeting::optimise_targets(&mut targeting, &mut opt_ctx);
+            }
 
             if run.status == Status::Interesting {
                 let origin = run.origin.clone().unwrap_or_default();
@@ -603,7 +655,7 @@ pub(crate) struct EngineCtx<'a> {
 }
 
 impl<'a> EngineCtx<'a> {
-    fn new(run_case: &'a mut dyn FnMut(Box<dyn DataSource>, bool)) -> Self {
+    pub(crate) fn new(run_case: &'a mut dyn FnMut(Box<dyn DataSource>, bool)) -> Self {
         EngineCtx {
             run_case,
             cache: HashMap::new(),
@@ -619,6 +671,7 @@ impl<'a> EngineCtx<'a> {
         (self.run_case)(Box::new(data_source), is_final);
         let nodes = NativeDataSource::take_nodes(&handle);
         let spans = NativeDataSource::take_spans(&handle);
+        let target_observations = NativeDataSource::take_target_observations(&handle);
         let tc_result = NativeDataSource::take_outcome(&handle);
 
         let (status, failure) = match tc_result {
@@ -635,6 +688,7 @@ impl<'a> EngineCtx<'a> {
             spans,
             origin,
             failure,
+            target_observations,
         }
     }
 
@@ -687,7 +741,7 @@ impl<'a> EngineCtx<'a> {
     }
 
     /// Run one test case as part of the search loop (not a final replay).
-    fn run(&mut self, ntc: NativeTestCase) -> RunResult {
+    pub(crate) fn run(&mut self, ntc: NativeTestCase) -> RunResult {
         self.execute(ntc, false)
     }
 }

--- a/tests/embedded/native/data_source_tests.rs
+++ b/tests/embedded/native/data_source_tests.rs
@@ -152,12 +152,46 @@ fn generate_integer_round_trips() {
     assert_eq!(n, ciborium::Value::Integer(5.into()));
 }
 
-// `tc.target()` is not yet implemented in the native backend — calling it
-// raises `todo!()`. The Phase::Target work will land in a follow-up PR.
+// `tc.target()` records observations into per-test-case state on the data
+// source handle; the targeting phase reads them back via
+// `NativeDataSource::take_target_observations` after the test body returns.
 
 #[test]
-#[should_panic(expected = "not yet supported by the native backend")]
-fn target_observation_raises_todo() {
+fn target_observation_records_finite_score() {
+    let (ds, handle) = random_source();
+    ds.target_observation(1.5, "x");
+    let obs = NativeDataSource::take_target_observations(&handle);
+    assert_eq!(obs.get("x"), Some(&1.5));
+}
+
+#[test]
+fn target_observation_take_drains() {
+    let (ds, handle) = random_source();
+    ds.target_observation(1.0, "x");
+    let first = NativeDataSource::take_target_observations(&handle);
+    assert_eq!(first.len(), 1);
+    let second = NativeDataSource::take_target_observations(&handle);
+    assert!(second.is_empty());
+}
+
+#[test]
+#[should_panic(expected = "requires a finite score")]
+fn target_observation_rejects_nan() {
+    let (ds, _handle) = random_source();
+    ds.target_observation(f64::NAN, "x");
+}
+
+#[test]
+#[should_panic(expected = "requires a finite score")]
+fn target_observation_rejects_infinity() {
+    let (ds, _handle) = random_source();
+    ds.target_observation(f64::INFINITY, "x");
+}
+
+#[test]
+#[should_panic(expected = "would overwrite previous")]
+fn target_observation_rejects_duplicate_label() {
     let (ds, _handle) = random_source();
     ds.target_observation(1.0, "x");
+    ds.target_observation(2.0, "x");
 }

--- a/tests/embedded/native/targeting_tests.rs
+++ b/tests/embedded/native/targeting_tests.rs
@@ -1,0 +1,409 @@
+use super::*;
+use crate::native::core::choices::{BooleanChoice, IntegerChoice};
+use crate::native::core::{BytesChoice, FloatChoice};
+
+fn integer_node(value: i128, min_value: i128, max_value: i128) -> ChoiceNode {
+    ChoiceNode {
+        kind: ChoiceKind::Integer(IntegerChoice {
+            min_value,
+            max_value,
+            shrink_towards: 0,
+        }),
+        value: ChoiceValue::Integer(value),
+        was_forced: false,
+    }
+}
+
+fn float_node(value: f64) -> ChoiceNode {
+    ChoiceNode {
+        kind: ChoiceKind::Float(FloatChoice {
+            min_value: f64::NEG_INFINITY,
+            max_value: f64::INFINITY,
+            allow_nan: false,
+            allow_infinity: true,
+        }),
+        value: ChoiceValue::Float(value),
+        was_forced: false,
+    }
+}
+
+fn bytes_node(value: Vec<u8>, min_size: usize, max_size: usize) -> ChoiceNode {
+    ChoiceNode {
+        kind: ChoiceKind::Bytes(BytesChoice { min_size, max_size }),
+        value: ChoiceValue::Bytes(value),
+        was_forced: false,
+    }
+}
+
+// ── TargetingState ────────────────────────────────────────────────────────
+
+#[test]
+fn targeting_state_starts_empty() {
+    let state = TargetingState::new();
+    assert!(state.is_empty());
+    assert_eq!(state.best_score("anything"), None);
+}
+
+#[test]
+fn targeting_state_records_first_observation() {
+    let mut state = TargetingState::new();
+    let choices = vec![ChoiceValue::Integer(7)];
+    let obs = std::collections::HashMap::from([("score".to_string(), 1.5)]);
+    state.record(&choices, &obs);
+    assert!(!state.is_empty());
+    assert_eq!(state.best_score("score"), Some(1.5));
+}
+
+#[test]
+fn targeting_state_overwrites_only_on_strict_improvement() {
+    let mut state = TargetingState::new();
+    let choices_a = vec![ChoiceValue::Integer(1)];
+    let choices_b = vec![ChoiceValue::Integer(2)];
+    state.record(
+        &choices_a,
+        &std::collections::HashMap::from([("s".to_string(), 1.0)]),
+    );
+    // Equal score: no overwrite.
+    state.record(
+        &choices_b,
+        &std::collections::HashMap::from([("s".to_string(), 1.0)]),
+    );
+    assert_eq!(state.best_score("s"), Some(1.0));
+    // Worse score: no overwrite.
+    state.record(
+        &choices_b,
+        &std::collections::HashMap::from([("s".to_string(), 0.5)]),
+    );
+    assert_eq!(state.best_score("s"), Some(1.0));
+    // Strictly better: overwrite.
+    state.record(
+        &choices_b,
+        &std::collections::HashMap::from([("s".to_string(), 2.0)]),
+    );
+    assert_eq!(state.best_score("s"), Some(2.0));
+}
+
+#[test]
+fn targeting_state_tracks_multiple_labels_independently() {
+    let mut state = TargetingState::new();
+    let choices = vec![ChoiceValue::Integer(0)];
+    state.record(
+        &choices,
+        &std::collections::HashMap::from([("a".to_string(), 1.0), ("b".to_string(), 2.0)]),
+    );
+    assert_eq!(state.best_score("a"), Some(1.0));
+    assert_eq!(state.best_score("b"), Some(2.0));
+    assert_eq!(state.best_score("c"), None);
+}
+
+// ── TargetingSchedule ─────────────────────────────────────────────────────
+
+#[test]
+fn schedule_fires_at_first_threshold() {
+    // max_examples=100 → step = max(50, 11, 10) = 50.
+    let mut s = TargetingSchedule::new(100);
+    assert!(!s.should_fire(49));
+    assert!(s.should_fire(50));
+    // Second call at the same count does not re-fire.
+    assert!(!s.should_fire(50));
+}
+
+#[test]
+fn schedule_re_fires_at_subsequent_thresholds() {
+    let mut s = TargetingSchedule::new(100);
+    assert!(s.should_fire(50));
+    // Next fire at 50 + step (50) = 100.
+    assert!(!s.should_fire(99));
+    assert!(s.should_fire(100));
+}
+
+#[test]
+fn schedule_for_small_max_examples_never_fires_in_range() {
+    // max_examples=1 → step = max(0, 1, 10) = 10.
+    let mut s = TargetingSchedule::new(1);
+    // Generation tops out at valid_test_cases=1; schedule never fires.
+    assert!(!s.should_fire(1));
+}
+
+// ── is_climbable ──────────────────────────────────────────────────────────
+
+#[test]
+fn is_climbable_accepts_integer_float_boolean_bytes() {
+    let int_node = integer_node(0, 0, 10);
+    let float_node = float_node(0.0);
+    let bool_node = ChoiceNode {
+        kind: ChoiceKind::Boolean(BooleanChoice),
+        value: ChoiceValue::Boolean(true),
+        was_forced: false,
+    };
+    let bytes_node = bytes_node(vec![0], 0, 8);
+    for node in [&int_node, &float_node, &bool_node, &bytes_node] {
+        assert!(
+            is_climbable(&node.value, &node.kind),
+            "expected climbable: {node:?}"
+        );
+    }
+}
+
+#[test]
+fn is_climbable_rejects_strings() {
+    use crate::native::core::StringChoice;
+    use crate::native::intervalsets::IntervalSet;
+    let sc = StringChoice {
+        intervals: IntervalSet::new(vec![(0x20, 0x7E)]),
+        min_size: 0,
+        max_size: 10,
+    };
+    assert!(!is_climbable(
+        &ChoiceValue::String(vec![b'a' as u32]),
+        &ChoiceKind::String(sc),
+    ));
+}
+
+#[test]
+fn is_climbable_returns_false_for_value_and_kind_mismatch() {
+    let int_kind = ChoiceKind::Integer(IntegerChoice {
+        min_value: 0,
+        max_value: 10,
+        shrink_towards: 0,
+    });
+    // Wrong-shape pairing: a bytes value with an integer kind is never
+    // produced by the engine, but `is_climbable` defensively rejects it.
+    assert!(!is_climbable(&ChoiceValue::Bytes(vec![0]), &int_kind));
+}
+
+// ── step_choice ───────────────────────────────────────────────────────────
+
+#[test]
+fn step_choice_integer_adds_delta_within_range() {
+    let node = integer_node(5, 0, 100);
+    assert_eq!(step_choice(&node, 3), Some(ChoiceValue::Integer(8)));
+    assert_eq!(step_choice(&node, -5), Some(ChoiceValue::Integer(0)));
+}
+
+#[test]
+fn step_choice_integer_returns_none_when_out_of_range() {
+    let node = integer_node(5, 0, 10);
+    assert_eq!(step_choice(&node, 100), None); // 5 + 100 > 10
+    assert_eq!(step_choice(&node, -10), None); // 5 - 10 < 0
+}
+
+#[test]
+fn step_choice_float_adds_delta_as_f64() {
+    let node = float_node(1.5);
+    match step_choice(&node, 2) {
+        Some(ChoiceValue::Float(f)) => assert!((f - 3.5).abs() < f64::EPSILON),
+        other => panic!("expected Float(3.5), got {other:?}"),
+    }
+}
+
+#[test]
+fn step_choice_boolean_only_steps_by_one() {
+    use crate::native::core::choices::BooleanChoice;
+    let node = ChoiceNode {
+        kind: ChoiceKind::Boolean(BooleanChoice),
+        value: ChoiceValue::Boolean(false),
+        was_forced: false,
+    };
+    assert_eq!(step_choice(&node, 1), Some(ChoiceValue::Boolean(true)));
+    assert_eq!(step_choice(&node, -1), Some(ChoiceValue::Boolean(false)));
+    assert_eq!(step_choice(&node, 0), Some(ChoiceValue::Boolean(false)));
+    // |delta| > 1 rejected.
+    assert_eq!(step_choice(&node, 2), None);
+    assert_eq!(step_choice(&node, -3), None);
+}
+
+#[test]
+fn step_choice_bytes_adds_big_endian_and_pads() {
+    let node = bytes_node(vec![0x00, 0x01], 0, 8);
+    // Step by 1 → 0x0002, padded to length 2.
+    assert_eq!(
+        step_choice(&node, 1),
+        Some(ChoiceValue::Bytes(vec![0x00, 0x02]))
+    );
+    // Step by 256 → 0x0101.
+    assert_eq!(
+        step_choice(&node, 256),
+        Some(ChoiceValue::Bytes(vec![0x01, 0x01]))
+    );
+}
+
+#[test]
+fn step_choice_bytes_returns_none_on_negative_result() {
+    let node = bytes_node(vec![0x01], 0, 8);
+    assert_eq!(step_choice(&node, -10), None);
+}
+
+#[test]
+fn step_choice_bytes_handles_zero_after_step() {
+    let node = bytes_node(vec![0x01], 0, 8);
+    assert_eq!(step_choice(&node, -1), Some(ChoiceValue::Bytes(vec![0x00])));
+}
+
+#[test]
+fn step_choice_bytes_returns_none_when_overflows_max_size() {
+    // BytesChoice with max_size=1, value=0xFF. Stepping by 1 produces a
+    // big-endian 0x0100, which needs 2 bytes — beyond max_size — so the
+    // post-step `kind.validate` rejects.
+    let node = bytes_node(vec![0xFF], 0, 1);
+    assert_eq!(step_choice(&node, 1), None);
+}
+
+#[test]
+fn step_choice_rejects_mismatched_value_and_kind() {
+    use crate::native::core::choices::BooleanChoice;
+    let node = ChoiceNode {
+        kind: ChoiceKind::Boolean(BooleanChoice),
+        value: ChoiceValue::Integer(0),
+        was_forced: false,
+    };
+    assert_eq!(step_choice(&node, 1), None);
+}
+
+// ── hill_climb integration paths (resize-restart, lateral-grow, etc.) ──
+//
+// These tests drive `optimise_targets` directly with a controlled
+// `EngineCtx` so each interior branch of `hill_climb` and `try_replace`
+// gets a deterministic path through it. The end-to-end integration
+// tests in `tests/test_targeting.rs` cover the *behaviour* (targeting
+// finds optima, doesn't exceed budget, etc.) but they sample randomly
+// against the RNG and don't reliably exercise every defensive branch.
+
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
+
+use crate::TestCase;
+use crate::generators::{self as gs};
+use crate::native::test_runner::EngineCtx;
+use crate::run_lifecycle::run_test_case;
+use crate::runner::{Mode, Verbosity};
+use std::collections::HashMap as StdHashMap;
+
+fn run_optimise<F>(start: Vec<ChoiceValue>, start_score: f64, mut test_fn: F)
+where
+    F: FnMut(TestCase),
+{
+    let mut run_case = move |ds: Box<dyn crate::backend::DataSource>, is_final: bool| {
+        run_test_case(ds, &mut test_fn, is_final, Mode::TestRun, Verbosity::Normal);
+    };
+    let mut ctx = EngineCtx::new(&mut run_case);
+
+    let mut targeting = TargetingState::new();
+    targeting.record(&start, &StdHashMap::from([("".to_string(), start_score)]));
+
+    let mut interesting = StdHashMap::new();
+    let mut calls = 0u64;
+    let mut valid = 0u64;
+    let mut rng = SmallRng::seed_from_u64(0xc0ffee);
+    let mut on_run = |_: &RunResult| {};
+    let mut opt_ctx = OptimiseCtx {
+        engine: &mut ctx,
+        interesting: &mut interesting,
+        calls: &mut calls,
+        valid_test_cases: &mut valid,
+        max_valid: 10_000,
+        max_calls: 100_000,
+        rng: &mut rng,
+        on_run: &mut on_run,
+    };
+    optimise_targets(&mut targeting, &mut opt_ctx);
+}
+
+/// Drives `hill_climb`'s resize-restart branch and the already-examined
+/// skip that follows it: an integer at a non-trailing position controls a
+/// downstream loop, so a successful `find_integer` step grows the choice
+/// count, the next outer iteration sees `current_nodes.len() != prev_len`
+/// and resets `i`, and walking back down hits indices that are still in
+/// `nodes_examined` from before the resize.
+#[test]
+fn hill_climb_resize_restart_and_already_examined_skip() {
+    // Start: [bool, int=2, int=2, bool, bool] (score = m + n = 4).
+    // The trailing int at idx=2 (a downstream `n`) can be climbed up,
+    // and each successful step pulls extra booleans from the random
+    // fallback so `current_nodes.len()` grows mid-walk.
+    let start = vec![
+        ChoiceValue::Boolean(false),
+        ChoiceValue::Integer(2),
+        ChoiceValue::Integer(2),
+        ChoiceValue::Boolean(false),
+        ChoiceValue::Boolean(false),
+    ];
+    run_optimise(start, 4.0, |tc| {
+        let _seed: bool = tc.draw(gs::booleans());
+        let m: i64 = tc.draw(gs::integers::<i64>().min_value(0).max_value(20));
+        let n: i64 = tc.draw(gs::integers::<i64>().min_value(0).max_value(20));
+        for _ in 0..n {
+            let _ = tc.draw(gs::booleans());
+        }
+        tc.target((m + n) as f64);
+    });
+}
+
+/// Drives `try_replace`'s `!strict && grew` rejection: a non-trailing
+/// boolean controls a downstream loop, and `tc.target(1.0)` returns a
+/// constant score so any flip is a lateral move. Flipping `false → true`
+/// adds three integer draws to the body, which `try_replace` rejects as
+/// a length-growing lateral move.
+#[test]
+fn hill_climb_rejects_lateral_grow() {
+    let start = vec![ChoiceValue::Boolean(false), ChoiceValue::Boolean(false)];
+    run_optimise(start, 1.0, |tc| {
+        let _seed: bool = tc.draw(gs::booleans());
+        let big: bool = tc.draw(gs::booleans());
+        if big {
+            for _ in 0..3 {
+                let _ = tc.draw(gs::integers::<i64>().min_value(0).max_value(10));
+            }
+        }
+        tc.target(1.0);
+    });
+}
+
+/// Drives `try_replace`'s `trial.status < Status::Valid` rejection: an
+/// `assume()` rules out a specific integer value, so any `find_integer`
+/// probe that lands on it comes back with `Status::Invalid` and gets
+/// short-circuited.
+#[test]
+fn hill_climb_rejects_invalid_trial_status() {
+    let start = vec![ChoiceValue::Integer(6)];
+    run_optimise(start, -1.0, |tc| {
+        let n: i64 = tc.draw(gs::integers::<i64>().min_value(0).max_value(20));
+        tc.assume(n != 7);
+        // Peak score at n=7, but n=7 is filtered; the climber walks
+        // toward 7, lands on 7 via `find_integer`'s linear probe, and
+        // hits the assume() — `trial.status == Invalid`, rejected.
+        tc.target(-((n - 7).saturating_abs() as f64));
+    });
+}
+
+/// Drives `hill_climb`'s `trial.status < Status::Valid` early-return when
+/// the *initial* replay of `start_choices` itself comes back non-Valid.
+/// For deterministic tests this is unreachable (a recorded Valid run
+/// replays Valid), but with a hand-constructed `TargetingState` whose
+/// "best" the test body rejects via `assume()` we can drive this branch
+/// explicitly.
+#[test]
+fn hill_climb_returns_zero_when_initial_replay_invalid() {
+    let start = vec![ChoiceValue::Integer(7)];
+    run_optimise(start, 0.0, |tc| {
+        let n: i64 = tc.draw(gs::integers::<i64>().min_value(0).max_value(20));
+        tc.assume(n != 7);
+        tc.target(n as f64);
+    });
+}
+
+/// Drives `run_trial`'s `Status::Interesting` branch — the bug-found
+/// path where targeting promotes a perturbation into the
+/// `interesting` map for the surrounding shrinker to pick up. Starting
+/// from `n = 6` (score `-1`), `find_integer` probes `n = 7` in the +1
+/// direction; the test body's `assert_ne!(n, 7)` panics there, so the
+/// trial comes back `Status::Interesting`.
+#[test]
+fn run_trial_records_interesting_result_into_ctx() {
+    let start = vec![ChoiceValue::Integer(6)];
+    run_optimise(start, -1.0, |tc| {
+        let n: i64 = tc.draw(gs::integers::<i64>().min_value(0).max_value(20));
+        assert_ne!(n, 7);
+        tc.target(-((n - 7).saturating_abs() as f64));
+    });
+}

--- a/tests/test_targeting.rs
+++ b/tests/test_targeting.rs
@@ -1,9 +1,5 @@
 //! Tests for `tc.target()`, the public targeted property-based testing API.
 
-// The native backend does not yet implement targeting (`tc.target()` raises
-// `todo!()`), so every test in this file is gated on the server backend.
-#![cfg(not(feature = "native"))]
-
 mod common;
 
 use common::utils::expect_panic;
@@ -216,4 +212,98 @@ fn test_target_rewrite_compiles_in_hegel_test(tc: hegel::TestCase) {
     tc.target(n as f64);
     tc.target((n * 2) as f64);
     tc.target_labelled(n as f64, "explicit");
+}
+
+/// Targeting on a non-trailing draw whose value changes the number of
+/// downstream draws drives the hill-climber through the resize-restart
+/// branch of `hill_climb`. When `find_integer` flips `big` from false to
+/// true, the body draws five extra integers, and the next outer-loop
+/// iteration sees `current_nodes.len() != prev_len` and resets `i` to the
+/// new tail. The walk then re-encounters indices that were in the
+/// pre-resize `nodes_examined` set, exercising the already-examined skip.
+/// Targeting on a non-monotone score (peak at `n=10`) with `n` controlling
+/// a downstream loop drives the hill-climber through a sequence whose
+/// length changes mid-walk. From a random best near (but not at) the peak,
+/// `find_integer` steps `n` toward 10, shrinking or growing the realised
+/// choice sequence each commit, which trips the resize-restart at the
+/// next outer-loop iteration (and the already-examined skip, since
+/// `nodes_examined` from the pre-resize pass stays populated).
+#[test]
+fn test_targeting_walks_through_choice_count_change() {
+    // Score depends on both `n` and the downstream booleans: each `true`
+    // boolean contributes +1. Random sampling rarely produces "all
+    // booleans true", so hill_climb actually makes progress flipping
+    // them, then eventually reaches the integer at the head of the
+    // sequence — where `find_integer` grows `n`, the trial pulls extra
+    // booleans from the random fallback (some `true`, raising the
+    // score), and `current_nodes.len()` changes mid-walk. The next
+    // outer iteration trips the resize-restart, and the
+    // `nodes_examined` set from the pre-resize pass forces the
+    // already-examined skip on the way back down.
+    Hegel::new(|tc| {
+        let _filler1: bool = tc.draw(gs::booleans());
+        let _filler2: bool = tc.draw(gs::booleans());
+        let n: i64 = tc.draw(gs::integers::<i64>().min_value(0).max_value(20));
+        let mut sum: i64 = 0;
+        for _ in 0..n {
+            if tc.draw(gs::booleans()) {
+                sum += 1;
+            }
+        }
+        tc.target(sum as f64);
+    })
+    .settings(
+        Settings::new()
+            .test_cases(500)
+            .database(None)
+            .derandomize(true),
+    )
+    .run();
+}
+
+/// Constant score means every perturbation is a lateral move. A non-trailing
+/// boolean whose flip adds five downstream draws is the canonical
+/// lateral-grow case — `try_replace`'s `!strict && grew` guard rejects it.
+/// A perturbation that drives the climbed integer onto an `assume()`-
+/// excluded value comes back from the runner with `Status::Invalid`;
+/// `try_replace` rejects it via its `trial.status < Status::Valid`
+/// guard rather than spuriously recording it as a step.
+#[test]
+fn test_targeting_rejects_perturbation_that_fails_assume() {
+    Hegel::new(|tc| {
+        let n: i64 = tc.draw(gs::integers::<i64>().min_value(0).max_value(20));
+        tc.assume(n != 7);
+        // Peak at n=7, but n=7 is filtered out, so the best Valid sample
+        // is n=6 or n=8 (score = -1). Hill-climb walks toward n=7,
+        // hits the assume(), and `try_replace` rejects the Invalid trial.
+        tc.target(-((n - 7).saturating_abs() as f64));
+    })
+    .settings(
+        Settings::new()
+            .test_cases(500)
+            .database(None)
+            .derandomize(true),
+    )
+    .run();
+}
+
+#[test]
+fn test_targeting_rejects_growing_lateral_move() {
+    Hegel::new(|tc| {
+        let _filler: bool = tc.draw(gs::booleans());
+        let big: bool = tc.draw(gs::booleans());
+        if big {
+            for _ in 0..5 {
+                let _ = tc.draw(gs::booleans());
+            }
+        }
+        tc.target(1.0);
+    })
+    .settings(
+        Settings::new()
+            .test_cases(500)
+            .database(None)
+            .derandomize(true),
+    )
+    .run();
 }


### PR DESCRIPTION
Makes TestCase::target actually do something on native.

This probably doesn't matter to anyone but it's part of getting the port complete so 🤷‍♂️ 

Also raises the TooSlow health check to 30s (the Hypothesis deadline=None version) rather than 1s (the default Hypothesis deadline version) as we don't do deadlines in Hegel.

> Extracted from \`DRMacIver/native\` by Claude as part of the incremental landing of the native backend. The branch is treated as an artefact of study — this PR is a hand-reviewed subset, not a direct cherry-pick.

<details>
<summary>Extraction notes</summary>

**Brought over (adapted, not cherry-picked):**
- \`src/native/targeting.rs\` — \`TargetingState\`, \`TargetingSchedule\`, \`OptimiseCtx\`, \`optimise_targets\`, \`hill_climb\`, \`find_integer\`, \`try_replace\`, \`run_trial\`, and the climbable-kind helpers (\`is_climbable\`, \`step_choice\`).
- \`tests/embedded/native/targeting_tests.rs\` — fresh unit tests for the new module's surface (\`TargetingState\` recording semantics, \`TargetingSchedule\` thresholds, \`is_climbable\`, \`step_choice\` per kind).

**Dropped from the source branch:**
- \`src/native/optimiser.rs\` from \`DRMacIver/native\` — its module header explicitly disclaims doing the production-runner integration (\"minimal, standalone implementation… target-observation hooks are not required for plain test runs\"). Exactly the §1 (silent option-ignoring) pattern the bullshit-detection skill names. The real integration is in \`targeting.rs\` + \`test_runner.rs\`.
- The standalone \`NativeConjectureRunner\` and \`NativeRunner\` trait — main's \`EngineCtx\` already provides the runner abstraction. The targeting code takes \`&mut EngineCtx<'_>\` directly via a small \`OptimiseCtx\` shim.

**Engine integration:**
- \`NativeDataSource::target_observation\` validates score (finite required, NaN/Infinity panic) and uniqueness (each label observed at most once per test case), matching \`ServerDataSource\` and \`hypothesis.control.target\`.
- \`NativeTestCaseInner\` gained a \`target_observations\` map; \`NativeDataSource::take_target_observations\` drains it for the engine.
- \`RunResult\` gained a \`target_observations\` field, populated by \`EngineCtx::execute\`.
- \`run_main\` records observations from every Valid run into a \`TargetingState\` and fires \`optimise_targets\` at scheduled points (when \`Phase::Target\` is enabled and no bug has been found yet).

**Tests:**
- \`tests/test_targeting.rs\` ungated: 13 / 13 pass under \`--features native\`.
- New unit tests in \`tests/embedded/native/targeting_tests.rs\` cover the new module's surface.
- \`tests/embedded/native/data_source_tests.rs\` had its \`target_observation_raises_todo\` test replaced with five real-behaviour tests (records / drains / rejects-NaN / rejects-Infinity / rejects-duplicate-label).

**Reviewed against the \`detecting-port-bullshit\` skill catalogue.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>