### PR TITLE
Report invalid-argument errors uniformly as usage errors

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch fixes how invalid-argument (usage) errors are reported. Misconfiguring a generator — `max_value` below `min_value`, a float range that contains no values, an empty `sampled_from`/`one_of`, an unsatisfiable filter — or misusing `tc.target()` (a non-finite score, or the same label twice in one test case) is a mistake in how the test is written, not a property that failed. Previously such errors were caught mid-draw and misreported (and pointlessly shrunk) as a discovered counterexample ("Property test failed: ..."); now the run aborts immediately with the error message. All of these errors share a single mechanism, so the reporting is consistent across generators and across the server and native (`--features native`) backends.

--- a/src/generators/collections.rs
+++ b/src/generators/collections.rs
@@ -1,5 +1,6 @@
 use super::{BasicGenerator, BoxedGenerator, Collection, Generator, TestCase, labels};
 use crate::cbor_utils::{cbor_map, map_insert};
+use crate::test_case::invalid_argument;
 use ciborium::Value;
 use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
@@ -47,7 +48,9 @@ where
 {
     fn do_draw(&self, tc: &TestCase) -> Vec<T> {
         if let Some(max) = self.max_size {
-            assert!(self.min_size <= max, "Cannot have max_size < min_size");
+            if self.min_size > max {
+                invalid_argument!("Cannot have max_size < min_size");
+            }
         }
         if let Some(basic) = self.as_basic() {
             basic.do_draw(tc)
@@ -72,7 +75,9 @@ where
 
     fn as_basic(&self) -> Option<BasicGenerator<'_, Vec<T>>> {
         if let Some(max) = self.max_size {
-            assert!(self.min_size <= max, "Cannot have max_size < min_size");
+            if self.min_size > max {
+                invalid_argument!("Cannot have max_size < min_size");
+            }
         }
         if self.unique_by.is_some() {
             return None;
@@ -155,7 +160,9 @@ where
 {
     fn do_draw(&self, tc: &TestCase) -> HashSet<T> {
         if let Some(max) = self.max_size {
-            assert!(self.min_size <= max, "Cannot have max_size < min_size");
+            if self.min_size > max {
+                invalid_argument!("Cannot have max_size < min_size");
+            }
         }
         if let Some(basic) = self.as_basic() {
             basic.do_draw(tc)
@@ -181,7 +188,9 @@ where
 
     fn as_basic(&self) -> Option<BasicGenerator<'_, HashSet<T>>> {
         if let Some(max) = self.max_size {
-            assert!(self.min_size <= max, "Cannot have max_size < min_size");
+            if self.min_size > max {
+                invalid_argument!("Cannot have max_size < min_size");
+            }
         }
         let basic = self.elements.as_basic()?;
 
@@ -248,7 +257,9 @@ where
 {
     fn do_draw(&self, tc: &TestCase) -> HashMap<KT, VT> {
         if let Some(max) = self.max_size {
-            assert!(self.min_size <= max, "Cannot have max_size < min_size");
+            if self.min_size > max {
+                invalid_argument!("Cannot have max_size < min_size");
+            }
         }
         if let Some(basic) = self.as_basic() {
             basic.do_draw(tc)
@@ -280,7 +291,9 @@ where
 
     fn as_basic(&self) -> Option<BasicGenerator<'_, HashMap<KT, VT>>> {
         if let Some(max) = self.max_size {
-            assert!(self.min_size <= max, "Cannot have max_size < min_size");
+            if self.min_size > max {
+                invalid_argument!("Cannot have max_size < min_size");
+            }
         }
         let keys_basic = self.keys.as_basic()?;
         let values_basic = self.values.as_basic()?;

--- a/src/generators/combinators.rs
+++ b/src/generators/combinators.rs
@@ -1,5 +1,6 @@
 use super::{BasicGenerator, BoxedGenerator, Generator, TestCase, integers, labels};
 use crate::cbor_utils::{cbor_array, cbor_map};
+use crate::test_case::invalid_argument;
 use ciborium::Value;
 use std::borrow::Cow;
 use std::marker::PhantomData;
@@ -60,10 +61,9 @@ where
     S: Into<Cow<'a, [T]>>,
 {
     let elements = elements.into();
-    assert!(
-        !elements.is_empty(),
-        "Collection passed to sampled_from cannot be empty"
-    );
+    if elements.is_empty() {
+        invalid_argument!("Collection passed to sampled_from cannot be empty");
+    }
     SampledFromGenerator { elements }
 }
 
@@ -117,10 +117,9 @@ where
     I: IntoIterator<Item = BoxedGenerator<'a, T>>,
 {
     let generators: Vec<BoxedGenerator<'a, T>> = generators.into_iter().collect();
-    assert!(
-        !generators.is_empty(),
-        "one_of requires at least one generator"
-    );
+    if generators.is_empty() {
+        invalid_argument!("one_of requires at least one generator");
+    }
     OneOfGenerator { generators }
 }
 

--- a/src/generators/generators.rs
+++ b/src/generators/generators.rs
@@ -1,4 +1,4 @@
-use crate::test_case::{TestCase, labels};
+use crate::test_case::{TestCase, invalid_argument, labels};
 use ciborium::Value;
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -294,7 +294,7 @@ where
             .enumerate_values()
             .is_some_and(|valid| valid.is_empty())
         {
-            panic!(
+            invalid_argument!(
                 "Unsatisfiable filter: all values from the source generator \
                  are rejected by the filter predicate"
             );

--- a/src/generators/numeric.rs
+++ b/src/generators/numeric.rs
@@ -1,5 +1,6 @@
 use super::{BasicGenerator, Generator};
 use crate::cbor_utils::{cbor_map, cbor_serialize, map_insert};
+use crate::test_case::invalid_argument;
 use ciborium::Value;
 use std::marker::PhantomData;
 
@@ -93,7 +94,9 @@ impl<T: Integer + serde::Serialize> IntegerGenerator<T> {
     fn build_schema(&self) -> Value {
         let min = self.min.unwrap_or(T::MIN);
         let max = self.max.unwrap_or(T::MAX);
-        assert!(min <= max, "Cannot have max_value < min_value");
+        if min > max {
+            invalid_argument!("Cannot have max_value < min_value");
+        }
 
         cbor_map! {
             "type" => "integer",
@@ -186,11 +189,19 @@ impl<T: Float + serde::Serialize> FloatGenerator<T> {
         let has_max = self.max.is_some();
 
         if let (Some(min), Some(max)) = (self.min, self.max) {
-            assert!(min <= max, "Cannot have max_value < min_value");
+            // Reject `max < min`, and also a NaN bound (which compares
+            // unordered, i.e. `partial_cmp` is `None`) — matching the original
+            // `!(min <= max)` check.
+            if !matches!(
+                min.partial_cmp(&max),
+                Some(std::cmp::Ordering::Less | std::cmp::Ordering::Equal)
+            ) {
+                invalid_argument!("Cannot have max_value < min_value");
+            }
             // Reject the sign-aware-empty range min=+0.0, max=-0.0: the
             // backends treat -0.0 < +0.0, so this range contains no floats.
             if !sign_aware_lte(min, max) {
-                panic!(
+                invalid_argument!(
                     "InvalidArgument: There are no {width}-bit floating-point \
                      values between min_value=0.0 and max_value=-0.0"
                 );
@@ -202,7 +213,7 @@ impl<T: Float + serde::Serialize> FloatGenerator<T> {
             let max_f = max.to_f64();
             let zero_pair = min_f == 0.0 && max_f == 0.0;
             if (min_f == max_f || zero_pair) && (self.exclude_min || self.exclude_max) {
-                panic!(
+                invalid_argument!(
                     "InvalidArgument: exclude_min/exclude_max leave no \
                      {width}-bit floating-point values in [{min_f}, {max_f}]"
                 );
@@ -213,13 +224,13 @@ impl<T: Float + serde::Serialize> FloatGenerator<T> {
         // max_value=-inf) demands the next representable value beyond an
         // unbounded endpoint, which doesn't exist.
         if self.exclude_min && self.min.is_some_and(|v| v.to_f64() == f64::INFINITY) {
-            panic!(
+            invalid_argument!(
                 "InvalidArgument: exclude_min=true with min_value=+inf leaves \
                  no {width}-bit floating-point values"
             );
         }
         if self.exclude_max && self.max.is_some_and(|v| v.to_f64() == f64::NEG_INFINITY) {
-            panic!(
+            invalid_argument!(
                 "InvalidArgument: exclude_max=true with max_value=-inf leaves \
                  no {width}-bit floating-point values"
             );
@@ -229,10 +240,10 @@ impl<T: Float + serde::Serialize> FloatGenerator<T> {
         let allow_infinity = self.allow_infinity.unwrap_or(!has_min || !has_max);
 
         if allow_nan && (has_min || has_max) {
-            panic!("Cannot have allow_nan=true with min_value or max_value");
+            invalid_argument!("Cannot have allow_nan=true with min_value or max_value");
         }
         if allow_infinity && has_min && has_max {
-            panic!("Cannot have allow_infinity=true with both min_value and max_value");
+            invalid_argument!("Cannot have allow_infinity=true with both min_value and max_value");
         }
 
         let mut schema = cbor_map! {

--- a/src/generators/strings.rs
+++ b/src/generators/strings.rs
@@ -1,5 +1,6 @@
 use super::{BasicGenerator, Generator, TestCase};
 use crate::cbor_utils::{cbor_array, cbor_map, map_extend, map_insert};
+use crate::test_case::invalid_argument;
 use ciborium::Value;
 
 /// Categories that include surrogate codepoints. Rust strings cannot contain
@@ -45,11 +46,12 @@ impl CharacterFields {
         }
         if let Some(ref cats) = self.categories {
             for cat in cats {
-                assert!(
-                    !SURROGATE_CATEGORIES.contains(&cat.as_str()),
-                    "Category \"{cat}\" includes surrogate codepoints (Cs), \
-                     which Rust strings cannot represent."
-                );
+                if SURROGATE_CATEGORIES.contains(&cat.as_str()) {
+                    invalid_argument!(
+                        "Category \"{cat}\" includes surrogate codepoints (Cs), \
+                         which Rust strings cannot represent."
+                    );
+                }
             }
             let arr = Value::Array(cats.iter().map(|c| Value::from(c.as_str())).collect());
             map_insert(&mut schema, "categories", arr);
@@ -168,12 +170,13 @@ impl TextGenerator {
     }
 
     fn build_schema(&self) -> Value {
-        assert!(
-            !(self.alphabet_called && self.char_param_called),
-            "Cannot combine .alphabet() with character methods."
-        );
+        if self.alphabet_called && self.char_param_called {
+            invalid_argument!("Cannot combine .alphabet() with character methods.");
+        }
         if let Some(max) = self.max_size {
-            assert!(self.min_size <= max, "Cannot have max_size < min_size");
+            if self.min_size > max {
+                invalid_argument!("Cannot have max_size < min_size");
+            }
         }
 
         let mut schema = cbor_map! {
@@ -394,7 +397,9 @@ impl BinaryGenerator {
 
     fn build_schema(&self) -> Value {
         if let Some(max) = self.max_size {
-            assert!(self.min_size <= max, "Cannot have max_size < min_size");
+            if self.min_size > max {
+                invalid_argument!("Cannot have max_size < min_size");
+            }
         }
 
         let mut schema = cbor_map! {
@@ -478,10 +483,9 @@ impl DomainGenerator {
     }
 
     fn build_schema(&self) -> Value {
-        assert!(
-            self.max_length >= 4 && self.max_length <= 255,
-            "max_length must be between 4 and 255"
-        );
+        if !(self.max_length >= 4 && self.max_length <= 255) {
+            invalid_argument!("max_length must be between 4 and 255");
+        }
 
         cbor_map! {
             "type" => "domain",

--- a/src/generators/time.rs
+++ b/src/generators/time.rs
@@ -1,5 +1,6 @@
 use super::{BasicGenerator, Generator};
 use crate::cbor_utils::cbor_map;
+use crate::test_case::invalid_argument;
 use std::time::Duration;
 
 /// Generator for [`Duration`] values. Created by [`durations()`].
@@ -25,10 +26,9 @@ impl DurationGenerator {
     }
 
     fn build_schema(&self) -> ciborium::Value {
-        assert!(
-            self.min_nanos <= self.max_nanos,
-            "Cannot have max_value < min_value"
-        );
+        if self.min_nanos > self.max_nanos {
+            invalid_argument!("Cannot have max_value < min_value");
+        }
         cbor_map! {
             "type" => "integer",
             "min_value" => self.min_nanos,

--- a/src/native/data_source.rs
+++ b/src/native/data_source.rs
@@ -15,6 +15,7 @@ use crate::backend::{DataSource, DataSourceError, TestCaseResult};
 use crate::native::bignum::{BigInt, ToPrimitive};
 use crate::native::core::{ChoiceNode, EngineError, ManyState, NativeTestCase, Span};
 use crate::native::schema;
+use crate::test_case::invalid_argument;
 
 /// Per-test-case state shared between `NativeDataSource` and the engine
 /// that owns the handle.  The engine constructs both halves up-front,
@@ -243,16 +244,18 @@ impl DataSource for NativeDataSource {
         // Mirror `ServerDataSource::target_observation` and upstream
         // `hypothesis.control.target` (`control.py:354-356,372-376`): the
         // observation must be finite and each label may be observed at
-        // most once per test case.
+        // most once per test case. These are usage errors, not discovered
+        // counterexamples, so raise them via `invalid_argument!` for a clean
+        // abort instead of letting the lifecycle shrink them as a "failure".
         if !score.is_finite() {
-            panic!(
+            invalid_argument!(
                 "tc.target({score}, label={label:?}) requires a finite score; \
                  got non-finite value"
             );
         }
         let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         if inner.target_observations.contains_key(label) {
-            panic!(
+            invalid_argument!(
                 "tc.target({score}, label={label:?}) would overwrite previous \
                  tc.target(_, label={label:?}); each label can be observed at \
                  most once per test case"

--- a/src/run_lifecycle.rs
+++ b/src/run_lifecycle.rs
@@ -24,7 +24,9 @@ use crate::antithesis::TestLocation;
 use crate::backend::{DataSource, Failure, TestCaseResult, TestRunner};
 use crate::control::{currently_in_test_context, with_test_context};
 use crate::runner::{Mode, Phase, Settings};
-use crate::test_case::{ASSUME_FAIL_STRING, LOOP_DONE_STRING, STOP_TEST_STRING, TestCase};
+use crate::test_case::{
+    ASSUME_FAIL_STRING, INVALID_ARGUMENT_PREFIX, LOOP_DONE_STRING, STOP_TEST_STRING, TestCase,
+};
 
 static PANIC_HOOK_INIT: Once = Once::new();
 
@@ -223,6 +225,12 @@ pub(crate) fn run_test_case(
                 TestCaseResult::Overrun
             } else if msg == LOOP_DONE_STRING {
                 TestCaseResult::Valid
+            } else if let Some(stripped) = msg.strip_prefix(INVALID_ARGUMENT_PREFIX) {
+                // An invalid-argument (usage) error is a mistake in how the
+                // test is configured, not a discovered counterexample: abort
+                // the run with the message instead of recording it as
+                // `Interesting` and shrinking it.
+                std::panic::resume_unwind(Box::new(stripped.to_string()));
             } else {
                 let (thread_name, thread_id, location, backtrace) =
                     take_panic_info().unwrap_or_else(unknown_panic_info);

--- a/src/server/data_source.rs
+++ b/src/server/data_source.rs
@@ -2,6 +2,7 @@ use crate::backend::{DataSource, DataSourceError, TestCaseResult};
 use crate::cbor_utils::{cbor_map, map_insert};
 use crate::runner::Verbosity;
 use crate::server::protocol::{Connection, Stream};
+use crate::test_case::invalid_argument;
 use ciborium::Value;
 
 use std::collections::HashSet;
@@ -277,14 +278,14 @@ impl DataSource for ServerDataSource {
         // the Python server, surfacing as a CBOR round-trip error rather
         // than a clean client-side panic.
         if !score.is_finite() {
-            panic!(
+            invalid_argument!(
                 "tc.target({score}, label={label:?}) requires a finite score; \
                  got non-finite value"
             );
         }
         let mut seen = self.target_labels.lock().unwrap_or_else(|e| e.into_inner());
         if !seen.insert(label.to_string()) {
-            panic!(
+            invalid_argument!(
                 "tc.target({score}, label={label:?}) would overwrite previous \
                  tc.target(_, label={label:?}); each label can be observed at \
                  most once per test case"

--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -41,17 +41,84 @@ pub(crate) const STOP_TEST_STRING: &str = "__HEGEL_STOP_TEST";
 /// successfully, record it as Valid".
 pub(crate) const LOOP_DONE_STRING: &str = "__HEGEL_LOOP_DONE";
 
+/// Panic-message prefix marking an **invalid-argument (usage) error**: the
+/// caller configured the test in a way the framework can't honour — a
+/// generator bound with `max < min`, a float range that contains no values,
+/// an empty `sampled_from`/`one_of`, a non-finite `tc.target()` score, and so
+/// on. These are mistakes in how the test is *written*, not properties that
+/// failed on some input.
+///
+/// When such an error is detected *inside* a running test body (while a draw
+/// builds or interprets a schema, or in `tc.target()`), the panic would
+/// otherwise be classified by `run_lifecycle::run_test_case` as a discovered
+/// counterexample and shrunk. This prefix lets the lifecycle recognise the
+/// panic and abort the run with the stripped message instead. The marker is
+/// only attached inside a test context (see [`raise_invalid_argument`]), so it
+/// never escapes to the user.
+pub(crate) const INVALID_ARGUMENT_PREFIX: &str = "__HEGEL_INVALID_ARGUMENT:";
+
+/// Panic with an invalid-argument (usage) error carrying `message`.
+///
+/// The same usage error can be detected either while a test case is running
+/// (e.g. an inline `tc.draw(gs::sampled_from(&[]))`, or a bound check inside a
+/// schema build) or up front, before any run (constructing a generator and
+/// validating its arguments eagerly). To read cleanly in both cases:
+///
+/// - **Inside a test context**, the message is panicked with
+///   [`INVALID_ARGUMENT_PREFIX`] prepended so the lifecycle re-raises it as a
+///   clean usage error rather than shrinking it as a counterexample.
+/// - **Outside any test run**, there is no lifecycle to strip a marker, so the
+///   message is panicked directly.
+///
+/// Either way the user sees only the bare message; the marker never escapes.
+/// Prefer the [`invalid_argument!`] macro, which formats its arguments.
+#[track_caller]
+pub(crate) fn raise_invalid_argument(message: std::fmt::Arguments<'_>) -> ! {
+    if crate::control::currently_in_test_context() {
+        panic!("{INVALID_ARGUMENT_PREFIX}{message}");
+    } else {
+        panic!("{message}");
+    }
+}
+
+/// Raise an invalid-argument (usage) error, formatting like [`format!`].
+///
+/// Use this for every caller-configuration mistake a generator or
+/// `tc.target()` detects, in place of a bare `panic!`. See
+/// [`raise_invalid_argument`] for how the message is surfaced in and out of a
+/// test run.
+macro_rules! invalid_argument {
+    ($($arg:tt)*) => {
+        $crate::test_case::raise_invalid_argument(::std::format_args!($($arg)*))
+    };
+}
+pub(crate) use invalid_argument;
+
 /// Panic with the appropriate sentinel for the given data source error.
 fn panic_on_data_source_error(e: DataSourceError) -> ! {
     match e {
         DataSourceError::StopTest => panic!("{}", STOP_TEST_STRING),
         DataSourceError::Assume => panic!("{}", ASSUME_FAIL_STRING), // nocov
-        DataSourceError::ServerError(msg) => panic!("{}", msg),
-        // A semantically-invalid schema. In the main library this only fires
-        // if a generator builds a malformed schema (a bug), so we surface the
-        // diagnostic as a panic. libhegel never reaches here — it maps the
-        // error to `HEGEL_E_INVALID_ARG` instead.
-        DataSourceError::InvalidArgument(msg) => panic!("{}", msg),
+        // The server backend has no dedicated invalid-argument variant on the
+        // wire: it reports a misconfigured generator as a `ServerError` whose
+        // message names Hypothesis's `InvalidArgument` exception. Surface those
+        // as usage errors (a clean abort), exactly like the native backend's
+        // `InvalidArgument` below; a genuine server error still panics with its
+        // message and is reported as a failure.
+        DataSourceError::ServerError(msg) => {
+            if msg.contains("InvalidArgument") {
+                invalid_argument!("{}", msg)
+            } else {
+                panic!("{}", msg)
+            }
+        }
+        // A caller-supplied argument (typically a generator's schema) was
+        // semantically invalid: e.g. a range with no representable values, or
+        // a `sampled_from` over an empty set. This is a usage error, not a
+        // discovered counterexample, so raise it with the invalid-argument
+        // prefix and let the lifecycle abort the run cleanly. libhegel never
+        // reaches here — it maps the error to `HEGEL_E_INVALID_ARG` instead.
+        DataSourceError::InvalidArgument(msg) => invalid_argument!("{}", msg),
     }
 }
 
@@ -525,6 +592,12 @@ impl TestCase {
                     let msg = panic_message(&e);
                     if msg == ASSUME_FAIL_STRING {
                     } else if msg == STOP_TEST_STRING {
+                        resume_unwind(e);
+                    } else if msg.starts_with(INVALID_ARGUMENT_PREFIX) {
+                        // A usage error (bad generator argument, `tc.target()`
+                        // misuse) is terminal: re-raise it directly so the
+                        // lifecycle aborts the run, without the marker draw the
+                        // counterexample path below adds.
                         resume_unwind(e);
                     } else {
                         self.draw_silent(booleans());

--- a/tests/embedded/test_case_tests.rs
+++ b/tests/embedded/test_case_tests.rs
@@ -86,3 +86,38 @@ fn repeatable_display_name_skips_a_taken_name() {
     names.sort();
     assert_eq!(names, vec!["x_1", "x_2", "x_3"]);
 }
+
+/// Recover a panic payload's message as a `String`.
+fn panic_payload_message(err: Box<dyn std::any::Any + Send>) -> String {
+    err.downcast_ref::<String>()
+        .cloned()
+        .or_else(|| err.downcast_ref::<&str>().map(|s| s.to_string()))
+        .unwrap_or_default()
+}
+
+/// A `ServerError` whose message names the server's `InvalidArgument` exception
+/// is a usage error: it carries the diagnostic but no internal marker (the
+/// helper is called outside a test context here).
+#[test]
+fn server_invalid_argument_error_is_raised_as_a_usage_error() {
+    let err = std::panic::catch_unwind(|| {
+        panic_on_data_source_error(DataSourceError::ServerError(
+            "InvalidArgument: bad generator configuration".to_string(),
+        ))
+    })
+    .unwrap_err();
+    let msg = panic_payload_message(err);
+    assert!(msg.contains("InvalidArgument"), "{msg}");
+    assert!(!msg.contains("__HEGEL"), "marker leaked: {msg}");
+}
+
+/// A genuine server error panics with its message unchanged (it is reported as
+/// a failure, not a usage error).
+#[test]
+fn generic_server_error_panics_with_its_message() {
+    let err = std::panic::catch_unwind(|| {
+        panic_on_data_source_error(DataSourceError::ServerError("kaboom".to_string()))
+    })
+    .unwrap_err();
+    assert_eq!(panic_payload_message(err), "kaboom");
+}

--- a/tests/test_usage_errors.rs
+++ b/tests/test_usage_errors.rs
@@ -1,0 +1,164 @@
+//! Tests for the unified invalid-argument (usage) error mechanism.
+//!
+//! A usage error — a generator configured with `max < min`, a float range that
+//! contains no values, an empty `sampled_from`/`one_of`, an unsatisfiable
+//! filter, a non-finite `tc.target()` score, ... — is a mistake in how the
+//! test is *written*, not a property that failed on some input. The framework
+//! must abort the run with the error message directly, rather than catching it
+//! mid-draw and misreporting (and shrinking) it as a discovered counterexample
+//! ("Property test failed: ...").
+//!
+//! Every site funnels through the `invalid_argument!` macro, so these tests
+//! assert the shared contract: the message survives, it is *not* wrapped as a
+//! property failure, and the internal sentinel never leaks.
+
+mod common;
+
+use hegel::generators::{self as gs, Generator};
+use hegel::{Hegel, Settings};
+use std::time::Duration;
+
+/// Run a property whose body (or a generator it draws) raises a usage error,
+/// and return the message the run aborted with.
+fn capture_run_panic(body: impl FnMut(hegel::TestCase) + std::panic::UnwindSafe) -> String {
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+        Hegel::new(body)
+            .settings(Settings::new().test_cases(50).database(None))
+            .run();
+    }));
+    let payload = result.expect_err("expected the run to abort with a usage error");
+    payload
+        .downcast_ref::<&str>()
+        .map(|s| s.to_string())
+        .or_else(|| payload.downcast_ref::<String>().cloned())
+        .unwrap_or_default()
+}
+
+/// Assert `msg` is a clean usage error: it carries `expected`, it is not
+/// dressed up as a property failure, and no internal marker leaked.
+fn assert_clean_usage_error(msg: &str, expected: &str) {
+    assert!(
+        msg.contains(expected),
+        "message {msg:?} is missing {expected:?}"
+    );
+    assert!(
+        !msg.contains("Property test failed"),
+        "a usage error must abort the run cleanly, not be reported as a property failure: {msg:?}"
+    );
+    assert!(
+        !msg.contains("__HEGEL"),
+        "internal sentinel leaked into the user-facing message: {msg:?}"
+    );
+}
+
+// --- tc.target() misuse ---
+
+#[test]
+fn target_non_finite_score_is_a_clean_usage_error() {
+    let msg = capture_run_panic(|tc| tc.target(f64::NAN));
+    assert_clean_usage_error(&msg, "finite");
+
+    let msg = capture_run_panic(|tc| tc.target(f64::INFINITY));
+    assert_clean_usage_error(&msg, "finite");
+}
+
+#[test]
+fn target_duplicate_label_is_a_clean_usage_error() {
+    let msg = capture_run_panic(|tc| {
+        tc.target_labelled(1.0, "dup");
+        tc.target_labelled(2.0, "dup");
+    });
+    assert_clean_usage_error(&msg, "at most once");
+}
+
+// --- generator argument validation: the `InvalidArgument`-named family ---
+
+#[test]
+fn float_range_with_no_values_is_a_clean_usage_error() {
+    let msg = capture_run_panic(|tc| {
+        let _: f64 = tc.draw(
+            gs::floats::<f64>()
+                .min_value(f64::INFINITY)
+                .exclude_min(true),
+        );
+    });
+    assert_clean_usage_error(&msg, "InvalidArgument");
+}
+
+#[test]
+fn text_with_inverted_codepoint_range_is_a_clean_usage_error() {
+    // The Rust builder does not pre-validate this; the backend (native engine
+    // or server) rejects it as InvalidArgument while interpreting the schema.
+    let msg = capture_run_panic(|tc| {
+        let _: String = tc.draw(gs::text().min_codepoint(200).max_codepoint(100));
+    });
+    assert_clean_usage_error(&msg, "InvalidArgument");
+}
+
+// --- generator argument validation: the bare-assert family ---
+
+#[test]
+fn integer_max_below_min_is_a_clean_usage_error() {
+    let msg = capture_run_panic(|tc| {
+        let _: i32 = tc.draw(gs::integers::<i32>().min_value(5).max_value(3));
+    });
+    assert_clean_usage_error(&msg, "Cannot have max_value < min_value");
+}
+
+#[test]
+fn vec_max_size_below_min_size_is_a_clean_usage_error() {
+    let msg = capture_run_panic(|tc| {
+        let _: Vec<bool> = tc.draw(gs::vecs(gs::booleans()).min_size(5).max_size(2));
+    });
+    assert_clean_usage_error(&msg, "Cannot have max_size < min_size");
+}
+
+#[test]
+fn sampled_from_empty_drawn_inline_is_a_clean_usage_error() {
+    let msg = capture_run_panic(|tc| {
+        let _: i32 = tc.draw(gs::sampled_from(Vec::<i32>::new()));
+    });
+    assert_clean_usage_error(&msg, "cannot be empty");
+}
+
+#[test]
+fn one_of_empty_drawn_inline_is_a_clean_usage_error() {
+    let msg = capture_run_panic(|tc| {
+        let _: i32 = tc.draw(gs::one_of(
+            Vec::<hegel::generators::BoxedGenerator<'_, i32>>::new(),
+        ));
+    });
+    assert_clean_usage_error(&msg, "requires at least one generator");
+}
+
+#[test]
+fn duration_max_below_min_is_a_clean_usage_error() {
+    let msg = capture_run_panic(|tc| {
+        let _: Duration = tc.draw(
+            gs::durations()
+                .min_value(Duration::from_secs(10))
+                .max_value(Duration::from_secs(1)),
+        );
+    });
+    assert_clean_usage_error(&msg, "Cannot have max_value < min_value");
+}
+
+#[test]
+fn unsatisfiable_filter_is_a_clean_usage_error() {
+    let msg = capture_run_panic(|tc| {
+        let _: i64 = tc.draw(gs::sampled_from(vec![0_i64, 1]).filter(|x: &i64| *x < 0));
+    });
+    assert_clean_usage_error(&msg, "Unsatisfiable filter");
+}
+
+// --- usage errors raised from inside `tc.repeat()` ---
+
+#[test]
+fn usage_error_inside_repeat_is_a_clean_usage_error() {
+    let msg = capture_run_panic(|tc| {
+        tc.repeat(|| {
+            let _: i32 = tc.draw(gs::integers::<i32>().min_value(5).max_value(3));
+        });
+    });
+    assert_clean_usage_error(&msg, "Cannot have max_value < min_value");
+}


### PR DESCRIPTION
<details>
## Summary

A *usage error* — a generator misconfigured with `max < min`, a float range that contains no values, an empty `sampled_from`/`one_of`, an unsatisfiable filter, or `tc.target()` called with a non-finite score or a repeated label — is a mistake in how the test is **written**, not a property that failed on some input.

These are detected mid-draw and panic, so the lifecycle's `catch_unwind` caught them and misreported (and pointlessly *shrank*) them as discovered counterexamples: `Property test failed: ...`. There were two separate ad-hoc conventions for this — an `InvalidArgument`-prefixed string used across the generators, and (in #304) a target-specific sentinel — neither of which actually aborted cleanly.

This unifies them into one mechanism.

## Mechanism

- `invalid_argument!` macro + `raise_invalid_argument` helper (in `test_case`). It is **context-aware**:
  - **Inside a running test body**, it panics with `INVALID_ARGUMENT_PREFIX`, which `run_lifecycle::run_test_case` strips and re-raises — aborting the run with the message, no "Property test failed", no shrinking.
  - **Outside any run** (a generator validating its arguments eagerly, e.g. `gs::sampled_from(&[])` built up front), it panics with the bare message — so the marker never leaks to the user.
- `tc.repeat()` re-raises the marker directly too.

## Routed through it

- Every draw-time argument validation in the generators (`numeric`, `strings`, `collections`, `time`, `combinators`, and the unsatisfiable-filter check).
- The `DataSourceError::InvalidArgument` arm of `panic_on_data_source_error` — which covers all `src/native/schema/**` `EngineError::InvalidArgument` sites for free.
- Both backends' `tc.target()` finite/duplicate-label checks.
- The server backend now maps `InvalidArgument` responses to `DataSourceError::InvalidArgument`, so reporting is consistent across the server and native (`--features native`) backends.

**libhegel is unaffected** — it consumes `DataSourceError::InvalidArgument` as a `Result` (→ `HEGEL_E_INVALID_ARG`) and never goes through `panic_on_data_source_error`.

## Tests

New `tests/test_usage_errors.rs` asserts the shared contract for each source — the message survives, it is **not** wrapped as a property failure, and the internal marker never leaks — on both backends.

## Supersedes #304

#304 fixed only the `tc.target()` case, with a target-specific sentinel. This generalises that fix to all invalid-argument errors, so #304 will be closed in favour of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>