### PR TITLE
Report native generation non-determinism as a failure instead of aborting

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,3 @@
 RELEASE_TYPE: patch
 
-Internal change to the native backend (`--features native`): the TooSlow health-check threshold is now passed into the engine rather than read from a constant, so it can be tested deterministically. No user-visible behaviour change.
-
 In the native backend (`--features native`), a non-deterministic generator (one whose choice kind changes at the same position across runs) is now reported as a failing run instead of panicking — so it no longer aborts the process when the engine is driven over FFI.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Internal change to the native backend (`--features native`): the TooSlow health-check threshold is now passed into the engine rather than read from a constant, so it can be tested deterministically. No user-visible behaviour change.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,5 @@
 RELEASE_TYPE: patch
 
 Internal change to the native backend (`--features native`): the TooSlow health-check threshold is now passed into the engine rather than read from a constant, so it can be tested deterministically. No user-visible behaviour change.
+
+In the native backend (`--features native`), a non-deterministic generator (one whose choice kind changes at the same position across runs) is now reported as a failing run instead of panicking — so it no longer aborts the process when the engine is driven over FFI.

--- a/src/native/data_tree.rs
+++ b/src/native/data_tree.rs
@@ -102,19 +102,23 @@ impl DataTreeNode {
     }
 }
 
-/// Walk `nodes` through `tree_root`, asserting that the schema at every
-/// position matches what was observed on previous runs. A mismatch
-/// panics with a non-determinism wording. Records the terminal `status`
-/// at the leaf (if the test concluded cleanly) and propagates
-/// exhaustion up the path so `generate_novel_prefix` can skip dead
-/// branches. `kill_depths` flags spans closed with `discard=true`
-/// (mirrors Python's `kill_branch()`).
+/// Walk `nodes` through `tree_root`, checking that the schema at every
+/// position matches what was observed on previous runs. Records the terminal
+/// `status` at the leaf (if the test concluded cleanly) and propagates
+/// exhaustion up the path so `generate_novel_prefix` can skip dead branches.
+/// `kill_depths` flags spans closed with `discard=true` (mirrors Python's
+/// `kill_branch()`).
+///
+/// Returns `Some(message)` if a non-determinism mismatch was detected (the
+/// schema at a position changed from a previous run), so the caller can fold
+/// it into a failing [`TestRunResult`] rather than panicking — keeping it from
+/// aborting an in-process engine driven over FFI. Returns `None` otherwise.
 pub(crate) fn record_tree(
     tree_root: &mut DataTreeNode,
     nodes: &[ChoiceNode],
     status: Status,
     kill_depths: &[usize],
-) {
+) -> Option<String> {
     // Iterative descent: a single-path walk can be thousands deep and
     // a recursive walk would blow the stack.
     let mut path: Vec<*mut DataTreeNode> = Vec::with_capacity(nodes.len() + 1);
@@ -128,12 +132,12 @@ pub(crate) fn record_tree(
         let node = unsafe { &mut *parent_ptr };
         match &node.kind {
             Some(expected_kind) if *expected_kind != first.kind => {
-                panic!(
+                return Some(format!(
                     "Your data generation is non-deterministic: at the same choice \
                      position with the same prefix, the schema changed from {:?} to {:?}. \
                      This usually means a generator depends on global mutable state.",
                     expected_kind, first.kind
-                );
+                ));
             }
             None => {
                 node.kind = Some(first.kind.clone());
@@ -170,6 +174,8 @@ pub(crate) fn record_tree(
         let node = unsafe { &mut *p };
         node.check_exhausted();
     }
+
+    None
 }
 
 /// Small-domain cap for enumeration fallback in

--- a/src/native/test_runner.rs
+++ b/src/native/test_runner.rs
@@ -235,7 +235,10 @@ fn run_main(
         && interesting.is_empty()
     {
         let run = ctx.run(NativeTestCase::for_simplest(BUFFER_SIZE));
-        crate::native::data_tree::record_tree(&mut tree_root, &run.nodes, run.status, &[]);
+        // This trivial-probe is one of the first recordings, so it can't yet
+        // mismatch; a non-deterministic generator is caught by the main
+        // generation loop's `record_tree` below.
+        let _ = crate::native::data_tree::record_tree(&mut tree_root, &run.nodes, run.status, &[]);
         calls += 1;
         if run.nodes.is_empty() && run.status >= Status::Invalid {
             test_is_trivial = true;
@@ -294,7 +297,11 @@ fn run_main(
 
             let tc_start = std::time::Instant::now();
             let run = ctx.run(ntc);
-            crate::native::data_tree::record_tree(&mut tree_root, &run.nodes, run.status, &[]);
+            if let Some(msg) =
+                crate::native::data_tree::record_tree(&mut tree_root, &run.nodes, run.status, &[])
+            {
+                return health_check_failure(msg);
+            }
             let elapsed = tc_start.elapsed();
             calls += 1;
 
@@ -365,7 +372,10 @@ fn run_main(
                 && target_schedule.should_fire(valid_test_cases)
             {
                 let mut on_run = |run: &RunResult| {
-                    crate::native::data_tree::record_tree(
+                    // A non-determinism mismatch here is dropped: it's a
+                    // generator property, so the next main-loop `record_tree`
+                    // (above) re-detects it and returns a clean failure.
+                    let _ = crate::native::data_tree::record_tree(
                         &mut tree_root,
                         &run.nodes,
                         run.status,

--- a/src/native/test_runner.rs
+++ b/src/native/test_runner.rs
@@ -79,7 +79,7 @@ impl TestRunner for NativeTestRunner {
         if settings.mode == Mode::SingleTestCase {
             return run_single(settings, run_case);
         }
-        run_main(settings, database_key, run_case)
+        run_main(settings, database_key, run_case, TOO_SLOW_THRESHOLD)
     }
 }
 
@@ -115,6 +115,9 @@ fn run_main(
     settings: &Settings,
     database_key: Option<&str>,
     run_case: &mut dyn FnMut(Box<dyn DataSource + Send + Sync>, bool),
+    // Injected (rather than read from the `TOO_SLOW_THRESHOLD` constant) so a
+    // test can trip the TooSlow check deterministically without a 30s sleep.
+    too_slow_threshold: std::time::Duration,
 ) -> TestRunResult {
     let mut rng = create_rng(settings, database_key);
     let max_examples = settings.test_cases;
@@ -342,7 +345,7 @@ fn run_main(
             if let Some(msg) = too_slow_check(
                 valid_test_cases,
                 total_test_time,
-                TOO_SLOW_THRESHOLD,
+                too_slow_threshold,
                 settings
                     .suppress_health_check
                     .contains(&HealthCheck::TooSlow),

--- a/tests/embedded/native/data_tree_tests.rs
+++ b/tests/embedded/native/data_tree_tests.rs
@@ -34,13 +34,15 @@ fn bool_node(value: bool) -> ChoiceNode {
 }
 
 #[test]
-#[should_panic(expected = "non-deterministic")]
-fn record_tree_panics_on_kind_mismatch() {
-    // First record an integer node at position 0; recording a boolean
-    // node at the same position trips the non-determinism panic.
+fn record_tree_reports_kind_mismatch() {
+    // First record an integer node at position 0; recording a boolean node at
+    // the same position reports the non-determinism (rather than panicking, so
+    // an FFI-driven engine doesn't abort).
     let mut root = DataTreeNode::default();
-    record_tree(&mut root, &[int_node(0, 10, 0)], Status::Valid, &[]);
-    record_tree(&mut root, &[bool_node(false)], Status::Valid, &[]);
+    assert!(record_tree(&mut root, &[int_node(0, 10, 0)], Status::Valid, &[]).is_none());
+    let msg = record_tree(&mut root, &[bool_node(false)], Status::Valid, &[])
+        .expect("kind mismatch should be reported");
+    assert!(msg.contains("non-deterministic"), "{msg}");
 }
 
 #[test]

--- a/tests/embedded/native/test_runner_tests.rs
+++ b/tests/embedded/native/test_runner_tests.rs
@@ -311,3 +311,26 @@ fn span_mutation_stops_when_example_budget_is_full() {
         },
     );
 }
+
+#[test]
+fn run_main_reports_too_slow_at_call_site() {
+    // Drive `run_main` with a zero TooSlow threshold so the (otherwise
+    // 30s-gated) call-site early-return fires deterministically — instead of
+    // relying on a test happening to exceed 30s of generation under coverage
+    // instrumentation. The body draws a value so each case is non-trivial.
+    crate::run_lifecycle::init_panic_hook();
+    let mut test_fn = |tc: crate::TestCase| {
+        tc.draw(crate::generators::booleans());
+    };
+    let mut run_case = |ds: Box<dyn crate::backend::DataSource + Send + Sync>, is_final: bool| {
+        run_test_case(ds, &mut test_fn, is_final, Mode::TestRun, Verbosity::Normal);
+    };
+    let settings = Settings::new().test_cases(100).database(None);
+    let result = run_main(&settings, None, &mut run_case, Duration::ZERO);
+    assert!(!result.passed);
+    assert!(
+        result.failures[0].panic_message.contains("TooSlow"),
+        "{:?}",
+        result.failures
+    );
+}


### PR DESCRIPTION
<details>
<summary>Implementation notes (AI-generated)</summary>

`record_tree` `panic!`d on a choice-kind mismatch (a non-deterministic generator). The panic unwinds fine for the in-process library, but across the C-ABI boundary in libhegel it aborts the host process. `record_tree` now returns `Option<String>` (the diagnostic); the main generation loop folds a `Some` into a failing `TestRunResult` via `health_check_failure`, while the early trivial-probe and targeting callbacks ignore it (the main loop re-detects it). The main library still turns the failing result into a panic with the same message, so the existing `should_panic` integration test (`test_flaky_global_state`) is unchanged. Embedded test updated to `record_tree_reports_kind_mismatch`.
</details>