### PR TITLE
Native: port ChoiceTemplate as a first-class type

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This release makes some minor internal changes to the native feature. It should have no user-visible impact.

--- a/src/native/core/choices.rs
+++ b/src/native/core/choices.rs
@@ -926,6 +926,55 @@ pub struct ChoiceNode {
     pub was_forced: bool,
 }
 
+/// Kind of fallback a [`ChoiceTemplate`] produces.  Mirrors Hypothesis's
+/// `Literal["simplest"]` field on `internal/conjecture/choice.ChoiceTemplate`.
+/// Carried as an enum so future kinds (`"random"`, etc., that Hypothesis has
+/// flirted with) can be added without changing the surrounding API.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ChoiceTemplateKind {
+    /// Resolve each templated draw to `kind.simplest()` of the requested
+    /// choice kind.
+    Simplest,
+}
+
+/// A deferred-resolution marker that drives every draw past the explicit
+/// `prefix` of a [`crate::native::core::NativeTestCase`].  Mirrors
+/// `ChoiceTemplate` from `hypothesis.internal.conjecture.choice`.
+///
+/// `count = None` is infinite — the template applies to every draw until
+/// the test case ends naturally (e.g. `max_size` is hit).  `count = Some(n)`
+/// produces exactly `n` resolved values, after which the next draw marks
+/// overrun (`Status::EarlyStop` + `StopTest`).
+///
+/// Hypothesis's literal source (`data.py::_pop_choice` lines 1054-1073)
+/// decrements the count *after* producing each value and then checks for
+/// `< 0`, which means a `count=N` template actually returns `N+1` values
+/// (the last one alongside the overrun status).  That looks like an
+/// unintentional off-by-one; we implement the cleaner "exactly N values,
+/// then overrun" semantics that the `count > 0` `__post_init__` assert
+/// suggests.  No current Hypothesis caller passes a finite count, so the
+/// divergence is invisible at the API boundary.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ChoiceTemplate {
+    pub kind: ChoiceTemplateKind,
+    pub count: Option<usize>,
+}
+
+impl ChoiceTemplate {
+    /// Build a [`ChoiceTemplateKind::Simplest`] template with the given
+    /// remaining-draws count.  `Some(0)` is rejected at construction time,
+    /// matching Hypothesis's `__post_init__` assertion.
+    pub fn simplest(count: Option<usize>) -> Self {
+        if let Some(n) = count {
+            assert!(n > 0, "ChoiceTemplate count must be positive (got 0)");
+        }
+        Self {
+            kind: ChoiceTemplateKind::Simplest,
+            count,
+        }
+    }
+}
+
 impl ChoiceNode {
     pub fn with_value(&self, value: ChoiceValue) -> ChoiceNode {
         ChoiceNode {

--- a/src/native/core/state.rs
+++ b/src/native/core/state.rs
@@ -4,12 +4,12 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::sync::{LazyLock, Mutex};
 
+use rand::RngExt;
 use rand::rngs::SmallRng;
-use rand::{RngExt, SeedableRng};
 
 use super::choices::{
-    BooleanChoice, BytesChoice, ChoiceKind, ChoiceNode, ChoiceValue, FloatChoice, IntegerChoice,
-    InterestingOrigin, Status, StopTest, StringChoice,
+    BooleanChoice, BytesChoice, ChoiceKind, ChoiceNode, ChoiceTemplate, ChoiceTemplateKind,
+    ChoiceValue, FloatChoice, IntegerChoice, InterestingOrigin, Status, StopTest, StringChoice,
 };
 use super::float_index::lex_to_float;
 use super::{BOUNDARY_PROBABILITY, BUFFER_SIZE};
@@ -780,72 +780,41 @@ pub struct NativeTestCase {
     /// `None` for test cases concluded by [`Self::freeze`] directly
     /// (`Status::Valid`).  Mirrors `ConjectureData.interesting_origin`.
     interesting_origin: Option<InterestingOrigin>,
-    /// When `true`, every draw bypasses the prefix/RNG paths and returns
-    /// `kind.simplest()`. Used by [`Self::for_simplest`] to mirror
-    /// Hypothesis's `ChoiceTemplate("simplest", count=None)` pre-Generate
-    /// test case (engine.py::generate_new_examples).
-    force_simplest: bool,
+    /// Optional template applied to every draw past the explicit `prefix`.
+    /// Mirrors the trailing `ChoiceTemplate` in `prefix + (template,)` from
+    /// Hypothesis's `engine.py::generate_new_examples`.  `count` is mutated
+    /// in-place as draws consume the template; when `count` reaches zero
+    /// the next draw is overrun (`Status::EarlyStop` + `StopTest`).
+    /// `None` means "no template" — draws past the prefix go to `rng` or
+    /// panic, as before.
+    trailing_template: Option<ChoiceTemplate>,
 }
 
 impl NativeTestCase {
     pub fn new_random(rng: SmallRng) -> Self {
-        NativeTestCase {
-            prefix: Vec::new(),
-            prefix_nodes: None,
-            rng: Some(rng),
-            max_size: BUFFER_SIZE,
-            nodes: Vec::new(),
-            status: None,
-            frozen: false,
-            collections: HashMap::new(),
-            next_collection_id: 0,
-            variable_pools: Vec::new(),
-            spans: Spans::new(),
-            span_stack: Vec::new(),
-            has_discards: false,
-            tags: HashSet::new(),
-            labels_for_structure_stack: Vec::new(),
-            observer: None,
-            interesting_origin: None,
-            force_simplest: false,
-        }
+        Self::for_choices_and_template(&[], None, None, BUFFER_SIZE, None).with_random(rng)
     }
 
-    /// A test case where every draw returns `kind.simplest()`. Used by the
-    /// Generate phase to run a single deterministic "all simplest" trial
-    /// before random sampling, mirroring Hypothesis's
-    /// `cached_test_function((ChoiceTemplate("simplest", count=None),))`
-    /// call in `engine.py::generate_new_examples`. Without it, find-any
-    /// tests over multi-component generators (e.g. midnight = h=m=s=0
-    /// across four independent draws) need an RNG that happens to land on
-    /// all-zeros, which becomes vanishingly unlikely as the number of
-    /// components grows.
+    /// Replay `choices` in order, then for every further draw resolve via
+    /// `trailing` if set.  Mirrors `ConjectureData.for_choices(prefix)` from
+    /// `hypothesis.internal.conjecture.data`, where `prefix` is
+    /// `choices + (trailing,)` when a trailing template is supplied.
     ///
-    /// The seed value is unused (every draw short-circuits to simplest
-    /// before reaching the RNG fallback in `resolve_choice`), but
-    /// `new_random` requires one, so we hand it a fixed seed for
-    /// reproducibility's sake.
-    pub fn for_simplest() -> Self {
-        let mut tc = Self::new_random(SmallRng::seed_from_u64(0));
-        tc.force_simplest = true;
-        tc
-    }
-
-    /// Construct a `NativeTestCase` that replays `choices` in order,
-    /// notifying `observer` after each draw and on conclusion.
-    ///
-    /// Mirrors `ConjectureData.for_choices(choices, observer=observer)`
-    /// from `hypothesis.internal.conjecture.data`.
-    pub fn for_choices(
+    /// `max_size` is the upper bound on the total number of choices the test
+    /// case will make.  It is floored to `choices.len()` so a too-tight value
+    /// can never truncate the explicit prefix.
+    pub fn for_choices_and_template(
         choices: &[ChoiceValue],
         prefix_nodes: Option<&[ChoiceNode]>,
+        trailing: Option<ChoiceTemplate>,
+        max_size: usize,
         observer: Option<Box<dyn DataObserver>>,
     ) -> Self {
         NativeTestCase {
             prefix: choices.to_vec(),
             prefix_nodes: prefix_nodes.map(|n| n.to_vec()),
             rng: None,
-            max_size: choices.len(),
+            max_size: max_size.max(choices.len()),
             nodes: Vec::new(),
             status: None,
             frozen: false,
@@ -859,8 +828,37 @@ impl NativeTestCase {
             labels_for_structure_stack: Vec::new(),
             observer,
             interesting_origin: None,
-            force_simplest: false,
+            trailing_template: trailing,
         }
+    }
+
+    /// A test case where every draw past the explicit prefix returns
+    /// `kind.simplest()` of the requested choice kind.  Mirrors Hypothesis's
+    /// `cached_test_function((ChoiceTemplate("simplest", count=None),))` at
+    /// the head of `engine.py::generate_new_examples`: a deterministic
+    /// all-simplest probe of the choice tree's "left leaf" before random
+    /// sampling begins.
+    pub fn for_simplest(max_size: usize) -> Self {
+        Self::for_choices_and_template(
+            &[],
+            None,
+            Some(ChoiceTemplate::simplest(None)),
+            max_size,
+            None,
+        )
+    }
+
+    /// Construct a `NativeTestCase` that replays `choices` in order,
+    /// notifying `observer` after each draw and on conclusion.
+    ///
+    /// Mirrors `ConjectureData.for_choices(choices, observer=observer)`
+    /// from `hypothesis.internal.conjecture.data`.
+    pub fn for_choices(
+        choices: &[ChoiceValue],
+        prefix_nodes: Option<&[ChoiceNode]>,
+        observer: Option<Box<dyn DataObserver>>,
+    ) -> Self {
+        Self::for_choices_and_template(choices, prefix_nodes, None, choices.len(), observer)
     }
 
     /// A test case that replays `prefix` for the first positions and then
@@ -871,26 +869,15 @@ impl NativeTestCase {
     /// `ConjectureData(prefix=..., random=..., max_size=...)`
     /// construction in `shrinking/mutation.py`.
     pub fn for_probe(prefix: &[ChoiceValue], rng: SmallRng, max_size: usize) -> Self {
-        NativeTestCase {
-            prefix: prefix.to_vec(),
-            prefix_nodes: None,
-            rng: Some(rng),
-            max_size,
-            nodes: Vec::new(),
-            status: None,
-            frozen: false,
-            collections: HashMap::new(),
-            next_collection_id: 0,
-            variable_pools: Vec::new(),
-            spans: Spans::new(),
-            span_stack: Vec::new(),
-            has_discards: false,
-            tags: HashSet::new(),
-            labels_for_structure_stack: Vec::new(),
-            observer: None,
-            interesting_origin: None,
-            force_simplest: false,
-        }
+        Self::for_choices_and_template(prefix, None, None, max_size, None).with_random(rng)
+    }
+
+    /// Attach an RNG for post-prefix random draws.  Internal builder used by
+    /// `new_random` and `for_probe` to share the [`Self::for_choices_and_template`]
+    /// constructor without duplicating the struct literal.
+    fn with_random(mut self, rng: SmallRng) -> Self {
+        self.rng = Some(rng);
+        self
     }
 
     /// Open a new span at the current choice position, labelled with `label`.
@@ -1222,36 +1209,52 @@ impl NativeTestCase {
     ) -> Result<(ChoiceValue, bool), StopTest> {
         self.pre_choice()?;
 
-        if self.force_simplest {
-            return Ok((simplest(), false));
-        }
-
         let idx = self.nodes.len();
 
+        // Branch 1: replay from the concrete prefix.  When the prefix value's
+        // recorded kind doesn't match the requested kind (e.g. a schema
+        // shifted between runs), `prefix_nodes` carries the original kind so
+        // we can route to `simplest()` or `unit()` of the *new* kind —
+        // Hypothesis's "punning" logic.
         if idx < self.prefix.len() {
             let prefix_value = &self.prefix[idx];
             if validate(prefix_value) {
-                Ok((prefix_value.clone(), false))
-            } else {
-                let is_simplest = self
-                    .prefix_nodes
-                    .as_ref()
-                    .and_then(|pn| pn.get(idx))
-                    .is_some_and(|pn| *prefix_value == pn.kind.simplest());
-
-                if is_simplest {
-                    Ok((simplest(), false))
-                } else {
-                    Ok((unit(), false))
-                }
+                return Ok((prefix_value.clone(), false));
             }
-        } else {
-            let rng = self
-                .rng
-                .as_mut()
-                .expect("No RNG available for random generation");
-            Ok((random(rng), false))
+            let is_simplest = self
+                .prefix_nodes
+                .as_ref()
+                .and_then(|pn| pn.get(idx))
+                .is_some_and(|pn| *prefix_value == pn.kind.simplest());
+            return Ok((if is_simplest { simplest() } else { unit() }, false));
         }
+
+        // Branch 2: trailing template (`prefix + (ChoiceTemplate, ...)` in
+        // Hypothesis).  Resolves every post-prefix draw to the template's
+        // kind, decrementing `count` if finite.  When `count` reaches zero
+        // the next draw marks overrun without producing a value — see the
+        // `ChoiceTemplate` docstring for the divergence from Hypothesis's
+        // literal off-by-one source.
+        if let Some(template) = self.trailing_template.as_mut() {
+            if matches!(template.count, Some(0)) {
+                self.status = Some(Status::EarlyStop);
+                return Err(StopTest);
+            }
+            let value = match template.kind {
+                ChoiceTemplateKind::Simplest => simplest(),
+            };
+            if let Some(c) = template.count.as_mut() {
+                *c -= 1;
+            }
+            return Ok((value, false));
+        }
+
+        // Branch 3: random fallback.
+        let rng = self
+            .rng
+            .as_mut()
+            .expect("No RNG available for random generation");
+        Ok((random(rng), false))
     }
 }
 

--- a/src/native/test_runner.rs
+++ b/src/native/test_runner.rs
@@ -234,7 +234,7 @@ fn run_main(
         && calls < max_examples * 10
         && interesting.is_empty()
     {
-        let run = ctx.run(NativeTestCase::for_simplest());
+        let run = ctx.run(NativeTestCase::for_simplest(BUFFER_SIZE));
         crate::native::data_tree::record_tree(&mut tree_root, &run.nodes, run.status, &[]);
         calls += 1;
         if run.nodes.is_empty() && run.status >= Status::Invalid {

--- a/tests/embedded/native/state_tests.rs
+++ b/tests/embedded/native/state_tests.rs
@@ -655,7 +655,7 @@ fn draw_float_half_bounded_below_explores_finite_range() {
 
 #[test]
 fn for_simplest_draws_integer_at_shrink_target_when_in_range() {
-    let mut tc = NativeTestCase::for_simplest();
+    let mut tc = NativeTestCase::for_simplest(BUFFER_SIZE);
     // shrink_towards=0 is hardcoded; for [0, 23] that's in range → simplest = 0.
     let v = tc.draw_integer(0, 23).ok().unwrap();
     assert_eq!(v, 0);
@@ -663,7 +663,7 @@ fn for_simplest_draws_integer_at_shrink_target_when_in_range() {
 
 #[test]
 fn for_simplest_draws_integer_clamped_to_range_when_target_below() {
-    let mut tc = NativeTestCase::for_simplest();
+    let mut tc = NativeTestCase::for_simplest(BUFFER_SIZE);
     // shrink_towards=0 below min=5 → simplest clamps to 5.
     let v = tc.draw_integer(5, 100).ok().unwrap();
     assert_eq!(v, 5);
@@ -671,7 +671,7 @@ fn for_simplest_draws_integer_clamped_to_range_when_target_below() {
 
 #[test]
 fn for_simplest_draws_integer_clamped_to_range_when_target_above() {
-    let mut tc = NativeTestCase::for_simplest();
+    let mut tc = NativeTestCase::for_simplest(BUFFER_SIZE);
     // shrink_towards=0 above max=-1 → simplest clamps to -1.
     let v = tc.draw_integer(-100, -1).ok().unwrap();
     assert_eq!(v, -1);
@@ -682,7 +682,7 @@ fn for_simplest_propagates_across_many_draws() {
     // The mode applies to every draw, not just the first. This is what makes
     // Hypothesis-style "midnight = all four time components are zero" findable
     // on a single pre-trial.
-    let mut tc = NativeTestCase::for_simplest();
+    let mut tc = NativeTestCase::for_simplest(BUFFER_SIZE);
     for _ in 0..10 {
         assert_eq!(tc.draw_integer(0, 99).ok().unwrap(), 0);
     }
@@ -690,7 +690,7 @@ fn for_simplest_propagates_across_many_draws() {
 
 #[test]
 fn for_simplest_draws_float_at_zero() {
-    let mut tc = NativeTestCase::for_simplest();
+    let mut tc = NativeTestCase::for_simplest(BUFFER_SIZE);
     let v = tc.draw_float(-10.0, 10.0, false, false).ok().unwrap();
     assert_eq!(v, 0.0);
     assert!(v.is_sign_positive(), "expected +0.0, got -0.0");
@@ -698,14 +698,14 @@ fn for_simplest_draws_float_at_zero() {
 
 #[test]
 fn for_simplest_draws_weighted_at_false() {
-    let mut tc = NativeTestCase::for_simplest();
+    let mut tc = NativeTestCase::for_simplest(BUFFER_SIZE);
     let v = tc.weighted(0.5, None).ok().unwrap();
     assert!(!v, "weighted draw in simplest mode should be false");
 }
 
 #[test]
 fn for_simplest_draws_bytes_at_min_size_all_zero() {
-    let mut tc = NativeTestCase::for_simplest();
+    let mut tc = NativeTestCase::for_simplest(BUFFER_SIZE);
     let v = tc.draw_bytes(2, 5).ok().unwrap();
     assert_eq!(v, vec![0u8; 2], "expected min-sized all-zero buffer");
 }
@@ -714,8 +714,8 @@ fn for_simplest_draws_bytes_at_min_size_all_zero() {
 fn for_simplest_is_independent_of_seed() {
     // Two simplest test cases produce identical traces — that's the whole
     // point: deterministic boundary trial that doesn't depend on RNG luck.
-    let mut a = NativeTestCase::for_simplest();
-    let mut b = NativeTestCase::for_simplest();
+    let mut a = NativeTestCase::for_simplest(BUFFER_SIZE);
+    let mut b = NativeTestCase::for_simplest(BUFFER_SIZE);
     for _ in 0..5 {
         let va = a.draw_integer(0, 1000).ok().unwrap();
         let vb = b.draw_integer(0, 1000).ok().unwrap();
@@ -729,8 +729,159 @@ fn for_simplest_records_choice_nodes() {
     // Forced-simplest draws still record nodes in the test case so the
     // engine can inspect what was drawn and feed the trace into the data
     // tree / shrinker if the test ends up Interesting.
-    let mut tc = NativeTestCase::for_simplest();
+    let mut tc = NativeTestCase::for_simplest(BUFFER_SIZE);
     let _ = tc.draw_integer(0, 23).ok().unwrap();
     let _ = tc.weighted(0.5, None).ok().unwrap();
     assert_eq!(tc.nodes.len(), 2);
+}
+
+// ── ChoiceTemplate / trailing_template ───────────────────────────────────────
+//
+// Direct tests for the new template mechanism. The for_simplest_* tests above
+// exercise the same paths through the `for_simplest` wrapper; these target
+// the underlying `for_choices_and_template` constructor and the count /
+// mixed-prefix behaviours that wrapper hides.
+
+#[test]
+fn template_simplest_infinite_resolves_every_draw_to_simplest() {
+    let mut tc = NativeTestCase::for_choices_and_template(
+        &[],
+        None,
+        Some(ChoiceTemplate::simplest(None)),
+        10,
+        None,
+    );
+    for _ in 0..5 {
+        assert_eq!(tc.draw_integer(-100, 100).ok().unwrap(), 0);
+    }
+    assert!(!tc.weighted(0.5, None).ok().unwrap());
+}
+
+#[test]
+fn template_simplest_finite_count_n_produces_exactly_n_values() {
+    let mut tc = NativeTestCase::for_choices_and_template(
+        &[],
+        None,
+        Some(ChoiceTemplate::simplest(Some(3))),
+        100,
+        None,
+    );
+    for _ in 0..3 {
+        assert_eq!(tc.draw_integer(0, 100).ok().unwrap(), 0);
+    }
+    // 4th draw is the overrun edge: returns Err and sets EarlyStop.
+    assert!(tc.draw_integer(0, 100).is_err());
+    assert_eq!(tc.status, Some(Status::EarlyStop));
+}
+
+#[test]
+fn template_concrete_prefix_then_template() {
+    let prefix = vec![ChoiceValue::Integer(42)];
+    let mut tc = NativeTestCase::for_choices_and_template(
+        &prefix,
+        None,
+        Some(ChoiceTemplate::simplest(None)),
+        10,
+        None,
+    );
+    // First draw replays the concrete prefix entry.
+    assert_eq!(tc.draw_integer(0, 100).ok().unwrap(), 42);
+    // Subsequent draws fall through to the template → simplest().
+    assert_eq!(tc.draw_integer(0, 100).ok().unwrap(), 0);
+    assert_eq!(tc.draw_integer(0, 100).ok().unwrap(), 0);
+}
+
+#[test]
+fn template_concrete_prefix_with_punning_then_template() {
+    // Prefix was originally a Boolean, but the test is drawing an Integer:
+    // punning routes the first draw to unit() (since the original wasn't
+    // "simplest"), and the template kicks in for subsequent draws.
+    let prefix = vec![ChoiceValue::Boolean(true)];
+    let prefix_nodes = vec![ChoiceNode {
+        kind: ChoiceKind::Boolean(BooleanChoice),
+        value: ChoiceValue::Boolean(true),
+        was_forced: false,
+    }];
+    let mut tc = NativeTestCase::for_choices_and_template(
+        &prefix,
+        Some(&prefix_nodes),
+        Some(ChoiceTemplate::simplest(None)),
+        10,
+        None,
+    );
+    // Draw 1: kind mismatch + non-simplest original → unit().
+    let v = tc.draw_integer(-100, 100).ok().unwrap();
+    assert_eq!(
+        v,
+        IntegerChoice {
+            min_value: -100,
+            max_value: 100,
+            shrink_towards: 0,
+        }
+        .unit()
+    );
+    // Draw 2: template branch → simplest().
+    assert_eq!(tc.draw_integer(0, 100).ok().unwrap(), 0);
+}
+
+#[test]
+#[should_panic(expected = "ChoiceTemplate count must be positive")]
+fn template_count_zero_panics_at_construction() {
+    let _ = ChoiceTemplate::simplest(Some(0));
+}
+
+#[test]
+fn for_simplest_wrapper_matches_template_with_count_none() {
+    // for_simplest is just sugar for the explicit template; identical traces.
+    let mut a = NativeTestCase::for_simplest(5);
+    let mut b = NativeTestCase::for_choices_and_template(
+        &[],
+        None,
+        Some(ChoiceTemplate::simplest(None)),
+        5,
+        None,
+    );
+    for _ in 0..5 {
+        let va = a.draw_integer(-10, 10).ok().unwrap();
+        let vb = b.draw_integer(-10, 10).ok().unwrap();
+        assert_eq!(va, vb);
+        assert_eq!(va, 0);
+    }
+}
+
+#[test]
+fn template_overrun_status_matches_max_size_overrun() {
+    // Finite-count exhaustion and max_size exhaustion both set Status::EarlyStop —
+    // overrun behaviour is uniform across both paths.
+    let mut tc_count = NativeTestCase::for_choices_and_template(
+        &[],
+        None,
+        Some(ChoiceTemplate::simplest(Some(2))),
+        100,
+        None,
+    );
+    assert_eq!(tc_count.draw_integer(0, 100).ok().unwrap(), 0);
+    assert_eq!(tc_count.draw_integer(0, 100).ok().unwrap(), 0);
+    assert!(tc_count.draw_integer(0, 100).is_err());
+    assert_eq!(tc_count.status, Some(Status::EarlyStop));
+}
+
+#[test]
+fn template_count_decrements_on_each_draw() {
+    // White-box check: count walks 3 → 2 → 1 → 0 across three draws, then
+    // the fourth draw flips to overrun without further decrement.
+    let mut tc = NativeTestCase::for_choices_and_template(
+        &[],
+        None,
+        Some(ChoiceTemplate::simplest(Some(3))),
+        100,
+        None,
+    );
+    for _ in 0..3 {
+        let _ = tc.draw_integer(0, 100).ok().unwrap();
+    }
+    assert_eq!(tc.trailing_template.as_ref().unwrap().count, Some(0));
+    assert!(tc.draw_integer(0, 100).is_err());
+    // After overrun, count stays at 0 (we don't underflow into wraparound).
+    assert_eq!(tc.trailing_template.as_ref().unwrap().count, Some(0));
 }


### PR DESCRIPTION
This adds a basic port of choice templates from hypothesis, which were previously skipped by the porting work.

> Extracted from `DRMacIver/native` by Claude as part of the incremental landing of the native backend. The branch is treated as an artefact of study — this PR is a hand-reviewed rewrite, not a direct cherry-pick.

<details>
<summary>Implementation notes</summary>

**New types in `src/native/core/choices.rs`**:
- `ChoiceTemplateKind::Simplest` — extension point for the `"type"` field Hypothesis carries (currently only `"simplest"`).
- `ChoiceTemplate { kind, count: Option<usize> }` matching the two fields on Hypothesis's `@dataclass ChoiceTemplate`. `ChoiceTemplate::simplest(count)` constructor with the same `count > 0` assert Hypothesis's `__post_init__` enforces.

**`NativeTestCase` field changes in `src/native/core/state.rs`**:
- Added `trailing_template: Option<ChoiceTemplate>` (drives every draw past the explicit prefix).
- Removed `force_simplest: bool`.
- New `for_choices_and_template(choices, prefix_nodes, trailing, max_size, observer)` constructor; existing `for_choices`, `for_probe`, `new_random` reframed as thin wrappers over it.
- `for_simplest(max_size)` now takes a `max_size` argument and delegates to `for_choices_and_template(&[], None, Some(ChoiceTemplate::simplest(None)), max_size, None)`.

**`resolve_choice` reshape**: replaced the prefix → force_simplest → rng tree with prefix → trailing_template → rng. Punning (`prefix_nodes`) is read only by the concrete-prefix branch, so it stays orthogonal to templates.

**Test coverage**:
- All nine existing `for_simplest_*` unit tests pass through the new wrapper (call sites adjusted for the `max_size` argument).
- Eight new tests covering: infinite-count template, finite-count exactly-N semantics, concrete prefix + trailing template, prefix + punning + trailing template, `count=0` panic at construction, wrapper-equivalence with the explicit form, overrun-status parity with `max_size` exhaustion, and count-decrement sanity.
- Behavioural tests in `tests/test_phases.rs` (`test_generate_phase_runs_all_simplest_first` and friends, landed in PR #276) continue to pass unchanged.

**Deliberate divergence from Hypothesis**: when `count=Some(N)`, this implementation produces exactly N simplest values and the (N+1)th draw is overrun. Hypothesis's literal source (`data.py:1054-1073`) decrements after producing the value and then checks for `< 0`, which means a `count=N` template actually emits N+1 values (the last one alongside the overrun status). That looks like an unintentional off-by-one — no current Hypothesis caller passes a finite count, so the divergence is invisible at the API boundary. Documented prominently on `ChoiceTemplate`'s rustdoc and locked in by `template_simplest_finite_count_n_produces_exactly_n_values`.

**What's still gated for a follow-up**: mid-prefix templates (Hypothesis's `data.py:1057` comment notes they considered allowing this but stayed conservative). If Hypothesis ever lifts the "last only" restriction, `Option<ChoiceTemplate>` becomes `Vec<PrefixEntry>` — a small refactor; we cross that bridge then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
</details>