### PR TITLE
Persistent intermediate failures to the database in native mode

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,8 @@
+RELEASE_TYPE: patch
+
+The native backend (`--features native`) now persists failing examples to the
+database as soon as they are discovered and after every shrink improvement,
+matching Hypothesis's `save_choices`/`downgrade_choices` behaviour. Previously
+the save happened only at the end of `run_main`, so killing the runner during
+shrinking (Ctrl-C, SIGTERM) would lose the failure even though it had already
+been found.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,6 @@ RELEASE_TYPE: patch
 
 The native backend (`--features native`) now persists failing examples to the
 database as soon as they are discovered and after every shrink improvement,
-matching Hypothesis's `save_choices`/`downgrade_choices` behaviour. Previously
-the save happened only at the end of `run_main`, so killing the runner during
+matching Hypothesis's behaviour. Previously the save happened only at the end of `run_main`, so killing the runner during
 shrinking (Ctrl-C, SIGTERM) would lose the failure even though it had already
 been found.

--- a/src/native/test_runner.rs
+++ b/src/native/test_runner.rs
@@ -139,6 +139,8 @@ fn run_main(
         Database::Disabled => None,
     };
 
+    let mut persister = Persister::new(db.as_deref(), database_key);
+
     let mut ctx = EngineCtx::new(run_case);
 
     // Local data tree used by the generation phase to drive `for_probe`
@@ -194,6 +196,14 @@ fn run_main(
                     if run.nodes.len() != stored_choices.len() {
                         replay_aligned = false;
                     }
+                    // Re-save the realised choice sequence: the stored
+                    // raw bytes may not match `serialize_choices(run.nodes)`
+                    // if the replay realised a shorter prefix, and we
+                    // want the persister's "last saved primary" entry to
+                    // be byte-accurate for later downgrades.  Any stale
+                    // raw bytes still in primary are reconciled to
+                    // `secondary` by the end-of-run save.
+                    persister.record(&origin, &run.nodes);
                     update_interesting(&mut interesting, origin, run.nodes);
                 } else {
                     // Non-interesting (or invalid) replay: the stored
@@ -247,6 +257,7 @@ fn run_main(
             let origin = run.origin.clone().unwrap_or_default();
             first_bug_at = Some(calls);
             last_bug_at = Some(calls);
+            persister.record(&origin, &run.nodes);
             update_interesting(&mut interesting, origin, run.nodes.clone());
         }
     }
@@ -402,6 +413,7 @@ fn run_main(
                     first_bug_at = Some(calls);
                 }
                 last_bug_at = Some(calls);
+                persister.record(&origin, &run.nodes);
                 update_interesting(&mut interesting, origin, run.nodes.clone());
             } else if run.status == Status::Valid {
                 // Bump `calls` by the *actual* number of probes
@@ -417,6 +429,7 @@ fn run_main(
                         first_bug_at = Some(calls);
                     }
                     last_bug_at = Some(calls);
+                    persister.record(&origin, &mut_nodes);
                     update_interesting(&mut interesting, origin, mut_nodes);
                 }
             }
@@ -475,6 +488,7 @@ fn run_main(
 
             let target_origin = origin.clone();
             let shrunk = {
+                let persister_ref = &mut persister;
                 let mut shrinker = Shrinker::with_probe(
                     Box::new(|req: ShrinkRun| {
                         if verbosity == Verbosity::Verbose {
@@ -491,6 +505,14 @@ fn run_main(
                             } => ctx.run_probe_with_origin(prefix, seed, max_size, &target_origin),
                         };
                         calls += 1;
+                        // If this probe matched the target origin, persist it
+                        // immediately. The persister's sort-key check ensures
+                        // only strict improvements actually touch the disk,
+                        // and a Ctrl-C any time after this returns leaves the
+                        // best known counterexample saved to the primary key.
+                        if result.0 {
+                            persister_ref.record(&target_origin, &result.1);
+                        }
                         result
                     }),
                     verify.nodes,
@@ -668,6 +690,65 @@ fn update_interesting(
                 e.insert(nodes);
             }
         }
+    }
+}
+
+/// Incremental database-save bookkeeping. Mirrors Hypothesis's
+/// `save_choices` / `downgrade_choices` calls inside `test_function`: every
+/// time a new interesting result is found (or an existing one is
+/// shortlex-improved), the realised choice sequence is saved to the primary
+/// key and the displaced previous entry is moved to the secondary key.
+///
+/// Persisting incrementally — rather than only at the end of `run_main` — is
+/// what guarantees that a failure survives a Ctrl-C / SIGTERM mid-shrink:
+/// the moment the runner discovers the failure (and at every subsequent
+/// improvement), the bytes are on disk.
+struct Persister<'a> {
+    db: Option<&'a dyn TestCaseDatabase>,
+    database_key: Option<&'a str>,
+    /// For each origin we've saved at least once, the choice-node sequence
+    /// of the most recent save. Used to (a) decide whether a new result is
+    /// shortlex-smaller and therefore worth saving, and (b) compute the
+    /// bytes to downgrade when it is.
+    last_saved: HashMap<String, Vec<ChoiceNode>>,
+}
+
+impl<'a> Persister<'a> {
+    fn new(db: Option<&'a dyn TestCaseDatabase>, database_key: Option<&'a str>) -> Self {
+        Persister {
+            db,
+            database_key,
+            last_saved: HashMap::new(),
+        }
+    }
+
+    /// Record an interesting result for `origin`. If this is the first
+    /// sighting, or shortlex-precedes the previous save, the new bytes are
+    /// written to the primary key and any previously-saved bytes for this
+    /// origin are downgraded to the secondary key.
+    fn record(&mut self, origin: &str, nodes: &[ChoiceNode]) {
+        let Some(db) = self.db else { return };
+        let Some(key) = self.database_key else { return };
+        let key_bytes = key.as_bytes();
+        let new_choices: Vec<ChoiceValue> = nodes.iter().map(|n| n.value.clone()).collect();
+        let new_bytes = serialize_choices(&new_choices);
+
+        let needs_save = match self.last_saved.get(origin) {
+            None => true,
+            Some(prev) => sort_key(nodes) < sort_key(prev),
+        };
+        if !needs_save {
+            return;
+        }
+
+        if let Some(prev) = self.last_saved.get(origin) {
+            let prev_choices: Vec<ChoiceValue> = prev.iter().map(|n| n.value.clone()).collect();
+            let prev_bytes = serialize_choices(&prev_choices);
+            let secondary_key = crate::native::data_tree::sub_key(key_bytes, b"secondary");
+            db.move_value(key_bytes, &secondary_key, &prev_bytes);
+        }
+        db.save(key_bytes, &new_bytes);
+        self.last_saved.insert(origin.to_string(), nodes.to_vec());
     }
 }
 

--- a/tests/test_database_key.rs
+++ b/tests/test_database_key.rs
@@ -226,4 +226,188 @@ mod replay_logic {
         run();
         assert_eq!(*last.lock().unwrap(), Some(0));
     }
+
+    /// Recursively count regular files under `dir`. Returns 0 if `dir`
+    /// does not exist. Used by the persistence tests below to check
+    /// whether the database has any stored entries without needing
+    /// access to internal hashing.
+    fn db_file_count(dir: &std::path::Path) -> usize {
+        let entries = match std::fs::read_dir(dir) {
+            Ok(d) => d,
+            Err(_) => return 0,
+        };
+        let mut n = 0;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                n += db_file_count(&path);
+            } else {
+                n += 1;
+            }
+        }
+        n
+    }
+
+    /// Regression test: a failing test case must be persisted to the
+    /// database as soon as it is discovered, not only at the end of the
+    /// run. If the runner is killed (e.g. Ctrl+C during shrinking), the
+    /// initially-found failure — and any intermediate shrunk version —
+    /// must already be saved.
+    ///
+    /// This test exercises the discovery save: from inside the test
+    /// body, we observe the database directory. By the time the body is
+    /// invoked again (during shrinking), the previously-discovered
+    /// failing example must already be on disk.
+    #[test]
+    fn test_failure_persisted_immediately_when_discovered() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let db_path = temp_dir.path().to_str().unwrap().to_string();
+        let db_path_for_check = db_path.clone();
+
+        // Earliest call number (1-indexed) on which the test body
+        // observed at least one entry in the database. `None` means the
+        // body never saw a populated database during the run.
+        let observed_at: Arc<Mutex<Option<u64>>> = Arc::new(Mutex::new(None));
+        let observed_cl = Arc::clone(&observed_at);
+        let calls: Arc<Mutex<u64>> = Arc::new(Mutex::new(0));
+        let calls_cl = Arc::clone(&calls);
+        let db_root = std::path::PathBuf::from(&db_path_for_check);
+
+        run_expecting_failure(std::panic::AssertUnwindSafe(move || {
+            Hegel::new(move |tc: TestCase| {
+                {
+                    let mut c = calls_cl.lock().unwrap();
+                    *c += 1;
+                    if observed_cl.lock().unwrap().is_none() && db_file_count(&db_root) > 0 {
+                        *observed_cl.lock().unwrap() = Some(*c);
+                    }
+                }
+                let n: i64 = tc.draw(gs::integers::<i64>().min_value(0));
+                assert!(n < 1_000_000);
+            })
+            .settings(
+                Settings::new()
+                    .database(Some(db_path))
+                    .derandomize(false)
+                    .test_cases(1000),
+            )
+            .__database_key("test_failure_persisted_immediately_when_discovered".to_string())
+            .run();
+        }));
+
+        // Sanity check: the run actually performed more than one test case.
+        // (A failing test with shrinking will run many more.)
+        let total_calls = *calls.lock().unwrap();
+        assert!(
+            total_calls > 1,
+            "expected the run to make more than one test-case call, got {total_calls}"
+        );
+
+        // The database must have entries STRICTLY BEFORE the final test
+        // body call. If `observed_at` is `None` (db never populated) or
+        // equals `total_calls` (db only populated for the final replay),
+        // persistence happens too late and killing mid-shrink loses the
+        // failure.
+        let observed = *observed_at.lock().unwrap();
+        assert!(
+            observed.is_some_and(|o| o < total_calls),
+            "Database was not populated during the run \
+             (observed_at={observed:?}, total_calls={total_calls}). \
+             Killing the runner mid-shrink would lose the failure."
+        );
+    }
+
+    /// Stronger regression test: intermediate shrunk versions must
+    /// reach the database before the next test-body call. We snapshot
+    /// the DB file count on every body invocation; if the shrinker is
+    /// improving the DB incrementally, the count should change between
+    /// the first observation (single discovered failure) and the last
+    /// (potentially the smallest shrunk version). If saves are batched
+    /// to end-of-run, observed snapshots would either all be 0 or all
+    /// jump from 0 to N on the final replay alone.
+    #[test]
+    fn test_intermediate_shrinks_update_db_during_run() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let db_path = temp_dir.path().to_str().unwrap().to_string();
+        let db_root = std::path::PathBuf::from(&db_path);
+        let db_root_cl = db_root.clone();
+
+        // Distinct (file-count, total-bytes) snapshots observed by the
+        // body across all of its calls. A working incremental persister
+        // shows at least two distinct snapshots (the DB grows / shrinks
+        // as the shrinker makes progress); a broken one shows just
+        // `{(0, 0)}` (DB empty during the run) or a single non-empty
+        // snapshot reached only at the very end.
+        let snapshots: Arc<Mutex<std::collections::HashSet<(usize, usize)>>> =
+            Arc::new(Mutex::new(std::collections::HashSet::new()));
+        let snapshots_cl = Arc::clone(&snapshots);
+        let calls: Arc<Mutex<u64>> = Arc::new(Mutex::new(0));
+        let calls_cl = Arc::clone(&calls);
+
+        run_expecting_failure(std::panic::AssertUnwindSafe(move || {
+            Hegel::new(move |tc: TestCase| {
+                {
+                    *calls_cl.lock().unwrap() += 1;
+                    let (count, total_bytes) = db_summary(&db_root_cl);
+                    snapshots_cl.lock().unwrap().insert((count, total_bytes));
+                }
+                let n: i64 = tc.draw(gs::integers::<i64>().min_value(0));
+                let v: Vec<i64> = tc.draw(gs::vecs(gs::integers::<i64>()).min_size(0));
+                let _ = v;
+                assert!(n < 1_000_000);
+            })
+            .settings(
+                Settings::new()
+                    .database(Some(db_path))
+                    .derandomize(false)
+                    .test_cases(1000),
+            )
+            .__database_key("test_intermediate_shrinks_update_db_during_run".to_string())
+            .run();
+        }));
+
+        let snaps = snapshots.lock().unwrap().clone();
+        // Reached the body at least a few times.
+        let total = *calls.lock().unwrap();
+        assert!(total > 1, "expected multiple test-body calls, got {total}");
+
+        // The DB went through multiple distinct *non-empty* states during
+        // the run — i.e. the shrinker's improvements were persisted as
+        // they happened, not collapsed into a single end-of-run write.
+        // Without incremental persistence, the body sees only `(0, 0)`
+        // throughout shrinking and a single end-state on the final
+        // replay → at most one non-empty snapshot.
+        let distinct_non_empty = snaps.iter().filter(|&&(_, b)| b > 0).count();
+        assert!(
+            distinct_non_empty >= 2,
+            "Only saw {distinct_non_empty} distinct non-empty DB \
+             state(s) across {total} test-body calls (snapshots: \
+             {snaps:?}). The shrinker is not persisting intermediate \
+             improvements — killing it mid-shrink would lose progress."
+        );
+    }
+
+    /// Recursively compute `(file_count, total_bytes)` for everything
+    /// under `root`. Used by the persistence tests to summarise the
+    /// database state without depending on the internal hashing.
+    fn db_summary(root: &std::path::Path) -> (usize, usize) {
+        let entries = match std::fs::read_dir(root) {
+            Ok(d) => d,
+            Err(_) => return (0, 0),
+        };
+        let mut count = 0;
+        let mut total = 0;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                let (c, t) = db_summary(&path);
+                count += c;
+                total += t;
+            } else if let Ok(meta) = std::fs::metadata(&path) {
+                count += 1;
+                total += meta.len() as usize;
+            }
+        }
+        (count, total)
+    }
 }


### PR DESCRIPTION
The native backend now saves failing examples to the database as they are discovered, matching Hypothesis behaviour. Previously a Ctrl-C during shrinking would lose the failure.

<details>
<summary>Implementation details</summary>

## Summary
- Adds a `Persister` helper in `src/native/test_runner.rs` that mirrors Hypothesis's `save_choices` / `downgrade_choices`: every interesting result is written to the primary key as soon as it's observed, and any previously-saved entry for the same origin is moved to the secondary key.
- Wired into all the call sites that previously only updated the in-memory `interesting` map: replay phase, all-simplest pre-trial, generation phase, span-mutation path, and (most importantly) inside the shrinker's test-function closure.
- The existing end-of-run save remains as a final reconciliation pass — incremental saves are additive.

## Why
Previously the native runner only saved interesting choice sequences at the end of `run_main`. Killing the runner during shrinking (Ctrl-C, SIGTERM, or any other early exit) lost the failure even though it had already been discovered and possibly shrunk.

## Test plan
- [x] Added `test_failure_persisted_immediately_when_discovered`: verifies the DB is non-empty before the run's final body call.
- [x] Added `test_intermediate_shrinks_update_db_during_run`: verifies the DB passes through multiple distinct non-empty states, proving shrinker improvements are persisted incrementally.
- [x] Both tests confirmed to fail on `main` without the fix and pass with it.
- [x] Existing `tests/test_database_key.rs` tests all still pass (server and native backends).
- [x] `just check-coverage` passes at 100%.
- [x] `cargo clippy --features native --all-targets` clean.
- [x] `cargo fmt --check` clean.
</details>