### PR TITLE
Report tc.target() misuse as a usage error rather than a counterexample

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+In the native backend (`--features native`), misusing `tc.target()` (a non-finite score, or the same label twice in one test case) now aborts the run with a clear usage error instead of being caught and misreported as a failing example.

--- a/src/native/data_source.rs
+++ b/src/native/data_source.rs
@@ -244,18 +244,22 @@ impl DataSource for NativeDataSource {
         // `hypothesis.control.target` (`control.py:354-356,372-376`): the
         // observation must be finite and each label may be observed at
         // most once per test case.
+        // These are usage errors, not discovered counterexamples. Prefix the
+        // message so the lifecycle aborts the run with it rather than shrinking
+        // it as a "failure" (see `TARGET_USAGE_ERROR_PREFIX`).
+        let prefix = crate::test_case::TARGET_USAGE_ERROR_PREFIX;
         if !score.is_finite() {
             panic!(
-                "tc.target({score}, label={label:?}) requires a finite score; \
-                 got non-finite value"
+                "{prefix}tc.target({score}, label={label:?}) requires a finite \
+                 score; got non-finite value"
             );
         }
         let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         if inner.target_observations.contains_key(label) {
             panic!(
-                "tc.target({score}, label={label:?}) would overwrite previous \
-                 tc.target(_, label={label:?}); each label can be observed at \
-                 most once per test case"
+                "{prefix}tc.target({score}, label={label:?}) would overwrite \
+                 previous tc.target(_, label={label:?}); each label can be \
+                 observed at most once per test case"
             );
         }
         inner.target_observations.insert(label.to_string(), score);

--- a/src/run_lifecycle.rs
+++ b/src/run_lifecycle.rs
@@ -24,7 +24,9 @@ use crate::antithesis::TestLocation;
 use crate::backend::{DataSource, Failure, TestCaseResult, TestRunner};
 use crate::control::{currently_in_test_context, with_test_context};
 use crate::runner::{Mode, Phase, Settings};
-use crate::test_case::{ASSUME_FAIL_STRING, LOOP_DONE_STRING, STOP_TEST_STRING, TestCase};
+use crate::test_case::{
+    ASSUME_FAIL_STRING, LOOP_DONE_STRING, STOP_TEST_STRING, TARGET_USAGE_ERROR_PREFIX, TestCase,
+};
 
 static PANIC_HOOK_INIT: Once = Once::new();
 
@@ -223,6 +225,11 @@ pub(crate) fn run_test_case(
                 TestCaseResult::Overrun
             } else if msg == LOOP_DONE_STRING {
                 TestCaseResult::Valid
+            } else if let Some(stripped) = msg.strip_prefix(TARGET_USAGE_ERROR_PREFIX) {
+                // A misuse of `tc.target()` is a configuration error, not a
+                // discovered counterexample: abort the run with the message
+                // instead of recording it as `Interesting` and shrinking it.
+                panic::resume_unwind(Box::new(stripped.to_string()));
             } else {
                 let (thread_name, thread_id, location, backtrace) =
                     take_panic_info().unwrap_or_else(unknown_panic_info);

--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -41,6 +41,12 @@ pub(crate) const STOP_TEST_STRING: &str = "__HEGEL_STOP_TEST";
 /// successfully, record it as Valid".
 pub(crate) const LOOP_DONE_STRING: &str = "__HEGEL_LOOP_DONE";
 
+/// Panic-message prefix marking a misuse of `tc.target()` (a non-finite score
+/// or a label observed more than once in a single test case). The lifecycle
+/// recognises this prefix and aborts the run with the stripped message rather
+/// than treating it as a discovered counterexample to be shrunk.
+pub(crate) const TARGET_USAGE_ERROR_PREFIX: &str = "__HEGEL_TARGET_USAGE_ERROR:";
+
 /// Panic with the appropriate sentinel for the given data source error.
 fn panic_on_data_source_error(e: DataSourceError) -> ! {
     match e {

--- a/tests/test_targeting.rs
+++ b/tests/test_targeting.rs
@@ -307,3 +307,54 @@ fn test_targeting_rejects_growing_lateral_move() {
     )
     .run();
 }
+
+// These assert native-engine behaviour (the server backend reports target
+// misuse differently), so they only run under `--features native`.
+#[cfg(feature = "native")]
+mod usage_errors {
+    use super::{Hegel, Settings};
+
+    fn run_and_capture_panic(body: impl FnMut(hegel::TestCase) + std::panic::UnwindSafe) -> String {
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+            Hegel::new(body)
+                .settings(Settings::new().test_cases(50).database(None))
+                .run();
+        }));
+        let payload = result.expect_err("expected the run to abort");
+        payload
+            .downcast_ref::<&str>()
+            .map(|s| s.to_string())
+            .or_else(|| payload.downcast_ref::<String>().cloned())
+            .unwrap_or_default()
+    }
+
+    /// A non-finite target score is a usage error: the run aborts with a clear
+    /// message, rather than misreporting it as a discovered counterexample.
+    #[test]
+    fn target_non_finite_score_is_usage_error() {
+        let msg = run_and_capture_panic(|tc| tc.target(f64::NAN));
+        assert!(msg.contains("finite"), "{msg}");
+        assert!(
+            !msg.contains("Property test failed"),
+            "usage error should not be reported as a property failure: {msg}"
+        );
+
+        let msg = run_and_capture_panic(|tc| tc.target(f64::INFINITY));
+        assert!(msg.contains("finite"), "{msg}");
+        assert!(!msg.contains("Property test failed"), "{msg}");
+    }
+
+    /// Observing the same target label twice in one test case is a usage error.
+    #[test]
+    fn target_duplicate_label_is_usage_error() {
+        let msg = run_and_capture_panic(|tc| {
+            tc.target_labelled(1.0, "dup");
+            tc.target_labelled(2.0, "dup");
+        });
+        assert!(
+            msg.contains("at most once") || msg.contains("overwrite"),
+            "{msg}"
+        );
+        assert!(!msg.contains("Property test failed"), "{msg}");
+    }
+}


### PR DESCRIPTION
<details>
<summary>Implementation notes (AI-generated)</summary>

In the native backend, `target_observation` panicked on a non-finite score or a repeated label; the lifecycle's `catch_unwind` turned that into a `TestCaseResult::Interesting`, so a usage error was reported (and shrunk) as a found counterexample. The native data source now prefixes those panic messages with a sentinel (`TARGET_USAGE_ERROR_PREFIX`); `run_lifecycle::run_test_case` detects the prefix and `resume_unwind`s the stripped message, aborting the run with a clear error. Shared lifecycle code compiles under both backends; the regression tests are gated to `--features native`.
</details>