### PR TITLE
Internal-only panic-free API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,14 @@ jobs:
       - name: Run C bindings test recipe
         run: just c-test
 
+      # Build libhegel with `panic = "abort"` and re-run the smoke tests + C
+      # examples against it. Proves no panic crosses the FFI boundary on the
+      # tested paths (an invalid schema that aborted instead of returning
+      # HEGEL_E_INVALID_ARG would crash the process and fail this step). The
+      # recipe is a no-op on Windows (bash-driven examples).
+      - name: Run C bindings under panic=abort
+        run: just c-test-abort
+
   test-min-protocol:
     name: test-min-protocol
     runs-on: ubuntu-latest

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,17 +1,7 @@
-RELEASE_TYPE: minor
+RELEASE_TYPE: patch
 
-This release stops the native engine from aborting the host process on an invalid schema. Previously, a generation request the engine could not interpret — for example a misspelled type such as `{"type": "ipv4"}`, an unparseable regex, or a character set that excludes every codepoint — would `panic!`. When the engine is driven in-process over the C FFI (`libhegel`), that panic crossed the `extern "C"` boundary and aborted the whole host process (SIGABRT), so a single bad schema from a binding could take down an embedding application. The engine now reports these as recoverable errors: `hegel_generate` returns `HEGEL_E_INVALID_ARG` with a diagnostic in `hegel_last_error_message`, matching the documented contract, and the process keeps running. The pure-Rust API is unchanged — it still panics at the API surface, since its generators only ever build valid schemas.
+This patch stops the native engine from aborting the host process on an invalid schema. Previously, a generation request the engine could not interpret — for example a misspelled type such as `{"type": "ipv4"}`, an unparseable regex, or a character set that excludes every codepoint — would `panic!`. When the engine is driven in-process over the C FFI (`libhegel`), that panic crossed the `extern "C"` boundary and aborted the whole host process (SIGABRT), so a single bad schema from a binding could take down an embedding application. The engine now reports these as recoverable errors: `hegel_generate` returns `HEGEL_E_INVALID_ARG` with a diagnostic in `hegel_last_error_message`, matching the documented contract, and the process keeps running.
 
 Run-loop health-check failures (`FilterTooMuch`, `TooSlow`, and flaky-test detection) are likewise no longer raised as panics inside the engine; they are surfaced as a normal failing run, which a libhegel caller can inspect instead of having the worker abort.
 
-This is a minor release because `hegel::backend::DataSourceError` gains a new `InvalidArgument(String)` variant and is now `#[non_exhaustive]`. Code that matches on `DataSourceError` exhaustively will need to add a wildcard arm:
-
-```rust
-match err {
-    DataSourceError::StopTest => { /* ... */ }
-    DataSourceError::Assume => { /* ... */ }
-    DataSourceError::ServerError(msg) => { /* ... */ }
-    // now required:
-    _ => { /* ... */ }
-}
-```
+The pure-Rust API is unchanged — it still panics at the API surface, since its generators only ever build valid schemas.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,5 @@
 RELEASE_TYPE: patch
 
-This patch stops the native engine from aborting the host process on an invalid schema. Previously, a generation request the engine could not interpret — for example a misspelled type such as `{"type": "ipv4"}`, an unparseable regex, or a character set that excludes every codepoint — would `panic!`. When the engine is driven in-process over the C FFI (`libhegel`), that panic crossed the `extern "C"` boundary and aborted the whole host process (SIGABRT), so a single bad schema from a binding could take down an embedding application. The engine now reports these as recoverable errors: `hegel_generate` returns `HEGEL_E_INVALID_ARG` with a diagnostic in `hegel_last_error_message`, matching the documented contract, and the process keeps running.
+This release only affects libhegel users and is otherwise a pure refactoring.
 
-Run-loop health-check failures (`FilterTooMuch`, `TooSlow`, and flaky-test detection) are likewise no longer raised as panics inside the engine; they are surfaced as a normal failing run, which a libhegel caller can inspect instead of having the worker abort.
-
-The pure-Rust API is unchanged — it still panics at the API surface, since its generators only ever build valid schemas.
+In libhegel, an invalid schema would abort the process improperly when the rust code panicked. Now the rust code uses Result everywhere internally and properly propagates these errors to callers.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,17 @@
+RELEASE_TYPE: minor
+
+This release stops the native engine from aborting the host process on an invalid schema. Previously, a generation request the engine could not interpret — for example a misspelled type such as `{"type": "ipv4"}`, an unparseable regex, or a character set that excludes every codepoint — would `panic!`. When the engine is driven in-process over the C FFI (`libhegel`), that panic crossed the `extern "C"` boundary and aborted the whole host process (SIGABRT), so a single bad schema from a binding could take down an embedding application. The engine now reports these as recoverable errors: `hegel_generate` returns `HEGEL_E_INVALID_ARG` with a diagnostic in `hegel_last_error_message`, matching the documented contract, and the process keeps running. The pure-Rust API is unchanged — it still panics at the API surface, since its generators only ever build valid schemas.
+
+Run-loop health-check failures (`FilterTooMuch`, `TooSlow`, and flaky-test detection) are likewise no longer raised as panics inside the engine; they are surfaced as a normal failing run, which a libhegel caller can inspect instead of having the worker abort.
+
+This is a minor release because `hegel::backend::DataSourceError` gains a new `InvalidArgument(String)` variant and is now `#[non_exhaustive]`. Code that matches on `DataSourceError` exhaustively will need to add a wildcard arm:
+
+```rust
+match err {
+    DataSourceError::StopTest => { /* ... */ }
+    DataSourceError::Assume => { /* ... */ }
+    DataSourceError::ServerError(msg) => { /* ... */ }
+    // now required:
+    _ => { /* ... */ }
+}
+```

--- a/hegel-c/examples/invalid_schema.c
+++ b/hegel-c/examples/invalid_schema.c
@@ -1,0 +1,85 @@
+/*
+ * invalid_schema.c — regression demo for the hegel-java SIGABRT report.
+ *
+ * A plausible-but-wrong schema type (`{"type":"ipv4"}`) used to
+ * `panic!("Unknown schema type")` inside the engine. Because hegel_generate
+ * is `extern "C"`, that panic crossed the FFI boundary and aborted the whole
+ * host process (SIGABRT) — it killed an embedding JVM.
+ *
+ * This program feeds such a schema to hegel_generate and asserts it returns
+ * HEGEL_E_INVALID_ARG with a diagnostic, then exits 0. The interesting case
+ * is the *statically linked* build under `panic = "abort"` (see
+ * `just c-test-abort`): if any panic were reachable here, the process would
+ * abort and this example would exit non-zero, failing the run.
+ *
+ * Build (from this directory, after `cargo build -p hegeltest-c --release`):
+ *
+ *   cc -o invalid_schema invalid_schema.c \
+ *      -I../include \
+ *      ../../target/release/libhegel.a -lpthread -ldl -lm -lrt
+ *
+ * Run:
+ *   ./invalid_schema
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "hegel.h"
+
+/*
+ * Hand-rolled CBOR encoding of { "type": "ipv4" }:
+ *   map(1) = 0xA1, text("type") = 0x64 + 4 bytes, text("ipv4") = 0x64 + 4 bytes.
+ */
+static const uint8_t IPV4_TYPE_SCHEMA[] = {
+    0xA1,                            /* map(1) */
+    0x64, 't', 'y', 'p', 'e',        /* "type" */
+    0x64, 'i', 'p', 'v', '4',        /* "ipv4" */
+};
+
+int main(void) {
+    hegel_settings_t *s = hegel_settings_new();
+    hegel_settings_test_cases(s, 1);
+    hegel_settings_database(s, "");
+    hegel_settings_derandomize(s, true);
+    hegel_settings_seed(s, 1, true);
+
+    hegel_run_t *run = hegel_run_start(s);
+    if (!run) {
+        fprintf(stderr, "hegel_run_start failed: %s\n", hegel_last_error_message());
+        hegel_settings_free(s);
+        return 1;
+    }
+
+    hegel_test_case_t *tc = hegel_next_test_case(run);
+    if (!tc) {
+        fprintf(stderr, "expected a test case\n");
+        hegel_run_free(run);
+        hegel_settings_free(s);
+        return 1;
+    }
+
+    const uint8_t *value;
+    size_t value_len;
+    int rc = hegel_generate(tc, IPV4_TYPE_SCHEMA, sizeof(IPV4_TYPE_SCHEMA), &value, &value_len);
+
+    int ok = 1;
+    if (rc != HEGEL_E_INVALID_ARG) {
+        fprintf(stderr, "expected HEGEL_E_INVALID_ARG (%d), got rc=%d\n",
+                HEGEL_E_INVALID_ARG, rc);
+        ok = 0;
+    }
+    const char *err = hegel_last_error_message();
+    if (err[0] == '\0') {
+        fprintf(stderr, "expected a diagnostic message for the invalid schema\n");
+        ok = 0;
+    } else {
+        printf("invalid schema correctly rejected: rc=%d, message=\"%s\"\n", rc, err);
+    }
+
+    hegel_mark_complete(tc, HEGEL_STATUS_INVALID, NULL);
+    hegel_run_free(run);
+    hegel_settings_free(s);
+    return ok ? 0 : 1;
+}

--- a/hegel-c/src/lib.rs
+++ b/hegel-c/src/lib.rs
@@ -876,6 +876,19 @@ fn translate_ds_error(e: DataSourceError) -> c_int {
             set_last_error(&msg);
             HEGEL_E_BACKEND
         }
+        // A caller-supplied schema was semantically invalid (e.g. an unknown
+        // type string). Surface it as HEGEL_E_INVALID_ARG with the diagnostic
+        // in hegel_last_error_message — never a panic across the FFI boundary.
+        DataSourceError::InvalidArgument(msg) => {
+            set_last_error(&msg);
+            HEGEL_E_INVALID_ARG
+        }
+        // `DataSourceError` is `#[non_exhaustive]`; treat any future variant as
+        // a backend error rather than failing to compile or panicking.
+        other => {
+            set_last_error(&other.to_string());
+            HEGEL_E_BACKEND
+        }
     }
 }
 

--- a/hegel-c/tests/smoke.rs
+++ b/hegel-c/tests/smoke.rs
@@ -14,11 +14,6 @@ use libloading::{Library, Symbol};
 // ─── Library loading ────────────────────────────────────────────────────────
 
 fn lib_path() -> PathBuf {
-    // The crate is part of a workspace, so the cdylib lands in
-    // ../target/{debug,release}/libhegel.<ext>. `cargo test` builds the debug
-    // profile by default; for --release tests we look there too.
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let target_dir = manifest_dir.parent().unwrap().join("target");
     let filename = if cfg!(target_os = "macos") {
         "libhegel.dylib"
     } else if cfg!(target_os = "windows") {
@@ -26,6 +21,23 @@ fn lib_path() -> PathBuf {
     } else {
         "libhegel.so"
     };
+    // `HEGEL_C_LIB_DIR` lets the harness load a library built into a separate
+    // target dir — e.g. the `panic = "abort"` build produced by
+    // `just c-test-abort`, which proves no panic crosses the FFI boundary.
+    if let Ok(dir) = std::env::var("HEGEL_C_LIB_DIR") {
+        let candidate = PathBuf::from(dir).join(filename);
+        assert!(
+            candidate.exists(),
+            "HEGEL_C_LIB_DIR is set but {} does not exist",
+            candidate.display()
+        );
+        return candidate;
+    }
+    // The crate is part of a workspace, so the cdylib lands in
+    // ../target/{debug,release}/libhegel.<ext>. `cargo test` builds the debug
+    // profile by default; for --release tests we look there too.
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let target_dir = manifest_dir.parent().unwrap().join("target");
     for profile in ["debug", "release"] {
         let candidate = target_dir.join(profile).join(filename);
         if candidate.exists() {
@@ -232,6 +244,66 @@ fn libhegel_runs_passing_property() {
         assert!((a.run_result_passed)(result), "expected passing run");
         assert_eq!((a.run_result_failure_count)(result), 0);
 
+        (a.run_free)(run);
+        (a.settings_free)(s);
+    }
+}
+
+/// HEGEL_E_INVALID_ARG from hegel.h.
+const HEGEL_E_INVALID_ARG: c_int = -5;
+
+#[test]
+fn invalid_schema_returns_error_not_abort() {
+    // Reproduces the hegel-java report: a plausible-but-wrong schema type
+    // (`{"type":"ipv4"}`) used to `panic!("Unknown schema type")` inside the
+    // engine, which — crossing the `extern "C"` boundary — aborted the host
+    // process (SIGABRT). It must now return HEGEL_E_INVALID_ARG with a
+    // diagnostic in hegel_last_error_message and leave the process running.
+    // Under the `panic = "abort"` build (`just c-test-abort`) this test only
+    // passes if no panic is reachable on the schema-interpretation path.
+    let lib = unsafe { load() };
+    let a = unsafe { bind(&lib) };
+
+    unsafe {
+        let s = (a.settings_new)();
+        (a.settings_test_cases)(s, 1);
+        let empty = CString::new("").unwrap();
+        (a.settings_database)(s, empty.as_ptr());
+        (a.settings_derandomize)(s, true);
+        (a.settings_seed)(s, 1, true);
+
+        let run = (a.run_start)(s);
+        assert!(!run.is_null());
+
+        let tc = (a.next_test_case)(run);
+        assert!(!tc.is_null(), "expected a test case");
+
+        // Several distinct malformed schemas, each of which previously
+        // panicked at a different site in the interpreter.
+        let unknown_type = encode(&Value::Map(vec![(
+            Value::Text("type".into()),
+            Value::Text("ipv4".into()),
+        )]));
+        let bad_codec = encode(&Value::Map(vec![
+            (Value::Text("type".into()), Value::Text("string".into())),
+            (Value::Text("codec".into()), Value::Text("ebcdic".into())),
+        ]));
+        for bad in [unknown_type, bad_codec] {
+            let mut val_ptr: *const u8 = ptr::null();
+            let mut val_len: usize = 0;
+            let rc = (a.generate)(tc, bad.as_ptr(), bad.len(), &mut val_ptr, &mut val_len);
+            assert_eq!(
+                rc, HEGEL_E_INVALID_ARG,
+                "invalid schema should return HEGEL_E_INVALID_ARG, got rc={rc}"
+            );
+            let err = CStr::from_ptr((a.last_error_message)()).to_string_lossy();
+            assert!(
+                !err.is_empty(),
+                "expected a diagnostic message for the invalid schema"
+            );
+        }
+
+        (a.mark_complete)(tc, CStatus::Invalid, ptr::null());
         (a.run_free)(run);
         (a.settings_free)(s);
     }

--- a/justfile
+++ b/justfile
@@ -111,6 +111,26 @@ c-test-examples:
 c-test-examples:
     @echo "Skipping c-test-examples on Windows (bash-based driver, follow-up)"
 
+# Build libhegel with `panic = "abort"` and run the smoke tests + C examples
+# against it. This proves no panic is reachable across the FFI boundary on
+# the tested paths: under abort, any panic aborts the process, so an
+# invalid-schema test that crashed instead of returning HEGEL_E_INVALID_ARG
+# would fail the run (the original hegel-java SIGABRT). The cdylib/staticlib
+# are built into a separate target dir so they don't clobber the unwind
+# artifacts; the smoke-test harness itself stays unwind (so its own
+# assertions report normally) and is pointed at the abort artifacts via
+# HEGEL_C_LIB_DIR.
+[unix]
+c-test-abort:
+    RUSTFLAGS="-C panic=abort" CARGO_TARGET_DIR=target/abort cargo build -p hegeltest-c
+    HEGEL_C_LIB_DIR={{justfile_directory()}}/target/abort/debug cargo test -p hegeltest-c
+    mkdir -p target/c-examples
+    HEGEL_C_LIB_DIR={{justfile_directory()}}/target/abort/debug scripts/c-examples-run.sh
+
+[windows]
+c-test-abort:
+    @echo "Skipping c-test-abort on Windows (bash-based driver, follow-up)"
+
 # Regenerate hegel-c/include/hegel.h from the Rust source (no diff check).
 c-header:
     HEGEL_C_HEADER_WRITE=1 cargo build -p hegeltest-c

--- a/scripts/c-examples-run.sh
+++ b/scripts/c-examples-run.sh
@@ -8,7 +8,9 @@ set -euo pipefail
 
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
 INCLUDE="$ROOT/hegel-c/include"
-LIBDIR="$ROOT/target/debug"
+# HEGEL_C_LIB_DIR lets the caller point at a library built into a separate
+# target dir — e.g. the panic=abort build produced by `just c-test-abort`.
+LIBDIR="${HEGEL_C_LIB_DIR:-$ROOT/target/debug}"
 OUT="$ROOT/target/c-examples"
 mkdir -p "$OUT"
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -2,6 +2,11 @@ use crate::Settings;
 use ciborium::Value;
 
 /// Error returned by [`DataSource`] methods when an operation cannot complete.
+///
+/// Not part of the public API: this is an implementation detail of the
+/// backend machinery (primarily for libhegel embedding) and may change in any
+/// release, including gaining new variants.
+#[doc(hidden)]
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum DataSourceError {

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -3,6 +3,7 @@ use ciborium::Value;
 
 /// Error returned by [`DataSource`] methods when an operation cannot complete.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum DataSourceError {
     /// The backend ran out of data for this test case.
     StopTest,
@@ -11,6 +12,11 @@ pub enum DataSourceError {
     Assume,
     /// The backend returned an error (e.g. invalid arguments, internal error).
     ServerError(String),
+    /// A caller-supplied argument (typically a schema) was semantically
+    /// invalid. The main library converts this to a panic at the API surface;
+    /// libhegel maps it to `HEGEL_E_INVALID_ARG` with the message exposed via
+    /// `hegel_last_error_message`. Carries a human-readable diagnostic.
+    InvalidArgument(String),
 }
 
 impl std::fmt::Display for DataSourceError {
@@ -21,6 +27,7 @@ impl std::fmt::Display for DataSourceError {
             }
             DataSourceError::Assume => write!(f, "Backend rejected the current draw (Assume)"),
             DataSourceError::ServerError(msg) => write!(f, "{}", msg),
+            DataSourceError::InvalidArgument(msg) => write!(f, "{}", msg),
         }
     }
 }

--- a/src/native/core/choices.rs
+++ b/src/native/core/choices.rs
@@ -1169,8 +1169,31 @@ pub enum Status {
     Interesting = 3,
 }
 
-/// Raised when a test case should stop executing.
-pub struct StopTest;
+/// Error raised while interpreting a schema / drawing from the engine.
+///
+/// `StopTest` is the overwhelmingly common case: normal data-exhaustion
+/// control flow that ends the current test case. `InvalidArgument` carries a
+/// caller-supplied-schema diagnostic that must surface as an error
+/// (libhegel: `HEGEL_E_INVALID_ARG`) or a panic (main library), but never an
+/// uncaught panic that crosses the FFI boundary and aborts the host process.
+#[derive(Debug)]
+pub enum EngineError {
+    /// The test case ran out of data and should stop executing.
+    StopTest,
+    /// A caller-supplied schema was semantically invalid (unknown type,
+    /// empty character set, unparseable regex, etc.). The string is a
+    /// human-readable diagnostic.
+    InvalidArgument(String),
+}
+
+impl std::fmt::Display for EngineError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EngineError::StopTest => write!(f, "test case should stop executing (StopTest)"),
+            EngineError::InvalidArgument(msg) => write!(f, "{msg}"),
+        }
+    }
+}
 
 /// Opaque key identifying one source of "interesting" outcomes
 /// (one bug). Matches the cross-backend protocol contract: it's

--- a/src/native/core/mod.rs
+++ b/src/native/core/mod.rs
@@ -9,8 +9,8 @@ pub(crate) mod choices;
 pub(crate) mod float_index;
 pub(crate) mod state;
 pub use choices::{
-    BytesChoice, ChoiceKind, ChoiceNode, ChoiceValue, FloatChoice, NodeSortKey, NodesSortKey,
-    Status, StopTest, StringChoice, sort_key,
+    BytesChoice, ChoiceKind, ChoiceNode, ChoiceValue, EngineError, FloatChoice, NodeSortKey,
+    NodesSortKey, Status, StringChoice, sort_key,
 };
 pub use float_index::{float_to_index, index_to_float};
 pub use state::{ManyState, NativeTestCase, NativeVariables, Span, Spans};

--- a/src/native/core/state.rs
+++ b/src/native/core/state.rs
@@ -9,7 +9,7 @@ use rand::rngs::SmallRng;
 
 use super::choices::{
     BooleanChoice, BytesChoice, ChoiceKind, ChoiceNode, ChoiceTemplate, ChoiceTemplateKind,
-    ChoiceValue, FloatChoice, IntegerChoice, InterestingOrigin, Status, StopTest, StringChoice,
+    ChoiceValue, EngineError, FloatChoice, IntegerChoice, InterestingOrigin, Status, StringChoice,
 };
 use super::float_index::lex_to_float;
 use super::{BOUNDARY_PROBABILITY, BUFFER_SIZE};
@@ -901,7 +901,7 @@ pub struct NativeTestCase {
     /// Optional template applied to every draw past the explicit `prefix`.
     /// `count` is mutated in-place as draws consume the template; when
     /// `count` reaches zero the next draw is overrun
-    /// (`Status::EarlyStop` + `StopTest`). `None` means "no template" —
+    /// (`Status::EarlyStop` + `EngineError`). `None` means "no template" —
     /// draws past the prefix go to `rng` or panic, as before.
     trailing_template: Option<ChoiceTemplate>,
 }
@@ -1086,7 +1086,7 @@ impl NativeTestCase {
     }
 
     /// Draw a random integer in [min_value, max_value].
-    pub fn draw_integer(&mut self, min_value: i128, max_value: i128) -> Result<i128, StopTest> {
+    pub fn draw_integer(&mut self, min_value: i128, max_value: i128) -> Result<i128, EngineError> {
         assert!(
             min_value <= max_value,
             "Invalid range [{min_value}, {max_value}]"
@@ -1132,7 +1132,7 @@ impl NativeTestCase {
         max_value: f64,
         allow_nan: bool,
         allow_infinity: bool,
-    ) -> Result<f64, StopTest> {
+    ) -> Result<f64, EngineError> {
         let kind = FloatChoice {
             min_value,
             max_value,
@@ -1166,7 +1166,7 @@ impl NativeTestCase {
     }
 
     /// Draw a bytes value with length in `[min_size, max_size]`.
-    pub fn draw_bytes(&mut self, min_size: usize, max_size: usize) -> Result<Vec<u8>, StopTest> {
+    pub fn draw_bytes(&mut self, min_size: usize, max_size: usize) -> Result<Vec<u8>, EngineError> {
         assert!(
             min_size <= max_size,
             "min_size ({min_size}) must be <= max_size ({max_size})"
@@ -1205,7 +1205,7 @@ impl NativeTestCase {
         intervals: IntervalSet,
         min_size: usize,
         max_size: usize,
-    ) -> Result<String, StopTest> {
+    ) -> Result<String, EngineError> {
         assert!(min_size <= max_size);
         assert!(
             !intervals.is_empty() || max_size == 0,
@@ -1246,7 +1246,7 @@ impl NativeTestCase {
 
     /// Draw a boolean with probability `p` of being true.
     /// If `forced` is Some, the result is forced to that value.
-    pub fn weighted(&mut self, p: f64, forced: Option<bool>) -> Result<bool, StopTest> {
+    pub fn weighted(&mut self, p: f64, forced: Option<bool>) -> Result<bool, EngineError> {
         let kind = BooleanChoice;
 
         let forced_value = forced.or(if p <= 0.0 {
@@ -1286,16 +1286,16 @@ impl NativeTestCase {
 
         Ok(v)
     }
-    fn pre_choice(&mut self) -> Result<(), StopTest> {
+    fn pre_choice(&mut self) -> Result<(), EngineError> {
         // A test case can become frozen mid-execution when `start_span`
         // exceeds `MAX_DEPTH` and sets `status = Some(Status::Invalid)`.
-        // Subsequent draws must propagate `StopTest` so the test halts.
+        // Subsequent draws must propagate `EngineError` so the test halts.
         if self.status.is_some() {
-            return Err(StopTest);
+            return Err(EngineError::StopTest);
         }
         if self.nodes.len() >= self.max_size {
             self.status = Some(Status::EarlyStop);
-            return Err(StopTest);
+            return Err(EngineError::StopTest);
         }
         Ok(())
     }
@@ -1311,7 +1311,7 @@ impl NativeTestCase {
         unit: impl FnOnce() -> ChoiceValue,
         validate: impl FnOnce(&ChoiceValue) -> bool,
         random: impl FnOnce(&mut SmallRng) -> ChoiceValue,
-    ) -> Result<(ChoiceValue, bool), StopTest> {
+    ) -> Result<(ChoiceValue, bool), EngineError> {
         self.pre_choice()?;
 
         let idx = self.nodes.len();
@@ -1341,7 +1341,7 @@ impl NativeTestCase {
         if let Some(template) = self.trailing_template.as_mut() {
             if matches!(template.count, Some(0)) {
                 self.status = Some(Status::EarlyStop);
-                return Err(StopTest);
+                return Err(EngineError::StopTest);
             }
             let value = match template.kind {
                 ChoiceTemplateKind::Simplest => simplest(),

--- a/src/native/data_source.rs
+++ b/src/native/data_source.rs
@@ -12,7 +12,7 @@ use std::sync::{Arc, Mutex};
 use ciborium::Value;
 
 use crate::backend::{DataSource, DataSourceError, TestCaseResult};
-use crate::native::core::{ChoiceNode, ManyState, NativeTestCase, Span, StopTest};
+use crate::native::core::{ChoiceNode, EngineError, ManyState, NativeTestCase, Span};
 use crate::native::schema;
 
 /// Per-test-case state shared between `NativeDataSource` and the engine
@@ -110,7 +110,7 @@ impl NativeDataSource {
             .expect("mark_complete must be called for every test case")
     }
 
-    /// Returns true if a previous request triggered a StopTest abort.
+    /// Returns true if a previous request triggered a EngineError abort.
     /// Test-only helper — not part of the `DataSource` interface, so
     /// callers must hold a concrete `&NativeDataSource`.
     #[cfg(test)]
@@ -119,20 +119,29 @@ impl NativeDataSource {
     }
 
     /// Acquire the test-case state under the abort guard.  Returns
-    /// `StopTest` immediately if a previous call has already aborted
-    /// the test case so subsequent draws short-circuit without
+    /// `DataSourceError::StopTest` immediately if a previous call has already
+    /// aborted the test case so subsequent draws short-circuit without
     /// touching `ntc`.
     fn with_ntc<R>(
         &self,
-        f: impl FnOnce(&mut NativeTestCase) -> Result<R, StopTest>,
+        f: impl FnOnce(&mut NativeTestCase) -> Result<R, EngineError>,
     ) -> Result<R, DataSourceError> {
         if self.aborted.load(Ordering::Relaxed) {
             return Err(DataSourceError::StopTest);
         }
         let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        f(&mut inner.ntc).map_err(|_stop| {
-            self.aborted.store(true, Ordering::Relaxed);
-            DataSourceError::StopTest
+        f(&mut inner.ntc).map_err(|e| match e {
+            EngineError::StopTest => {
+                // Budget exhausted: latch the abort flag so subsequent draws
+                // short-circuit without touching `ntc`.
+                self.aborted.store(true, Ordering::Relaxed);
+                DataSourceError::StopTest
+            }
+            // A semantically-invalid schema is not budget exhaustion — do not
+            // latch `aborted`; carry the diagnostic through so the main
+            // library can panic with it and libhegel can return it as an
+            // error code.
+            EngineError::InvalidArgument(msg) => DataSourceError::InvalidArgument(msg),
         })
     }
 }
@@ -210,7 +219,7 @@ impl DataSource for NativeDataSource {
             let active = ntc.variable_pools[pool_idx].active();
             if active.is_empty() {
                 // No variables available: mark the test case invalid.
-                return Err(StopTest);
+                return Err(EngineError::StopTest);
             }
             // Index arithmetic uses `i128` to match `draw_integer`; the
             // variable ids drawn out of `active` are `i64`.

--- a/src/native/schema/bytes.rs
+++ b/src/native/schema/bytes.rs
@@ -1,13 +1,13 @@
 // Bytes schema interpreter.
 
 use crate::cbor_utils::{as_u64, map_get};
-use crate::native::core::{NativeTestCase, StopTest};
+use crate::native::core::{EngineError, NativeTestCase};
 use ciborium::Value;
 
 pub(super) fn interpret_binary(
     ntc: &mut NativeTestCase,
     schema: &Value,
-) -> Result<Value, StopTest> {
+) -> Result<Value, EngineError> {
     let min_size = map_get(schema, "min_size").and_then(as_u64).unwrap_or(0) as usize;
     // Unbounded `max_size` falls back to a generous ceiling — Hypothesis's
     // server backend also truncates generation at some finite cap, and

--- a/src/native/schema/collections.rs
+++ b/src/native/schema/collections.rs
@@ -1,15 +1,22 @@
 // Collection schema interpreters: list, dict, tuple, one_of, sampled_from.
 
 use crate::cbor_utils::{as_bool, as_u64, map_get};
-use crate::native::core::{ManyState, NativeTestCase, StopTest};
+use crate::native::core::{EngineError, ManyState, NativeTestCase};
 use ciborium::Value;
 
-use super::{cbor_to_i128, interpret_schema, many_more, many_reject};
+use super::{cbor_to_i128, interpret_schema, many_more, many_reject, require};
 
-pub(super) fn interpret_tuple(ntc: &mut NativeTestCase, schema: &Value) -> Result<Value, StopTest> {
-    let elements = match map_get(schema, "elements") {
-        Some(Value::Array(arr)) => arr,
-        _ => panic!("tuple schema must have elements array"),
+pub(super) fn interpret_tuple(
+    ntc: &mut NativeTestCase,
+    schema: &Value,
+) -> Result<Value, EngineError> {
+    let elements = match require(schema, "elements")? {
+        Value::Array(arr) => arr,
+        other => {
+            return Err(EngineError::InvalidArgument(format!(
+                "tuple schema \"elements\" must be an array, got {other:?}"
+            )));
+        }
     };
     let mut results = Vec::with_capacity(elements.len());
     for element_schema in elements {
@@ -21,15 +28,15 @@ pub(super) fn interpret_tuple(ntc: &mut NativeTestCase, schema: &Value) -> Resul
 pub(super) fn interpret_one_of(
     ntc: &mut NativeTestCase,
     schema: &Value,
-) -> Result<Value, StopTest> {
-    let generators = match map_get(schema, "generators") {
-        Some(Value::Array(arr)) => arr,
-        _ => panic!("one_of schema must have generators array"),
+) -> Result<Value, EngineError> {
+    let generators = match require(schema, "generators")? {
+        Value::Array(arr) if !arr.is_empty() => arr,
+        _ => {
+            return Err(EngineError::InvalidArgument(
+                "one_of schema \"generators\" must be a non-empty array".to_string(),
+            ));
+        }
     };
-    assert!(
-        !generators.is_empty(),
-        "one_of schema must have at least one generator"
-    );
     let idx = ntc.draw_integer(0, generators.len() as i128 - 1)?;
     let value = interpret_schema(ntc, &generators[idx as usize])?;
     Ok(Value::Array(vec![
@@ -41,21 +48,24 @@ pub(super) fn interpret_one_of(
 pub(super) fn interpret_sampled_from(
     ntc: &mut NativeTestCase,
     schema: &Value,
-) -> Result<Value, StopTest> {
-    let values = match map_get(schema, "values") {
-        Some(Value::Array(arr)) => arr,
-        _ => panic!("sampled_from schema must have values array"),
+) -> Result<Value, EngineError> {
+    let values = match require(schema, "values")? {
+        Value::Array(arr) if !arr.is_empty() => arr,
+        _ => {
+            return Err(EngineError::InvalidArgument(
+                "sampled_from schema \"values\" must be a non-empty array".to_string(),
+            ));
+        }
     };
-    assert!(
-        !values.is_empty(),
-        "sampled_from schema must have at least one value"
-    );
     let idx = ntc.draw_integer(0, values.len() as i128 - 1)?;
     Ok(encode_schema_value(&values[idx as usize]))
 }
 
-pub(super) fn interpret_list(ntc: &mut NativeTestCase, schema: &Value) -> Result<Value, StopTest> {
-    let element_schema = map_get(schema, "elements").expect("list schema must have elements");
+pub(super) fn interpret_list(
+    ntc: &mut NativeTestCase,
+    schema: &Value,
+) -> Result<Value, EngineError> {
+    let element_schema = require(schema, "elements")?;
     let min_size = map_get(schema, "min_size").and_then(as_u64).unwrap_or(0) as usize;
     let max_size = map_get(schema, "max_size")
         .and_then(as_u64)
@@ -96,7 +106,7 @@ fn interpret_unique_integer_list(
     max_size: Option<usize>,
     min_val: i128,
     range_size: usize,
-) -> Result<Value, StopTest> {
+) -> Result<Value, EngineError> {
     let effective_max = max_size.map_or(range_size, |m| m.min(range_size));
     let mut state = ManyState::new(min_size, Some(effective_max));
     let mut remaining: Vec<i128> = (min_val..min_val + range_size as i128).collect();
@@ -120,17 +130,23 @@ fn bounded_integer_range(schema: &Value) -> Option<(i128, i128)> {
     if schema_type != "integer" {
         return None;
     }
-    let min_val = cbor_to_i128(map_get(schema, "min_value")?);
-    let max_val = cbor_to_i128(map_get(schema, "max_value")?);
+    // Treat unparseable bounds as "not a bounded range" and fall back to the
+    // generic list path, which surfaces the real `InvalidArgument` when it
+    // interprets the element schema.
+    let min_val = cbor_to_i128(map_get(schema, "min_value")?).ok()?;
+    let max_val = cbor_to_i128(map_get(schema, "max_value")?).ok()?;
     if !(1..=10_000).contains(&(max_val - min_val + 1)) {
         return None;
     }
     Some((min_val, max_val))
 }
 
-pub(super) fn interpret_dict(ntc: &mut NativeTestCase, schema: &Value) -> Result<Value, StopTest> {
-    let key_schema = map_get(schema, "keys").expect("dict schema must have keys");
-    let val_schema = map_get(schema, "values").expect("dict schema must have values");
+pub(super) fn interpret_dict(
+    ntc: &mut NativeTestCase,
+    schema: &Value,
+) -> Result<Value, EngineError> {
+    let key_schema = require(schema, "keys")?;
+    let val_schema = require(schema, "values")?;
     let min_size = map_get(schema, "min_size").and_then(as_u64).unwrap_or(0) as usize;
     let max_size = map_get(schema, "max_size")
         .and_then(as_u64)

--- a/src/native/schema/float.rs
+++ b/src/native/schema/float.rs
@@ -1,23 +1,29 @@
 // Float schema interpreter.
 
 use crate::cbor_utils::{as_bool, as_u64, map_get};
-use crate::native::core::{NativeTestCase, StopTest};
+use crate::native::core::{EngineError, NativeTestCase};
 use ciborium::Value;
 
-pub(super) fn interpret_float(ntc: &mut NativeTestCase, schema: &Value) -> Result<Value, StopTest> {
+pub(super) fn interpret_float(
+    ntc: &mut NativeTestCase,
+    schema: &Value,
+) -> Result<Value, EngineError> {
     let width: u64 = map_get(schema, "width").and_then(as_u64).unwrap_or(64);
     // `width=64` is backed by `f64` and `width=32` by `f64` rounded to
-    // `f32` precision (no `f16` Rust type yet). The schema is constructed
-    // by Rust generators, so any other value is a Rust-side bug — fail
-    // loud at the boundary rather than silently treating it as f64.
+    // `f32` precision (no `f16` Rust type yet). Any other value means the
+    // caller's schema is invalid.
     if width != 32 && width != 64 {
-        panic!("unsupported float width: {width} — Hegel supports widths 32 and 64");
+        return Err(EngineError::InvalidArgument(format!(
+            "unsupported float width: {width} — Hegel supports widths 32 and 64"
+        )));
     }
     let min_value = map_get(schema, "min_value")
         .map(cbor_to_f64)
+        .transpose()?
         .unwrap_or(f64::NEG_INFINITY);
     let max_value = map_get(schema, "max_value")
         .map(cbor_to_f64)
+        .transpose()?
         .unwrap_or(f64::INFINITY);
     let allow_nan = map_get(schema, "allow_nan")
         .and_then(as_bool)
@@ -82,12 +88,17 @@ pub(super) fn interpret_float(ntc: &mut NativeTestCase, schema: &Value) -> Resul
     Ok(Value::Float(v))
 }
 
-/// Extract an f64 from a CBOR value (Float or Integer).
-fn cbor_to_f64(value: &Value) -> f64 {
+/// Extract an f64 from a CBOR value (Float or Integer). Returns
+/// [`EngineError::InvalidArgument`] for any other value, since a float
+/// bound that is neither a float nor an integer means the caller's schema
+/// is invalid.
+fn cbor_to_f64(value: &Value) -> Result<f64, EngineError> {
     match value {
-        Value::Float(f) => *f,
-        Value::Integer(i) => i128::from(*i) as f64,
-        _ => panic!("Expected CBOR float/integer, got {:?}", value),
+        Value::Float(f) => Ok(*f),
+        Value::Integer(i) => Ok(i128::from(*i) as f64),
+        _ => Err(EngineError::InvalidArgument(format!(
+            "expected a CBOR float or integer, got {value:?}"
+        ))),
     }
 }
 

--- a/src/native/schema/internet.rs
+++ b/src/native/schema/internet.rs
@@ -6,7 +6,7 @@
 use std::sync::LazyLock;
 
 use crate::cbor_utils::{as_u64, map_get};
-use crate::native::core::{ManyState, NativeTestCase, Status, StopTest};
+use crate::native::core::{EngineError, ManyState, NativeTestCase, Status};
 use crate::native::intervalsets::IntervalSet;
 use ciborium::Value;
 
@@ -74,9 +74,9 @@ fn encode_string(s: String) -> Value {
     Value::Tag(91, Box::new(Value::Bytes(s.into_bytes())))
 }
 
-fn mark_invalid(ntc: &mut NativeTestCase) -> Result<Value, StopTest> {
+fn mark_invalid(ntc: &mut NativeTestCase) -> Result<Value, EngineError> {
     ntc.status = Some(Status::Invalid);
-    Err(StopTest)
+    Err(EngineError::StopTest)
 }
 
 /// `domain` schema → an RFC 1035 fully-qualified domain name.
@@ -94,7 +94,7 @@ fn mark_invalid(ntc: &mut NativeTestCase) -> Result<Value, StopTest> {
 pub(super) fn interpret_domain(
     ntc: &mut NativeTestCase,
     schema: &Value,
-) -> Result<Value, StopTest> {
+) -> Result<Value, EngineError> {
     let max_length = map_get(schema, "max_length")
         .and_then(as_u64)
         .unwrap_or(255) as usize;
@@ -104,7 +104,7 @@ pub(super) fn interpret_domain(
 /// Shared domain-string draw used by `interpret_domain`, `interpret_email`
 /// and `interpret_url`. `max_length` follows `DomainNameStrategy.max_length`
 /// (RFC 1035 §2.3.4): 4..=255.
-fn draw_domain(ntc: &mut NativeTestCase, max_length: usize) -> Result<String, StopTest> {
+fn draw_domain(ntc: &mut NativeTestCase, max_length: usize) -> Result<String, EngineError> {
     // RFC 1035 §2.3.4 limits a single label to 63 octets. Hypothesis
     // exposes this as a parameter, but the `DomainGenerator` schema doesn't,
     // so we hard-code the RFC limit here.
@@ -171,7 +171,7 @@ fn draw_domain(ntc: &mut NativeTestCase, max_length: usize) -> Result<String, St
 /// alphanumeric, and position 1 is too close to the start. We inline that
 /// constraint by coercing index 3 to alphanumeric whenever index 2 was
 /// drawn as a hyphen, producing the same alphabet without a retry loop.
-fn draw_dns_label(ntc: &mut NativeTestCase, max_len: usize) -> Result<String, StopTest> {
+fn draw_dns_label(ntc: &mut NativeTestCase, max_len: usize) -> Result<String, EngineError> {
     let len = ntc.draw_integer(1, max_len as i128)? as usize;
     let mut s = String::with_capacity(len);
     s.push(draw_ascii_letter(ntc)?);
@@ -189,13 +189,13 @@ fn draw_dns_label(ntc: &mut NativeTestCase, max_len: usize) -> Result<String, St
     Ok(s)
 }
 
-fn draw_ascii_letter(ntc: &mut NativeTestCase) -> Result<char, StopTest> {
+fn draw_ascii_letter(ntc: &mut NativeTestCase) -> Result<char, EngineError> {
     let i = ntc.draw_integer(0, 51)? as u8;
     let b = if i < 26 { b'a' + i } else { b'A' + (i - 26) };
     Ok(b as char)
 }
 
-fn draw_ascii_alnum(ntc: &mut NativeTestCase) -> Result<char, StopTest> {
+fn draw_ascii_alnum(ntc: &mut NativeTestCase) -> Result<char, EngineError> {
     let i = ntc.draw_integer(0, 61)? as u8;
     let b = if i < 26 {
         b'a' + i
@@ -207,7 +207,7 @@ fn draw_ascii_alnum(ntc: &mut NativeTestCase) -> Result<char, StopTest> {
     Ok(b as char)
 }
 
-fn draw_ascii_alnum_or_hyphen(ntc: &mut NativeTestCase) -> Result<char, StopTest> {
+fn draw_ascii_alnum_or_hyphen(ntc: &mut NativeTestCase) -> Result<char, EngineError> {
     let i = ntc.draw_integer(0, 62)? as u8;
     let b = if i < 26 {
         b'a' + i
@@ -229,7 +229,7 @@ fn draw_ascii_alnum_or_hyphen(ntc: &mut NativeTestCase) -> Result<char, StopTest
 ///   - Filter: overall length ≤ 254 (RFC 5321 §4.5.3.1.3). Implemented by
 ///     marking the test case invalid when the filter fails — the engine
 ///     then retries with a different choice prefix.
-pub(super) fn interpret_email(ntc: &mut NativeTestCase) -> Result<Value, StopTest> {
+pub(super) fn interpret_email(ntc: &mut NativeTestCase) -> Result<Value, EngineError> {
     let local = ntc.draw_string(email_local_part_intervals(), 1, 64)?;
     let domain = draw_domain(ntc, 255)?;
     let address = format!("{local}@{domain}");
@@ -249,7 +249,7 @@ pub(super) fn interpret_email(ntc: &mut NativeTestCase) -> Result<Value, StopTes
 ///   - `path` is the `/`-join of 0..N path components, each a url-encoded
 ///     `text(string.printable)` value.
 ///   - `fragment` is empty or `#…` of url-encoded chars in `0..=255`.
-pub(super) fn interpret_url(ntc: &mut NativeTestCase) -> Result<Value, StopTest> {
+pub(super) fn interpret_url(ntc: &mut NativeTestCase) -> Result<Value, EngineError> {
     let scheme = if ntc.weighted(0.5, None)? {
         "https"
     } else {
@@ -326,7 +326,7 @@ fn url_encode_path(s: &str) -> String {
 /// Apply Hypothesis's `_url_fragments_strategy` per-char rule: with
 /// probability 0.5 force `%XX`, otherwise `%XX` only if the char isn't in
 /// `FRAGMENT_SAFE_CHARACTERS`.
-fn url_encode_fragment(ntc: &mut NativeTestCase, s: &str) -> Result<String, StopTest> {
+fn url_encode_fragment(ntc: &mut NativeTestCase, s: &str) -> Result<String, EngineError> {
     let mut out = String::with_capacity(s.len());
     for c in s.chars() {
         let force_encode = ntc.weighted(0.5, None)?;

--- a/src/native/schema/mod.rs
+++ b/src/native/schema/mod.rs
@@ -24,8 +24,18 @@ mod text;
 
 use crate::cbor_utils::map_get;
 use crate::native::core::state::MAX_DEPTH;
-use crate::native::core::{ManyState, NativeTestCase, Span, Status, StopTest};
+use crate::native::core::{EngineError, ManyState, NativeTestCase, Span, Status};
 use ciborium::Value;
+
+/// Look up a required schema field, returning [`EngineError::InvalidArgument`]
+/// (rather than panicking) when it is absent. Used for fields whose presence
+/// is part of the schema contract — a missing one means the caller's schema
+/// is malformed.
+pub(super) fn require<'a>(schema: &'a Value, field: &str) -> Result<&'a Value, EngineError> {
+    map_get(schema, field).ok_or_else(|| {
+        EngineError::InvalidArgument(format!("schema is missing required \"{field}\" field"))
+    })
+}
 
 /// Interpret a CBOR schema and produce a value using the native test case.
 ///
@@ -38,11 +48,11 @@ use ciborium::Value;
 pub(crate) fn interpret_schema(
     ntc: &mut NativeTestCase,
     schema: &Value,
-) -> Result<Value, StopTest> {
+) -> Result<Value, EngineError> {
     use crate::cbor_utils::as_text;
-    let schema_type = map_get(schema, "type")
-        .and_then(as_text)
-        .expect("Schema must have a \"type\" field");
+    let schema_type = map_get(schema, "type").and_then(as_text).ok_or_else(|| {
+        EngineError::InvalidArgument("schema is missing a string \"type\" field".to_string())
+    })?;
 
     // Open a dispatch span. We push a Span directly rather than calling
     // `start_span` because `start_span` takes a u64 label, and schema
@@ -90,7 +100,9 @@ pub(crate) fn interpret_schema(
         "email" => internet::interpret_email(ntc),
         "url" => internet::interpret_url(ntc),
 
-        other => panic!("Unknown schema type: {}", other),
+        other => Err(EngineError::InvalidArgument(format!(
+            "unknown schema type: {other:?}"
+        ))),
     };
 
     ntc.span_stack.pop();
@@ -102,7 +114,10 @@ pub(crate) fn interpret_schema(
 
 /// Advance the many state by one element.  Returns true if another
 /// element should be drawn.  Mirrors `Hypothesis`'s `many.more()`.
-pub(crate) fn many_more(ntc: &mut NativeTestCase, state: &mut ManyState) -> Result<bool, StopTest> {
+pub(crate) fn many_more(
+    ntc: &mut NativeTestCase,
+    state: &mut ManyState,
+) -> Result<bool, EngineError> {
     let should_continue = if state.min_size as f64 == state.max_size {
         // Fixed size: draw exactly min_size elements.
         state.count < state.min_size
@@ -126,14 +141,17 @@ pub(crate) fn many_more(ntc: &mut NativeTestCase, state: &mut ManyState) -> Resu
 }
 
 /// Reject the last drawn element.  Mirrors Hypothesis's `many.reject()`.
-pub(crate) fn many_reject(ntc: &mut NativeTestCase, state: &mut ManyState) -> Result<(), StopTest> {
+pub(crate) fn many_reject(
+    ntc: &mut NativeTestCase,
+    state: &mut ManyState,
+) -> Result<(), EngineError> {
     assert!(state.count > 0);
     state.count -= 1;
     state.rejections += 1;
     if state.rejections > std::cmp::max(3, 2 * state.count) {
         if state.count < state.min_size {
             ntc.status = Some(Status::Invalid);
-            return Err(StopTest);
+            return Err(EngineError::StopTest);
         } else {
             state.force_stop = true;
         }
@@ -144,35 +162,44 @@ pub(crate) fn many_reject(ntc: &mut NativeTestCase, state: &mut ManyState) -> Re
 /// Convert a CBOR value to i128, handling bignum tags.
 ///
 /// For positive bignums (tag 2) that exceed i128::MAX (e.g. u128::MAX),
-/// we saturate at i128::MAX so the integer range remains valid.
-pub(super) fn cbor_to_i128(value: &Value) -> i128 {
+/// we saturate at i128::MAX so the integer range remains valid. Returns
+/// [`EngineError::InvalidArgument`] for any value that is not a CBOR
+/// integer (or a malformed bignum tag), since that means the caller's
+/// schema is invalid.
+pub(super) fn cbor_to_i128(value: &Value) -> Result<i128, EngineError> {
     match value {
-        Value::Integer(i) => (*i).into(),
+        Value::Integer(i) => Ok((*i).into()),
         Value::Tag(2, inner) => {
             // CBOR tag 2: positive bignum (big-endian bytes)
             let Value::Bytes(bytes) = inner.as_ref() else {
-                panic!("Expected Bytes inside bignum tag 2, got {:?}", inner)
+                return Err(EngineError::InvalidArgument(format!(
+                    "expected bytes inside bignum tag 2, got {inner:?}"
+                )));
             };
             let mut n = 0u128;
             for b in bytes {
                 n = (n << 8) | (*b as u128);
             }
             // Saturating cast: values above i128::MAX (e.g. u128::MAX) cap at i128::MAX.
-            i128::try_from(n).unwrap_or(i128::MAX)
+            Ok(i128::try_from(n).unwrap_or(i128::MAX))
         }
         Value::Tag(3, inner) => {
             // CBOR tag 3: negative bignum, value is -1 - n
             let Value::Bytes(bytes) = inner.as_ref() else {
-                panic!("Expected Bytes inside bignum tag 3, got {:?}", inner)
+                return Err(EngineError::InvalidArgument(format!(
+                    "expected bytes inside bignum tag 3, got {inner:?}"
+                )));
             };
             let mut n = 0u128;
             for b in bytes {
                 n = (n << 8) | (*b as u128);
             }
             // Safe: -1 - n where n <= i128::MAX is always representable.
-            -1i128 - i128::try_from(n).unwrap_or(i128::MAX)
+            Ok(-1i128 - i128::try_from(n).unwrap_or(i128::MAX))
         }
-        _ => panic!("Expected CBOR integer, got {:?}", value),
+        _ => Err(EngineError::InvalidArgument(format!(
+            "expected a CBOR integer, got {value:?}"
+        ))),
     }
 }
 

--- a/src/native/schema/numeric.rs
+++ b/src/native/schema/numeric.rs
@@ -1,19 +1,18 @@
 // Numeric schema interpreters: integer, boolean, constant.
 
-use crate::native::core::{NativeTestCase, StopTest};
+use crate::native::core::{EngineError, NativeTestCase};
 use ciborium::Value;
 
-use super::{bignum_overflows_i128, cbor_to_i128, i128_to_cbor, u128_to_cbor};
-use crate::cbor_utils::map_get;
+use super::{bignum_overflows_i128, cbor_to_i128, i128_to_cbor, require, u128_to_cbor};
 
 pub(super) fn interpret_integer(
     ntc: &mut NativeTestCase,
     schema: &Value,
-) -> Result<Value, StopTest> {
-    let min_cbor = map_get(schema, "min_value").expect("integer schema must have min_value");
-    let max_cbor = map_get(schema, "max_value").expect("integer schema must have max_value");
-    let min_value = cbor_to_i128(min_cbor);
-    let max_value = cbor_to_i128(max_cbor);
+) -> Result<Value, EngineError> {
+    let min_cbor = require(schema, "min_value")?;
+    let max_cbor = require(schema, "max_value")?;
+    let min_value = cbor_to_i128(min_cbor)?;
+    let max_value = cbor_to_i128(max_cbor)?;
 
     // If max saturated because it exceeded i128::MAX (e.g. u128::MAX), draw using
     // a selector + two 64-bit halves to cover the full u128 range.
@@ -38,12 +37,16 @@ pub(super) fn interpret_integer(
     Ok(i128_to_cbor(v))
 }
 
-pub(super) fn interpret_boolean(ntc: &mut NativeTestCase) -> Result<Value, StopTest> {
+pub(super) fn interpret_boolean(ntc: &mut NativeTestCase) -> Result<Value, EngineError> {
     let v = ntc.weighted(0.5, None)?;
     Ok(Value::Bool(v))
 }
 
-pub(super) fn interpret_constant(schema: &Value) -> Result<Value, StopTest> {
-    let value = map_get(schema, "value").expect("constant schema must have value");
+pub(super) fn interpret_constant(schema: &Value) -> Result<Value, EngineError> {
+    let value = require(schema, "value")?;
     Ok(value.clone())
 }
+
+#[cfg(test)]
+#[path = "../../../tests/embedded/native/schema/numeric_tests.rs"]
+mod tests;

--- a/src/native/schema/regex.rs
+++ b/src/native/schema/regex.rs
@@ -10,7 +10,7 @@ use std::rc::Rc;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::cbor_utils::{as_bool, as_text, map_get};
-use crate::native::core::{ManyState, NativeTestCase, Status, StopTest};
+use crate::native::core::{EngineError, ManyState, NativeTestCase, Status};
 use crate::native::intervalsets::IntervalSet;
 use crate::native::re::constants::{
     AtCode, ChCode, SRE_FLAG_ASCII, SRE_FLAG_DOTALL, SRE_FLAG_IGNORECASE, SRE_FLAG_MULTILINE,
@@ -26,18 +26,26 @@ fn is_surrogate_cp(cp: u32) -> bool {
     (0xD800..=0xDFFF).contains(&cp)
 }
 
-pub(super) fn interpret_regex(ntc: &mut NativeTestCase, schema: &Value) -> Result<Value, StopTest> {
+pub(super) fn interpret_regex(
+    ntc: &mut NativeTestCase,
+    schema: &Value,
+) -> Result<Value, EngineError> {
     let pattern = map_get(schema, "pattern")
         .and_then(as_text)
-        .expect("regex schema must have pattern");
+        .ok_or_else(|| {
+            EngineError::InvalidArgument(
+                "regex schema is missing a string \"pattern\" field".to_string(),
+            )
+        })?;
     let fullmatch = map_get(schema, "fullmatch")
         .and_then(as_bool)
         .unwrap_or(false);
     let alphabet_schema = map_get(schema, "alphabet");
-    let alphabet = alphabet_schema.map(build_intervals);
+    let alphabet = alphabet_schema.map(build_intervals).transpose()?;
 
-    let parsed = parse_pattern(pattern, 0)
-        .unwrap_or_else(|e| panic!("invalid regex pattern {:?}: {}", pattern, e));
+    let parsed = parse_pattern(pattern, 0).map_err(|e| {
+        EngineError::InvalidArgument(format!("invalid regex pattern {pattern:?}: {e}"))
+    })?;
 
     let mut state = GenState {
         groups: HashMap::new(),
@@ -128,7 +136,7 @@ fn draw_pad(
     ntc: &mut NativeTestCase,
     alphabet: &Option<IntervalSet>,
     out: &mut String,
-) -> Result<(), StopTest> {
+) -> Result<(), EngineError> {
     let n = ntc.draw_integer(0, 10)?;
     for _ in 0..n {
         let c = draw_any_char(ntc, alphabet)?;
@@ -165,7 +173,7 @@ fn draw_prefix(
     parsed: &ParsedPattern,
     alphabet: &Option<IntervalSet>,
     out: &mut String,
-) -> Result<(), StopTest> {
+) -> Result<(), EngineError> {
     // Mirror of hypothesis.regex_strategy's left-pad logic.
     if let Some(OpCode::At(at)) = effective_first(&parsed.pattern) {
         match at {
@@ -190,7 +198,7 @@ fn draw_suffix(
     parsed: &ParsedPattern,
     alphabet: &Option<IntervalSet>,
     out: &mut String,
-) -> Result<(), StopTest> {
+) -> Result<(), EngineError> {
     // Mirror of hypothesis.regex_strategy's right-pad logic.
     if let Some(OpCode::At(at)) = effective_last(&parsed.pattern) {
         match at {
@@ -219,7 +227,7 @@ fn generate_subpattern(
     state: &mut GenState,
     alphabet: &Option<IntervalSet>,
     out: &mut String,
-) -> Result<(), StopTest> {
+) -> Result<(), EngineError> {
     for op in &sp.data {
         generate_op(ntc, op, state, alphabet, out)?;
     }
@@ -231,7 +239,7 @@ fn generate_op(
     state: &mut GenState,
     alphabet: &Option<IntervalSet>,
     out: &mut String,
-) -> Result<(), StopTest> {
+) -> Result<(), EngineError> {
     match op {
         OpCode::Literal(cp) => {
             let c = codepoint_to_char(*cp);
@@ -636,7 +644,7 @@ fn alphabet_allows(alphabet: &Option<IntervalSet>, c: char) -> bool {
 fn draw_any_char(
     ntc: &mut NativeTestCase,
     alphabet: &Option<IntervalSet>,
-) -> Result<char, StopTest> {
+) -> Result<char, EngineError> {
     match alphabet {
         None => {
             let cp = ntc.draw_integer(32, 126)?;
@@ -660,7 +668,7 @@ fn emit_from_chars(
     ntc: &mut NativeTestCase,
     chars: &[char],
     out: &mut String,
-) -> Result<(), StopTest> {
+) -> Result<(), EngineError> {
     if chars.is_empty() {
         mark_invalid(ntc)?;
     }
@@ -682,9 +690,9 @@ fn emit_from_chars(
     Ok(())
 }
 
-fn mark_invalid(ntc: &mut NativeTestCase) -> Result<(), StopTest> {
+fn mark_invalid(ntc: &mut NativeTestCase) -> Result<(), EngineError> {
     ntc.status = Some(Status::Invalid);
-    Err(StopTest)
+    Err(EngineError::StopTest)
 }
 
 fn codepoint_to_char(cp: u32) -> char {

--- a/src/native/schema/special.rs
+++ b/src/native/schema/special.rs
@@ -8,7 +8,7 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 use std::sync::LazyLock;
 
 use crate::cbor_utils::map_get;
-use crate::native::core::{NativeTestCase, StopTest};
+use crate::native::core::{EngineError, NativeTestCase};
 use ciborium::Value;
 
 /// Encode a `String` as a CBOR tag-91 value, the wire format used by the hegel
@@ -39,7 +39,7 @@ fn days_in_month(year: i128, month: i128) -> i128 {
 /// offset from 2000 to get the same shrink target. The observable
 /// distribution is identical because `biased_integer_sample` boosts the
 /// endpoints (here ±offset bounds) at the same rate either way.
-pub(super) fn interpret_date(ntc: &mut NativeTestCase) -> Result<Value, StopTest> {
+pub(super) fn interpret_date(ntc: &mut NativeTestCase) -> Result<Value, EngineError> {
     let (year, month, day) = draw_date(ntc)?;
     Ok(encode_string(format!("{year:04}-{month:02}-{day:02}")))
 }
@@ -47,7 +47,7 @@ pub(super) fn interpret_date(ntc: &mut NativeTestCase) -> Result<Value, StopTest
 /// `time` schema → `HH:MM:SS` or `HH:MM:SS.ffffff`, matching
 /// `st.times().isoformat()`. The fractional part is present iff
 /// `microsecond != 0` (Python's `time.isoformat()` semantics).
-pub(super) fn interpret_time(ntc: &mut NativeTestCase) -> Result<Value, StopTest> {
+pub(super) fn interpret_time(ntc: &mut NativeTestCase) -> Result<Value, EngineError> {
     let (hour, minute, second, microsecond) = draw_time(ntc)?;
     Ok(encode_string(format_time(
         hour,
@@ -60,7 +60,7 @@ pub(super) fn interpret_time(ntc: &mut NativeTestCase) -> Result<Value, StopTest
 /// `datetime` schema → `YYYY-MM-DDTHH:MM:SS[.ffffff]`, matching
 /// `st.datetimes().isoformat()`. As with `interpret_time`, the fractional
 /// seconds appear only when non-zero.
-pub(super) fn interpret_datetime(ntc: &mut NativeTestCase) -> Result<Value, StopTest> {
+pub(super) fn interpret_datetime(ntc: &mut NativeTestCase) -> Result<Value, EngineError> {
     let (year, month, day) = draw_date(ntc)?;
     let (hour, minute, second, microsecond) = draw_time(ntc)?;
     let time_part = format_time(hour, minute, second, microsecond);
@@ -69,14 +69,14 @@ pub(super) fn interpret_datetime(ntc: &mut NativeTestCase) -> Result<Value, Stop
     )))
 }
 
-fn draw_date(ntc: &mut NativeTestCase) -> Result<(i128, i128, i128), StopTest> {
+fn draw_date(ntc: &mut NativeTestCase) -> Result<(i128, i128, i128), EngineError> {
     let year = 2000 + ntc.draw_integer(1 - 2000, 9999 - 2000)?;
     let month = ntc.draw_integer(1, 12)?;
     let day = ntc.draw_integer(1, days_in_month(year, month))?;
     Ok((year, month, day))
 }
 
-fn draw_time(ntc: &mut NativeTestCase) -> Result<(i128, i128, i128, i128), StopTest> {
+fn draw_time(ntc: &mut NativeTestCase) -> Result<(i128, i128, i128, i128), EngineError> {
     let hour = ntc.draw_integer(0, 23)?;
     let minute = ntc.draw_integer(0, 59)?;
     let second = ntc.draw_integer(0, 59)?;
@@ -110,7 +110,10 @@ fn format_time(hour: i128, minute: i128, second: i128, microsecond: i128) -> Str
 /// "uuids never produce nil" property carries over. The proper fix is a
 /// non-recording RNG-direct draw API on `NativeTestCase` to mirror Hypothesis
 /// exactly — out of scope for this PR.
-pub(super) fn interpret_uuid(ntc: &mut NativeTestCase, schema: &Value) -> Result<Value, StopTest> {
+pub(super) fn interpret_uuid(
+    ntc: &mut NativeTestCase,
+    schema: &Value,
+) -> Result<Value, EngineError> {
     use crate::cbor_utils::as_u64;
     let version = map_get(schema, "version").and_then(as_u64).map(|v| v as u8);
 
@@ -293,19 +296,23 @@ fn parse_v6_cidr(s: &str) -> V6Network {
 pub(super) fn interpret_ip_address(
     ntc: &mut NativeTestCase,
     schema: &Value,
-) -> Result<Value, StopTest> {
+) -> Result<Value, EngineError> {
     use crate::cbor_utils::as_u64;
-    let version = map_get(schema, "version")
-        .and_then(as_u64)
-        .expect("ip_address schema must have a \"version\" field");
+    let version = map_get(schema, "version").and_then(as_u64).ok_or_else(|| {
+        EngineError::InvalidArgument(
+            "ip_address schema is missing an integer \"version\" field".to_string(),
+        )
+    })?;
     match version {
         4 => interpret_ipv4(ntc),
         6 => interpret_ipv6(ntc),
-        _ => panic!("ip_address: unsupported version {version}; expected 4 or 6"),
+        other => Err(EngineError::InvalidArgument(format!(
+            "ip_address: unsupported version {other}; expected 4 or 6"
+        ))),
     }
 }
 
-fn interpret_ipv4(ntc: &mut NativeTestCase) -> Result<Value, StopTest> {
+fn interpret_ipv4(ntc: &mut NativeTestCase) -> Result<Value, EngineError> {
     // one_of([random_bytes, sampled_from(SPECIAL).flatmap(in_network)]).
     let addr_int: u32 = if ntc.draw_integer(0, 1)? == 0 {
         // Four uniform bytes — `binary(min_size=4, max_size=4).map(IPv4Address)`.
@@ -326,7 +333,7 @@ fn interpret_ipv4(ntc: &mut NativeTestCase) -> Result<Value, StopTest> {
     Ok(encode_string(Ipv4Addr::from(addr_int).to_string()))
 }
 
-fn interpret_ipv6(ntc: &mut NativeTestCase) -> Result<Value, StopTest> {
+fn interpret_ipv6(ntc: &mut NativeTestCase) -> Result<Value, EngineError> {
     let addr_int: u128 = if ntc.draw_integer(0, 1)? == 0 {
         // 16 uniform bytes via two 64-bit halves.
         let hi = ntc.draw_integer(0, u64::MAX as i128)? as u64;

--- a/src/native/schema/text.rs
+++ b/src/native/schema/text.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::cbor_utils::{as_text, as_u64, map_get};
-use crate::native::core::{NativeTestCase, StopTest};
+use crate::native::core::{EngineError, NativeTestCase};
 use crate::native::intervalsets::IntervalSet;
 use crate::unicodedata;
 use ciborium::Value;
@@ -20,23 +20,26 @@ const DEFAULT_MAX_SIZE: usize = 100;
 pub(super) fn interpret_string(
     ntc: &mut NativeTestCase,
     schema: &Value,
-) -> Result<Value, StopTest> {
+) -> Result<Value, EngineError> {
     let min_size = map_get(schema, "min_size").and_then(as_u64).unwrap_or(0) as usize;
     let max_size = map_get(schema, "max_size")
         .and_then(as_u64)
         .map(|n| n as usize)
         .unwrap_or(min_size.max(DEFAULT_MAX_SIZE));
 
-    let intervals = build_intervals(schema);
+    let intervals = build_intervals(schema)?;
     if intervals.is_empty() && max_size > 0 {
         // Empty alphabets are a schema-level error — Hypothesis raises
-        // `InvalidArgument` at strategy-construction time, but the Hegel
-        // protocol can't catch it that early, so panic at draw time.
-        panic!(
+        // `InvalidArgument` at strategy-construction time. The Hegel protocol
+        // can't catch it that early, so surface it as an error at draw time.
+        // The "InvalidArgument" token matches the cross-backend (server)
+        // wording so backend-agnostic tests recognise the same failure.
+        return Err(EngineError::InvalidArgument(
             "InvalidArgument: No valid characters in the specified range. \
              The schema's codec/codepoint/category/include/exclude constraints \
              leave no characters available."
-        );
+                .to_string(),
+        ));
     }
 
     let s = ntc.draw_string(intervals, min_size, max_size)?;
@@ -46,7 +49,7 @@ pub(super) fn interpret_string(
 /// Build the effective character alphabet for a string schema, memoised by
 /// the schema's canonical CBOR encoding. Mirrors Hypothesis's
 /// `limited_category_index_cache` in `internal/charmap.py`.
-pub(super) fn build_intervals(schema: &Value) -> IntervalSet {
+pub(super) fn build_intervals(schema: &Value) -> Result<IntervalSet, EngineError> {
     type Cache = Mutex<HashMap<Vec<u8>, Arc<IntervalSet>>>;
     static CACHE: OnceLock<Cache> = OnceLock::new();
     let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
@@ -56,20 +59,26 @@ pub(super) fn build_intervals(schema: &Value) -> IntervalSet {
     // un-encodable values (which `Value` rules out by construction).
     ciborium::into_writer(schema, &mut key).expect("CBOR encoding of schema cannot fail");
     if let Some(cached) = cache.lock().unwrap().get(&key) {
-        return (**cached).clone();
+        return Ok((**cached).clone());
     }
-    let computed = Arc::new(build_intervals_uncached(schema));
+    // Only successful results are cached; an invalid schema returns the error
+    // and leaves the cache untouched.
+    let computed = Arc::new(build_intervals_uncached(schema)?);
     cache.lock().unwrap().insert(key, Arc::clone(&computed));
-    (*computed).clone()
+    Ok((*computed).clone())
 }
 
-fn build_intervals_uncached(schema: &Value) -> IntervalSet {
+fn build_intervals_uncached(schema: &Value) -> Result<IntervalSet, EngineError> {
     let codec = map_get(schema, "codec").and_then(as_text);
     let (mut cp_min, mut cp_max): (u32, u32) = match codec {
         Some("ascii") => (0, 127),
         Some("latin-1") | Some("iso-8859-1") => (0, 255),
         Some("utf-8") | None => (0, 0x10FFFF),
-        Some(other) => panic!("Invalid codec: {}", other),
+        Some(other) => {
+            return Err(EngineError::InvalidArgument(format!(
+                "invalid codec: {other}"
+            )));
+        }
     };
 
     if let Some(min_cp) = map_get(schema, "min_codepoint").and_then(as_u64) {
@@ -95,7 +104,9 @@ fn build_intervals_uncached(schema: &Value) -> IntervalSet {
         .chain(exclude_categories.iter().flatten())
     {
         if !is_valid_category(cat) {
-            panic!("InvalidArgument: {cat:?} is not a valid Unicode category.");
+            return Err(EngineError::InvalidArgument(format!(
+                "{cat:?} is not a valid Unicode category"
+            )));
         }
     }
 
@@ -104,10 +115,10 @@ fn build_intervals_uncached(schema: &Value) -> IntervalSet {
         if !overlap.is_empty() {
             let incl_str: String = incl.iter().collect();
             let excl_str: String = excl.iter().collect();
-            panic!(
-                "InvalidArgument: Characters {overlap:?} are present in both \
+            return Err(EngineError::InvalidArgument(format!(
+                "characters {overlap:?} are present in both \
                  include_characters={incl_str:?} and exclude_characters={excl_str:?} (overlap)"
-            );
+            )));
         }
     }
 
@@ -178,7 +189,7 @@ fn build_intervals_uncached(schema: &Value) -> IntervalSet {
         }
     }
 
-    intervals
+    Ok(intervals)
 }
 
 /// Build an [`IntervalSet`] containing `[min, max]` with the surrogate block

--- a/src/native/test_runner.rs
+++ b/src/native/test_runner.rs
@@ -326,27 +326,29 @@ fn run_main(
                         .suppress_health_check
                         .contains(&HealthCheck::FilterTooMuch)
                 {
-                    panic!(
+                    return health_check_failure(format!(
                         "FailedHealthCheck: FilterTooMuch — it looks like this \
                          test is filtering out too many inputs. \
                          {invalid_calls} inputs were filtered out by assume() \
                          before any valid input was generated. \
                          If this is expected, suppress the check with \
                          suppress_health_check = [HealthCheck::FilterTooMuch]."
-                    );
+                    ));
                 }
             } else {
                 invalid_calls = 0;
             }
 
-            too_slow_check(
+            if let Some(msg) = too_slow_check(
                 valid_test_cases,
                 total_test_time,
                 TOO_SLOW_THRESHOLD,
                 settings
                     .suppress_health_check
                     .contains(&HealthCheck::TooSlow),
-            );
+            ) {
+                return health_check_failure(msg);
+            }
 
             // Fire `optimise_targets` periodically once enough valid
             // examples have accumulated. Counts share the generation
@@ -421,13 +423,13 @@ fn run_main(
             .contains(&HealthCheck::FilterTooMuch)
         && invalid_calls > 0
     {
-        panic!(
+        return health_check_failure(format!(
             "FailedHealthCheck: FilterTooMuch — every reachable input was \
              filtered out by assume() before any valid input was generated. \
              {invalid_calls} inputs were filtered out across the full search \
              space. If this is expected, suppress the check with \
              suppress_health_check = [HealthCheck::FilterTooMuch]."
-        );
+        ));
     }
 
     // --- Shrinking phase ---
@@ -450,13 +452,7 @@ fn run_main(
             let verify_ntc = NativeTestCase::for_choices(&choices, Some(&initial), None);
             let verify = ctx.run(verify_ntc);
             if verify.status != Status::Interesting {
-                panic!(
-                    "Flaky test detected: Your test produced different outcomes \
-                     when run with the same generated data — it failed when it \
-                     previously succeeded, or succeeded when it previously failed. \
-                     This usually means your test depends on external state such as \
-                     global variables, system time, or external random number generators."
-                );
+                return health_check_failure(flaky_diagnostic());
             }
 
             let target_origin = origin.clone();
@@ -596,10 +592,9 @@ fn run_main(
             // which requires the test body to flip its outcome strictly
             // between the last shrink call and the final replay.
             // Deterministic reproduction needs precise call-count
-            // alignment that's brittle in CI; the function itself is
-            // tested directly via
-            // `flaky_final_replay_panic_panics_with_diagnostic`.
-            _ => flaky_final_replay_panic(), // nocov
+            // alignment that's brittle in CI; the message builder itself is
+            // tested directly via `flaky_diagnostic_mentions_flaky`.
+            _ => return health_check_failure(flaky_diagnostic()), // nocov
         }
     }
 
@@ -623,42 +618,65 @@ fn run_main(
 const MIN_TEST_CALLS: u64 = 10;
 const POST_BUG_EXTRA_CALLS: u64 = 1000;
 
-/// Panics with the `FailedHealthCheck: TooSlow` message when input
-/// generation has consumed more than `threshold` of wall-clock time
-/// without producing `HEALTH_CHECK_MAX_VALID` valid examples, unless
-/// the user has explicitly suppressed the check.
+/// Returns the `FailedHealthCheck: TooSlow` message when input generation
+/// has consumed more than `threshold` of wall-clock time without producing
+/// `HEALTH_CHECK_MAX_VALID` valid examples, unless the user has explicitly
+/// suppressed the check; otherwise returns `None`.
 ///
-/// Extracted from the runner's main loop so a unit test can exercise
-/// both the panicking and the suppressed branches without needing to
-/// stall the in-process test harness for `TOO_SLOW_THRESHOLD` of
-/// real time.
+/// Returning the message (rather than panicking) lets the caller fold it
+/// into a failing [`TestRunResult`] so no panic crosses the FFI boundary
+/// (see [`health_check_failure`]). Extracted from the runner's main loop so
+/// a unit test can exercise both branches without stalling the in-process
+/// harness for `TOO_SLOW_THRESHOLD` of real time.
 pub(crate) fn too_slow_check(
     valid_test_cases: u64,
     total_test_time: std::time::Duration,
     threshold: std::time::Duration,
     suppressed: bool,
-) {
+) -> Option<String> {
     if valid_test_cases < HEALTH_CHECK_MAX_VALID && total_test_time > threshold && !suppressed {
-        panic!(
+        Some(format!(
             "FailedHealthCheck: TooSlow — input generation is slow: \
              only {valid_test_cases} valid inputs after {:?} (threshold \
              {:?}). Slow generation makes property testing much less \
              effective. If this is expected, suppress the check with \
              suppress_health_check = [HealthCheck::TooSlow].",
             total_test_time, threshold
-        );
+        ))
+    } else {
+        None
     }
 }
 
-#[cold]
-pub(crate) fn flaky_final_replay_panic() -> ! {
-    panic!(
-        "Flaky test detected: Your test produced different outcomes \
-         when run with the same generated data — it failed when it \
-         previously succeeded, or succeeded when it previously failed. \
-         This usually means your test depends on external state such as \
-         global variables, system time, or external random number generators."
-    );
+/// Diagnostic for a flaky test — one whose outcome changed when re-run with
+/// the same generated data. Returned as a message (rather than panicked) so
+/// the caller can fold it into a failing [`TestRunResult`].
+pub(crate) fn flaky_diagnostic() -> String {
+    "Flaky test detected: Your test produced different outcomes \
+     when run with the same generated data — it failed when it \
+     previously succeeded, or succeeded when it previously failed. \
+     This usually means your test depends on external state such as \
+     global variables, system time, or external random number generators."
+        .to_string()
+}
+
+/// Build a failing [`TestRunResult`] from a health-check diagnostic.
+///
+/// Health-check failures (FilterTooMuch / TooSlow / flaky) are reported as a
+/// normal failing run rather than via `panic!`, so that an in-process engine
+/// driven over FFI (libhegel) surfaces them as a result the caller can
+/// inspect instead of an uncaught panic that aborts the host process. The
+/// main library still turns this into a panic at its API surface, preserving
+/// its existing behaviour.
+fn health_check_failure(message: String) -> TestRunResult {
+    TestRunResult {
+        passed: false,
+        failures: vec![Failure {
+            panic_message: message.clone(),
+            diagnostic: format!("{message}\n"),
+            origin: "FailedHealthCheck".to_string(),
+        }],
+    }
 }
 
 fn should_generate_more(

--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -47,6 +47,11 @@ fn panic_on_data_source_error(e: DataSourceError) -> ! {
         DataSourceError::StopTest => panic!("{}", STOP_TEST_STRING),
         DataSourceError::Assume => panic!("{}", ASSUME_FAIL_STRING), // nocov
         DataSourceError::ServerError(msg) => panic!("{}", msg),
+        // A semantically-invalid schema. In the main library this only fires
+        // if a generator builds a malformed schema (a bug), so we surface the
+        // diagnostic as a panic. libhegel never reaches here — it maps the
+        // error to `HEGEL_E_INVALID_ARG` instead.
+        DataSourceError::InvalidArgument(msg) => panic!("{}", msg),
     }
 }
 

--- a/tests/embedded/native/choices_tests.rs
+++ b/tests/embedded/native/choices_tests.rs
@@ -699,3 +699,14 @@ fn nodes_sort_key_shortlex_orders_by_length_then_element() {
     let empty: Vec<ChoiceNode> = Vec::new();
     assert!(sort_key(&empty) < sort_key(&a));
 }
+
+// ── EngineError Display ──────────────────────────────────────────────────────
+
+#[test]
+fn engine_error_display_covers_both_variants() {
+    assert!(EngineError::StopTest.to_string().contains("StopTest"));
+    assert_eq!(
+        EngineError::InvalidArgument("nope".to_string()).to_string(),
+        "nope"
+    );
+}

--- a/tests/embedded/native/data_source_tests.rs
+++ b/tests/embedded/native/data_source_tests.rs
@@ -112,6 +112,19 @@ fn pool_generate_on_empty_pool_returns_stop_test() {
 }
 
 #[test]
+fn generate_invalid_schema_maps_to_invalid_argument_without_aborting() {
+    let (ds, _handle) = random_source();
+    let schema = cbor_map! { "type" => "no-such-type" };
+    let err = ds.generate(&schema).unwrap_err();
+    assert!(matches!(err, DataSourceError::InvalidArgument(_)));
+    // A schema error is not data exhaustion: the test case is not latched as
+    // aborted, so a (valid) subsequent draw still dispatches normally.
+    assert!(!ds.test_aborted());
+    let good = cbor_map! { "type" => "integer", "min_value" => 0, "max_value" => 0 };
+    assert!(ds.generate(&good).is_ok());
+}
+
+#[test]
 fn generate_stoptest_sets_aborted_and_short_circuits() {
     let (ds, _handle) = exhausted_source();
     let schema = cbor_map! {

--- a/tests/embedded/native/schema/collections_tests.rs
+++ b/tests/embedded/native/schema/collections_tests.rs
@@ -35,11 +35,21 @@ fn interpret_tuple_returns_array_of_elements() {
 }
 
 #[test]
-#[should_panic(expected = "tuple schema must have elements array")]
-fn interpret_tuple_without_elements_panics() {
+fn interpret_tuple_without_elements_is_invalid_argument() {
     let mut ntc = fresh_ntc();
     let schema = cbor_map! { "type" => "tuple" };
-    let _ = interpret_tuple(&mut ntc, &schema);
+    let err = interpret_tuple(&mut ntc, &schema).unwrap_err();
+    assert!(matches!(err, EngineError::InvalidArgument(_)));
+    assert!(err.to_string().contains("elements"));
+}
+
+#[test]
+fn interpret_tuple_non_array_elements_is_invalid_argument() {
+    let mut ntc = fresh_ntc();
+    let schema = cbor_map! { "type" => "tuple", "elements" => 7 };
+    let err = interpret_tuple(&mut ntc, &schema).unwrap_err();
+    assert!(matches!(err, EngineError::InvalidArgument(_)));
+    assert!(err.to_string().contains("must be an array"));
 }
 
 // ── interpret_one_of ────────────────────────────────────────────────────────
@@ -73,22 +83,24 @@ fn interpret_one_of_selects_a_branch() {
 }
 
 #[test]
-#[should_panic(expected = "one_of schema must have generators array")]
-fn interpret_one_of_without_generators_panics() {
+fn interpret_one_of_without_generators_is_invalid_argument() {
     let mut ntc = fresh_ntc();
     let schema = cbor_map! { "type" => "one_of" };
-    let _ = interpret_one_of(&mut ntc, &schema);
+    let err = interpret_one_of(&mut ntc, &schema).unwrap_err();
+    assert!(matches!(err, EngineError::InvalidArgument(_)));
+    assert!(err.to_string().contains("generators"));
 }
 
 #[test]
-#[should_panic(expected = "one_of schema must have at least one generator")]
-fn interpret_one_of_empty_generators_panics() {
+fn interpret_one_of_empty_generators_is_invalid_argument() {
     let mut ntc = fresh_ntc();
     let schema = cbor_map! {
         "type" => "one_of",
         "generators" => Vec::<Value>::new(),
     };
-    let _ = interpret_one_of(&mut ntc, &schema);
+    let err = interpret_one_of(&mut ntc, &schema).unwrap_err();
+    assert!(matches!(err, EngineError::InvalidArgument(_)));
+    assert!(err.to_string().contains("non-empty"));
 }
 
 // ── interpret_sampled_from ──────────────────────────────────────────────────
@@ -125,25 +137,55 @@ fn interpret_sampled_from_returns_non_text_as_is() {
 }
 
 #[test]
-#[should_panic(expected = "sampled_from schema must have values array")]
-fn interpret_sampled_from_without_values_panics() {
+fn interpret_sampled_from_without_values_is_invalid_argument() {
     let mut ntc = fresh_ntc();
     let schema = cbor_map! { "type" => "sampled_from" };
-    let _ = interpret_sampled_from(&mut ntc, &schema);
+    let err = interpret_sampled_from(&mut ntc, &schema).unwrap_err();
+    assert!(matches!(err, EngineError::InvalidArgument(_)));
+    assert!(err.to_string().contains("values"));
 }
 
 #[test]
-#[should_panic(expected = "sampled_from schema must have at least one value")]
-fn interpret_sampled_from_empty_values_panics() {
+fn interpret_sampled_from_empty_values_is_invalid_argument() {
     let mut ntc = fresh_ntc();
     let schema = cbor_map! {
         "type" => "sampled_from",
         "values" => Vec::<Value>::new(),
     };
-    let _ = interpret_sampled_from(&mut ntc, &schema);
+    let err = interpret_sampled_from(&mut ntc, &schema).unwrap_err();
+    assert!(matches!(err, EngineError::InvalidArgument(_)));
+    assert!(err.to_string().contains("non-empty"));
 }
 
 // ── interpret_list ──────────────────────────────────────────────────────────
+
+#[test]
+fn interpret_list_without_elements_is_invalid_argument() {
+    let mut ntc = fresh_ntc();
+    let schema = cbor_map! { "type" => "list" };
+    let err = interpret_list(&mut ntc, &schema).unwrap_err();
+    assert!(matches!(err, EngineError::InvalidArgument(_)));
+    assert!(err.to_string().contains("elements"));
+}
+
+#[test]
+fn interpret_list_unique_with_invalid_integer_bounds_falls_back() {
+    // A `unique` integer list whose bounds are not CBOR integers can't take
+    // the bounded-range fast path (`bounded_integer_range` returns `None`);
+    // the generic path then surfaces the real `InvalidArgument` when it
+    // interprets the element schema.
+    let mut ntc = fresh_ntc();
+    let schema = cbor_map! {
+        "type" => "list",
+        "unique" => true,
+        "min_size" => 1u64,
+        "elements" => cbor_map! {
+            "type" => "integer", "min_value" => "lo", "max_value" => 5,
+        },
+    };
+    let err = interpret_list(&mut ntc, &schema).unwrap_err();
+    assert!(matches!(err, EngineError::InvalidArgument(_)));
+}
 
 #[test]
 fn interpret_list_with_fixed_size_returns_that_many_elements() {
@@ -230,6 +272,27 @@ fn interpret_list_unique_large_range_falls_back_to_rejection() {
 }
 
 // ── interpret_dict ──────────────────────────────────────────────────────────
+
+#[test]
+fn interpret_dict_without_keys_is_invalid_argument() {
+    let mut ntc = fresh_ntc();
+    let schema = cbor_map! { "type" => "dict" };
+    let err = interpret_dict(&mut ntc, &schema).unwrap_err();
+    assert!(matches!(err, EngineError::InvalidArgument(_)));
+    assert!(err.to_string().contains("keys"));
+}
+
+#[test]
+fn interpret_dict_without_values_is_invalid_argument() {
+    let mut ntc = fresh_ntc();
+    let schema = cbor_map! {
+        "type" => "dict",
+        "keys" => cbor_map! { "type" => "integer", "min_value" => 0, "max_value" => 1 },
+    };
+    let err = interpret_dict(&mut ntc, &schema).unwrap_err();
+    assert!(matches!(err, EngineError::InvalidArgument(_)));
+    assert!(err.to_string().contains("values"));
+}
 
 #[test]
 fn interpret_dict_with_fixed_size_returns_pairs() {

--- a/tests/embedded/native/schema/float_tests.rs
+++ b/tests/embedded/native/schema/float_tests.rs
@@ -2,18 +2,19 @@ use super::*;
 
 #[test]
 fn cbor_to_f64_from_integer() {
-    assert_eq!(cbor_to_f64(&Value::Integer(42.into())), 42.0);
+    assert_eq!(cbor_to_f64(&Value::Integer(42.into())).unwrap(), 42.0);
 }
 
 #[test]
 fn cbor_to_f64_from_negative_integer() {
-    assert_eq!(cbor_to_f64(&Value::Integer((-7i64).into())), -7.0);
+    assert_eq!(cbor_to_f64(&Value::Integer((-7i64).into())).unwrap(), -7.0);
 }
 
 #[test]
-#[should_panic(expected = "Expected CBOR float/integer")]
-fn cbor_to_f64_panics_on_non_numeric() {
-    let _ = cbor_to_f64(&Value::Bool(true));
+fn cbor_to_f64_non_numeric_is_invalid_argument() {
+    let err = cbor_to_f64(&Value::Bool(true)).unwrap_err();
+    assert!(matches!(err, EngineError::InvalidArgument(_)));
+    assert!(err.to_string().contains("CBOR float or integer"));
 }
 
 // interpret_float must reject widths outside `{32, 64}`: Hypothesis only
@@ -22,7 +23,6 @@ fn cbor_to_f64_panics_on_non_numeric() {
 // treating unknown widths as f64.
 
 #[test]
-#[should_panic(expected = "unsupported float width")]
 fn interpret_float_rejects_width_16() {
     use crate::cbor_utils::cbor_map;
     use crate::native::core::NativeTestCase;
@@ -30,11 +30,12 @@ fn interpret_float_rejects_width_16() {
     use rand::rngs::SmallRng;
     let mut ntc = NativeTestCase::new_random(SmallRng::seed_from_u64(0));
     let schema = cbor_map! { "type" => "float", "width" => 16 };
-    let _ = interpret_float(&mut ntc, &schema);
+    let err = interpret_float(&mut ntc, &schema).unwrap_err();
+    assert!(matches!(err, EngineError::InvalidArgument(_)));
+    assert!(err.to_string().contains("unsupported float width"));
 }
 
 #[test]
-#[should_panic(expected = "unsupported float width")]
 fn interpret_float_rejects_width_128() {
     use crate::cbor_utils::cbor_map;
     use crate::native::core::NativeTestCase;
@@ -42,7 +43,22 @@ fn interpret_float_rejects_width_128() {
     use rand::rngs::SmallRng;
     let mut ntc = NativeTestCase::new_random(SmallRng::seed_from_u64(0));
     let schema = cbor_map! { "type" => "float", "width" => 128 };
-    let _ = interpret_float(&mut ntc, &schema);
+    let err = interpret_float(&mut ntc, &schema).unwrap_err();
+    assert!(matches!(err, EngineError::InvalidArgument(_)));
+    assert!(err.to_string().contains("unsupported float width"));
+}
+
+#[test]
+fn interpret_float_non_numeric_bound_is_invalid_argument() {
+    use crate::cbor_utils::cbor_map;
+    use crate::native::core::NativeTestCase;
+    use rand::SeedableRng;
+    use rand::rngs::SmallRng;
+    let mut ntc = NativeTestCase::new_random(SmallRng::seed_from_u64(0));
+    let schema = cbor_map! { "type" => "float", "min_value" => "low" };
+    let err = interpret_float(&mut ntc, &schema).unwrap_err();
+    assert!(matches!(err, EngineError::InvalidArgument(_)));
+    assert!(err.to_string().contains("CBOR float or integer"));
 }
 
 #[test]

--- a/tests/embedded/native/schema/mod_tests.rs
+++ b/tests/embedded/native/schema/mod_tests.rs
@@ -13,11 +13,21 @@ fn fresh_ntc() -> NativeTestCase {
 }
 
 #[test]
-#[should_panic(expected = "Unknown schema type: mystery")]
-fn interpret_schema_unknown_type_panics() {
+fn interpret_schema_unknown_type_is_invalid_argument() {
     let mut ntc = fresh_ntc();
     let schema = cbor_map! { "type" => "mystery" };
-    let _ = interpret_schema(&mut ntc, &schema);
+    let err = interpret_schema(&mut ntc, &schema).unwrap_err();
+    assert!(matches!(err, EngineError::InvalidArgument(_)));
+    assert!(err.to_string().contains("unknown schema type"));
+}
+
+#[test]
+fn interpret_schema_missing_type_is_invalid_argument() {
+    let mut ntc = fresh_ntc();
+    let schema = cbor_map! { "min_value" => 0 };
+    let err = interpret_schema(&mut ntc, &schema).unwrap_err();
+    assert!(matches!(err, EngineError::InvalidArgument(_)));
+    assert!(err.to_string().contains("\"type\""));
 }
 
 // ── Every schema dispatch records an enclosing span ─────────────────────────
@@ -192,23 +202,26 @@ fn many_reject_marks_invalid_when_cannot_reach_min_size() {
 // ── cbor_to_i128 panic branches ─────────────────────────────────────────────
 
 #[test]
-#[should_panic(expected = "Expected Bytes inside bignum tag 2")]
-fn cbor_to_i128_tag2_non_bytes_panics() {
+fn cbor_to_i128_tag2_non_bytes_is_invalid_argument() {
     let bad = Value::Tag(2, Box::new(Value::Integer(1.into())));
-    let _ = cbor_to_i128(&bad);
+    let err = cbor_to_i128(&bad).unwrap_err();
+    assert!(matches!(err, EngineError::InvalidArgument(_)));
+    assert!(err.to_string().contains("bignum tag 2"));
 }
 
 #[test]
-#[should_panic(expected = "Expected Bytes inside bignum tag 3")]
-fn cbor_to_i128_tag3_non_bytes_panics() {
+fn cbor_to_i128_tag3_non_bytes_is_invalid_argument() {
     let bad = Value::Tag(3, Box::new(Value::Integer(1.into())));
-    let _ = cbor_to_i128(&bad);
+    let err = cbor_to_i128(&bad).unwrap_err();
+    assert!(matches!(err, EngineError::InvalidArgument(_)));
+    assert!(err.to_string().contains("bignum tag 3"));
 }
 
 #[test]
-#[should_panic(expected = "Expected CBOR integer")]
-fn cbor_to_i128_non_integer_panics() {
-    let _ = cbor_to_i128(&Value::Bool(true));
+fn cbor_to_i128_non_integer_is_invalid_argument() {
+    let err = cbor_to_i128(&Value::Bool(true)).unwrap_err();
+    assert!(matches!(err, EngineError::InvalidArgument(_)));
+    assert!(err.to_string().contains("CBOR integer"));
 }
 
 // ── bignum_overflows_i128 branches ──────────────────────────────────────────

--- a/tests/embedded/native/schema/numeric_tests.rs
+++ b/tests/embedded/native/schema/numeric_tests.rs
@@ -1,0 +1,48 @@
+// Embedded tests for src/native/schema/numeric.rs — focuses on the
+// caller-reachable `InvalidArgument` paths for malformed integer/constant
+// schemas. The happy paths are covered by the integration generator tests.
+
+use super::*;
+use crate::cbor_utils::cbor_map;
+use crate::native::core::NativeTestCase;
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
+
+fn fresh_ntc() -> NativeTestCase {
+    NativeTestCase::new_random(SmallRng::seed_from_u64(0))
+}
+
+#[test]
+fn interpret_integer_missing_min_value_is_invalid_argument() {
+    let mut ntc = fresh_ntc();
+    let schema = cbor_map! { "type" => "integer", "max_value" => 10 };
+    let err = interpret_integer(&mut ntc, &schema).unwrap_err();
+    assert!(matches!(err, EngineError::InvalidArgument(_)));
+    assert!(err.to_string().contains("min_value"));
+}
+
+#[test]
+fn interpret_integer_missing_max_value_is_invalid_argument() {
+    let mut ntc = fresh_ntc();
+    let schema = cbor_map! { "type" => "integer", "min_value" => 0 };
+    let err = interpret_integer(&mut ntc, &schema).unwrap_err();
+    assert!(matches!(err, EngineError::InvalidArgument(_)));
+    assert!(err.to_string().contains("max_value"));
+}
+
+#[test]
+fn interpret_integer_non_integer_bound_is_invalid_argument() {
+    let mut ntc = fresh_ntc();
+    let schema = cbor_map! { "type" => "integer", "min_value" => "lo", "max_value" => 10 };
+    let err = interpret_integer(&mut ntc, &schema).unwrap_err();
+    assert!(matches!(err, EngineError::InvalidArgument(_)));
+    assert!(err.to_string().contains("CBOR integer"));
+}
+
+#[test]
+fn interpret_constant_missing_value_is_invalid_argument() {
+    let schema = cbor_map! { "type" => "constant" };
+    let err = interpret_constant(&schema).unwrap_err();
+    assert!(matches!(err, EngineError::InvalidArgument(_)));
+    assert!(err.to_string().contains("value"));
+}

--- a/tests/embedded/native/schema/regex_tests.rs
+++ b/tests/embedded/native/schema/regex_tests.rs
@@ -733,3 +733,26 @@ fn generate_op_ignorecase_literal_outside_alphabet_marks_invalid() {
     assert!(result.is_err());
     assert_eq!(ntc.status, Some(Status::Invalid));
 }
+
+// ----- interpret_regex: caller-reachable InvalidArgument paths -----
+
+#[test]
+fn interpret_regex_missing_pattern_is_invalid_argument() {
+    use crate::cbor_utils::cbor_map;
+    let mut ntc = NativeTestCase::for_choices(&[], None, None);
+    let schema = cbor_map! { "type" => "regex" };
+    let err = interpret_regex(&mut ntc, &schema).unwrap_err();
+    assert!(matches!(err, EngineError::InvalidArgument(_)));
+    assert!(err.to_string().contains("pattern"));
+}
+
+#[test]
+fn interpret_regex_unparseable_pattern_is_invalid_argument() {
+    use crate::cbor_utils::cbor_map;
+    let mut ntc = NativeTestCase::for_choices(&[], None, None);
+    // An unbalanced group is a parse error in the Python-compatible parser.
+    let schema = cbor_map! { "type" => "regex", "pattern" => "(unclosed" };
+    let err = interpret_regex(&mut ntc, &schema).unwrap_err();
+    assert!(matches!(err, EngineError::InvalidArgument(_)));
+    assert!(err.to_string().contains("invalid regex pattern"));
+}

--- a/tests/embedded/native/schema/special_tests.rs
+++ b/tests/embedded/native/schema/special_tests.rs
@@ -33,7 +33,7 @@ fn decode_string(v: ciborium::Value) -> String {
 /// (e.g. "at least one draw is a 127.x.x.x address").
 fn collect<F>(n: u64, mut f: F) -> Vec<String>
 where
-    F: FnMut(&mut NativeTestCase) -> Result<ciborium::Value, crate::native::core::StopTest>,
+    F: FnMut(&mut NativeTestCase) -> Result<ciborium::Value, crate::native::core::EngineError>,
 {
     (0..n)
         .filter_map(|seed| {
@@ -273,19 +273,21 @@ fn interpret_ipv6_hits_special_ranges() {
 }
 
 #[test]
-#[should_panic(expected = "ip_address: unsupported version 5")]
-fn interpret_ip_address_unknown_version_panics() {
+fn interpret_ip_address_unknown_version_is_invalid_argument() {
     let mut ntc = fresh_ntc(0);
     let schema = cbor_map! { "type" => "ip_address", "version" => 5u64 };
-    let _ = interpret_ip_address(&mut ntc, &schema);
+    let err = interpret_ip_address(&mut ntc, &schema).unwrap_err();
+    assert!(matches!(err, EngineError::InvalidArgument(_)));
+    assert!(err.to_string().contains("unsupported version 5"));
 }
 
 #[test]
-#[should_panic(expected = "ip_address schema must have a \"version\" field")]
-fn interpret_ip_address_missing_version_panics() {
+fn interpret_ip_address_missing_version_is_invalid_argument() {
     let mut ntc = fresh_ntc(0);
     let schema = cbor_map! { "type" => "ip_address" };
-    let _ = interpret_ip_address(&mut ntc, &schema);
+    let err = interpret_ip_address(&mut ntc, &schema).unwrap_err();
+    assert!(matches!(err, EngineError::InvalidArgument(_)));
+    assert!(err.to_string().contains("\"version\""));
 }
 
 // ── interpret_uuid: distribution across versions ─────────────────────────────

--- a/tests/embedded/native/schema/text_tests.rs
+++ b/tests/embedded/native/schema/text_tests.rs
@@ -15,7 +15,7 @@ fn schema(builder: fn(&mut Vec<(ciborium::Value, ciborium::Value)>)) -> ciborium
 #[test]
 fn build_intervals_default_excludes_surrogates() {
     let s = schema(|_| {});
-    let iv = build_intervals(&s);
+    let iv = build_intervals(&s).unwrap();
     // 0..=0x10FFFF minus the 2048-codepoint surrogate block.
     assert_eq!(iv.len(), 0x110000 - 2048);
     assert!(!iv.contains(0xD800));
@@ -28,7 +28,7 @@ fn build_intervals_codec_ascii() {
         "type" => "string",
         "codec" => "ascii",
     };
-    let iv = build_intervals(&s);
+    let iv = build_intervals(&s).unwrap();
     assert_eq!(iv.len(), 128);
     assert!(iv.contains(0));
     assert!(iv.contains(127));
@@ -41,17 +41,18 @@ fn build_intervals_codec_latin1() {
         "type" => "string",
         "codec" => "latin-1",
     };
-    assert_eq!(build_intervals(&s).len(), 256);
+    assert_eq!(build_intervals(&s).unwrap().len(), 256);
 }
 
 #[test]
-#[should_panic(expected = "Invalid codec")]
-fn build_intervals_unknown_codec_panics() {
+fn build_intervals_unknown_codec_is_invalid_argument() {
     let s = cbor_map! {
         "type" => "string",
         "codec" => "ebcdic",
     };
-    build_intervals(&s);
+    let err = build_intervals(&s).unwrap_err();
+    assert!(matches!(err, EngineError::InvalidArgument(_)));
+    assert!(err.to_string().contains("invalid codec"));
 }
 
 #[test]
@@ -61,7 +62,7 @@ fn build_intervals_codepoint_range() {
         "min_codepoint" => b'a' as u64,
         "max_codepoint" => b'z' as u64,
     };
-    let iv = build_intervals(&s);
+    let iv = build_intervals(&s).unwrap();
     assert_eq!(iv.len(), 26);
 }
 
@@ -72,7 +73,7 @@ fn build_intervals_range_straddles_surrogates() {
         "min_codepoint" => 0xD700u64,
         "max_codepoint" => 0xE100u64,
     };
-    let iv = build_intervals(&s);
+    let iv = build_intervals(&s).unwrap();
     // [0xD700..=0xD7FF] ∪ [0xE000..=0xE100] = 0x100 + 0x101 codepoints.
     assert_eq!(iv.len(), 0x100 + 0x101);
 }
@@ -84,7 +85,7 @@ fn build_intervals_range_entirely_in_surrogates_is_empty() {
         "min_codepoint" => 0xD800u64,
         "max_codepoint" => 0xDFFFu64,
     };
-    assert_eq!(build_intervals(&s).len(), 0);
+    assert_eq!(build_intervals(&s).unwrap().len(), 0);
 }
 
 #[test]
@@ -94,7 +95,7 @@ fn build_intervals_categories_subset_intersects_base() {
         "type" => "string",
         "categories" => cbor_array![ciborium::Value::Text("Nd".into())],
     };
-    let iv = build_intervals(&s);
+    let iv = build_intervals(&s).unwrap();
     // BMP has multiple Nd ranges; at minimum '0'..='9' are present.
     assert!(iv.contains(b'0' as u32));
     assert!(iv.contains(b'9' as u32));
@@ -108,7 +109,7 @@ fn build_intervals_exclude_categories_subtracts_from_base() {
         "codec" => "ascii",
         "exclude_categories" => cbor_array![ciborium::Value::Text("Cc".into())],
     };
-    let iv = build_intervals(&s);
+    let iv = build_intervals(&s).unwrap();
     // ASCII (128) minus control characters (33: 0x00..=0x1F + 0x7F).
     assert_eq!(iv.len(), 128 - 33);
     assert!(!iv.contains(0));
@@ -123,7 +124,7 @@ fn build_intervals_exclude_characters_subtracts() {
         "max_codepoint" => b'z' as u64,
         "exclude_characters" => "aeiou",
     };
-    let iv = build_intervals(&s);
+    let iv = build_intervals(&s).unwrap();
     assert_eq!(iv.len(), 21);
     assert!(!iv.contains(b'a' as u32));
     assert!(iv.contains(b'b' as u32));
@@ -136,7 +137,7 @@ fn build_intervals_include_characters_unions_in() {
         "categories" => cbor_array![],
         "include_characters" => "xyz",
     };
-    let iv = build_intervals(&s);
+    let iv = build_intervals(&s).unwrap();
     assert_eq!(iv.len(), 3);
     assert!(iv.contains(b'x' as u32));
 }
@@ -148,29 +149,31 @@ fn build_intervals_include_characters_drops_surrogates() {
         "categories" => cbor_array![],
         "include_characters" => "ab",
     };
-    let iv = build_intervals(&s);
+    let iv = build_intervals(&s).unwrap();
     assert_eq!(iv.len(), 2);
 }
 
 #[test]
-#[should_panic(expected = "InvalidArgument")]
-fn build_intervals_invalid_category_panics() {
+fn build_intervals_invalid_category_is_invalid_argument() {
     let s = cbor_map! {
         "type" => "string",
         "categories" => cbor_array![ciborium::Value::Text("Xx".into())],
     };
-    build_intervals(&s);
+    let err = build_intervals(&s).unwrap_err();
+    assert!(matches!(err, EngineError::InvalidArgument(_)));
+    assert!(err.to_string().contains("valid Unicode category"));
 }
 
 #[test]
-#[should_panic(expected = "overlap")]
-fn build_intervals_overlap_between_include_and_exclude_panics() {
+fn build_intervals_overlap_between_include_and_exclude_is_invalid_argument() {
     let s = cbor_map! {
         "type" => "string",
         "include_characters" => "abc",
         "exclude_characters" => "bcd",
     };
-    build_intervals(&s);
+    let err = build_intervals(&s).unwrap_err();
+    assert!(matches!(err, EngineError::InvalidArgument(_)));
+    assert!(err.to_string().contains("overlap"));
 }
 
 #[test]
@@ -180,8 +183,8 @@ fn build_intervals_caches_repeated_schema() {
         "min_codepoint" => b'a' as u64,
         "max_codepoint" => b'z' as u64,
     };
-    let a = build_intervals(&s);
-    let b = build_intervals(&s);
+    let a = build_intervals(&s).unwrap();
+    let b = build_intervals(&s).unwrap();
     assert_eq!(a.len(), b.len());
 }
 
@@ -196,7 +199,7 @@ fn build_intervals_unions_multiple_categories() {
             ciborium::Value::Text("Ll".into()),
         ],
     };
-    let iv = build_intervals(&s);
+    let iv = build_intervals(&s).unwrap();
     // Both 'A' (Lu) and 'a' (Ll) are present.
     assert!(iv.contains(b'A' as u32));
     assert!(iv.contains(b'a' as u32));
@@ -214,7 +217,7 @@ fn build_intervals_category_with_run_into_surrogates() {
         "type" => "string",
         "categories" => cbor_array![ciborium::Value::Text("Lo".into())],
     };
-    let iv = build_intervals(&s);
+    let iv = build_intervals(&s).unwrap();
     assert!(iv.contains(0xD7A3));
     assert!(!iv.contains(0xD800));
 }
@@ -228,7 +231,7 @@ fn build_intervals_category_running_to_bmp_end() {
         "type" => "string",
         "categories" => cbor_array![ciborium::Value::Text("Cn".into())],
     };
-    let iv = build_intervals(&s);
+    let iv = build_intervals(&s).unwrap();
     assert!(iv.contains(0xFFFF));
 }
 
@@ -242,7 +245,7 @@ fn build_intervals_treats_non_array_categories_field_as_absent() {
         "codec" => "ascii",
         "categories" => "not-an-array",
     };
-    let iv = build_intervals(&s);
+    let iv = build_intervals(&s).unwrap();
     // 128 ASCII codepoints (no category filter applied).
     assert_eq!(iv.len(), 128);
 }

--- a/tests/embedded/native/test_runner_tests.rs
+++ b/tests/embedded/native/test_runner_tests.rs
@@ -1,40 +1,46 @@
-//! Embedded tests for `src/native/test_runner.rs` helpers.  Cover
-//! the defensive branches (flaky-final-replay panic and TooSlow
-//! health-check) that were previously masked by `// nocov` annotations.
+//! Embedded tests for `src/native/test_runner.rs` helpers.  Cover the
+//! health-check diagnostics (TooSlow and the flaky-replay message) that the
+//! runner folds into a failing `TestRunResult` instead of panicking, so no
+//! panic crosses the FFI boundary into libhegel.
 
 use super::*;
 use std::time::Duration;
 
 #[test]
-fn too_slow_check_panics_when_under_threshold_and_unsuppressed() {
-    let result = std::panic::catch_unwind(|| {
-        too_slow_check(
-            /* valid_test_cases */ 1,
-            /* total_test_time */ Duration::from_secs(60),
-            /* threshold */ Duration::from_secs(30),
-            /* suppressed */ false,
-        );
-    });
-    assert!(result.is_err(), "expected too_slow_check to panic");
+fn too_slow_check_reports_when_under_threshold_and_unsuppressed() {
+    let msg = too_slow_check(
+        /* valid_test_cases */ 1,
+        /* total_test_time */ Duration::from_secs(60),
+        /* threshold */ Duration::from_secs(30),
+        /* suppressed */ false,
+    );
+    assert!(msg.is_some(), "expected too_slow_check to report a failure");
+    assert!(msg.unwrap().contains("TooSlow"));
 }
 
 #[test]
 fn too_slow_check_quiet_when_suppressed() {
-    too_slow_check(
-        /* valid_test_cases */ 1,
-        /* total_test_time */ Duration::from_secs(60),
-        /* threshold */ Duration::from_secs(30),
-        /* suppressed */ true,
+    assert!(
+        too_slow_check(
+            /* valid_test_cases */ 1,
+            /* total_test_time */ Duration::from_secs(60),
+            /* threshold */ Duration::from_secs(30),
+            /* suppressed */ true,
+        )
+        .is_none()
     );
 }
 
 #[test]
 fn too_slow_check_quiet_when_under_threshold() {
-    too_slow_check(
-        /* valid_test_cases */ 1,
-        /* total_test_time */ Duration::from_secs(1),
-        /* threshold */ Duration::from_secs(30),
-        /* suppressed */ false,
+    assert!(
+        too_slow_check(
+            /* valid_test_cases */ 1,
+            /* total_test_time */ Duration::from_secs(1),
+            /* threshold */ Duration::from_secs(30),
+            /* suppressed */ false,
+        )
+        .is_none()
     );
 }
 
@@ -42,16 +48,18 @@ fn too_slow_check_quiet_when_under_threshold() {
 fn too_slow_check_quiet_when_enough_valid_cases() {
     // Once enough valid cases have run, the health check is no longer
     // applied even if total_test_time exceeds the threshold.
-    too_slow_check(
-        /* valid_test_cases */ 10_000,
-        /* total_test_time */ Duration::from_secs(60),
-        /* threshold */ Duration::from_secs(30),
-        /* suppressed */ false,
+    assert!(
+        too_slow_check(
+            /* valid_test_cases */ 10_000,
+            /* total_test_time */ Duration::from_secs(60),
+            /* threshold */ Duration::from_secs(30),
+            /* suppressed */ false,
+        )
+        .is_none()
     );
 }
 
 #[test]
-#[should_panic(expected = "Flaky test detected")]
-fn flaky_final_replay_panic_panics_with_diagnostic() {
-    flaky_final_replay_panic();
+fn flaky_diagnostic_mentions_flaky() {
+    assert!(flaky_diagnostic().contains("Flaky test detected"));
 }

--- a/tests/test_backend.rs
+++ b/tests/test_backend.rs
@@ -7,8 +7,10 @@ fn test_data_source_error_display() {
     let stop = DataSourceError::StopTest;
     let assume = DataSourceError::Assume;
     let server = DataSourceError::ServerError("something went wrong".to_string());
+    let invalid = DataSourceError::InvalidArgument("bad schema".to_string());
 
     assert!(stop.to_string().contains("StopTest"));
     assert!(assume.to_string().contains("Assume"));
     assert_eq!(server.to_string(), "something went wrong");
+    assert_eq!(invalid.to_string(), "bad schema");
 }


### PR DESCRIPTION
This primarily exists as an implementation detail for libhegel.

<details>
<summary>Details</summary>

The native engine `panic!`d on a broad class of caller-supplied-schema problems (e.g. `{"type":"ipv4"}` → `panic!("Unknown schema type")`). Driven in-process over the C FFI (`libhegel`), such a panic crossed the `extern "C"` boundary and aborted the host process (SIGABRT) — it killed an embedding JVM on a schema typo, contradicting the `hegel_generate` contract of returning `HEGEL_E_INVALID_ARG`.

**Change**
- Replace the `StopTest` marker with an internal `EngineError { StopTest, InvalidArgument(String) }` threaded through the schema interpreter, and convert every caller-schema-reachable panic (unknown/missing type, bad codec/category/regex, missing required fields, unsupported float width / IP version, malformed CBOR bounds, empty character set, empty `one_of`/`sampled_from`) into `EngineError::InvalidArgument`. Genuine internal invariants stay panics.
- `DataSourceError` (now `#[doc(hidden)]` — not public API) gains an `InvalidArgument(String)` variant. The pure-Rust API still panics at its surface (`panic_on_data_source_error`), so behaviour is unchanged; libhegel maps it to `HEGEL_E_INVALID_ARG` with the diagnostic in `hegel_last_error_message`.
- Run-loop health-check failures (`FilterTooMuch` / `TooSlow` / flaky) now return a failing `TestRunResult` instead of panicking, so they no longer rely on hegel-c's `catch_unwind` (inert under `panic = "abort"`).

**Proof**
- New `just c-test-abort` builds libhegel with `panic = "abort"` and runs the smoke tests + C examples against it (the unwind harness loads the abort artifact via `HEGEL_C_LIB_DIR`), wired into CI. A new static-link `hegel-c/examples/invalid_schema.c` reproduces the original JVM scenario — it returns `rc=-5` and exits cleanly instead of aborting.

**Verification**
- `cargo fmt --check`, clippy on both backends — clean.
- Native + server test suites pass.
- Coverage 100% — 0 uncovered code lines, `// nocov` count unchanged at 381 (no ratchet increase).
- panic=abort smoke tests + all C examples pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)