### PR TITLE
Native: always record an enclosing span around schema dispatch

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-This release improves an internal invariant: the native backend (`--features native`) now records an enclosing span around every schema it interprets, so the shrinker can see compound draws as logical units.
+This release makes some minor internal changes to the native feature. It should have no user-visible impact.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This release improves an internal invariant: the native backend (`--features native`) now records an enclosing span around every schema it interprets, so the shrinker can see compound draws as logical units.

--- a/src/native/core/state.rs
+++ b/src/native/core/state.rs
@@ -865,30 +865,6 @@ impl NativeTestCase {
         }
     }
 
-    /// Record a finished span covering choice nodes `[start, end)` with the
-    /// given label.  The span is assigned a parent (the innermost
-    /// currently-open span, if any) and a depth (one greater than that
-    /// parent's depth, or 0 if there is no enclosing span).
-    ///
-    /// Used by leaf-schema interpretation in `schema/mod.rs` and by
-    /// `feature_flag` draws.  Higher-level callers should prefer
-    /// [`Self::start_span`] / [`Self::stop_span`], which preserve span-tree
-    /// structure for nested draws.
-    pub fn record_span(&mut self, start: usize, end: usize, label: String) {
-        if end > start {
-            let parent = self.span_stack.last().copied();
-            let depth = self.span_stack.len() as u32;
-            self.spans.push(Span {
-                start,
-                end,
-                label,
-                depth,
-                parent,
-                discarded: false,
-            });
-        }
-    }
-
     /// Open a new span at the current choice position, labelled with `label`.
     ///
     /// Returns the index assigned to the span in `self.spans`.  The span's

--- a/src/native/schema/mod.rs
+++ b/src/native/schema/mod.rs
@@ -19,16 +19,18 @@ mod numeric;
 mod text;
 
 use crate::cbor_utils::map_get;
-use crate::native::core::{ManyState, NativeTestCase, Status, StopTest};
+use crate::native::core::state::MAX_DEPTH;
+use crate::native::core::{ManyState, NativeTestCase, Span, Status, StopTest};
 use ciborium::Value;
 
 /// Interpret a CBOR schema and produce a value using the native test case.
 ///
-/// For leaf schemas (those that don't call `interpret_schema` recursively),
-/// records a span in `ntc.spans` so that span-mutation exploration can find
-/// structurally-duplicate values (e.g. two equal strings in a tuple).
-/// Compound schemas get their spans from the user-level `start_span` /
-/// `stop_span` commands that higher-level generators emit.
+/// Records an enclosing span around the dispatch so the shrinker sees every
+/// schema's result — leaf or compound — as a logical unit. The span's label
+/// is the schema-type string, and nested `interpret_schema` calls correctly
+/// attribute their parent through `ntc.span_stack`. Mirrors Hypothesis's
+/// `ConjectureData.draw`, which wraps every strategy draw in a matched
+/// `start_span` / `stop_span` pair.
 pub(crate) fn interpret_schema(
     ntc: &mut NativeTestCase,
     schema: &Value,
@@ -38,12 +40,28 @@ pub(crate) fn interpret_schema(
         .and_then(as_text)
         .expect("Schema must have a \"type\" field");
 
-    // Record spans for leaf schemas (no recursive interpret_schema calls).
-    let is_leaf = matches!(
-        schema_type,
-        "integer" | "boolean" | "float" | "binary" | "string" | "sampled_from"
-    );
-    let span_start = if is_leaf { ntc.nodes.len() } else { 0 };
+    // Open a dispatch span. We push a Span directly rather than calling
+    // `start_span` because `start_span` takes a u64 label, and schema
+    // types are naturally strings. The structural-coverage stack stays
+    // untouched — coverage tags are a property of the u64 label space
+    // that user-level `start_span` uses.
+    let span_idx = ntc.spans.len();
+    let span_start = ntc.nodes.len();
+    let depth = ntc.span_stack.len() as u32;
+    let parent = ntc.span_stack.last().copied();
+    ntc.spans.push(Span {
+        start: span_start,
+        end: span_start,
+        label: schema_type.to_string(),
+        depth,
+        parent,
+        discarded: false,
+    });
+    ntc.span_stack.push(span_idx);
+    if depth + 1 > MAX_DEPTH && ntc.status.is_none() {
+        ntc.status = Some(Status::Invalid);
+        ntc.freeze();
+    }
 
     // Native backs integer + boolean + float + binary + string leaves, plus the
     // compound schemas (tuple/list/dict/one_of/sampled_from) that recurse
@@ -70,8 +88,10 @@ pub(crate) fn interpret_schema(
 
         other => panic!("Unknown schema type: {}", other),
     };
-    if is_leaf && result.is_ok() {
-        ntc.record_span(span_start, ntc.nodes.len(), schema_type.to_string());
+
+    ntc.span_stack.pop();
+    if let Some(span) = ntc.spans.get_mut(span_idx) {
+        span.end = ntc.nodes.len();
     }
     result
 }

--- a/tests/embedded/native/schema/mod_tests.rs
+++ b/tests/embedded/native/schema/mod_tests.rs
@@ -20,6 +20,154 @@ fn interpret_schema_unknown_type_panics() {
     let _ = interpret_schema(&mut ntc, &schema);
 }
 
+// ── Every schema dispatch records an enclosing span ─────────────────────────
+//
+// Without an enclosing span, the basic-generator path (which goes from the
+// generator API straight through `interpret_schema` without any user-level
+// `start_span`/`stop_span` calls) leaves the shrinker with no way to recognise
+// a compound draw as a logical unit.
+
+#[test]
+fn interpret_schema_records_leaf_span_for_integer() {
+    let mut ntc = fresh_ntc();
+    let schema = cbor_map! {
+        "type" => "integer",
+        "min_value" => 0,
+        "max_value" => 0,
+    };
+    interpret_schema(&mut ntc, &schema).ok().unwrap();
+
+    assert_eq!(ntc.spans.len(), 1);
+    assert_eq!(ntc.spans[0usize].label, "integer");
+    assert_eq!(ntc.spans[0usize].start, 0);
+    assert_eq!(ntc.spans[0usize].end, 1);
+    assert_eq!(ntc.spans[0usize].parent, None);
+    assert_eq!(ntc.spans[0usize].depth, 0);
+}
+
+#[test]
+fn interpret_schema_records_enclosing_span_for_tuple() {
+    let mut ntc = fresh_ntc();
+    let schema = cbor_map! {
+        "type" => "tuple",
+        "elements" => vec![
+            cbor_map! { "type" => "integer", "min_value" => 0, "max_value" => 0 },
+            cbor_map! { "type" => "integer", "min_value" => 7, "max_value" => 7 },
+        ],
+    };
+    interpret_schema(&mut ntc, &schema).ok().unwrap();
+
+    // Three spans: the outer tuple plus the two integer children.
+    assert_eq!(ntc.spans.len(), 3);
+
+    // The outer tuple was pushed first (so it has the lowest index) and
+    // covers all the child nodes.
+    assert_eq!(ntc.spans[0usize].label, "tuple");
+    assert_eq!(ntc.spans[0usize].start, 0);
+    assert_eq!(ntc.spans[0usize].end, 2);
+    assert_eq!(ntc.spans[0usize].parent, None);
+    assert_eq!(ntc.spans[0usize].depth, 0);
+
+    // The integer children point at the tuple as their parent.
+    for child in ntc.spans.iter().skip(1) {
+        assert_eq!(child.label, "integer");
+        assert_eq!(child.parent, Some(0));
+        assert_eq!(child.depth, 1);
+    }
+}
+
+#[test]
+fn interpret_schema_records_enclosing_span_for_list() {
+    let mut ntc = fresh_ntc();
+    let schema = cbor_map! {
+        "type" => "list",
+        "elements" => cbor_map! { "type" => "boolean" },
+        "min_size" => 0,
+        "max_size" => 5,
+    };
+    interpret_schema(&mut ntc, &schema).ok().unwrap();
+
+    // The outer list span exists at index 0, regardless of how many
+    // elements were drawn.
+    assert_eq!(ntc.spans[0usize].label, "list");
+    assert_eq!(ntc.spans[0usize].parent, None);
+    assert_eq!(ntc.spans[0usize].depth, 0);
+    for child in ntc.spans.iter().skip(1) {
+        assert_eq!(child.parent, Some(0));
+        assert_eq!(child.depth, 1);
+    }
+}
+
+#[test]
+fn interpret_schema_records_enclosing_span_for_one_of() {
+    let mut ntc = fresh_ntc();
+    let schema = cbor_map! {
+        "type" => "one_of",
+        "generators" => vec![
+            cbor_map! { "type" => "integer", "min_value" => 10, "max_value" => 10 },
+            cbor_map! { "type" => "integer", "min_value" => 20, "max_value" => 20 },
+        ],
+    };
+    interpret_schema(&mut ntc, &schema).ok().unwrap();
+
+    assert_eq!(ntc.spans[0usize].label, "one_of");
+    assert_eq!(ntc.spans[0usize].parent, None);
+    assert_eq!(ntc.spans[0usize].depth, 0);
+}
+
+#[test]
+fn interpret_schema_nests_spans_for_tuple_of_tuples() {
+    let mut ntc = fresh_ntc();
+    let inner_tuple = cbor_map! {
+        "type" => "tuple",
+        "elements" => vec![
+            cbor_map! { "type" => "integer", "min_value" => 0, "max_value" => 0 },
+        ],
+    };
+    let schema = cbor_map! {
+        "type" => "tuple",
+        "elements" => vec![inner_tuple.clone(), inner_tuple],
+    };
+    interpret_schema(&mut ntc, &schema).ok().unwrap();
+
+    // Outer tuple at index 0, depth 0; the two inner tuples have
+    // parent = 0, depth = 1; the integer leaves have depth 2.
+    assert_eq!(ntc.spans[0usize].label, "tuple");
+    assert_eq!(ntc.spans[0usize].depth, 0);
+
+    let inner_tuple_indices: Vec<usize> = ntc
+        .spans
+        .iter()
+        .enumerate()
+        .filter_map(|(i, s)| (s.label == "tuple" && i != 0).then_some(i))
+        .collect();
+    assert_eq!(inner_tuple_indices.len(), 2);
+    for &i in &inner_tuple_indices {
+        assert_eq!(ntc.spans[i].parent, Some(0));
+        assert_eq!(ntc.spans[i].depth, 1);
+    }
+    for span in ntc.spans.iter().filter(|s| s.label == "integer") {
+        assert_eq!(span.depth, 2);
+        // The parent must be one of the inner tuples.
+        assert!(inner_tuple_indices.contains(&span.parent.unwrap()));
+    }
+}
+
+#[test]
+fn interpret_schema_records_zero_node_span_for_null() {
+    // `null` consumes no choice nodes but still represents a logical draw.
+    // Recording an empty span keeps parity with start_span/stop_span, which
+    // also retain empty spans (see test_has_examples_even_when_empty on the
+    // Hypothesis side).
+    let mut ntc = fresh_ntc();
+    let schema = cbor_map! { "type" => "null" };
+    interpret_schema(&mut ntc, &schema).ok().unwrap();
+
+    assert_eq!(ntc.spans.len(), 1);
+    assert_eq!(ntc.spans[0usize].label, "null");
+    assert_eq!(ntc.spans[0usize].start, ntc.spans[0usize].end);
+}
+
 // ── many_reject: invalid when too many rejections under min_size ────────────
 
 #[test]


### PR DESCRIPTION
The native port had this weird `is_leaf` optimisation that mostly made things strictly worse. This removes that and always puts a span around schema dispatch.