### PR TITLE
Make the native TooSlow health-check call site deterministically testable

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Internal change to the native backend (`--features native`): the TooSlow health-check threshold is now passed into the engine rather than read from a constant, so it can be tested deterministically. No user-visible behaviour change.

--- a/src/native/test_runner.rs
+++ b/src/native/test_runner.rs
@@ -79,7 +79,7 @@ impl TestRunner for NativeTestRunner {
         if settings.mode == Mode::SingleTestCase {
             return run_single(settings, run_case);
         }
-        run_main(settings, database_key, run_case)
+        run_main(settings, database_key, run_case, TOO_SLOW_THRESHOLD)
     }
 }
 
@@ -115,6 +115,9 @@ fn run_main(
     settings: &Settings,
     database_key: Option<&str>,
     run_case: &mut dyn FnMut(Box<dyn DataSource + Send + Sync>, bool),
+    // Injected (rather than read from the `TOO_SLOW_THRESHOLD` constant) so a
+    // test can trip the TooSlow check deterministically without a 30s sleep.
+    too_slow_threshold: std::time::Duration,
 ) -> TestRunResult {
     let mut rng = create_rng(settings, database_key);
     let max_examples = settings.test_cases;
@@ -342,7 +345,7 @@ fn run_main(
             if let Some(msg) = too_slow_check(
                 valid_test_cases,
                 total_test_time,
-                TOO_SLOW_THRESHOLD,
+                too_slow_threshold,
                 settings
                     .suppress_health_check
                     .contains(&HealthCheck::TooSlow),

--- a/tests/embedded/native/test_runner_tests.rs
+++ b/tests/embedded/native/test_runner_tests.rs
@@ -311,3 +311,26 @@ fn span_mutation_stops_when_example_budget_is_full() {
         },
     );
 }
+
+#[test]
+fn run_main_reports_too_slow_at_call_site() {
+    // Drive `run_main` with a zero TooSlow threshold so the (otherwise
+    // 30s-gated) call-site early-return fires deterministically — instead of
+    // relying on a test happening to exceed 30s of generation under coverage
+    // instrumentation. The body draws a value so each case is non-trivial.
+    crate::run_lifecycle::init_panic_hook();
+    let mut test_fn = |tc: crate::TestCase| {
+        tc.draw(crate::generators::booleans());
+    };
+    let mut run_case = |ds: Box<dyn crate::backend::DataSource + Send + Sync>, is_final: bool| {
+        run_test_case(ds, &mut test_fn, is_final, Mode::TestRun, Verbosity::Normal);
+    };
+    let settings = Settings::new().test_cases(100).database(None);
+    let result = run_main(&settings, None, &mut run_case, Duration::ZERO);
+    assert!(!result.passed);
+    assert!(
+        result.failures[0].panic_message.contains("TooSlow"),
+        "{:?}",
+        result.failures
+    );
+}


### PR DESCRIPTION
<details>
<summary>Implementation notes (AI-generated)</summary>

The `return health_check_failure(msg)` for TooSlow in `run_main` could only be covered by a test that actually exceeded the 30s `TOO_SLOW_THRESHOLD` under coverage instrumentation — a timing-flaky coverage dependency. `run_main` now takes `too_slow_threshold: Duration` (the `TestRunner::run` impl passes the 30s constant), and an embedded test drives `run_main` with `Duration::ZERO` and a value-drawing body to trip the check deterministically and fast. No user-visible behaviour change. Regression test: `run_main_reports_too_slow_at_call_site`.
</details>