### PR TITLE
Fix native backend running many more test cases than server

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,5 @@
-RELEASE_TYPE: patch
+RELEASE_TYPE: minor
 
-This patch improves the performance of the native backend by caching the results of span mutations, so a test is no longer re-run for mutated inputs whose outcome is already known. Tests that spend most of their time in the mutation phase should run noticeably faster.
+This release makes the native backend count span mutations towards the `test_cases` budget. Previously each generated example could spawn several extra mutated test cases that ran *on top of* `test_cases`, so a test executed its body several times more often than the configured number of examples. Span mutations are now generated examples like any other and share the same budget, matching Hypothesis.
+
+As a result a run executes roughly `test_cases` times rather than a multiple of it. Tests that were implicitly relying on those extra executions to find a counterexample may need a larger `test_cases` to keep finding it.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,5 @@
-RELEASE_TYPE: minor
+RELEASE_TYPE: patch
 
-This release makes the native backend count span mutations towards the `test_cases` budget. Previously each generated example could spawn several extra mutated test cases that ran *on top of* `test_cases`, so a test executed its body several times more often than the configured number of examples. Span mutations are now generated examples like any other and share the same budget, matching Hypothesis.
+This patch makes the native backend count span mutations towards the `test_cases` budget. Previously each generated example could spawn several extra mutated test cases that ran *on top of* `test_cases`, so a test executed its body several times more often than the configured number of examples. Span mutations are now generated examples like any other and share the same budget, matching Hypothesis.
 
 As a result a run executes roughly `test_cases` times rather than a multiple of it. Tests that were implicitly relying on those extra executions to find a counterexample may need a larger `test_cases` to keep finding it.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,6 @@
 RELEASE_TYPE: patch
 
-This patch makes the native backend count span mutations towards the `test_cases` budget. Previously each generated example could spawn several extra mutated test cases that ran *on top of* `test_cases`, so a test executed its body several times more often than the configured number of examples. Span mutations are now generated examples like any other and share the same budget, matching Hypothesis.
+This patch fixes two bugs in the native feature.
 
-As a result a run executes roughly `test_cases` times rather than a multiple of it. Tests that were implicitly relying on those extra executions to find a counterexample may need a larger `test_cases` to keep finding it.
+1. test case limits were not properly being respected, leading to running up to 5x as many test cases as requested
+2. some checks that were supposed to prevent duplicate test cases were not properly being honoured, leading to duplicate tests

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch improves the performance of the native backend by caching the results of span mutations, so a test is no longer re-run for mutated inputs whose outcome is already known. Tests that spend most of their time in the mutation phase should run noticeably faster.

--- a/src/native/core/choices.rs
+++ b/src/native/core/choices.rs
@@ -773,6 +773,21 @@ impl ChoiceKind {
         }
     }
 
+    /// The "unit" value for this choice kind — the fallback a replayed draw
+    /// resolves to when its prefix value fails this kind's validation and no
+    /// original-kind information is available to pun towards `simplest()`.
+    /// Mirrors the `unit()` branch of
+    /// [`crate::native::core::state::NativeTestCase::resolve_choice`].
+    pub fn unit(&self) -> ChoiceValue {
+        match self {
+            ChoiceKind::Integer(ic) => ChoiceValue::Integer(ic.unit()),
+            ChoiceKind::Boolean(bc) => ChoiceValue::Boolean(bc.unit()),
+            ChoiceKind::Float(fc) => ChoiceValue::Float(fc.unit()),
+            ChoiceKind::Bytes(bc) => ChoiceValue::Bytes(bc.unit()),
+            ChoiceKind::String(sc) => ChoiceValue::String(sc.unit()),
+        }
+    }
+
     /// Largest valid index for [`from_index`].
     pub fn max_index(&self) -> crate::native::bignum::BigUint {
         match self {

--- a/src/native/data_tree.rs
+++ b/src/native/data_tree.rs
@@ -44,6 +44,12 @@ impl From<&ChoiceValue> for ChoiceValueKey {
 #[derive(Default)]
 pub(crate) struct DataTreeNode {
     kind: Option<Arc<ChoiceKind>>,
+    /// Whether the draw made *from* this node was forced (set alongside
+    /// `kind` on first visit). Forcing is deterministic given the prefix, so
+    /// a forced position has exactly one child — the forced value — and a
+    /// replay's prefix value at that position is ignored. [`simulate`] needs
+    /// this to predict realised values correctly.
+    forced: bool,
     children: HashMap<ChoiceValueKey, Box<DataTreeNode>>,
     /// Terminal status if the test case ended at this node. Only set
     /// when the recording run concluded with `Status >= Invalid`.
@@ -131,6 +137,7 @@ pub(crate) fn record_tree(
             }
             None => {
                 node.kind = Some(first.kind.clone());
+                node.forced = first.was_forced;
             }
             _ => {}
         }
@@ -231,6 +238,71 @@ pub(crate) fn generate_novel_prefix(
         }
     }
     prefix
+}
+
+/// Predict the outcome of replaying `choices` through
+/// [`super::core::NativeTestCase::for_choices`] *without* running the test
+/// body, by walking them through the recorded tree. Port of the subset of
+/// Hypothesis's `DataTree.simulate_test_function` the runner needs.
+///
+/// The walk reproduces how `resolve_choice` turns a replayed prefix value
+/// into the *realised* value the tree is keyed on, which is **not** always
+/// the prefix value itself:
+///
+/// * At a **forced** position the prefix value is ignored and the draw
+///   always yields the single recorded (forced) value; the prefix cursor
+///   still advances past the skipped slot.
+/// * At an unforced position whose prefix value fails the requested kind's
+///   validation, the draw puns to `kind.unit()` (there is no original-kind
+///   information for a bare `for_choices` replay, so the `simplest()` branch
+///   never applies).
+///
+/// Returns `Some(status)` when the walk reaches a recorded conclusion
+/// (either because a previous run terminated exactly here, or because it
+/// terminated at a prefix of `choices` whose trailing values are never
+/// read). Returns `None` — Hypothesis's `PreviouslyUnseenBehaviour` — when
+/// the realised path diverges from anything seen before, or when `choices`
+/// runs out while the tree still expects another draw (a real run would
+/// overrun, which `for_choices` never records as a conclusion); in both
+/// cases the caller must actually execute to learn the outcome.
+///
+/// Only `Status >= Invalid` is ever recorded as a conclusion (see
+/// [`record_tree`]), so `EarlyStop` is never returned.
+pub(crate) fn simulate(tree_root: &DataTreeNode, choices: &[ChoiceValue]) -> Option<Status> {
+    let mut current = tree_root;
+    // `i` tracks the prefix cursor, which equals `nodes.len()` in the real
+    // run: every draw — forced or not — advances it by one.
+    let mut i = 0usize;
+    loop {
+        // A run terminated here drawing fewer choices than we walked past;
+        // its outcome is fixed regardless of any later values.
+        if let Some(status) = current.conclusion {
+            return Some(status);
+        }
+        // No draw was ever made from this node (and it didn't conclude), so
+        // the path beyond it is unknown.
+        let kind = current.kind.as_ref()?;
+        // `for_choices` caps `max_size` at `choices.len()`, so the draw that
+        // would read position `choices.len()` overruns (EarlyStop) — and
+        // that is never recorded as a conclusion. We can't predict it.
+        if i >= choices.len() {
+            return None;
+        }
+        let next = if current.forced {
+            // Forced: ignore the prefix value, follow the single recorded
+            // (forced) child.
+            current.children.values().next()?
+        } else {
+            let realised = if kind.validate(&choices[i]) {
+                choices[i].clone()
+            } else {
+                kind.unit()
+            };
+            current.children.get(&ChoiceValueKey::from(&realised))?
+        };
+        i += 1;
+        current = next;
+    }
 }
 
 /// Concatenate `database_key + b"." + sub` to derive a sub-corpus key.

--- a/src/native/shrinker/sequence.rs
+++ b/src/native/shrinker/sequence.rs
@@ -165,3 +165,7 @@ impl<'a> Shrinker<'a> {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "../../../tests/embedded/native/shrinker_sequence_tests.rs"]
+mod tests;

--- a/src/native/test_runner.rs
+++ b/src/native/test_runner.rs
@@ -397,7 +397,7 @@ fn run_main(
                 // Interesting) the closure short-circuits below
                 // `SPAN_MUTATION_ATTEMPTS`.
                 let (mutation_result, mutation_attempts) =
-                    try_span_mutation(&run.nodes, &run.spans, &mut rng, &mut ctx);
+                    try_span_mutation(&run.nodes, &run.spans, &mut rng, &mut ctx, &mut tree_root);
                 calls += mutation_attempts as u64;
                 if let Some((mut_nodes, origin)) = mutation_result {
                     if first_bug_at.is_none() {
@@ -897,6 +897,61 @@ impl<'a> EngineCtx<'a> {
     pub(crate) fn run(&mut self, ntc: NativeTestCase) -> RunResult {
         self.execute(ntc, false)
     }
+
+    /// Hypothesis's `cached_test_function`, ported: replay `choices` only
+    /// when their outcome isn't already known. First the exact-input data
+    /// cache is consulted; failing that, `choices` are *simulated* against
+    /// the generation `tree_root` (read-only) — if that simulation reaches a
+    /// recorded conclusion without hitting a previously-unseen draw, the test
+    /// body is not run at all. Only a genuinely novel sequence (or a
+    /// known-`Interesting` one, whose nodes/origin the tree can't carry)
+    /// falls through to a real [`Self::execute`], whose result is memoised in
+    /// the data cache.
+    ///
+    /// The realised result is deliberately *not* recorded back into
+    /// `tree_root`. The tree drives generation's `generate_novel_prefix`
+    /// walk, whose RNG consumption depends on the tree's shape; folding the
+    /// mutation pass's paths into it would perturb that walk and so shift the
+    /// entire (seeded) generation trajectory — changing *which* inputs and
+    /// mutations are explored — for no gain to this cache, which only needs
+    /// to recognise paths generation already covered. Leaving the tree
+    /// generation-only keeps the search identical to the pre-cache behaviour
+    /// (where mutations never touched the tree) while still skipping the
+    /// redundant re-executions; the data cache catches exact mutation repeats
+    /// the tree can't.
+    ///
+    /// Returns the result plus whether the test body actually ran, so
+    /// callers charge their execution budget to real runs only. Span
+    /// mutation proposes many sequences whose paths are already covered by
+    /// generation (e.g. duplicating a span the test never reads past);
+    /// pre-cache the native backend ran the body for every one of them,
+    /// executing the test several times more often than Hypothesis.
+    fn cached_run(
+        &mut self,
+        choices: &[ChoiceValue],
+        tree_root: &mut crate::native::data_tree::DataTreeNode,
+    ) -> (RunResult, bool) {
+        if let Some(cached) = self.cache.get(choices) {
+            return (cached.clone(), false);
+        }
+        if let Some(status) = crate::native::data_tree::simulate(tree_root, choices) {
+            if status != Status::Interesting {
+                let result = RunResult {
+                    status,
+                    nodes: Vec::new(),
+                    spans: Vec::new(),
+                    origin: None,
+                    failure: None,
+                    target_observations: HashMap::new(),
+                };
+                return (result, false);
+            }
+        }
+        let ntc = NativeTestCase::for_choices(choices, None, None);
+        let run = self.execute(ntc, false);
+        self.cache.insert(choices.to_vec(), run.clone());
+        (run, true)
+    }
 }
 
 /// Try span mutation: find two spans with the same label and either duplicate
@@ -905,18 +960,25 @@ impl<'a> EngineCtx<'a> {
 ///
 /// Returns the mutated shrunk nodes plus the panic origin if the attempt
 /// produced an interesting result.
-/// Runs up to [`SPAN_MUTATION_ATTEMPTS`] span-mutation probes via `ctx`.
+/// Makes up to [`SPAN_MUTATION_ATTEMPTS`] span-mutation probes through
+/// [`EngineCtx::cached_run`], so a proposed sequence whose path is already
+/// covered by the `tree_root` (or sits in the data cache) costs no test-body
+/// execution — matching Hypothesis, which routes mutations through
+/// `cached_test_function`.
+///
 /// Returns the mutated counterexample (if one was found) plus the number of
-/// `ctx.execute` calls that actually ran — N3 fix: pre-N3 the caller
-/// unconditionally added `SPAN_MUTATION_ATTEMPTS` to its `calls` counter,
-/// even when no labels with ≥2 occurrences exist (multi is empty → 0 probes
-/// run) or when a probe fired Interesting on attempt 1 (only 1 probe ran).
-/// The accounting now reflects what actually happened.
+/// probes that *actually executed* the test body — both the
+/// `SPAN_MUTATION_ATTEMPTS` iteration cap and the cache/tree short-circuits
+/// keep this at or below the maximum, so the caller's `calls` counter only
+/// ever grows by real runs. (Pre-N3 the caller unconditionally added
+/// `SPAN_MUTATION_ATTEMPTS`, even when no labels with ≥2 occurrences exist —
+/// multi is empty → 0 probes run — or when a probe fired Interesting early.)
 fn try_span_mutation(
     nodes: &[ChoiceNode],
     spans: &[Span],
     rng: &mut SmallRng,
     ctx: &mut EngineCtx<'_>,
+    tree_root: &mut crate::native::data_tree::DataTreeNode,
 ) -> (Option<(Vec<ChoiceNode>, String)>, usize) {
     use std::collections::HashSet;
 
@@ -984,9 +1046,10 @@ fn try_span_mutation(
             out
         };
 
-        let ntc = NativeTestCase::for_choices(&attempt, None, None);
-        let run = ctx.execute(ntc, false);
-        attempts += 1;
+        let (run, executed) = ctx.cached_run(&attempt, tree_root);
+        if executed {
+            attempts += 1;
+        }
         if run.status == Status::Interesting {
             let origin = run.origin.unwrap_or_default();
             return (Some((run.nodes, origin)), attempts);

--- a/src/native/test_runner.rs
+++ b/src/native/test_runner.rs
@@ -396,8 +396,15 @@ fn run_main(
                 // have ≥2 occurrences (or when the first probe fires
                 // Interesting) the closure short-circuits below
                 // `SPAN_MUTATION_ATTEMPTS`.
-                let (mutation_result, mutation_attempts) =
-                    try_span_mutation(&run.nodes, &run.spans, &mut rng, &mut ctx, &mut tree_root);
+                let (mutation_result, mutation_attempts) = try_span_mutation(
+                    &run.nodes,
+                    &run.spans,
+                    &mut rng,
+                    &mut ctx,
+                    &mut tree_root,
+                    &mut valid_test_cases,
+                    max_examples,
+                );
                 calls += mutation_attempts as u64;
                 if let Some((mut_nodes, origin)) = mutation_result {
                     if first_bug_at.is_none() {
@@ -966,19 +973,27 @@ impl<'a> EngineCtx<'a> {
 /// execution — matching Hypothesis, which routes mutations through
 /// `cached_test_function`.
 ///
+/// A span mutation is itself a generated test case, so each probe that
+/// *actually executes* and is valid consumes the same `max_examples` budget
+/// as a freshly generated example: it bumps `*valid_test_cases`, and the
+/// probe loop stops as soon as that budget is full. (In Hypothesis the
+/// mutation executions go through `cached_test_function` → `test_function`,
+/// which increments `valid_examples` exactly as a fresh draw does; cache/tree
+/// hits bypass it and so cost nothing.) Without this the native backend ran
+/// `max_examples` fresh cases *plus* up to five mutations each, executing the
+/// test several times more often than Hypothesis.
+///
 /// Returns the mutated counterexample (if one was found) plus the number of
-/// probes that *actually executed* the test body — both the
-/// `SPAN_MUTATION_ATTEMPTS` iteration cap and the cache/tree short-circuits
-/// keep this at or below the maximum, so the caller's `calls` counter only
-/// ever grows by real runs. (Pre-N3 the caller unconditionally added
-/// `SPAN_MUTATION_ATTEMPTS`, even when no labels with ≥2 occurrences exist —
-/// multi is empty → 0 probes run — or when a probe fired Interesting early.)
+/// probes that actually executed the test body, which the caller adds to its
+/// `calls` counter.
 fn try_span_mutation(
     nodes: &[ChoiceNode],
     spans: &[Span],
     rng: &mut SmallRng,
     ctx: &mut EngineCtx<'_>,
     tree_root: &mut crate::native::data_tree::DataTreeNode,
+    valid_test_cases: &mut u64,
+    max_examples: u64,
 ) -> (Option<(Vec<ChoiceNode>, String)>, usize) {
     use std::collections::HashSet;
 
@@ -1006,6 +1021,11 @@ fn try_span_mutation(
 
     let mut attempts: usize = 0;
     for _ in 0..SPAN_MUTATION_ATTEMPTS {
+        // A mutation probe is a generated example: once the example budget is
+        // full there is no room for another, so stop proposing.
+        if *valid_test_cases >= max_examples {
+            break;
+        }
         let group = &multi[rng.random_range(0..multi.len())];
         let i_a = rng.random_range(0..group.len());
         let mut i_b = rng.random_range(0..group.len() - 1);
@@ -1049,6 +1069,11 @@ fn try_span_mutation(
         let (run, executed) = ctx.cached_run(&attempt, tree_root);
         if executed {
             attempts += 1;
+            // A valid mutation execution is a valid example and consumes the
+            // budget, exactly like a freshly generated one.
+            if run.status == Status::Valid {
+                *valid_test_cases += 1;
+            }
         }
         if run.status == Status::Interesting {
             let origin = run.origin.unwrap_or_default();

--- a/tests/embedded/native/choices_tests.rs
+++ b/tests/embedded/native/choices_tests.rs
@@ -791,9 +791,9 @@ fn choice_kind_unit_dispatches_to_each_sub_kind() {
     // replays) must forward to the matching sub-kind's `unit()` for every
     // variant.
     let ic = IntegerChoice {
-        min_value: 0,
-        max_value: 10,
-        shrink_towards: 0,
+        min_value: BigInt::from(0),
+        max_value: BigInt::from(10),
+        shrink_towards: BigInt::from(0),
     };
     assert_eq!(
         ChoiceKind::Integer(ic.clone()).unit(),

--- a/tests/embedded/native/choices_tests.rs
+++ b/tests/embedded/native/choices_tests.rs
@@ -783,6 +783,50 @@ fn nodes_sort_key_shortlex_orders_by_length_then_element() {
     assert!(sort_key(&empty) < sort_key(&a));
 }
 
+// ── ChoiceKind::unit dispatch ────────────────────────────────────────────────
+
+#[test]
+fn choice_kind_unit_dispatches_to_each_sub_kind() {
+    // `ChoiceKind::unit()` (used by data-tree simulation to predict punned
+    // replays) must forward to the matching sub-kind's `unit()` for every
+    // variant.
+    let ic = IntegerChoice {
+        min_value: 0,
+        max_value: 10,
+        shrink_towards: 0,
+    };
+    assert_eq!(
+        ChoiceKind::Integer(ic.clone()).unit(),
+        ChoiceValue::Integer(ic.unit())
+    );
+
+    assert_eq!(
+        ChoiceKind::Boolean(BooleanChoice).unit(),
+        ChoiceValue::Boolean(BooleanChoice.unit())
+    );
+
+    let fch = fc(0.0, 10.0, false, false);
+    assert_eq!(
+        ChoiceKind::Float(fch.clone()).unit(),
+        ChoiceValue::Float(fch.unit())
+    );
+
+    let bc = BytesChoice {
+        min_size: 0,
+        max_size: 4,
+    };
+    assert_eq!(
+        ChoiceKind::Bytes(bc.clone()).unit(),
+        ChoiceValue::Bytes(bc.unit())
+    );
+
+    let sc = string_choice(vec![(b'a' as u32, b'z' as u32)], 0, 4);
+    assert_eq!(
+        ChoiceKind::String(sc.clone()).unit(),
+        ChoiceValue::String(sc.unit())
+    );
+}
+
 // ── EngineError Display ──────────────────────────────────────────────────────
 
 #[test]

--- a/tests/embedded/native/data_tree_tests.rs
+++ b/tests/embedded/native/data_tree_tests.rs
@@ -108,3 +108,121 @@ fn generate_novel_prefix_terminates_when_subtree_exhausted() {
     // Tree is now exhausted; novel prefix is empty (root.is_exhausted is true).
     assert!(prefix.is_empty());
 }
+
+#[test]
+fn simulate_unseen_on_empty_tree() {
+    // Nothing recorded: any choices are previously-unseen behaviour.
+    let root = DataTreeNode::default();
+    assert_eq!(simulate(&root, &[ChoiceValue::Boolean(false)]), None);
+    assert_eq!(simulate(&root, &[]), None);
+}
+
+#[test]
+fn simulate_returns_recorded_conclusion_for_exact_match() {
+    let mut root = DataTreeNode::default();
+    record_tree(&mut root, &[bool_node(false)], Status::Valid, &[]);
+    assert_eq!(
+        simulate(&root, &[ChoiceValue::Boolean(false)]),
+        Some(Status::Valid)
+    );
+}
+
+#[test]
+fn simulate_ignores_trailing_choices_past_a_conclusion() {
+    // The recorded run drew a single boolean and concluded; replaying a
+    // longer sequence that shares that prefix never reads past the first
+    // choice, so the outcome is the recorded one — this is the fixed-shape
+    // case span mutation hits when it duplicates a span the test ignores.
+    let mut root = DataTreeNode::default();
+    record_tree(&mut root, &[bool_node(false)], Status::Invalid, &[]);
+    assert_eq!(
+        simulate(
+            &root,
+            &[
+                ChoiceValue::Boolean(false),
+                ChoiceValue::Boolean(true),
+                ChoiceValue::Boolean(true),
+            ],
+        ),
+        Some(Status::Invalid)
+    );
+}
+
+#[test]
+fn simulate_unseen_when_path_diverges() {
+    // The recorded path went through `false`; `true` is an unrecorded
+    // child, so the outcome is unknown.
+    let mut root = DataTreeNode::default();
+    record_tree(
+        &mut root,
+        &[bool_node(false), bool_node(false)],
+        Status::Valid,
+        &[],
+    );
+    assert_eq!(simulate(&root, &[ChoiceValue::Boolean(true)]), None);
+}
+
+#[test]
+fn simulate_unseen_when_choices_run_out_mid_path() {
+    // The recorded run drew two booleans; supplying only the first leaves
+    // the tree still expecting a draw, so the real run would read past what
+    // we hold — report unseen rather than guessing.
+    let mut root = DataTreeNode::default();
+    record_tree(
+        &mut root,
+        &[bool_node(false), bool_node(true)],
+        Status::Valid,
+        &[],
+    );
+    assert_eq!(simulate(&root, &[ChoiceValue::Boolean(false)]), None);
+}
+
+#[test]
+fn simulate_returns_interesting_conclusion() {
+    let mut root = DataTreeNode::default();
+    record_tree(&mut root, &[int_node(0, 100, 7)], Status::Interesting, &[]);
+    assert_eq!(
+        simulate(&root, &[ChoiceValue::Integer(7)]),
+        Some(Status::Interesting)
+    );
+}
+
+#[test]
+fn simulate_follows_forced_value_ignoring_prefix() {
+    // A forced draw ignores the replayed prefix value and always reproduces
+    // the recorded (forced) value, so simulation must follow the single
+    // forced child even when the supplied choice differs.
+    let forced_true = ChoiceNode {
+        kind: ChoiceKind::Boolean(BooleanChoice),
+        value: ChoiceValue::Boolean(true),
+        was_forced: true,
+    };
+    let mut root = DataTreeNode::default();
+    record_tree(&mut root, &[forced_true], Status::Valid, &[]);
+
+    // Supplying `false` (≠ the forced `true`) still resolves to the forced
+    // path and its conclusion.
+    assert_eq!(
+        simulate(&root, &[ChoiceValue::Boolean(false)]),
+        Some(Status::Valid)
+    );
+}
+
+#[test]
+fn simulate_puns_out_of_range_prefix_to_unit() {
+    // For Integer{0,10}, simplest() == 0 and unit() == 1. A replayed prefix
+    // value outside the range fails validation and puns to unit() (a bare
+    // `for_choices` replay has no original-kind info, so the `simplest()`
+    // branch never applies), so a recorded path through the unit value is
+    // matched.
+    let mut root = DataTreeNode::default();
+    record_tree(&mut root, &[int_node(0, 10, 1)], Status::Valid, &[]);
+
+    // 999 is out of range → punned to unit() == 1 → matches the recorded path.
+    assert_eq!(
+        simulate(&root, &[ChoiceValue::Integer(999)]),
+        Some(Status::Valid)
+    );
+    // 7 is in range → used as-is → diverges from the recorded value (1).
+    assert_eq!(simulate(&root, &[ChoiceValue::Integer(7)]), None);
+}

--- a/tests/embedded/native/data_tree_tests.rs
+++ b/tests/embedded/native/data_tree_tests.rs
@@ -182,7 +182,7 @@ fn simulate_returns_interesting_conclusion() {
     let mut root = DataTreeNode::default();
     record_tree(&mut root, &[int_node(0, 100, 7)], Status::Interesting, &[]);
     assert_eq!(
-        simulate(&root, &[ChoiceValue::Integer(7)]),
+        simulate(&root, &[ChoiceValue::Integer(BigInt::from(7))]),
         Some(Status::Interesting)
     );
 }
@@ -192,11 +192,11 @@ fn simulate_follows_forced_value_ignoring_prefix() {
     // A forced draw ignores the replayed prefix value and always reproduces
     // the recorded (forced) value, so simulation must follow the single
     // forced child even when the supplied choice differs.
-    let forced_true = ChoiceNode {
-        kind: ChoiceKind::Boolean(BooleanChoice),
-        value: ChoiceValue::Boolean(true),
-        was_forced: true,
-    };
+    let forced_true = ChoiceNode::new(
+        ChoiceKind::Boolean(BooleanChoice),
+        ChoiceValue::Boolean(true),
+        true,
+    );
     let mut root = DataTreeNode::default();
     record_tree(&mut root, &[forced_true], Status::Valid, &[]);
 
@@ -220,9 +220,12 @@ fn simulate_puns_out_of_range_prefix_to_unit() {
 
     // 999 is out of range → punned to unit() == 1 → matches the recorded path.
     assert_eq!(
-        simulate(&root, &[ChoiceValue::Integer(999)]),
+        simulate(&root, &[ChoiceValue::Integer(BigInt::from(999))]),
         Some(Status::Valid)
     );
     // 7 is in range → used as-is → diverges from the recorded value (1).
-    assert_eq!(simulate(&root, &[ChoiceValue::Integer(7)]), None);
+    assert_eq!(
+        simulate(&root, &[ChoiceValue::Integer(BigInt::from(7))]),
+        None
+    );
 }

--- a/tests/embedded/native/shrinker_sequence_tests.rs
+++ b/tests/embedded/native/shrinker_sequence_tests.rs
@@ -1,35 +1,36 @@
 //! Unit tests for the sequence-ordering shrink pass (`sort_values`).
 
+use crate::native::bignum::BigInt;
 use crate::native::core::choices::{BooleanChoice, IntegerChoice};
 use crate::native::core::{ChoiceKind, ChoiceNode, ChoiceValue, Spans};
 use crate::native::shrinker::{ShrinkRun, Shrinker};
 
 fn int_node(value: i128) -> ChoiceNode {
-    ChoiceNode {
-        kind: ChoiceKind::Integer(IntegerChoice {
-            min_value: 0,
-            max_value: 100,
-            shrink_towards: 0,
+    ChoiceNode::new(
+        ChoiceKind::Integer(IntegerChoice {
+            min_value: BigInt::from(0),
+            max_value: BigInt::from(100),
+            shrink_towards: BigInt::from(0),
         }),
-        value: ChoiceValue::Integer(value),
-        was_forced: false,
-    }
+        ChoiceValue::Integer(BigInt::from(value)),
+        false,
+    )
 }
 
 fn bool_node(value: bool) -> ChoiceNode {
-    ChoiceNode {
-        kind: ChoiceKind::Boolean(BooleanChoice),
-        value: ChoiceValue::Boolean(value),
-        was_forced: false,
-    }
+    ChoiceNode::new(
+        ChoiceKind::Boolean(BooleanChoice),
+        ChoiceValue::Boolean(value),
+        false,
+    )
 }
 
 fn int_values(shrinker: &Shrinker) -> Vec<i128> {
     shrinker
         .current_nodes
         .iter()
-        .map(|n| match n.value {
-            ChoiceValue::Integer(v) => v,
+        .map(|n| match &n.value {
+            ChoiceValue::Integer(v) => i128::try_from(v.clone()).unwrap(),
             _ => unreachable!(),
         })
         .collect()

--- a/tests/embedded/native/shrinker_sequence_tests.rs
+++ b/tests/embedded/native/shrinker_sequence_tests.rs
@@ -1,0 +1,76 @@
+//! Unit tests for the sequence-ordering shrink pass (`sort_values`).
+
+use crate::native::core::choices::{BooleanChoice, IntegerChoice};
+use crate::native::core::{ChoiceKind, ChoiceNode, ChoiceValue, Spans};
+use crate::native::shrinker::{ShrinkRun, Shrinker};
+
+fn int_node(value: i128) -> ChoiceNode {
+    ChoiceNode {
+        kind: ChoiceKind::Integer(IntegerChoice {
+            min_value: 0,
+            max_value: 100,
+            shrink_towards: 0,
+        }),
+        value: ChoiceValue::Integer(value),
+        was_forced: false,
+    }
+}
+
+fn bool_node(value: bool) -> ChoiceNode {
+    ChoiceNode {
+        kind: ChoiceKind::Boolean(BooleanChoice),
+        value: ChoiceValue::Boolean(value),
+        was_forced: false,
+    }
+}
+
+fn int_values(shrinker: &Shrinker) -> Vec<i128> {
+    shrinker
+        .current_nodes
+        .iter()
+        .map(|n| match n.value {
+            ChoiceValue::Integer(v) => v,
+            _ => unreachable!(),
+        })
+        .collect()
+}
+
+/// An always-accepting probe takes the full sort in one shot: `try_sort_group`
+/// builds the sorted-order replacement, `replace` succeeds, and the pass
+/// returns immediately (its bulk-sort fast path) rather than falling back to
+/// the per-swap insertion sort.
+#[test]
+fn sort_values_takes_the_full_sort_when_accepted() {
+    let initial = vec![int_node(5), int_node(1), int_node(3)];
+    let mut shrinker = Shrinker::with_probe(
+        Box::new(|run| match run {
+            ShrinkRun::Full(nodes) => (true, nodes.to_vec(), Spans::new()),
+            ShrinkRun::Probe { .. } => (false, Vec::new(), Spans::new()),
+        }),
+        initial,
+        Spans::new(),
+    );
+    shrinker.sort_values_integers();
+    assert_eq!(int_values(&shrinker), vec![1, 3, 5]);
+}
+
+/// Booleans sort `false` (0) before `true` (1) via the same bulk path.
+#[test]
+fn sort_values_sorts_booleans() {
+    let initial = vec![bool_node(true), bool_node(false), bool_node(true)];
+    let mut shrinker = Shrinker::with_probe(
+        Box::new(|run| match run {
+            ShrinkRun::Full(nodes) => (true, nodes.to_vec(), Spans::new()),
+            ShrinkRun::Probe { .. } => (false, Vec::new(), Spans::new()),
+        }),
+        initial,
+        Spans::new(),
+    );
+    shrinker.sort_values_booleans();
+    let bools: Vec<bool> = shrinker
+        .current_nodes
+        .iter()
+        .map(|n| matches!(n.value, ChoiceValue::Boolean(true)))
+        .collect();
+    assert_eq!(bools, vec![false, true, true]);
+}

--- a/tests/embedded/native/test_runner_tests.rs
+++ b/tests/embedded/native/test_runner_tests.rs
@@ -99,11 +99,11 @@ where
 }
 
 fn bool_node(value: bool) -> ChoiceNode {
-    ChoiceNode {
-        kind: ChoiceKind::Boolean(BooleanChoice),
-        value: ChoiceValue::Boolean(value),
-        was_forced: false,
-    }
+    ChoiceNode::new(
+        ChoiceKind::Boolean(BooleanChoice),
+        ChoiceValue::Boolean(value),
+        false,
+    )
 }
 
 #[test]

--- a/tests/embedded/native/test_runner_tests.rs
+++ b/tests/embedded/native/test_runner_tests.rs
@@ -63,3 +63,202 @@ fn too_slow_check_quiet_when_enough_valid_cases() {
 fn flaky_diagnostic_mentions_flaky() {
     assert!(flaky_diagnostic().contains("Flaky test detected"));
 }
+
+// ── cached_run / span-mutation caching ──
+//
+// Span mutation proposes choice sequences whose paths are frequently
+// already covered by generation. Pre-fix the native backend ran the test
+// body for every proposal (`ctx.execute`), executing the test ~6× as often
+// as Hypothesis, which routes mutations through `cached_test_function`.
+// These tests pin the cache/tree short-circuits that close that gap.
+
+use std::cell::Cell;
+use std::rc::Rc;
+
+use crate::native::core::ChoiceKind;
+use crate::native::core::choices::BooleanChoice;
+use crate::native::data_tree::{DataTreeNode, record_tree};
+use crate::run_lifecycle::run_test_case;
+
+/// Build an [`EngineCtx`] whose `run_case` runs `test_fn` and counts how many
+/// times the test body actually executed, then hand both to `body`.
+fn with_counting_ctx<T, B>(mut test_fn: T, body: B)
+where
+    T: FnMut(crate::TestCase),
+    B: FnOnce(&mut EngineCtx<'_>, &Rc<Cell<usize>>),
+{
+    crate::run_lifecycle::init_panic_hook();
+    let exec_count = Rc::new(Cell::new(0usize));
+    let counter = exec_count.clone();
+    let mut run_case = |ds: Box<dyn crate::backend::DataSource + Send + Sync>, is_final: bool| {
+        counter.set(counter.get() + 1);
+        run_test_case(ds, &mut test_fn, is_final, Mode::TestRun, Verbosity::Normal);
+    };
+    let mut ctx = EngineCtx::new(&mut run_case);
+    body(&mut ctx, &exec_count);
+}
+
+fn bool_node(value: bool) -> ChoiceNode {
+    ChoiceNode {
+        kind: ChoiceKind::Boolean(BooleanChoice),
+        value: ChoiceValue::Boolean(value),
+        was_forced: false,
+    }
+}
+
+#[test]
+fn cached_run_skips_execution_when_tree_knows_the_path() {
+    with_counting_ctx(
+        |tc| {
+            tc.draw(crate::generators::booleans());
+        },
+        |ctx, count| {
+            // The tree already records a one-boolean run that concluded
+            // Valid; replaying that path (plus an unread trailing choice,
+            // as a duplicated span would produce) must not run the body.
+            let mut tree = DataTreeNode::default();
+            record_tree(&mut tree, &[bool_node(false)], Status::Valid, &[]);
+
+            let (run, executed) = ctx.cached_run(
+                &[ChoiceValue::Boolean(false), ChoiceValue::Boolean(true)],
+                &mut tree,
+            );
+            assert_eq!(run.status, Status::Valid);
+            assert!(!executed);
+            assert_eq!(count.get(), 0);
+        },
+    );
+}
+
+#[test]
+fn cached_run_executes_novel_then_serves_repeat_from_cache() {
+    with_counting_ctx(
+        |tc| {
+            tc.draw(crate::generators::booleans());
+        },
+        |ctx, count| {
+            let mut tree = DataTreeNode::default();
+            let choices = [ChoiceValue::Boolean(true)];
+
+            let (first, executed_first) = ctx.cached_run(&choices, &mut tree);
+            assert!(executed_first);
+            assert_eq!(count.get(), 1);
+
+            // A second identical replay is served without re-running.
+            let (second, executed_second) = ctx.cached_run(&choices, &mut tree);
+            assert!(!executed_second);
+            assert_eq!(count.get(), 1);
+            assert_eq!(first.status, second.status);
+        },
+    );
+}
+
+#[test]
+fn cached_run_reexecutes_known_interesting_path_to_recover_payload() {
+    // The tree can record that a path was Interesting but not the failure's
+    // nodes/origin, so a cached_run on a tree-known Interesting path falls
+    // through to a real execution to recover that payload.
+    with_counting_ctx(
+        |tc| {
+            if tc.draw(crate::generators::booleans()) {
+                panic!("boom");
+            }
+        },
+        |ctx, count| {
+            let mut tree = DataTreeNode::default();
+            record_tree(&mut tree, &[bool_node(true)], Status::Interesting, &[]);
+
+            let (run, executed) = ctx.cached_run(&[ChoiceValue::Boolean(true)], &mut tree);
+            assert_eq!(run.status, Status::Interesting);
+            assert!(executed);
+            assert_eq!(count.get(), 1);
+            assert!(run.origin.is_some());
+        },
+    );
+}
+
+#[test]
+fn span_mutation_does_not_re_execute_identical_proposals() {
+    use rand::SeedableRng;
+    use rand::rngs::SmallRng;
+
+    with_counting_ctx(
+        |tc| {
+            tc.draw(crate::generators::booleans());
+        },
+        |ctx, count| {
+            // Two spans of the same label, one nested in the other. Every
+            // span-mutation attempt then proposes the *same* duplicated
+            // choice sequence, so only the first proposal runs the body and
+            // the rest are served from the cache.
+            let nodes = vec![
+                bool_node(false),
+                bool_node(true),
+                bool_node(false),
+                bool_node(true),
+            ];
+            let span = |start, end| Span {
+                start,
+                end,
+                label: "L".to_string(),
+                depth: 0,
+                parent: None,
+                discarded: false,
+            };
+            let spans = vec![span(0, 4), span(1, 3)];
+
+            let mut tree = DataTreeNode::default();
+            let mut rng = SmallRng::seed_from_u64(0);
+            let (result, attempts) = try_span_mutation(&nodes, &spans, &mut rng, ctx, &mut tree);
+
+            assert!(result.is_none());
+            assert_eq!(attempts, 1);
+            assert_eq!(count.get(), 1);
+        },
+    );
+}
+
+#[test]
+fn span_mutation_returns_interesting_proposal() {
+    use rand::SeedableRng;
+    use rand::rngs::SmallRng;
+
+    with_counting_ctx(
+        // Panics on a `false` draw, so the all-`false` mutated proposal is
+        // Interesting.
+        |tc| {
+            if !tc.draw(crate::generators::booleans()) {
+                panic!("boom on false");
+            }
+        },
+        |ctx, count| {
+            // Nested same-label spans → the deterministic proposal duplicates
+            // the (false) prefix, and the body's single draw resolves to
+            // `false` → Interesting on the first probe.
+            let nodes = vec![
+                bool_node(false),
+                bool_node(false),
+                bool_node(false),
+                bool_node(false),
+            ];
+            let span = |start, end| Span {
+                start,
+                end,
+                label: "L".to_string(),
+                depth: 0,
+                parent: None,
+                discarded: false,
+            };
+            let spans = vec![span(0, 4), span(1, 3)];
+
+            let mut tree = DataTreeNode::default();
+            let mut rng = SmallRng::seed_from_u64(0);
+            let (result, attempts) = try_span_mutation(&nodes, &spans, &mut rng, ctx, &mut tree);
+
+            let (_nodes, origin) = result.expect("the first proposal should be Interesting");
+            assert!(origin.contains("Panic"));
+            assert_eq!(attempts, 1);
+            assert_eq!(count.get(), 1);
+        },
+    );
+}

--- a/tests/embedded/native/test_runner_tests.rs
+++ b/tests/embedded/native/test_runner_tests.rs
@@ -209,11 +209,15 @@ fn span_mutation_does_not_re_execute_identical_proposals() {
 
             let mut tree = DataTreeNode::default();
             let mut rng = SmallRng::seed_from_u64(0);
-            let (result, attempts) = try_span_mutation(&nodes, &spans, &mut rng, ctx, &mut tree);
+            let mut valid = 0u64;
+            let (result, attempts) =
+                try_span_mutation(&nodes, &spans, &mut rng, ctx, &mut tree, &mut valid, 100);
 
             assert!(result.is_none());
             assert_eq!(attempts, 1);
             assert_eq!(count.get(), 1);
+            // The single valid execution consumed one unit of the budget.
+            assert_eq!(valid, 1);
         },
     );
 }
@@ -253,12 +257,57 @@ fn span_mutation_returns_interesting_proposal() {
 
             let mut tree = DataTreeNode::default();
             let mut rng = SmallRng::seed_from_u64(0);
-            let (result, attempts) = try_span_mutation(&nodes, &spans, &mut rng, ctx, &mut tree);
+            let mut valid = 0u64;
+            let (result, attempts) =
+                try_span_mutation(&nodes, &spans, &mut rng, ctx, &mut tree, &mut valid, 100);
 
             let (_nodes, origin) = result.expect("the first proposal should be Interesting");
             assert!(origin.contains("Panic"));
             assert_eq!(attempts, 1);
             assert_eq!(count.get(), 1);
+            // An Interesting probe is not a valid example; budget untouched.
+            assert_eq!(valid, 0);
+        },
+    );
+}
+
+#[test]
+fn span_mutation_stops_when_example_budget_is_full() {
+    use rand::SeedableRng;
+    use rand::rngs::SmallRng;
+
+    with_counting_ctx(
+        |tc| {
+            tc.draw(crate::generators::booleans());
+        },
+        |ctx, count| {
+            let nodes = vec![
+                bool_node(false),
+                bool_node(true),
+                bool_node(false),
+                bool_node(true),
+            ];
+            let span = |start, end| Span {
+                start,
+                end,
+                label: "L".to_string(),
+                depth: 0,
+                parent: None,
+                discarded: false,
+            };
+            let spans = vec![span(0, 4), span(1, 3)];
+
+            let mut tree = DataTreeNode::default();
+            let mut rng = SmallRng::seed_from_u64(0);
+            // Budget already full: no probe should run.
+            let mut valid = 100u64;
+            let (result, attempts) =
+                try_span_mutation(&nodes, &spans, &mut rng, ctx, &mut tree, &mut valid, 100);
+
+            assert!(result.is_none());
+            assert_eq!(attempts, 0);
+            assert_eq!(count.get(), 0);
+            assert_eq!(valid, 100);
         },
     );
 }

--- a/tests/test_quality.rs
+++ b/tests/test_quality.rs
@@ -312,10 +312,18 @@ mod shrink_quality {
 
     #[test]
     fn test_duplicate_containment() {
-        let (xs, x): (Vec<i64>, i64) = minimal(
+        // This counterexample is discovered by a span mutation that copies one
+        // integer's span over another. Span mutations are generated examples
+        // and consume the `test_cases` budget like any other, so finding it
+        // needs a few hundred more examples than the 500 default — previously
+        // this passed only because mutations ran *outside* the budget, letting
+        // a 500-example run secretly execute several thousand cases.
+        let (xs, x): (Vec<i64>, i64) = Minimal::new(
             gs::tuples!(gs::vecs(gs::integers::<i64>()), gs::integers::<i64>()),
             |(xs, x): &(Vec<i64>, i64)| xs.iter().filter(|&&v| v == *x).count() > 1,
-        );
+        )
+        .test_cases(1000)
+        .run();
         assert_eq!(xs, vec![0, 0]);
         assert_eq!(x, 0);
     }


### PR DESCRIPTION
Two problems:

1. Test function caching wasn't being used in the mutation phase, so we were replaying a lot of test cases that should have been cache hits
2. We were not counting mutations towards the test case budget, so were exceeding it by a factor of 5+

(kudos to @echoumcp1 for the spot)