### PR TITLE
Invert the integer shrink ordering in closed form instead of by binary search

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-This patch improves the performance of generating and shrinking bounded integers, and of any generator built on them (collection sizes, sampled-from indices, and similar). The mapping from a choice's shrink-order position back to its value is now computed in closed form instead of by binary search, removing a per-draw cost that grew with the width of the integer's range.
+This patch improves the performance of generating and shrinking bounded integers, and of any generator built on them (collection sizes, sampled-from indices, and similar).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch improves the performance of generating and shrinking bounded integers, and of any generator built on them (collection sizes, sampled-from indices, and similar). The mapping from a choice's shrink-order position back to its value is now computed in closed form instead of by binary search, removing a per-draw cost that grew with the width of the integer's range.

--- a/src/native/core/choices.rs
+++ b/src/native/core/choices.rs
@@ -84,31 +84,34 @@ impl IntegerChoice {
         }
         let above = (&self.max_value - &s).magnitude();
         let below = (&s - &self.min_value).magnitude();
-        let one = BigUint::from(1u32);
-        let mut lo = one.clone();
-        let mut hi = std::cmp::max(&above, &below).clone();
-        while lo < hi {
-            let mid = &lo + (&(&hi - &lo) >> 1u32);
-            let total = std::cmp::min(&mid, &above) + std::cmp::min(&mid, &below);
-            if total >= index {
-                hi = mid;
-            } else {
-                lo = mid + &one;
-            }
-        }
-        let d = lo;
-        let total_at_d = std::cmp::min(&d, &above) + std::cmp::min(&d, &below);
-        if total_at_d < index {
+        // Values are enumerated by increasing distance `d` from `s`, emitting
+        // the up value `s + d` before the down value `s - d` at each distance,
+        // and dropping whichever side has run past its bound. The number of
+        // values within distance `d` is therefore
+        //     total(d) = min(d, above) + min(d, below),
+        // a piecewise-linear function of `d` with breakpoints at `a` and `b`
+        // (the smaller and larger of `above`/`below`):
+        //     d <= a       -> 2d        (both sides live)
+        //     a < d <= b   -> a + d     (small side exhausted)
+        //     d >  b       -> a + b     (both sides exhausted = max_index)
+        // Each regime inverts in closed form, so no search over `d` is needed.
+        if index > &above + &below {
             return None;
         }
-        let d_minus_one = &d - &one;
-        let before = std::cmp::min(&d_minus_one, &above) + std::cmp::min(&d_minus_one, &below);
-        let pos_in_d = &index - &before;
-        if pos_in_d == one && d <= above {
-            return Some(s + BigInt::from(d));
-        }
-        debug_assert!(d <= below);
-        Some(s - BigInt::from(d))
+        let two_a = std::cmp::min(&above, &below) << 1usize;
+        let one = BigUint::from(1u32);
+        let (d, up) = if index <= two_a {
+            // Both sides live: index 2d-1 is `s + d`, index 2d is `s - d`.
+            let d = (&index + &one) >> 1u32;
+            let up = !(&index % &BigUint::from(2u32)).is_zero();
+            (d, up)
+        } else {
+            // Only the larger side continues, one value per distance beyond `a`.
+            let d = &index - std::cmp::min(&above, &below);
+            (d, above > below)
+        };
+        let d = BigInt::from(d);
+        if up { Some(s + d) } else { Some(s - d) }
     }
 
     pub fn max_children(&self) -> BigUint {

--- a/tests/embedded/native/choices_tests.rs
+++ b/tests/embedded/native/choices_tests.rs
@@ -340,6 +340,37 @@ fn integer_choice_from_index_overflowing_u128_returns_none() {
 }
 
 #[test]
+fn integer_choice_index_round_trip_nonzero_shrink_towards() {
+    // shrink_towards is the index-0 anchor and biases the up/down interleave,
+    // so exercise a non-zero one (inside range) across the full span.
+    let ic = IntegerChoice {
+        min_value: BigInt::from(-5),
+        max_value: BigInt::from(40),
+        shrink_towards: BigInt::from(7),
+    };
+    for v in -5i128..=40 {
+        let bv = BigInt::from(v);
+        let idx = ic.to_index(&bv);
+        assert_eq!(ic.from_index(idx), Some(bv), "round-trip failed for v={v}");
+    }
+}
+
+#[test]
+fn integer_choice_index_round_trip_shrink_towards_clamped_outside_range() {
+    // shrink_towards below min clamps to min, making the choice one-sided.
+    let ic = IntegerChoice {
+        min_value: BigInt::from(10),
+        max_value: BigInt::from(30),
+        shrink_towards: BigInt::from(-100),
+    };
+    for v in 10i128..=30 {
+        let bv = BigInt::from(v);
+        let idx = ic.to_index(&bv);
+        assert_eq!(ic.from_index(idx), Some(bv), "round-trip failed for v={v}");
+    }
+}
+
+#[test]
 fn boolean_is_always_two() {
     assert_eq!((ChoiceKind::Boolean(BooleanChoice)).max_children(), bu(2));
 }


### PR DESCRIPTION
<details>
<summary>What changed and why</summary>

`IntegerChoice::from_index` maps a position in the shrink ordering back to a concrete integer. It did so with a binary search over the distance `d` from the shrink target, inverting

```
total(d) = min(d, above) + min(d, below)
```

`total` is a two-breakpoint piecewise-linear function, so its inverse is closed-form. The search added a `log(range)` factor (up to ~128 iterations for a full `i128` range), and each iteration did several heap-capable `BigUint` operations. This replaces it with the direct closed-form inverse — no loop, no per-iteration bignum work.

Profiling (an `inline(never)` dashu build under samply) originally surfaced `from_index` as the single hottest non-system call site during integer generation.

**Tests:** all 18 `integer_choice` unit tests pass. Adds regression tests for the non-zero and clamped `shrink_towards` cases, which the existing round-trip tests didn't exercise.
</details>
