### PR TITLE
Fix Verbosity::Verbose to print test cases as they execute.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+RELEASE_TYPE: patch
+
+This patch makes `Verbosity::Verbose` (and `Verbosity::Debug`) actually show what's happening inside a run. Previously these levels only added a single `Running test case` line; everything else (drawn values, notes, panic messages) was suppressed until the final replay.
+
+At `Verbose` or higher:
+
+- `tc.note(...)` and the per-draw `let x = ...;` lines now print on every test case, not only the final replay of a failing example.
+- When a test case panics, the full panic diagnostic (thread, location, message, and backtrace if `RUST_BACKTRACE` is set) is emitted as soon as the panic happens, so you can see which inputs caused which failure as the run progresses.
+- Each test case rejected by the backend prints a short reason line — `Test case stopped: failed assumption` for `assume`/`reject` calls, and `Test case stopped: out of data` when the backend exhausts its choice budget.

--- a/src/run_lifecycle.rs
+++ b/src/run_lifecycle.rs
@@ -201,7 +201,11 @@ pub(crate) fn run_test_case(
     mode: Mode,
     verbosity: crate::runner::Verbosity,
 ) -> TestCaseResult {
-    let tc = TestCase::new(data_source, is_final, mode);
+    let verbose = matches!(
+        verbosity,
+        crate::runner::Verbosity::Verbose | crate::runner::Verbosity::Debug
+    );
+    let tc = TestCase::new(data_source, is_final, mode, verbose);
     let result = with_test_context(|| catch_unwind(AssertUnwindSafe(|| test_fn(tc.clone()))));
 
     let tc_result = match &result {
@@ -229,10 +233,39 @@ pub(crate) fn run_test_case(
         }
     };
 
+    if verbose {
+        emit_verbose_test_case_outcome(&tc_result, is_final);
+    }
+
     tc.mark_complete(&tc_result);
 
-    let _ = (is_final, verbosity);
     tc_result
+}
+
+/// Print a per-test-case line describing why this test case stopped, and
+/// — for genuine panics on non-final test cases — the full panic
+/// diagnostic. Final-replay panics are already covered by the run-level
+/// summary in [`drive`]; printing them here too would just duplicate the
+/// block.
+fn emit_verbose_test_case_outcome(result: &TestCaseResult, is_final: bool) {
+    match result {
+        TestCaseResult::Invalid => {
+            crate::test_case::emit_verbose_line("Test case stopped: failed assumption");
+        }
+        TestCaseResult::Overrun => {
+            crate::test_case::emit_verbose_line("Test case stopped: out of data");
+        }
+        TestCaseResult::Interesting(failure) if !is_final => {
+            // `diagnostic` already ends with a newline, so use `eprint!`-
+            // style emission (no extra newline). The sink interface only
+            // takes whole lines, so split on '\n' and drop the trailing
+            // empty piece if any.
+            for line in failure.diagnostic.trim_end_matches('\n').split('\n') {
+                crate::test_case::emit_verbose_line(line);
+            }
+        }
+        TestCaseResult::Valid | TestCaseResult::Interesting(_) => {}
+    }
 }
 
 /// Render the per-failure diagnostic block previously emitted inline.

--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -51,7 +51,6 @@ fn panic_on_data_source_error(e: DataSourceError) -> ! {
 }
 
 pub(crate) struct TestCaseGlobalData {
-    is_last_run: bool,
     mode: Mode,
     /// Fine-grained lock over the state shared between clones of a
     /// `TestCase`. Acquired briefly around each individual backend call
@@ -209,6 +208,24 @@ pub fn with_output_override<R>(sink: OutputSink, f: impl FnOnce() -> R) -> R {
     result
 }
 
+/// Return a clone of the currently-installed output sink, if any. Lets the
+/// run lifecycle's verbose output (stop-reason lines, per-test-case panic
+/// diagnostics) flow through `with_output_override` so tests can capture
+/// them in-process without having to spawn a subprocess.
+pub(crate) fn current_output_sink() -> Option<OutputSink> {
+    OUTPUT_OVERRIDE.with(|cell| cell.borrow().clone())
+}
+
+/// Emit a single line of verbose runner output, going through the
+/// installed output sink if there is one and otherwise to stderr.
+pub(crate) fn emit_verbose_line(msg: &str) {
+    if let Some(sink) = current_output_sink() {
+        sink(msg);
+    } else {
+        eprintln!("{}", msg);
+    }
+}
+
 fn panic_message(payload: &Box<dyn Any + Send>) -> String {
     if let Some(s) = payload.downcast_ref::<&str>() {
         s.to_string()
@@ -220,16 +237,21 @@ fn panic_message(payload: &Box<dyn Any + Send>) -> String {
 }
 
 impl TestCase {
-    pub(crate) fn new(data_source: Box<dyn DataSource>, is_last_run: bool, mode: Mode) -> Self {
-        let override_sink = OUTPUT_OVERRIDE.with(|cell| cell.borrow().clone());
+    pub(crate) fn new(
+        data_source: Box<dyn DataSource>,
+        is_last_run: bool,
+        mode: Mode,
+        verbose: bool,
+    ) -> Self {
+        let override_sink = current_output_sink();
+        let should_emit = is_last_run || verbose;
         let on_draw: OutputSink = match override_sink {
-            Some(sink) if is_last_run => sink,
-            _ if is_last_run => Arc::new(|msg| eprintln!("{}", msg)),
+            Some(sink) if should_emit => sink,
+            _ if should_emit => Arc::new(|msg| eprintln!("{}", msg)),
             _ => Arc::new(|_| {}),
         };
         TestCase {
             global: Arc::new(TestCaseGlobalData {
-                is_last_run,
                 mode,
                 shared: Mutex::new(SharedState {
                     data_source,
@@ -363,7 +385,9 @@ impl TestCase {
 
     /// Note a message which will be displayed with the reported failing test case.
     ///
-    /// Only prints during the final replay of a failing test case.
+    /// At the default verbosity, only prints during the final replay of a
+    /// failing test case. At [`Verbose`](crate::Verbosity::Verbose) or
+    /// higher, prints on every test case.
     ///
     /// # Example
     ///
@@ -377,9 +401,6 @@ impl TestCase {
     /// }
     /// ```
     pub fn note(&self, message: &str) {
-        if !self.global.is_last_run {
-            return;
-        }
         let local = self.local.borrow();
         let indent = local.indent;
         (local.on_draw)(&format!("{:indent$}{}", "", message, indent = indent));

--- a/tests/test_output.rs
+++ b/tests/test_output.rs
@@ -545,21 +545,19 @@ mod verbose_per_test_case_output {
         );
     }
 
-    #[cfg(feature = "native")]
     #[test]
     fn verbose_prints_stop_reason_for_out_of_data() {
-        // A vec with a min_size larger than the native choice budget
-        // (`BUFFER_SIZE = 8192`) forces StopTest, which the lifecycle
-        // records as Overrun. The server backend triggers a
-        // Hypothesis-side `large_base_example` health check long before
-        // we can reach this codepath, so this test runs on native only.
-        // The tight integer range keeps the sampler quick — we only
-        // need to fill choice slots, not generate interesting values.
-        let lines = collect_output_with_cases(Verbosity::Verbose, 2, |tc| {
-            let _: Vec<i64> = tc.draw(
-                gs::vecs(gs::integers::<i64>().min_value(0).max_value(1))
-                    .min_size(9_000),
-            );
+        // A failing run over a `vecs(...).min_size(10)` body forces
+        // shrinking, and the shrinker's probes are capped at the
+        // current shrunk length: the body needs at least 10 element
+        // draws to satisfy `min_size`, so probes with too-tight budgets
+        // raise StopTest and surface as `Overrun` here. This is the
+        // natural way Overrun arises in practice and works on both
+        // backends.
+        let lines = collect_output(Verbosity::Verbose, |tc| {
+            let xs: Vec<i64> = tc.draw(gs::vecs(gs::integers::<i64>()).min_size(10));
+            let sum: i128 = xs.iter().map(|&x| i128::from(x)).sum();
+            assert!(sum < 1000);
         });
         assert!(
             lines.iter().any(|s| s.contains("out of data")),

--- a/tests/test_output.rs
+++ b/tests/test_output.rs
@@ -449,6 +449,157 @@ fn main() {
     }
 }
 
+mod verbose_per_test_case_output {
+    //! In-process tests for the per-test-case verbose output: notes printing
+    //! in every test case, stop-reason lines for Invalid/Overrun, and the
+    //! panic diagnostic emitted as soon as a non-final test case fails.
+    //!
+    //! These tests capture output via `hegel::with_output_override`, which
+    //! also intercepts the new verbose output paths.
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+    use std::sync::{Arc, Mutex};
+
+    use hegel::generators as gs;
+    use hegel::{Hegel, Settings, Verbosity};
+
+    fn collect_output<F>(verbosity: Verbosity, body: F) -> Vec<String>
+    where
+        F: FnMut(hegel::TestCase) + 'static,
+    {
+        collect_output_with_cases(verbosity, 20, body)
+    }
+
+    fn collect_output_with_cases<F>(verbosity: Verbosity, test_cases: u64, body: F) -> Vec<String>
+    where
+        F: FnMut(hegel::TestCase) + 'static,
+    {
+        let buf: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let buf_writer = buf.clone();
+        let sink: Arc<dyn Fn(&str) + Send + Sync> =
+            Arc::new(move |s: &str| buf_writer.lock().unwrap().push(s.to_string()));
+
+        let _ = catch_unwind(AssertUnwindSafe(|| {
+            hegel::with_output_override(sink, || {
+                Hegel::new(body)
+                    .settings(
+                        Settings::new()
+                            .verbosity(verbosity)
+                            .test_cases(test_cases)
+                            .database(None)
+                            .derandomize(true),
+                    )
+                    .run();
+            });
+        }));
+
+        buf.lock().unwrap().clone()
+    }
+
+    #[test]
+    fn verbose_notes_print_in_every_test_case() {
+        // At Verbose, `note()` should emit on every test case, not just on
+        // the final replay. The exact number of test cases the backend
+        // actually executes is up to the engine (Hypothesis may
+        // short-circuit at derandomize), so we assert "more than one",
+        // which is the bit that wasn't true before this change.
+        let lines = collect_output(Verbosity::Verbose, |tc| {
+            let _ = tc.draw(gs::booleans());
+            tc.note("hello from a test case");
+        });
+        let n = lines
+            .iter()
+            .filter(|s| s.contains("hello from a test case"))
+            .count();
+        assert!(
+            n >= 2,
+            "expected the note to print in multiple test cases, got {} matches in {:?}",
+            n,
+            lines
+        );
+    }
+
+    #[test]
+    fn normal_mode_does_not_print_notes_for_non_final_test_cases() {
+        // Regression check on the original behavior: at Normal verbosity a
+        // passing run prints no notes at all (there's no final replay).
+        let lines = collect_output(Verbosity::Normal, |tc| {
+            let _ = tc.draw(gs::booleans());
+            tc.note("should not appear");
+        });
+        assert!(
+            !lines.iter().any(|s| s.contains("should not appear")),
+            "expected no notes at Normal verbosity, got {:?}",
+            lines
+        );
+    }
+
+    #[test]
+    fn verbose_prints_stop_reason_for_failed_assumption() {
+        let lines = collect_output(Verbosity::Verbose, |tc| {
+            tc.assume(false);
+        });
+        assert!(
+            lines.iter().any(|s| s.contains("failed assumption")),
+            "expected a stop-reason line about a failed assumption, got {:?}",
+            lines
+        );
+    }
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn verbose_prints_stop_reason_for_out_of_data() {
+        // A vec with a min_size larger than the native choice budget
+        // (`BUFFER_SIZE = 8192`) forces StopTest, which the lifecycle
+        // records as Overrun. The server backend triggers a
+        // Hypothesis-side `large_base_example` health check long before
+        // we can reach this codepath, so this test runs on native only.
+        // The tight integer range keeps the sampler quick — we only
+        // need to fill choice slots, not generate interesting values.
+        let lines = collect_output_with_cases(Verbosity::Verbose, 2, |tc| {
+            let _: Vec<i64> = tc.draw(
+                gs::vecs(gs::integers::<i64>().min_value(0).max_value(1))
+                    .min_size(9_000),
+            );
+        });
+        assert!(
+            lines.iter().any(|s| s.contains("out of data")),
+            "expected a stop-reason line about out of data, got {:?}",
+            lines
+        );
+    }
+
+    #[test]
+    fn verbose_prints_full_panic_message_when_a_test_case_fails() {
+        // The full panic diagnostic ("thread '...' panicked at ...:\n<msg>")
+        // should appear as soon as a non-final test case fails, not only in
+        // the final summary.
+        let lines = collect_output(Verbosity::Verbose, |tc| {
+            let _ = tc.draw(gs::booleans());
+            panic!("the canary panic message");
+        });
+        assert!(
+            lines.iter().any(|s| s.contains("the canary panic message")),
+            "expected the panic message to appear during the verbose run, got {:?}",
+            lines
+        );
+    }
+
+    #[test]
+    fn normal_mode_does_not_print_stop_reason_for_failed_assumption() {
+        // The new stop-reason lines must be silent at Normal verbosity.
+        let lines = collect_output(Verbosity::Normal, |tc| {
+            tc.assume(false);
+        });
+        assert!(
+            !lines
+                .iter()
+                .any(|s| s.contains("failed assumption") || s.contains("out of data")),
+            "did not expect any stop-reason lines at Normal verbosity, got {:?}",
+            lines
+        );
+    }
+}
+
 mod debug_information {
     use super::common::project::TempRustProject;
     use std::sync::OnceLock;


### PR DESCRIPTION
<details>
<summary>AI-generated implementation notes</summary>

## Summary

`Verbosity::Verbose` and `Verbosity::Debug` previously only added a single `Running test case` line per test case — drawn values, notes, and panic messages were suppressed until the final replay. This PR wires verbosity through `TestCase::new` so the verbose levels actually show what's happening as the run progresses.

At Verbose or higher:

- `tc.note(...)` and the per-draw `let x = ...;` lines print on every test case, not only the final replay.
- The full panic diagnostic (thread / location / message, plus backtrace if `RUST_BACKTRACE` is set) is emitted as soon as a non-final test case fails. The final-replay diagnostic still prints once via the run-level summary.
- Test cases rejected by the backend print a one-line reason: `Test case stopped: failed assumption` for `assume(false)` / `reject()`, and `Test case stopped: out of data` when the backend exhausts its choice budget.

## Implementation

- `src/test_case.rs` — `TestCase::new` takes a new `verbose: bool`. The on-draw sink emits whenever `is_last_run || verbose`. Added `current_output_sink()` and `emit_verbose_line()` so the run lifecycle can route output through `with_output_override` for in-process testing.
- `src/run_lifecycle.rs` — `run_test_case` passes verbosity through to `TestCase::new` and, at Verbose+, emits the stop-reason / panic-diagnostic lines via `emit_verbose_line`. Per-test-case Interesting diagnostics are skipped on the final replay to avoid duplicating the run-level summary.
- `tests/test_output.rs` — six new in-process tests under `verbose_per_test_case_output` covering notes, stop-reason lines, and panic diagnostics. The Overrun test triggers naturally via shrinking probes capped at the current shrunk length, so it works on both backends.

## Test plan

- [x] `cargo test` (default features) — full suite passes
- [x] `cargo test --features native` for the affected tests (`test_output`, `test_loop`, `test_hegel_test`, `test_settings`, `test_single_test_case`, `test_combinators`) passes
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (default + `--features native`)
- [ ] Coverage CI (`just check-coverage`) — not run locally; relying on CI
</details>