### PR TITLE
Switch the native engine's internal maps from SipHash to FxHash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,6 +398,7 @@ dependencies = [
  "paste",
  "rand",
  "regex",
+ "rustc-hash",
  "serde",
  "serde_json",
  "tempfile",
@@ -736,6 +737,12 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,11 @@ hegeltest-macros = { version = "=0.14.22", path = "hegel-macros" }
 rand = { version = "0.10", optional = true }
 serde_json = { version = "1.0.61", optional = true }
 dashu-int = { version = "0.4.1", default-features = false, features = ["std"], optional = true }
+# Fast, non-DoS-resistant hasher for the native engine's internal maps
+# (data tree + span-mutation bookkeeping; keys are our own choice values /
+# span labels, never adversarial). Replaces the default SipHash, which
+# profiling showed prominently on the generation hot path.
+rustc-hash = { version = "2", optional = true }
 # opting out of the clock, now, and wasmbind features.
 # 0.4.41 is the minimum version that has WeekdaySet.
 chrono = { version = "0.4.41", default-features = false, features = ["std"], optional = true }
@@ -77,7 +82,7 @@ required-features = ["__bench"]
 default = []
 rand = ["dep:rand"]
 antithesis = ["dep:serde_json"]
-native = ["dep:rand", "dep:dashu-int"]
+native = ["dep:rand", "dep:dashu-int", "dep:rustc-hash"]
 chrono = ["dep:chrono"]
 jiff = ["dep:jiff"]
 serde_json = ["dep:serde_json"]

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-This patch improves the performance of value generation on the native engine by using a faster hasher for the engine's internal lookup tables (the choice tree and the span-tracking maps), which are keyed only by Hegel's own data and never by adversarial input. This speeds up generation across all generators, most noticeably for tests that make many draws per test case.
+This patch improves the performance of value generation on the native engine by using a faster hasher for the engine's internal lookup tables, which are keyed only by Hegel's own data and never by adversarial input. This speeds up generation across all generators, most noticeably for tests that make many draws per test case.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch improves the performance of value generation on the native engine by using a faster hasher for the engine's internal lookup tables (the choice tree and the span-tracking maps), which are keyed only by Hegel's own data and never by adversarial input. This speeds up generation across all generators, most noticeably for tests that make many draws per test case.

--- a/src/native/data_tree.rs
+++ b/src/native/data_tree.rs
@@ -8,8 +8,9 @@
 //! drawn, an optional terminal `Status`, and a cached exhaustion flag
 //! so the walker can short-circuit dead branches.
 
-use std::collections::HashMap;
 use std::sync::Arc;
+
+use rustc_hash::FxHashMap;
 
 use rand::rngs::SmallRng;
 use rand::seq::SliceRandom;
@@ -50,7 +51,7 @@ pub(crate) struct DataTreeNode {
     /// replay's prefix value at that position is ignored. [`simulate`] needs
     /// this to predict realised values correctly.
     forced: bool,
-    children: HashMap<ChoiceValueKey, Box<DataTreeNode>>,
+    children: FxHashMap<ChoiceValueKey, Box<DataTreeNode>>,
     /// Terminal status if the test case ended at this node. Only set
     /// when the recording run concluded with `Status >= Invalid`.
     conclusion: Option<Status>,
@@ -182,7 +183,7 @@ const ENUMERATION_CAP: u64 = 1024;
 /// exhausted too).
 fn pick_non_exhausted_value(
     kind: &ChoiceKind,
-    children: &HashMap<ChoiceValueKey, Box<DataTreeNode>>,
+    children: &FxHashMap<ChoiceValueKey, Box<DataTreeNode>>,
     rng: &mut SmallRng,
 ) -> Option<ChoiceValue> {
     for _ in 0..10 {

--- a/src/native/test_runner.rs
+++ b/src/native/test_runner.rs
@@ -995,9 +995,12 @@ fn try_span_mutation(
     valid_test_cases: &mut u64,
     max_examples: u64,
 ) -> (Option<(Vec<ChoiceNode>, String)>, usize) {
-    use std::collections::HashSet;
-
-    let mut by_label: HashMap<&str, HashSet<(usize, usize)>> = HashMap::new();
+    // Fast, non-DoS-resistant hashers: these maps are keyed by our own span
+    // labels / extents (never adversarial) and are rebuilt for every recorded
+    // result, so the default SipHash showed up prominently in generation
+    // profiles. FxHash is a clear win here.
+    let mut by_label: rustc_hash::FxHashMap<&str, rustc_hash::FxHashSet<(usize, usize)>> =
+        rustc_hash::FxHashMap::default();
     for span in spans.iter() {
         by_label
             .entry(span.label.as_str())


### PR DESCRIPTION
<details>
<summary>What changed and why</summary>

The native engine's internal `HashMap`/`HashSet`s — the data-tree child map (`data_tree.rs`) and the span-mutation bookkeeping maps (`test_runner.rs::try_span_mutation`) — are keyed by our own choice values and span labels, never by adversarial input. The standard library's default hasher (SipHash) is DoS-resistant by design, which is pure overhead here. These maps are touched on the generation hot path (the data tree on every recorded choice; the span maps rebuilt per valid result), and SipHash showed up prominently in profiling.

This switches them to `rustc-hash`'s FxHash (added as an optional dependency gated on the `native` feature). `FxBuildHasher: Default`, so the `#[derive(Default)]` on the affected structs keeps working unchanged.

**Tests:** `data_tree` unit tests, plus `test_collections` / `test_targeting`, all pass; full native suite green.
</details>
