### PR TITLE
Make native targeting and shrinking iteration order deterministic

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+The native backend (`--features native`) now iterates targeting labels, shrink origins, and changed-node indices in a deterministic order, so a seeded run with multiple targets or failure origins is reproducible run-to-run.

--- a/src/native/shrinker/integers.rs
+++ b/src/native/shrinker/integers.rs
@@ -674,7 +674,10 @@ impl<'a> Shrinker<'a> {
     /// Always called after a successful pass that may have changed
     /// integer values; clears the change-tracking set on exit.
     pub(crate) fn lower_common_node_offset(&mut self) {
-        let changed: Vec<usize> = self.changed_nodes().iter().copied().collect();
+        let mut changed: Vec<usize> = self.changed_nodes().iter().copied().collect();
+        // `changed_nodes` is a `HashSet`; sort for a deterministic, run-to-run
+        // stable iteration order.
+        changed.sort_unstable();
         if changed.len() <= 1 {
             return;
         }

--- a/src/native/targeting.rs
+++ b/src/native/targeting.rs
@@ -161,7 +161,11 @@ fn run_trial(
 /// Hill-climb every target until no further improvements are found or the
 /// budget is exhausted. Mirrors `engine.py::optimise_targets`.
 pub(crate) fn optimise_targets(targeting: &mut TargetingState, ctx: &mut OptimiseCtx<'_, '_, '_>) {
-    let targets: Vec<String> = targeting.best_observed_targets.keys().cloned().collect();
+    let mut targets: Vec<String> = targeting.best_observed_targets.keys().cloned().collect();
+    // Iterate in a deterministic order: each hill-climb consumes the shared
+    // call budget, so `HashMap`'s per-process-randomised key order would make a
+    // seeded multi-target run non-reproducible.
+    targets.sort();
     let mut max_improvements: usize = 10;
     loop {
         let prev_calls = *ctx.calls;

--- a/src/native/test_runner.rs
+++ b/src/native/test_runner.rs
@@ -449,7 +449,11 @@ fn run_main(
                 total
             );
         }
-        let origins: Vec<String> = interesting.keys().cloned().collect();
+        let mut origins: Vec<String> = interesting.keys().cloned().collect();
+        // Deterministic shrink order: `interesting` is a `HashMap`, whose key
+        // order is randomised per process, and each origin's shrink shares the
+        // run-level call budget.
+        origins.sort();
         for origin in origins {
             let initial = interesting.get(&origin).cloned().unwrap_or_default();
 


### PR DESCRIPTION
<details>
<summary>Implementation notes (AI-generated)</summary>

Three native code paths iterated `HashMap`/`HashSet` keys in `HashMap`'s per-process-randomised order, where the order influences the shared call budget — so a seeded run was not reproducible run-to-run: `optimise_targets` (target labels), the multi-origin shrink loop (`interesting` origins), and `lower_common_node_offset` (changed-node indices). Each now sorts before iterating. Covered by the existing targeting and multi-failure tests under `--features native`.
</details>