### PR TITLE
Write native example-database values atomically

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+The native backend (`--features native`) now writes example-database values atomically (temp file plus rename), so a process sharing the database directory can't observe a partially-written value.

--- a/src/native/database.rs
+++ b/src/native/database.rs
@@ -132,7 +132,16 @@ impl TestCaseDatabase for DirectoryTestCaseDatabase {
         if path.exists() {
             return;
         }
-        let _ = std::fs::write(&path, value);
+        // Write to a temp file in the same directory, then atomically rename it
+        // into place, so a concurrent reader never sees a partially-written
+        // value. (The value's content is fixed by its path — its own hash — so
+        // racing writers of the same value are harmless.)
+        if let Ok(mut tmp) = tempfile::NamedTempFile::new_in(&dir) {
+            use std::io::Write;
+            if tmp.write_all(value).is_ok() {
+                let _ = tmp.persist(&path);
+            }
+        }
     }
 
     fn delete(&self, key: &[u8], value: &[u8]) {


### PR DESCRIPTION
<details>
<summary>Implementation notes (AI-generated)</summary>

`DirectoryTestCaseDatabase::save` used `fs::write` directly to the value's final path, so a concurrent reader (a parallel `cargo test` binary or another process sharing `.hegel/examples`) could read a half-written value. It now writes to a `NamedTempFile` in the same directory and atomically `persist`s (renames) it into place. The value's content is fixed by its path (its FNV hash), so two processes writing the same value race harmlessly. Covered by the existing database tests under `--features native`.
</details>