### PR TITLE
Native: date / time / datetime / uuid / ip_address schemas

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+The native backend (`--features native`) now supports `gs::dates()`, `gs::times()`, `gs::datetimes()`, `gs::ip_addresses()`, and `gs::uuids()`.

--- a/src/native/core/state.rs
+++ b/src/native/core/state.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::sync::{LazyLock, Mutex};
 
-use rand::RngExt;
+use rand::{RngExt, SeedableRng};
 use rand::rngs::SmallRng;
 
 use super::choices::{
@@ -820,27 +820,15 @@ impl NativeTestCase {
     /// across four independent draws) need an RNG that happens to land on
     /// all-zeros, which becomes vanishingly unlikely as the number of
     /// components grows.
+    ///
+    /// The seed value is unused (every draw short-circuits to simplest
+    /// before reaching the RNG fallback in `resolve_choice`), but
+    /// `new_random` requires one, so we hand it a fixed seed for
+    /// reproducibility's sake.
     pub fn for_simplest() -> Self {
-        NativeTestCase {
-            prefix: Vec::new(),
-            prefix_nodes: None,
-            rng: None,
-            max_size: BUFFER_SIZE,
-            nodes: Vec::new(),
-            status: None,
-            frozen: false,
-            collections: HashMap::new(),
-            next_collection_id: 0,
-            variable_pools: Vec::new(),
-            spans: Spans::new(),
-            span_stack: Vec::new(),
-            has_discards: false,
-            tags: HashSet::new(),
-            labels_for_structure_stack: Vec::new(),
-            observer: None,
-            interesting_origin: None,
-            force_simplest: true,
-        }
+        let mut tc = Self::new_random(SmallRng::seed_from_u64(0));
+        tc.force_simplest = true;
+        tc
     }
 
     /// Construct a `NativeTestCase` that replays `choices` in order,

--- a/src/native/core/state.rs
+++ b/src/native/core/state.rs
@@ -4,8 +4,8 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::sync::{LazyLock, Mutex};
 
-use rand::{RngExt, SeedableRng};
 use rand::rngs::SmallRng;
+use rand::{RngExt, SeedableRng};
 
 use super::choices::{
     BooleanChoice, BytesChoice, ChoiceKind, ChoiceNode, ChoiceValue, FloatChoice, IntegerChoice,

--- a/src/native/core/state.rs
+++ b/src/native/core/state.rs
@@ -780,6 +780,11 @@ pub struct NativeTestCase {
     /// `None` for test cases concluded by [`Self::freeze`] directly
     /// (`Status::Valid`).  Mirrors `ConjectureData.interesting_origin`.
     interesting_origin: Option<InterestingOrigin>,
+    /// When `true`, every draw bypasses the prefix/RNG paths and returns
+    /// `kind.simplest()`. Used by [`Self::for_simplest`] to mirror
+    /// Hypothesis's `ChoiceTemplate("simplest", count=None)` pre-Generate
+    /// test case (engine.py::generate_new_examples).
+    force_simplest: bool,
 }
 
 impl NativeTestCase {
@@ -802,6 +807,39 @@ impl NativeTestCase {
             labels_for_structure_stack: Vec::new(),
             observer: None,
             interesting_origin: None,
+            force_simplest: false,
+        }
+    }
+
+    /// A test case where every draw returns `kind.simplest()`. Used by the
+    /// Generate phase to run a single deterministic "all simplest" trial
+    /// before random sampling, mirroring Hypothesis's
+    /// `cached_test_function((ChoiceTemplate("simplest", count=None),))`
+    /// call in `engine.py::generate_new_examples`. Without it, find-any
+    /// tests over multi-component generators (e.g. midnight = h=m=s=0
+    /// across four independent draws) need an RNG that happens to land on
+    /// all-zeros, which becomes vanishingly unlikely as the number of
+    /// components grows.
+    pub fn for_simplest() -> Self {
+        NativeTestCase {
+            prefix: Vec::new(),
+            prefix_nodes: None,
+            rng: None,
+            max_size: BUFFER_SIZE,
+            nodes: Vec::new(),
+            status: None,
+            frozen: false,
+            collections: HashMap::new(),
+            next_collection_id: 0,
+            variable_pools: Vec::new(),
+            spans: Spans::new(),
+            span_stack: Vec::new(),
+            has_discards: false,
+            tags: HashSet::new(),
+            labels_for_structure_stack: Vec::new(),
+            observer: None,
+            interesting_origin: None,
+            force_simplest: true,
         }
     }
 
@@ -833,6 +871,7 @@ impl NativeTestCase {
             labels_for_structure_stack: Vec::new(),
             observer,
             interesting_origin: None,
+            force_simplest: false,
         }
     }
 
@@ -862,6 +901,7 @@ impl NativeTestCase {
             labels_for_structure_stack: Vec::new(),
             observer: None,
             interesting_origin: None,
+            force_simplest: false,
         }
     }
 
@@ -1193,6 +1233,10 @@ impl NativeTestCase {
         random: impl FnOnce(&mut SmallRng) -> ChoiceValue,
     ) -> Result<(ChoiceValue, bool), StopTest> {
         self.pre_choice()?;
+
+        if self.force_simplest {
+            return Ok((simplest(), false));
+        }
 
         let idx = self.nodes.len();
 

--- a/src/native/schema/mod.rs
+++ b/src/native/schema/mod.rs
@@ -10,12 +10,13 @@
 //   text        — interpret_string, StringAlphabet helpers
 //   regex       — interpret_regex, generate_hir_string
 //   collections — interpret_list, interpret_dict, interpret_tuple, interpret_one_of, interpret_sampled_from
-//   special     — date, time, datetime, ipv4, ipv6, domain, email, url
+//   special     — date, time, datetime, ip_address, uuid
 
 mod bytes;
 mod collections;
 mod float;
 mod numeric;
+mod special;
 mod text;
 
 use crate::cbor_utils::map_get;
@@ -63,10 +64,10 @@ pub(crate) fn interpret_schema(
         ntc.freeze();
     }
 
-    // Native backs integer + boolean + float + binary + string leaves, plus the
-    // compound schemas (tuple/list/dict/one_of/sampled_from) that recurse
-    // into them. Schemas backed by regex/datetime/etc. leaves panic with
-    // todo!() until those schema interpreters land in a follow-up PR.
+    // The remaining `todo!()` arm covers schemas still unported: regex (which
+    // needs the HIR walker) and the three internet-flavoured schemas
+    // (domain / email / url, which share the IANA TLD list and
+    // percent-encoding machinery).
     let result = match schema_type {
         "integer" => numeric::interpret_integer(ntc, schema),
         "boolean" => numeric::interpret_boolean(ntc),
@@ -80,9 +81,13 @@ pub(crate) fn interpret_schema(
         "sampled_from" => collections::interpret_sampled_from(ntc, schema),
         "list" => collections::interpret_list(ntc, schema),
         "dict" => collections::interpret_dict(ntc, schema),
+        "date" => special::interpret_date(ntc),
+        "time" => special::interpret_time(ntc),
+        "datetime" => special::interpret_datetime(ntc),
+        "ip_address" => special::interpret_ip_address(ntc, schema),
+        "uuid" => special::interpret_uuid(ntc, schema),
 
-        "regex" | "email" | "url" | "domain" | "ip_address" | "uuid" | "ipv4" | "ipv6" | "date"
-        | "time" | "datetime" => {
+        "regex" | "email" | "url" | "domain" => {
             todo!("schema {:?} not yet supported in native mode", schema_type)
         }
 

--- a/src/native/schema/special.rs
+++ b/src/native/schema/special.rs
@@ -1,0 +1,347 @@
+// Interpreters for special string schemas: date, time, datetime, ip_address,
+// uuid. All produce ciborium::Value strings matching the output of
+// Hypothesis's `st.dates() / st.times() / st.datetimes() / st.ip_addresses() /
+// st.uuids()` strategies (with `.isoformat()` / `str(...)` mapping applied
+// server-side, per `hegel.schema._from_schema`).
+
+use std::net::{Ipv4Addr, Ipv6Addr};
+use std::sync::LazyLock;
+
+use crate::cbor_utils::map_get;
+use crate::native::core::{NativeTestCase, StopTest};
+use ciborium::Value;
+
+/// Encode a `String` as a CBOR tag-91 value, the wire format used by the hegel
+/// server for strings (`HEGEL_STRING_TAG = 91` in `hegel.schema`).
+fn encode_string(s: String) -> Value {
+    Value::Tag(91, Box::new(Value::Bytes(s.into_bytes())))
+}
+
+/// Days in the given month of the Gregorian `year`. Leap years follow the
+/// usual rule: divisible by 4 unless divisible by 100 but not 400.
+fn days_in_month(year: i128, month: i128) -> i128 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 => {
+            let is_leap = year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
+            if is_leap { 29 } else { 28 }
+        }
+        _ => unreachable!("days_in_month: month {} out of range 1..=12", month),
+    }
+}
+
+/// `date` schema → `YYYY-MM-DD`, matching `st.dates().isoformat()`.
+///
+/// Hypothesis draws year ∈ [1, 9999] with shrink_towards=2000, month ∈ [1, 12],
+/// then day ∈ [1, days_in_month(year, month)]. Native lacks a parameterised
+/// `shrink_towards` on `draw_integer` (always 0), so we draw the year as an
+/// offset from 2000 to get the same shrink target. The observable
+/// distribution is identical because `biased_integer_sample` boosts the
+/// endpoints (here ±offset bounds) at the same rate either way.
+pub(super) fn interpret_date(ntc: &mut NativeTestCase) -> Result<Value, StopTest> {
+    let (year, month, day) = draw_date(ntc)?;
+    Ok(encode_string(format!("{year:04}-{month:02}-{day:02}")))
+}
+
+/// `time` schema → `HH:MM:SS` or `HH:MM:SS.ffffff`, matching
+/// `st.times().isoformat()`. The fractional part is present iff
+/// `microsecond != 0` (Python's `time.isoformat()` semantics).
+pub(super) fn interpret_time(ntc: &mut NativeTestCase) -> Result<Value, StopTest> {
+    let (hour, minute, second, microsecond) = draw_time(ntc)?;
+    Ok(encode_string(format_time(
+        hour,
+        minute,
+        second,
+        microsecond,
+    )))
+}
+
+/// `datetime` schema → `YYYY-MM-DDTHH:MM:SS[.ffffff]`, matching
+/// `st.datetimes().isoformat()`. As with `interpret_time`, the fractional
+/// seconds appear only when non-zero.
+pub(super) fn interpret_datetime(ntc: &mut NativeTestCase) -> Result<Value, StopTest> {
+    let (year, month, day) = draw_date(ntc)?;
+    let (hour, minute, second, microsecond) = draw_time(ntc)?;
+    let time_part = format_time(hour, minute, second, microsecond);
+    Ok(encode_string(format!(
+        "{year:04}-{month:02}-{day:02}T{time_part}"
+    )))
+}
+
+fn draw_date(ntc: &mut NativeTestCase) -> Result<(i128, i128, i128), StopTest> {
+    let year = 2000 + ntc.draw_integer(1 - 2000, 9999 - 2000)?;
+    let month = ntc.draw_integer(1, 12)?;
+    let day = ntc.draw_integer(1, days_in_month(year, month))?;
+    Ok((year, month, day))
+}
+
+fn draw_time(ntc: &mut NativeTestCase) -> Result<(i128, i128, i128, i128), StopTest> {
+    let hour = ntc.draw_integer(0, 23)?;
+    let minute = ntc.draw_integer(0, 59)?;
+    let second = ntc.draw_integer(0, 59)?;
+    let microsecond = ntc.draw_integer(0, 999_999)?;
+    Ok((hour, minute, second, microsecond))
+}
+
+fn format_time(hour: i128, minute: i128, second: i128, microsecond: i128) -> String {
+    if microsecond == 0 {
+        format!("{hour:02}:{minute:02}:{second:02}")
+    } else {
+        format!("{hour:02}:{minute:02}:{second:02}.{microsecond:06}")
+    }
+}
+
+/// `uuid` schema → canonical hyphenated UUID string, matching
+/// `str(st.uuids(version=...))`.
+///
+/// Hypothesis's `uuids()` strategy uses `random.getrandbits(128)` via
+/// `use_true_random=True`, so its UUIDs sit outside the choice tree and do
+/// not shrink. The native port records two 64-bit integer draws instead —
+/// the observable distribution still matches (uniform over 2^128 values when
+/// `version` is unset, with the RFC 4122 version + variant nibbles overridden
+/// when `version` is set), but native UUIDs nominally shrink toward
+/// all-zeros.
+///
+/// When `version` is unset and the draws land at all-zeros (which the
+/// Generate-phase all-simplest pre-trial hits deterministically), the result
+/// would be the nil UUID. Hypothesis can't produce nil because `getrandbits`
+/// sits outside the choice tree; here we bump the low bit so the
+/// "uuids never produce nil" property carries over. The proper fix is a
+/// non-recording RNG-direct draw API on `NativeTestCase` to mirror Hypothesis
+/// exactly — out of scope for this PR.
+pub(super) fn interpret_uuid(ntc: &mut NativeTestCase, schema: &Value) -> Result<Value, StopTest> {
+    use crate::cbor_utils::as_u64;
+    let version = map_get(schema, "version").and_then(as_u64).map(|v| v as u8);
+
+    // Two 64-bit halves: u64::MAX fits comfortably in i128 so the draw is in range.
+    let hi = ntc.draw_integer(0, u64::MAX as i128)? as u64;
+    let lo = ntc.draw_integer(0, u64::MAX as i128)? as u64;
+    let mut n: u128 = (u128::from(hi) << 64) | u128::from(lo);
+
+    if let Some(v) = version {
+        // Clear and set the RFC 4122 variant (top 2 bits of the 9th byte = bits 62..63 of a
+        // big-endian u128 = bits 48..63 within the second-from-low 16-bit group).
+        // Hypothesis's `UUID(version=v, int=n)`: `n &= ~(0xc000 << 48); n |= 0x8000 << 48`.
+        n &= !(0xc000u128 << 48);
+        n |= 0x8000u128 << 48;
+        // Clear and set the version nibble (high nibble of the 7th byte = bits 76..79).
+        // `n &= ~(0xf000 << 64); n |= version << 76`.
+        n &= !(0xf000u128 << 64);
+        n |= u128::from(v) << 76;
+    } else if n == 0 {
+        n = 1;
+    }
+
+    let bytes = n.to_be_bytes();
+    Ok(encode_string(format!(
+        "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+        bytes[0],
+        bytes[1],
+        bytes[2],
+        bytes[3],
+        bytes[4],
+        bytes[5],
+        bytes[6],
+        bytes[7],
+        bytes[8],
+        bytes[9],
+        bytes[10],
+        bytes[11],
+        bytes[12],
+        bytes[13],
+        bytes[14],
+        bytes[15],
+    )))
+}
+
+// ── IP addresses ─────────────────────────────────────────────────────────────
+//
+// Hypothesis biases toward reserved / private / loopback / documentation
+// ranges so bugs around special-address handling get exercised. Per
+// `hypothesis.strategies._internal.ipaddress`:
+//
+//     four = binary(4).map(IPv4Address) | sampled_from(SPECIAL_IPv4_RANGES).flatmap(ip_in_network)
+//     six  = binary(16).map(IPv6Address) | sampled_from(SPECIAL_IPv6_RANGES).flatmap(ip_in_network)
+//
+// `a | b` is `one_of([a, b])`, which draws an index in {0, 1} uniformly.
+// `ip_in_network` draws an integer in `[int(network[0]), int(network[-1])]`
+// uniformly.
+
+// IANA's IPv4 special-purpose registry. Sourced from
+// `hypothesis.strategies._internal.ipaddress::SPECIAL_IPv4_RANGES`.
+const SPECIAL_IPV4_CIDRS: &[&str] = &[
+    "0.0.0.0/8",
+    "10.0.0.0/8",
+    "100.64.0.0/10",
+    "127.0.0.0/8",
+    "169.254.0.0/16",
+    "172.16.0.0/12",
+    "192.0.0.0/24",
+    "192.0.0.0/29",
+    "192.0.0.8/32",
+    "192.0.0.9/32",
+    "192.0.0.10/32",
+    "192.0.0.170/32",
+    "192.0.0.171/32",
+    "192.0.2.0/24",
+    "192.31.196.0/24",
+    "192.52.193.0/24",
+    "192.88.99.0/24",
+    "192.168.0.0/16",
+    "192.175.48.0/24",
+    "198.18.0.0/15",
+    "198.51.100.0/24",
+    "203.0.113.0/24",
+    "240.0.0.0/4",
+    "255.255.255.255/32",
+];
+
+// IANA's IPv6 special-purpose registry. Sourced from
+// `hypothesis.strategies._internal.ipaddress::SPECIAL_IPv6_RANGES`.
+const SPECIAL_IPV6_CIDRS: &[&str] = &[
+    "::1/128",
+    "::/128",
+    "::ffff:0:0/96",
+    "64:ff9b::/96",
+    "64:ff9b:1::/48",
+    "100::/64",
+    "2001::/23",
+    "2001::/32",
+    "2001:1::1/128",
+    "2001:1::2/128",
+    "2001:2::/48",
+    "2001:3::/32",
+    "2001:4:112::/48",
+    "2001:10::/28",
+    "2001:20::/28",
+    "2001:db8::/32",
+    "2002::/16",
+    "2620:4f:8000::/48",
+    "fc00::/7",
+    "fe80::/10",
+];
+
+/// A CIDR network as `(base address, size - 1)`. `size - 1` is the inclusive
+/// upper bound on the host-part offset, drawn as `draw_integer(0, size_minus_1)`
+/// then added to `base`. Storing the offset bound rather than the last address
+/// avoids `as i128` reinterpret-casts on values above `i128::MAX` (e.g.
+/// `fc00::/7` whose base has the top bit set).
+struct V4Network {
+    base: u32,
+    size_minus_1: u32,
+}
+
+struct V6Network {
+    base: u128,
+    size_minus_1: u128,
+}
+
+static SPECIAL_IPV4_NETWORKS: LazyLock<Vec<V4Network>> = LazyLock::new(|| {
+    SPECIAL_IPV4_CIDRS
+        .iter()
+        .map(|s| parse_v4_cidr(s))
+        .collect()
+});
+
+static SPECIAL_IPV6_NETWORKS: LazyLock<Vec<V6Network>> = LazyLock::new(|| {
+    SPECIAL_IPV6_CIDRS
+        .iter()
+        .map(|s| parse_v6_cidr(s))
+        .collect()
+});
+
+fn parse_v4_cidr(s: &str) -> V4Network {
+    let (addr, prefix) = s.split_once('/').unwrap();
+    let addr: Ipv4Addr = addr.parse().unwrap();
+    let prefix: u32 = prefix.parse().unwrap();
+    // Every range we ship has prefix in 1..=32. /0 would shift by 32 and
+    // overflow `u32`; reject it explicitly rather than silently masking it.
+    assert!(
+        (1..=32).contains(&prefix),
+        "IPv4 prefix must be in 1..=32, got /{prefix}"
+    );
+    let mask = u32::MAX << (32 - prefix);
+    let base = u32::from(addr) & mask;
+    let size_minus_1 = !mask;
+    V4Network { base, size_minus_1 }
+}
+
+fn parse_v6_cidr(s: &str) -> V6Network {
+    let (addr, prefix) = s.split_once('/').unwrap();
+    let addr: Ipv6Addr = addr.parse().unwrap();
+    let prefix: u32 = prefix.parse().unwrap();
+    // Every range we ship has prefix in 7..=128, comfortably under
+    // i128::MAX (≤ 2^121 host bits). /0 would shift by 128 and overflow
+    // `u128`; reject it explicitly.
+    assert!(
+        (1..=128).contains(&prefix),
+        "IPv6 prefix must be in 1..=128, got /{prefix}"
+    );
+    let mask = u128::MAX << (128 - prefix);
+    let base = u128::from(addr) & mask;
+    let size_minus_1 = !mask;
+    assert!(
+        size_minus_1 <= i128::MAX as u128,
+        "IPv6 special range too wide to fit offset in i128: prefix /{prefix}"
+    );
+    V6Network { base, size_minus_1 }
+}
+
+/// `ip_address` schema → IPv4 dotted-decimal or IPv6 colon-hex string,
+/// matching `str(st.ip_addresses(v=schema["version"]))`.
+pub(super) fn interpret_ip_address(
+    ntc: &mut NativeTestCase,
+    schema: &Value,
+) -> Result<Value, StopTest> {
+    use crate::cbor_utils::as_u64;
+    let version = map_get(schema, "version")
+        .and_then(as_u64)
+        .expect("ip_address schema must have a \"version\" field");
+    match version {
+        4 => interpret_ipv4(ntc),
+        6 => interpret_ipv6(ntc),
+        _ => panic!("ip_address: unsupported version {version}; expected 4 or 6"),
+    }
+}
+
+fn interpret_ipv4(ntc: &mut NativeTestCase) -> Result<Value, StopTest> {
+    // one_of([random_bytes, sampled_from(SPECIAL).flatmap(in_network)]).
+    let addr_int: u32 = if ntc.draw_integer(0, 1)? == 0 {
+        // Four uniform bytes — `binary(min_size=4, max_size=4).map(IPv4Address)`.
+        let a = ntc.draw_integer(0, 255)? as u32;
+        let b = ntc.draw_integer(0, 255)? as u32;
+        let c = ntc.draw_integer(0, 255)? as u32;
+        let d = ntc.draw_integer(0, 255)? as u32;
+        (a << 24) | (b << 16) | (c << 8) | d
+    } else {
+        let nets = &*SPECIAL_IPV4_NETWORKS;
+        let idx = ntc.draw_integer(0, (nets.len() - 1) as i128)? as usize;
+        let net = &nets[idx];
+        // integers(int(network[0]), int(network[-1])) — drawn as
+        // base + offset so the i128 cast never sees a value above i128::MAX.
+        let offset = ntc.draw_integer(0, net.size_minus_1 as i128)? as u32;
+        net.base + offset
+    };
+    Ok(encode_string(Ipv4Addr::from(addr_int).to_string()))
+}
+
+fn interpret_ipv6(ntc: &mut NativeTestCase) -> Result<Value, StopTest> {
+    let addr_int: u128 = if ntc.draw_integer(0, 1)? == 0 {
+        // 16 uniform bytes via two 64-bit halves.
+        let hi = ntc.draw_integer(0, u64::MAX as i128)? as u64;
+        let lo = ntc.draw_integer(0, u64::MAX as i128)? as u64;
+        (u128::from(hi) << 64) | u128::from(lo)
+    } else {
+        let nets = &*SPECIAL_IPV6_NETWORKS;
+        let idx = ntc.draw_integer(0, (nets.len() - 1) as i128)? as usize;
+        let net = &nets[idx];
+        let offset = ntc.draw_integer(0, net.size_minus_1 as i128)? as u128;
+        net.base + offset
+    };
+    Ok(encode_string(Ipv6Addr::from(addr_int).to_string()))
+}
+
+#[cfg(test)]
+#[path = "../../../tests/embedded/native/schema/special_tests.rs"]
+mod tests;

--- a/src/native/test_runner.rs
+++ b/src/native/test_runner.rs
@@ -220,6 +220,37 @@ fn run_main(
     let mut first_bug_at: Option<u64> = None;
     let mut last_bug_at: Option<u64> = None;
     let shrink_enabled = settings.phases.contains(&Phase::Shrink);
+
+    // All-simplest pre-trial. Mirrors Hypothesis's `cached_test_function(
+    // (ChoiceTemplate("simplest", count=None),))` call at the head of
+    // `engine.py::generate_new_examples`. Drawing every choice at its
+    // shrink-target value gives find-any tests over multi-component
+    // generators (e.g. midnight = h=m=s=μ=0 across four draws) a
+    // deterministic chance to hit the all-zeros joint event before
+    // random sampling — the joint event grows vanishingly unlikely as
+    // the number of components increases.
+    if settings.phases.contains(&Phase::Generate)
+        && !test_is_trivial
+        && calls < max_examples * 10
+        && interesting.is_empty()
+    {
+        let run = ctx.run(NativeTestCase::for_simplest());
+        crate::native::data_tree::record_tree(&mut tree_root, &run.nodes, run.status, &[]);
+        calls += 1;
+        if run.nodes.is_empty() && run.status >= Status::Invalid {
+            test_is_trivial = true;
+        }
+        if run.status >= Status::Valid {
+            valid_test_cases += 1;
+        }
+        if run.status == Status::Interesting {
+            let origin = run.origin.clone().unwrap_or_default();
+            first_bug_at = Some(calls);
+            last_bug_at = Some(calls);
+            update_interesting(&mut interesting, origin, run.nodes.clone());
+        }
+    }
+
     while settings.phases.contains(&Phase::Generate)
         && !test_is_trivial
         && valid_test_cases < max_examples

--- a/tests/embedded/native/schema/special_tests.rs
+++ b/tests/embedded/native/schema/special_tests.rs
@@ -1,0 +1,312 @@
+// Embedded tests for src/native/schema/special.rs — drive each interpreter
+// across many seeds and assert structural invariants. The integration tests
+// in tests/test_strings.rs and tests/test_time.rs exercise the same
+// interpreters via the user-facing API, but at coarser granularity.
+
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
+
+use super::*;
+use crate::cbor_utils::cbor_map;
+use crate::native::core::NativeTestCase;
+
+fn fresh_ntc(seed: u64) -> NativeTestCase {
+    NativeTestCase::new_random(SmallRng::seed_from_u64(seed))
+}
+
+fn decode_string(v: ciborium::Value) -> String {
+    // The interpreters wrap strings in tag-91 (HEGEL_STRING_TAG). Match the
+    // `deserialize_value` path in src/test_case.rs.
+    let ciborium::Value::Tag(91, inner) = v else {
+        panic!("expected tag-91 string, got {v:?}")
+    };
+    let ciborium::Value::Bytes(bytes) = *inner else {
+        panic!("expected bytes inside tag-91")
+    };
+    String::from_utf8(bytes).unwrap()
+}
+
+/// Run an interpreter across many seeds, collecting the decoded string from
+/// each successful draw. Useful for asserting distributional properties
+/// (e.g. "at least one draw is a 127.x.x.x address").
+fn collect<F>(n: u64, mut f: F) -> Vec<String>
+where
+    F: FnMut(&mut NativeTestCase) -> Result<ciborium::Value, crate::native::core::StopTest>,
+{
+    (0..n)
+        .filter_map(|seed| {
+            let mut ntc = fresh_ntc(seed);
+            f(&mut ntc).ok().map(decode_string)
+        })
+        .collect()
+}
+
+// ── interpret_date ───────────────────────────────────────────────────────────
+
+#[test]
+fn interpret_date_produces_iso_format() {
+    for seed in 0..50 {
+        let mut ntc = fresh_ntc(seed);
+        let s = decode_string(interpret_date(&mut ntc).ok().unwrap());
+        // YYYY-MM-DD (10 chars) and parses as date components in valid ranges.
+        assert_eq!(s.len(), 10, "wrong length for {s:?}");
+        let parts: Vec<&str> = s.split('-').collect();
+        assert_eq!(parts.len(), 3, "{s:?}");
+        let year: i32 = parts[0].parse().unwrap();
+        let month: u32 = parts[1].parse().unwrap();
+        let day: u32 = parts[2].parse().unwrap();
+        assert!((1..=9999).contains(&year), "year out of range in {s:?}");
+        assert!((1..=12).contains(&month), "month out of range in {s:?}");
+        assert!((1..=31).contains(&day), "day out of range in {s:?}");
+    }
+}
+
+#[test]
+fn interpret_date_day_respects_month_length() {
+    // Feb 30 must never appear: day is drawn against days_in_month(year, month).
+    let mut seen_feb = false;
+    for seed in 0..1000 {
+        let mut ntc = fresh_ntc(seed);
+        let s = decode_string(interpret_date(&mut ntc).ok().unwrap());
+        let parts: Vec<&str> = s.split('-').collect();
+        let year: i128 = parts[0].parse().unwrap();
+        let month: i128 = parts[1].parse().unwrap();
+        let day: i128 = parts[2].parse().unwrap();
+        if month == 2 {
+            seen_feb = true;
+            let is_leap = year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
+            let max_day = if is_leap { 29 } else { 28 };
+            assert!(
+                day <= max_day,
+                "Feb day {day} exceeds {max_day} in year {year} ({s:?})"
+            );
+        }
+        if matches!(month, 4 | 6 | 9 | 11) {
+            assert!(day <= 30, "30+ day in 30-day month: {s:?}");
+        }
+    }
+    assert!(seen_feb, "no February dates drawn across 1000 seeds");
+}
+
+// ── interpret_time ───────────────────────────────────────────────────────────
+
+#[test]
+fn interpret_time_format_omits_microseconds_when_zero() {
+    // Force microsecond to 0 by running until we get one (high prob given
+    // biased_integer_sample favours boundary values).
+    let mut seen_microsecond_zero = false;
+    let mut seen_microsecond_nonzero = false;
+    for seed in 0..200 {
+        let mut ntc = fresh_ntc(seed);
+        let s = decode_string(interpret_time(&mut ntc).ok().unwrap());
+        match s.len() {
+            8 => seen_microsecond_zero = true,     // HH:MM:SS
+            15 => seen_microsecond_nonzero = true, // HH:MM:SS.ffffff
+            _ => panic!("unexpected time format: {s:?}"),
+        }
+        // Components in valid ranges.
+        let head: &str = s.split('.').next().unwrap();
+        let parts: Vec<&str> = head.split(':').collect();
+        let hour: u32 = parts[0].parse().unwrap();
+        let minute: u32 = parts[1].parse().unwrap();
+        let second: u32 = parts[2].parse().unwrap();
+        assert!(hour <= 23 && minute <= 59 && second <= 59, "{s:?}");
+    }
+    assert!(
+        seen_microsecond_zero,
+        "no zero-microsecond times across 200 seeds"
+    );
+    assert!(
+        seen_microsecond_nonzero,
+        "no nonzero-microsecond times across 200 seeds"
+    );
+}
+
+// ── interpret_datetime ───────────────────────────────────────────────────────
+
+#[test]
+fn interpret_datetime_format_has_t_separator() {
+    for seed in 0..50 {
+        let mut ntc = fresh_ntc(seed);
+        let s = decode_string(interpret_datetime(&mut ntc).ok().unwrap());
+        let parts: Vec<&str> = s.splitn(2, 'T').collect();
+        assert_eq!(parts.len(), 2, "missing T separator in {s:?}");
+        assert_eq!(parts[0].len(), 10, "date part wrong length in {s:?}");
+        // Time part: 8 chars (HH:MM:SS) or 15 chars (HH:MM:SS.ffffff).
+        assert!(
+            matches!(parts[1].len(), 8 | 15),
+            "time part wrong length in {s:?}"
+        );
+    }
+}
+
+// ── interpret_uuid ───────────────────────────────────────────────────────────
+
+#[test]
+fn interpret_uuid_default_format() {
+    for seed in 0..50 {
+        let mut ntc = fresh_ntc(seed);
+        let schema = cbor_map! { "type" => "uuid" };
+        let s = decode_string(interpret_uuid(&mut ntc, &schema).ok().unwrap());
+        assert_eq!(s.len(), 36, "{s:?}");
+        // Hyphens at positions 8, 13, 18, 23.
+        for &pos in &[8usize, 13, 18, 23] {
+            assert_eq!(s.as_bytes()[pos], b'-', "missing hyphen at {pos} in {s:?}");
+        }
+        // Everything else is a lowercase hex digit.
+        for (i, b) in s.bytes().enumerate() {
+            if matches!(i, 8 | 13 | 18 | 23) {
+                continue;
+            }
+            assert!(
+                b.is_ascii_hexdigit() && !b.is_ascii_uppercase(),
+                "non-hex / non-lowercase byte {b:#x} at {i} in {s:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn interpret_uuid_respects_version_field() {
+    for version in 1u8..=5 {
+        let schema = cbor_map! { "type" => "uuid", "version" => u64::from(version) };
+        for seed in 0..30 {
+            let mut ntc = fresh_ntc(seed);
+            let s = decode_string(interpret_uuid(&mut ntc, &schema).ok().unwrap());
+            // Version nibble is at index 14.
+            let v_hex = s.as_bytes()[14];
+            let v_digit = (v_hex as char).to_digit(16).unwrap() as u8;
+            assert_eq!(v_digit, version, "version mismatch in {s:?}");
+            // Variant nibble at index 19 must be one of 8, 9, a, b.
+            let var_hex = s.as_bytes()[19];
+            let var_digit = (var_hex as char).to_digit(16).unwrap();
+            assert!(
+                matches!(var_digit, 0x8..=0xb),
+                "variant nibble {var_digit:x} in {s:?} not in 8..=b"
+            );
+        }
+    }
+}
+
+// ── interpret_ip_address ─────────────────────────────────────────────────────
+
+#[test]
+fn interpret_ipv4_parses_back() {
+    let schema = cbor_map! { "type" => "ip_address", "version" => 4u64 };
+    for seed in 0..100 {
+        let mut ntc = fresh_ntc(seed);
+        let s = decode_string(interpret_ip_address(&mut ntc, &schema).ok().unwrap());
+        s.parse::<Ipv4Addr>()
+            .unwrap_or_else(|e| panic!("invalid IPv4 {s:?}: {e}"));
+    }
+}
+
+#[test]
+fn interpret_ipv6_parses_back() {
+    let schema = cbor_map! { "type" => "ip_address", "version" => 6u64 };
+    for seed in 0..100 {
+        let mut ntc = fresh_ntc(seed);
+        let s = decode_string(interpret_ip_address(&mut ntc, &schema).ok().unwrap());
+        s.parse::<Ipv6Addr>()
+            .unwrap_or_else(|e| panic!("invalid IPv6 {s:?}: {e}"));
+    }
+}
+
+#[test]
+fn interpret_ipv4_hits_special_ranges() {
+    // With 50/50 between uniform and special-range, ~half of draws should
+    // land inside one of the SPECIAL_IPV4_RANGES. We assert the much weaker
+    // "at least one loopback, one private, and one documentation address
+    // appears across 200 seeds" — vanishingly unlikely under pure uniform.
+    let schema = cbor_map! { "type" => "ip_address", "version" => 4u64 };
+    let addrs: Vec<Ipv4Addr> = (0..200)
+        .map(|seed| {
+            let mut ntc = fresh_ntc(seed);
+            decode_string(interpret_ip_address(&mut ntc, &schema).ok().unwrap())
+                .parse()
+                .unwrap()
+        })
+        .collect();
+
+    let saw_loopback = addrs.iter().any(|a| a.octets()[0] == 127);
+    let saw_private_10 = addrs.iter().any(|a| a.octets()[0] == 10);
+    let saw_192_168 = addrs.iter().any(|a| {
+        let o = a.octets();
+        o[0] == 192 && o[1] == 168
+    });
+    assert!(
+        saw_loopback,
+        "no 127.x.x.x address in 200 draws — special-range biasing missing"
+    );
+    assert!(saw_private_10, "no 10.x.x.x address in 200 draws");
+    assert!(saw_192_168, "no 192.168.x.x address in 200 draws");
+}
+
+#[test]
+fn interpret_ipv6_hits_special_ranges() {
+    let schema = cbor_map! { "type" => "ip_address", "version" => 6u64 };
+    let addrs: Vec<Ipv6Addr> = (0..200)
+        .map(|seed| {
+            let mut ntc = fresh_ntc(seed);
+            decode_string(interpret_ip_address(&mut ntc, &schema).ok().unwrap())
+                .parse()
+                .unwrap()
+        })
+        .collect();
+
+    // Loopback (::1) or unspecified (::) — the /128 entries in SPECIAL_IPV6_RANGES.
+    let saw_loopback_or_unspecified = addrs
+        .iter()
+        .any(|a| *a == Ipv6Addr::LOCALHOST || *a == Ipv6Addr::UNSPECIFIED);
+    // Documentation prefix 2001:db8::/32.
+    let saw_doc = addrs.iter().any(|a| {
+        let s = a.segments();
+        s[0] == 0x2001 && s[1] == 0x0db8
+    });
+    assert!(
+        saw_loopback_or_unspecified,
+        "no ::1 / :: in 200 draws — special-range biasing missing"
+    );
+    assert!(saw_doc, "no 2001:db8::/32 address in 200 draws");
+}
+
+#[test]
+#[should_panic(expected = "ip_address: unsupported version 5")]
+fn interpret_ip_address_unknown_version_panics() {
+    let mut ntc = fresh_ntc(0);
+    let schema = cbor_map! { "type" => "ip_address", "version" => 5u64 };
+    let _ = interpret_ip_address(&mut ntc, &schema);
+}
+
+#[test]
+#[should_panic(expected = "ip_address schema must have a \"version\" field")]
+fn interpret_ip_address_missing_version_panics() {
+    let mut ntc = fresh_ntc(0);
+    let schema = cbor_map! { "type" => "ip_address" };
+    let _ = interpret_ip_address(&mut ntc, &schema);
+}
+
+// ── interpret_uuid: distribution across versions ─────────────────────────────
+
+#[test]
+fn interpret_uuid_default_can_produce_non_rfc_versions() {
+    // Hypothesis's `uuids(version=None)` uses raw 128 random bits — every
+    // version nibble in 0..=f is reachable. The agent's port restricted the
+    // nibble to 1..=5; the Hypothesis-faithful port must not. Across 200
+    // draws of a uniform 4-bit value, P(no nibble outside 1..=5) =
+    // (5/16)^200 ≈ 0, so seeing one is essentially certain when the port
+    // is correct.
+    let schema = cbor_map! { "type" => "uuid" };
+    let strings = collect(200, |ntc| interpret_uuid(ntc, &schema));
+    let saw_non_rfc = strings.iter().any(|s| {
+        let nibble = (s.as_bytes()[14] as char).to_digit(16).unwrap();
+        nibble == 0 || nibble >= 6
+    });
+    assert!(
+        saw_non_rfc,
+        "every version nibble was in 1..=5 across 200 draws — \
+         port is restricting the version field rather than passing through random bits"
+    );
+}

--- a/tests/embedded/native/state_tests.rs
+++ b/tests/embedded/native/state_tests.rs
@@ -643,3 +643,94 @@ fn draw_float_half_bounded_below_explores_finite_range() {
         .unwrap();
     assert!(v >= 1.0 && !v.is_nan());
 }
+
+// ── NativeTestCase::for_simplest ─────────────────────────────────────────────
+//
+// Mirrors the `cached_test_function((ChoiceTemplate("simplest", count=None),))`
+// pre-trial that Hypothesis's engine runs at the head of the Generate phase
+// (engine.py::generate_new_examples). Every draw must return the kind's
+// `simplest()` value — `shrink_towards` clamped to range for integers, 0.0
+// for floats, false for booleans, the empty / lower-bound size for bytes
+// and strings.
+
+#[test]
+fn for_simplest_draws_integer_at_shrink_target_when_in_range() {
+    let mut tc = NativeTestCase::for_simplest();
+    // shrink_towards=0 is hardcoded; for [0, 23] that's in range → simplest = 0.
+    let v = tc.draw_integer(0, 23).ok().unwrap();
+    assert_eq!(v, 0);
+}
+
+#[test]
+fn for_simplest_draws_integer_clamped_to_range_when_target_below() {
+    let mut tc = NativeTestCase::for_simplest();
+    // shrink_towards=0 below min=5 → simplest clamps to 5.
+    let v = tc.draw_integer(5, 100).ok().unwrap();
+    assert_eq!(v, 5);
+}
+
+#[test]
+fn for_simplest_draws_integer_clamped_to_range_when_target_above() {
+    let mut tc = NativeTestCase::for_simplest();
+    // shrink_towards=0 above max=-1 → simplest clamps to -1.
+    let v = tc.draw_integer(-100, -1).ok().unwrap();
+    assert_eq!(v, -1);
+}
+
+#[test]
+fn for_simplest_propagates_across_many_draws() {
+    // The mode applies to every draw, not just the first. This is what makes
+    // Hypothesis-style "midnight = all four time components are zero" findable
+    // on a single pre-trial.
+    let mut tc = NativeTestCase::for_simplest();
+    for _ in 0..10 {
+        assert_eq!(tc.draw_integer(0, 99).ok().unwrap(), 0);
+    }
+}
+
+#[test]
+fn for_simplest_draws_float_at_zero() {
+    let mut tc = NativeTestCase::for_simplest();
+    let v = tc.draw_float(-10.0, 10.0, false, false).ok().unwrap();
+    assert_eq!(v, 0.0);
+    assert!(v.is_sign_positive(), "expected +0.0, got -0.0");
+}
+
+#[test]
+fn for_simplest_draws_weighted_at_false() {
+    let mut tc = NativeTestCase::for_simplest();
+    let v = tc.weighted(0.5, None).ok().unwrap();
+    assert!(!v, "weighted draw in simplest mode should be false");
+}
+
+#[test]
+fn for_simplest_draws_bytes_at_min_size_all_zero() {
+    let mut tc = NativeTestCase::for_simplest();
+    let v = tc.draw_bytes(2, 5).ok().unwrap();
+    assert_eq!(v, vec![0u8; 2], "expected min-sized all-zero buffer");
+}
+
+#[test]
+fn for_simplest_is_independent_of_seed() {
+    // Two simplest test cases produce identical traces — that's the whole
+    // point: deterministic boundary trial that doesn't depend on RNG luck.
+    let mut a = NativeTestCase::for_simplest();
+    let mut b = NativeTestCase::for_simplest();
+    for _ in 0..5 {
+        let va = a.draw_integer(0, 1000).ok().unwrap();
+        let vb = b.draw_integer(0, 1000).ok().unwrap();
+        assert_eq!(va, vb);
+        assert_eq!(va, 0);
+    }
+}
+
+#[test]
+fn for_simplest_records_choice_nodes() {
+    // Forced-simplest draws still record nodes in the test case so the
+    // engine can inspect what was drawn and feed the trace into the data
+    // tree / shrinker if the test ends up Interesting.
+    let mut tc = NativeTestCase::for_simplest();
+    let _ = tc.draw_integer(0, 23).ok().unwrap();
+    let _ = tc.weighted(0.5, None).ok().unwrap();
+    assert_eq!(tc.nodes.len(), 2);
+}

--- a/tests/test_phases.rs
+++ b/tests/test_phases.rs
@@ -82,6 +82,82 @@ fn test_disabling_shrink_limits_interesting_calls() {
     );
 }
 
+// At the head of the Generate phase, Hypothesis's ConjectureRunner runs a
+// deterministic all-simplest test case (engine.py:1147,
+// `cached_test_function((ChoiceTemplate("simplest", count=None),))`). The
+// native runner ports the same pre-trial. Verify behaviorally that the
+// first test case sees every draw at its `simplest()` value — for an
+// unbounded `gs::integers::<i32>()`, that's 0.
+#[test]
+fn test_generate_phase_runs_all_simplest_first() {
+    use std::sync::Arc;
+    use std::sync::Mutex;
+
+    let draws: Arc<Mutex<Vec<i32>>> = Arc::new(Mutex::new(Vec::new()));
+    let draws_clone = Arc::clone(&draws);
+
+    Hegel::new(move |tc: TestCase| {
+        let v: i32 = tc.draw(gs::integers::<i32>());
+        draws_clone.lock().unwrap().push(v);
+    })
+    .settings(
+        Settings::new()
+            .phases([Phase::Generate])
+            .database(None)
+            .test_cases(5),
+    )
+    .run();
+
+    let recorded = draws.lock().unwrap();
+    assert!(!recorded.is_empty(), "no test cases ran");
+    assert_eq!(
+        recorded[0], 0,
+        "first test case should be the all-simplest pre-trial (drawn value = 0), \
+         got {} — pre-trial likely not running",
+        recorded[0]
+    );
+}
+
+#[test]
+fn test_generate_phase_simplest_propagates_to_all_draws() {
+    // The pre-trial forces every choice (not just the first) to simplest.
+    // A test that draws five independent integers should see (0, 0, 0, 0, 0)
+    // on its very first call.
+    use std::sync::Arc;
+    use std::sync::Mutex;
+
+    type FirstDraws = Option<[i32; 5]>;
+    let first_call: Arc<Mutex<FirstDraws>> = Arc::new(Mutex::new(None));
+    let first_call_clone = Arc::clone(&first_call);
+
+    Hegel::new(move |tc: TestCase| {
+        let arr: [i32; 5] = [
+            tc.draw(gs::integers::<i32>()),
+            tc.draw(gs::integers::<i32>()),
+            tc.draw(gs::integers::<i32>()),
+            tc.draw(gs::integers::<i32>()),
+            tc.draw(gs::integers::<i32>()),
+        ];
+        let mut slot = first_call_clone.lock().unwrap();
+        if slot.is_none() {
+            *slot = Some(arr);
+        }
+    })
+    .settings(
+        Settings::new()
+            .phases([Phase::Generate])
+            .database(None)
+            .test_cases(3),
+    )
+    .run();
+
+    let first = first_call.lock().unwrap().expect("no test cases ran");
+    assert_eq!(
+        first, [0; 5],
+        "first test case should have every draw at simplest, got {first:?}"
+    );
+}
+
 // Default phases include Explicit so that explicit_test_case attributes work
 // without any phases configuration.
 #[test]

--- a/tests/test_standard_generators.rs
+++ b/tests/test_standard_generators.rs
@@ -469,7 +469,6 @@ mod direct_strategies {
         );
     }
 
-    #[not_supported_on_native]
     #[test]
     fn test_ip_addresses_kwargs() {
         check_can_generate_examples(gs::ip_addresses());

--- a/tests/test_strings.rs
+++ b/tests/test_strings.rs
@@ -151,7 +151,6 @@ fn test_regex_with_alphabet() {
 
 // --- Special schema generators ---
 
-#[not_supported_on_native]
 #[test]
 fn test_dates_format() {
     assert_all_examples(gs::dates(), |s: &String| {
@@ -168,7 +167,6 @@ fn test_dates_format() {
     });
 }
 
-#[not_supported_on_native]
 #[test]
 fn test_times_format() {
     assert_all_examples(gs::times(), |s: &String| {
@@ -190,7 +188,6 @@ fn test_times_format() {
     });
 }
 
-#[not_supported_on_native]
 #[test]
 fn test_datetimes_format() {
     assert_all_examples(gs::datetimes(), |s: &String| {
@@ -227,7 +224,6 @@ fn test_datetimes_format() {
     });
 }
 
-#[not_supported_on_native]
 #[test]
 fn test_ip_addresses_format() {
     assert_all_examples(gs::ip_addresses(), |s: &String| {
@@ -236,7 +232,6 @@ fn test_ip_addresses_format() {
     });
 }
 
-#[not_supported_on_native]
 #[test]
 fn test_ip_addresses_v4_only() {
     assert_all_examples(gs::ip_addresses().v4(), |s: &String| {
@@ -248,7 +243,6 @@ fn test_ip_addresses_v4_only() {
     });
 }
 
-#[not_supported_on_native]
 #[test]
 fn test_ip_addresses_v6_only() {
     assert_all_examples(gs::ip_addresses().v6(), |s: &String| {
@@ -259,13 +253,11 @@ fn test_ip_addresses_v6_only() {
 
 const NIL_UUID: &str = "00000000-0000-0000-0000-000000000000";
 
-#[not_supported_on_native]
 #[test]
 fn test_no_nil_uuid_by_default() {
     assert_no_examples(gs::uuids(), |s: &String| s == NIL_UUID);
 }
 
-#[not_supported_on_native]
 #[test]
 fn test_uuids_have_canonical_form() {
     assert_all_examples(gs::uuids(), |s: &String| {
@@ -297,7 +289,6 @@ fn test_domains_format() {
     });
 }
 
-#[not_supported_on_native]
 #[test]
 fn test_can_generate_specified_version() {
     for version in 1u8..=5 {

--- a/tests/test_time.rs
+++ b/tests/test_time.rs
@@ -1,8 +1,5 @@
-#![cfg_attr(feature = "native", allow(unused_imports, dead_code))]
-
 mod common;
 
-use common::not_supported_on_native;
 use common::utils::assert_all_examples;
 use hegel::generators as gs;
 use std::time::Duration;
@@ -43,8 +40,6 @@ mod datetimes {
     //! added in a follow-up once the missing features land.
 
     use super::common::utils::{assert_all_examples, find_any, minimal};
-    #[allow(unused_imports)]
-    use super::not_supported_on_native;
     use hegel::generators::{self as gs};
 
     fn date_year(s: &str) -> i32 {
@@ -77,7 +72,6 @@ mod datetimes {
 
     // --- datetime tests ---
 
-    #[not_supported_on_native]
     #[test]
     fn test_simplifies_towards_millenium() {
         // Hypothesis shrinks datetimes toward 2000-01-01T00:00:00.
@@ -92,7 +86,6 @@ mod datetimes {
         assert_eq!(microsecond, 0);
     }
 
-    #[not_supported_on_native]
     #[test]
     fn test_default_datetimes_are_naive() {
         assert_all_examples(gs::datetimes(), |s: &String| {
@@ -100,7 +93,6 @@ mod datetimes {
         });
     }
 
-    #[not_supported_on_native]
     #[test]
     fn test_allow_imaginary_is_not_an_error_for_naive_datetimes() {
         // gs::datetimes() always produces naive datetimes; allow_imaginary=False is a no-op
@@ -109,14 +101,12 @@ mod datetimes {
 
     // --- date tests ---
 
-    #[not_supported_on_native]
     #[test]
     fn test_can_find_after_the_year_2000() {
         let d = minimal(gs::dates(), |s: &String| date_year(s) > 2000);
         assert_eq!(date_year(&d), 2001);
     }
 
-    #[not_supported_on_native]
     #[test]
     fn test_can_find_before_the_year_2000() {
         // Hypothesis shrinks toward 2000, so the minimal year < 2000 is 1999.
@@ -124,7 +114,6 @@ mod datetimes {
         assert_eq!(date_year(&d), 1999);
     }
 
-    #[not_supported_on_native]
     #[test]
     fn test_can_find_each_month() {
         for month in 1u32..=12 {
@@ -134,7 +123,6 @@ mod datetimes {
 
     // --- time tests ---
 
-    #[not_supported_on_native]
     #[test]
     fn test_can_find_midnight() {
         find_any(gs::times(), |s: &String| {
@@ -143,26 +131,22 @@ mod datetimes {
         });
     }
 
-    #[not_supported_on_native]
     #[test]
     fn test_can_find_non_midnight() {
         let t = minimal(gs::times(), |s: &String| parse_time_parts(s).0 != 0);
         assert_eq!(parse_time_parts(&t).0, 1);
     }
 
-    #[not_supported_on_native]
     #[test]
     fn test_can_find_on_the_minute() {
         find_any(gs::times(), |s: &String| parse_time_parts(s).2 == 0);
     }
 
-    #[not_supported_on_native]
     #[test]
     fn test_can_find_off_the_minute() {
         find_any(gs::times(), |s: &String| parse_time_parts(s).2 != 0);
     }
 
-    #[not_supported_on_native]
     #[test]
     fn test_simplifies_towards_midnight() {
         let t = minimal(gs::times(), |_: &String| true);
@@ -173,7 +157,6 @@ mod datetimes {
         assert_eq!(microsecond, 0);
     }
 
-    #[not_supported_on_native]
     #[test]
     fn test_can_generate_naive_time() {
         find_any(gs::times(), |s: &String| {
@@ -181,7 +164,6 @@ mod datetimes {
         });
     }
 
-    #[not_supported_on_native]
     #[test]
     fn test_naive_times_are_naive() {
         assert_all_examples(gs::times(), |s: &String| {


### PR DESCRIPTION
Adds native interpreters for five schema types — `date`, `time`, `datetime`, `uuid`, and `ip_address`.

Also adds an all-simplest test case run at the head of the Generate phase, following Hypothesis, which lets us reliably find the minimum in these (without which we were failing some of the tests flakily).

> Extracted from `DRMacIver/native` by Claude as part of the incremental landing of the native backend. The branch is treated as an artefact of study — this PR is a hand-reviewed rewrite, not a direct cherry-pick.

<details>
<summary>Implementation notes</summary>

**Schema interpreters** (`src/native/schema/special.rs`):

- `date` / `time` / `datetime` follow `draw_capped_multipart`'s shape: independent integer draws for each component, with `time.isoformat()` semantics for the fractional-seconds suffix (present iff `microsecond != 0`). The year draws as an offset from 2000 so the shrinker pulls toward 2000-01-01 (matching Hypothesis's `shrink_towards=2000`); the day's max is clamped to `days_in_month(year, month)` so Feb 30 is unreachable while every valid Gregorian day in 1..=9999 is.
- `ip_address` ports the `one_of([uniform_bytes, sampled_from(SPECIAL_*).flatmap(in_network)])` structure verbatim. The IPv4 and IPv6 special-range tables are vendored as CIDR strings and parsed once at startup into `(base, size_minus_1)` tuples. The offset is drawn as `[0, size_minus_1]` rather than the absolute `[base, last]` range, which avoids reinterpret-casts on values above `i128::MAX` (e.g. fc00::/7).
- `uuid` does two 64-bit draws into a `u128` and applies the RFC 4122 version + variant nibble overrides when `version` is set. One acknowledged divergence: Hypothesis's `uuids()` uses `random.getrandbits(128)` via `use_true_random=True`, so its UUIDs sit outside the choice tree and never produce nil (`P = 2^-128`). Native uses `draw_integer`, so the all-simplest pre-trial would land at nil — we bump to non-nil at the interpreter level. A proper fix needs a non-recording RNG-direct draw API on `NativeTestCase`, which is a separate change.

**Engine** (`src/native/{core/state.rs,test_runner.rs}`):

- New `NativeTestCase::for_simplest()` constructor sets a `force_simplest` flag; `resolve_choice` returns `kind.simplest()` immediately when that flag is set.
- `test_runner` runs one `for_simplest()` test case at the top of the Generate phase, before the random batch loop.
- Direct unit tests in `tests/embedded/native/state_tests.rs` cover the `for_simplest` mode (clamping behaviour, multi-draw propagation, kind-specific simplest values, determinism). Behavioural tests in `tests/test_phases.rs` (`test_generate_phase_runs_all_simplest_first`, `test_generate_phase_simplest_propagates_to_all_draws`) verify the runner actually invokes the pre-trial under both backends.

**Ungated tests**:

- `tests/test_strings.rs`: 9 tests for dates / times / datetimes / ip_addresses-v4-v6-mixed / uuid versions.
- `tests/test_time.rs`: 11 datetime/date/time tests (find-any reachability checks and shrinker-minimal targets).
- `tests/test_standard_generators.rs`: `test_ip_addresses_kwargs` (the `not_supported_on_native` macro caught this automatically once the schema landed — exactly the auto-surfacing the macro is designed for).

The lint-noise suppression block on `tests/test_time.rs` (`#![cfg_attr(feature = "native", allow(unused_imports, dead_code))]`) is removed too — the helpers it was suppressing are live under native now.

**Still gated**:

- Regex-related tests (interpret_regex unported).
- Domain / email / url tests (the next chunk).
- Note: the `// nocov` annotations on `gs::uuids()`, `gs::dates()`, etc. in `src/generators/strings.rs` were not changed by this PR — they cover the generators' `as_basic` thunks, not the schema interpreters this PR adds.

Reviewed against the `detecting-port-bullshit` skill catalogue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
</details>