### PR TITLE
Reject the \z regex anchor in native to match Python re

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+The native backend (`--features native`) now rejects the regex `\z` anchor, matching CPython's `re` (which only supports `\Z`).

--- a/src/native/re/parser.rs
+++ b/src/native/re/parser.rs
@@ -402,7 +402,6 @@ fn lookup_category(escape: &str) -> Option<CategoryCode> {
         "\\S" => Some(CategoryCode::In(ChCode::NotSpace)),
         "\\w" => Some(CategoryCode::In(ChCode::Word)),
         "\\W" => Some(CategoryCode::In(ChCode::NotWord)),
-        "\\z" => Some(CategoryCode::At(AtCode::EndString)),
         "\\Z" => Some(CategoryCode::At(AtCode::EndString)),
         _ => None,
     }

--- a/tests/embedded/native/re_parser_tests.rs
+++ b/tests/embedded/native/re_parser_tests.rs
@@ -2172,3 +2172,12 @@ fn err_class_range_with_category_endpoint() {
     let err = parse_err(r"[\d-z]");
     assert!(err.msg.contains("bad character range"), "{}", err.msg);
 }
+
+#[test]
+fn err_z_anchor_not_supported() {
+    // CPython's `re` only has `\Z`; `\z` is "bad escape \z".
+    let err = parse_err(r"\z");
+    assert!(err.msg.contains("bad escape"), "{}", err.msg);
+    // `\Z` is still accepted.
+    parse_pattern(r"\Z", 0).unwrap();
+}


### PR DESCRIPTION
<details>
<summary>Implementation notes (AI-generated)</summary>

The native regex parser mapped `\z` to an end-of-string anchor, but CPython's `re` has no `\z` (only `\Z`) and reports "bad escape \z". Removed the `\z` entry from `lookup_category` so it falls through to the bad-escape path, matching Python. Regression test: `err_z_anchor_not_supported`.
</details>