### PR TITLE
Bound regex nesting depth to avoid a native stack overflow

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+The native backend (`--features native`) now rejects regex patterns nested beyond a fixed depth with a clear error, instead of overflowing the stack (and aborting the process) on pathologically nested groups.

--- a/src/native/re/constants.rs
+++ b/src/native/re/constants.rs
@@ -8,6 +8,15 @@
 pub const MAXREPEAT: u32 = u32::MAX;
 pub const MAXGROUPS: u32 = 500;
 
+/// Maximum group/alternation nesting depth. CPython relies on the interpreter
+/// recursion limit to raise a (catchable) `RecursionError` on pathologically
+/// nested patterns; the native parser and generator recurse on the Rust stack,
+/// so we bound the depth explicitly and surface a clean parse error instead of
+/// overflowing the stack. `parse`/`parse_sub` add ~2 to the depth per nested
+/// group, so this allows well over 50 levels of real nesting while staying far
+/// below what would exhaust a small (e.g. 2 MiB) thread stack.
+pub const MAX_NESTING: u32 = 100;
+
 pub const SRE_FLAG_IGNORECASE: u32 = 2;
 pub const SRE_FLAG_LOCALE: u32 = 4;
 pub const SRE_FLAG_MULTILINE: u32 = 8;

--- a/src/native/re/parser.rs
+++ b/src/native/re/parser.rs
@@ -773,6 +773,9 @@ fn parse(
     nested: u32,
     first: bool,
 ) -> ParseResult<SubPattern> {
+    if nested > MAX_NESTING {
+        return Err(source.error("regex nesting too deep", 0));
+    }
     let mut subpattern = SubPattern::new();
 
     loop {

--- a/tests/embedded/native/re_parser_tests.rs
+++ b/tests/embedded/native/re_parser_tests.rs
@@ -2172,3 +2172,19 @@ fn err_class_range_with_category_endpoint() {
     let err = parse_err(r"[\d-z]");
     assert!(err.msg.contains("bad character range"), "{}", err.msg);
 }
+
+#[test]
+fn err_deeply_nested_groups() {
+    // A pathologically nested pattern must surface a clean error rather than
+    // overflowing the stack.
+    let pat = format!("{}a{}", "(?:".repeat(5000), ")".repeat(5000));
+    let err = parse_err(&pat);
+    assert!(err.msg.contains("nesting"), "{}", err.msg);
+}
+
+#[test]
+fn moderately_nested_groups_parse() {
+    // Well within the nesting limit.
+    let pat = format!("{}a{}", "(?:".repeat(20), ")".repeat(20));
+    parse_pattern(&pat, 0).unwrap();
+}


### PR DESCRIPTION
<details>
<summary>Implementation notes (AI-generated)</summary>

The native regex parser recurses (`parse`/`parse_sub`) once per nested group/alternation; only *capturing* groups were bounded (`MAXGROUPS`), so a pattern like `"(?:"*N + ")"*N` overflowed the Rust stack and aborted the process. Generation recurses over the same AST, so bounding parse depth bounds both. A new `MAX_NESTING` constant (100) makes `parse` return a clean `InvalidArgument` parse error, matching CPython's catchable `RecursionError` behaviour. Regression tests: `err_deeply_nested_groups`, `moderately_nested_groups_parse`.
</details>