### PR TITLE
Skip formatting drawn values for output except on the final failing replay

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-This patch improves the performance of running tests on the native engine. Hegel no longer formats each drawn value for display unless the output is actually needed — the final replay of a failing example, or verbose mode. Previously every draw on every test case paid this formatting cost even though the rendered text was discarded. The improvement is largest for values that are expensive to format, such as strings and collections.
+This patch improves the performance of running tests. Previously every draw on every test case paid a formatting cost even though the rendered text was discarded, now this formatting is skipped unless the printed result is needed. The improvement is largest for values that are expensive to format, such as strings and collections.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch improves the performance of running tests on the native engine. Hegel no longer formats each drawn value for display unless the output is actually needed — the final replay of a failing example, or verbose mode. Previously every draw on every test case paid this formatting cost even though the rendered text was discarded. The improvement is largest for values that are expensive to format, such as strings and collections.

--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -57,6 +57,12 @@ fn panic_on_data_source_error(e: DataSourceError) -> ! {
 
 pub(crate) struct TestCaseGlobalData {
     mode: Mode,
+    /// Whether drawn-value records and notes are surfaced for this test case
+    /// (true on the final replay of a failure, or when verbose output is on).
+    /// When false `on_draw` is a no-op, so the draw-recording bookkeeping in
+    /// [`TestCase::record_named_draw`] (display-name allocation + `Debug`
+    /// rendering of the value) can be skipped entirely.
+    emit: bool,
     /// Fine-grained lock over the state shared between clones of a
     /// `TestCase`. Acquired briefly around each individual backend call
     /// and around each mutation of the draw-tracking bookkeeping, not
@@ -258,6 +264,7 @@ impl TestCase {
         TestCase {
             global: Arc::new(TestCaseGlobalData {
                 mode,
+                emit: should_emit,
                 shared: Mutex::new(SharedState {
                     data_source,
                     draw_state: DrawState {
@@ -543,6 +550,15 @@ impl TestCase {
     }
 
     fn record_named_draw<T: std::fmt::Debug>(&self, value: &T, name: &str, repeatable: bool) {
+        // The drawn-value record is only ever surfaced through `on_draw`, which
+        // is a no-op unless this is the final replay or verbose output is on.
+        // On ordinary generation/shrinking runs we therefore skip the
+        // display-name allocation and the (often expensive, e.g. Unicode) Debug
+        // render entirely. The usage-error checks below still run every test
+        // case so that misuse fails deterministically, not only on a failure's
+        // final replay.
+        let emit = self.global.emit;
+
         let display_name = self.with_shared(|shared| {
             let draw_state = &mut shared.draw_state;
 
@@ -555,19 +571,28 @@ impl TestCase {
                         name, prev, repeatable
                     );
                 }
-                _ => {
+                Some(_) => {}
+                // Only the first occurrence of a name needs to allocate the key.
+                None => {
                     draw_state
                         .named_draw_repeatable
                         .insert(name.to_string(), repeatable);
                 }
             }
 
-            let count = draw_state
-                .named_draw_counts
-                .entry(name.to_string())
-                .or_insert(0);
-            *count += 1;
-            let current_count = *count;
+            // Look the counter up by `&str` first so repeated draws of the same
+            // name (e.g. a `draw` inside a loop) don't allocate a fresh key on
+            // every call.
+            let current_count = match draw_state.named_draw_counts.get_mut(name) {
+                Some(count) => {
+                    *count += 1;
+                    *count
+                }
+                None => {
+                    draw_state.named_draw_counts.insert(name.to_string(), 1);
+                    1
+                }
+            };
 
             if !repeatable && current_count > 1 {
                 panic!(
@@ -577,7 +602,13 @@ impl TestCase {
                 );
             }
 
-            if repeatable {
+            // Display-name uniqueness bookkeeping is output-only; skip it (and
+            // its allocations) when nothing will be emitted.
+            if !emit {
+                return None;
+            }
+
+            let display = if repeatable {
                 let mut candidate = current_count;
                 loop {
                     let name = format!("{}_{}", name, candidate);
@@ -590,8 +621,13 @@ impl TestCase {
                 let name = name.to_string();
                 draw_state.allocated_display_names.insert(name.clone());
                 name
-            }
+            };
+            Some(display)
         });
+
+        let Some(display_name) = display_name else {
+            return;
+        };
 
         let local = self.local.borrow();
         let indent = local.indent;
@@ -765,3 +801,7 @@ pub mod labels {
     pub const SAMPLED_FROM: u64 = 14;
     pub const ENUM_VARIANT: u64 = 15;
 }
+
+#[cfg(test)]
+#[path = "../tests/embedded/test_case_tests.rs"]
+mod tests;

--- a/tests/embedded/test_case_tests.rs
+++ b/tests/embedded/test_case_tests.rs
@@ -1,0 +1,88 @@
+use super::*;
+
+/// A `DataSource` stub for unit-testing `TestCase`'s draw-output bookkeeping.
+///
+/// `record_named_draw` only mutates the draw-tracking state and writes to the
+/// output sink — it never calls back into the backend — so none of these
+/// methods are reached by the tests below.
+struct StubDataSource;
+
+impl DataSource for StubDataSource {
+    fn generate(&self, _schema: &Value) -> Result<Value, DataSourceError> {
+        unimplemented!()
+    }
+    fn start_span(&self, _label: u64) -> Result<(), DataSourceError> {
+        unimplemented!()
+    }
+    fn stop_span(&self, _discard: bool) -> Result<(), DataSourceError> {
+        unimplemented!()
+    }
+    fn new_collection(
+        &self,
+        _min_size: u64,
+        _max_size: Option<u64>,
+    ) -> Result<i64, DataSourceError> {
+        unimplemented!()
+    }
+    fn collection_more(&self, _collection_id: i64) -> Result<bool, DataSourceError> {
+        unimplemented!()
+    }
+    fn collection_reject(
+        &self,
+        _collection_id: i64,
+        _why: Option<&str>,
+    ) -> Result<(), DataSourceError> {
+        unimplemented!()
+    }
+    fn new_pool(&self) -> Result<i64, DataSourceError> {
+        unimplemented!()
+    }
+    fn pool_add(&self, _pool_id: i64) -> Result<i64, DataSourceError> {
+        unimplemented!()
+    }
+    fn pool_generate(&self, _pool_id: i64, _consume: bool) -> Result<i64, DataSourceError> {
+        unimplemented!()
+    }
+    fn target_observation(&self, _score: f64, _label: &str) {
+        unimplemented!()
+    }
+    fn mark_complete(&self, _result: &crate::backend::TestCaseResult) {
+        unimplemented!()
+    }
+}
+
+/// Build a `TestCase` whose draw output is emitted (`is_last_run = true`), so
+/// the display-name bookkeeping in `record_named_draw` runs — the same path a
+/// failing test's final replay takes.
+fn emitting_test_case() -> TestCase {
+    TestCase::new(Box::new(StubDataSource), true, Mode::TestRun, false)
+}
+
+#[test]
+fn debug_is_non_exhaustive() {
+    let tc = emitting_test_case();
+    assert_eq!(format!("{:?}", tc), "TestCase { .. }");
+}
+
+#[test]
+fn repeatable_display_name_skips_a_taken_name() {
+    let tc = emitting_test_case();
+    // A non-repeatable draw named "x_1" claims the display name "x_1".
+    tc.record_named_draw(&false, "x_1", false);
+    // Two repeatable draws named "x" want "x_1" then "x_2"; the first collides
+    // with the explicit "x_1" above and must advance the counter, so they end
+    // up as "x_2" and "x_3".
+    tc.record_named_draw(&false, "x", true);
+    tc.record_named_draw(&false, "x", true);
+
+    let mut names: Vec<String> = tc.with_shared(|shared| {
+        shared
+            .draw_state
+            .allocated_display_names
+            .iter()
+            .cloned()
+            .collect()
+    });
+    names.sort();
+    assert_eq!(names, vec!["x_1", "x_2", "x_3"]);
+}


### PR DESCRIPTION
<details>
<summary>What changed and why</summary>

`record_named_draw` allocated a unique display name and rendered the drawn value via `Debug` (`{:?}`) on every top-level draw, then passed the formatted string to `on_draw`. But `on_draw` is a no-op closure unless this is the final replay of a failing example or verbose output is enabled (`emit`). Hegel runs the test body many times (every generation example, every shrink probe); the `let x = …;` reconstruction is only ever shown once, on the final replay.

This gates the display-name allocation and the `Debug` render behind the `emit` flag (stored on the test case), so ordinary generation and shrinking runs skip both. The `Debug` render is the expensive part for some types — e.g. a Unicode `String` walks every char through `escape_debug`/`is_printable`.

Correctness: the usage-error checks (inconsistent `repeatable` flag; reused non-repeatable name) still run on **every** test case, so misuse fails deterministically rather than only on some unrelated failure's final replay. Also looks the name counter up by `&str` first so repeated draws of one name don't re-allocate the key.

**Tests:** full native lib suite (945) plus the output-sensitive `test_output` and `test_draw_named` suites pass — the failing-example reconstruction is unchanged.
</details>
