### PR TITLE
Stop building libhegel for Intel macOS (darwin-amd64)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -567,14 +567,16 @@ jobs:
         platform:
           - linux-amd64
           - linux-arm64
-          - darwin-amd64
           - darwin-arm64
           - windows-amd64
           - windows-arm64
         include:
           - { platform: linux-amd64,   runner: ubuntu-latest,    target: x86_64-unknown-linux-gnu,    goos: linux,   goarch: amd64, ext: so }
           - { platform: linux-arm64,   runner: ubuntu-24.04-arm, target: aarch64-unknown-linux-gnu,   goos: linux,   goarch: arm64, ext: so }
-          - { platform: darwin-amd64,  runner: macos-13,         target: x86_64-apple-darwin,         goos: darwin,  goarch: amd64, ext: dylib }
+          # Intel macOS (darwin-amd64) is intentionally not built: the
+          # macos-13 (x86_64) runners are scarce and routinely leave the
+          # release job stuck for hours waiting for a runner, and we do not
+          # support Intel Macs. Apple-silicon macOS is covered below.
           - { platform: darwin-arm64,  runner: macos-14,         target: aarch64-apple-darwin,        goos: darwin,  goarch: arm64, ext: dylib }
           - { platform: windows-amd64, runner: windows-latest,   target: x86_64-pc-windows-msvc,      goos: windows, goarch: amd64, ext: dll }
           # aarch64-pc-windows-msvc is cross-compiled from the x86_64 runner.
@@ -677,7 +679,6 @@ jobs:
           expected=(
             libhegel-linux-amd64.so
             libhegel-linux-arm64.so
-            libhegel-darwin-amd64.dylib
             libhegel-darwin-arm64.dylib
             libhegel-windows-amd64.dll
             libhegel-windows-arm64.dll

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Prebuilt `libhegel` binaries are no longer published for Intel macOS (`darwin/amd64`). The `macos-13` (x86_64) GitHub-hosted runners are scarce and routinely left the release job stuck for hours waiting for a runner, and we do not support Intel Macs. Apple-silicon macOS (`darwin/arm64`), Linux, and Windows binaries are unaffected; Intel-mac users can still build the `hegeltest-c` crate themselves.

--- a/hegel-c/README.md
+++ b/hegel-c/README.md
@@ -13,5 +13,6 @@ rather than building this crate yourself:
 > <https://github.com/hegeldev/hegel-rust/releases>
 
 Each release publishes `libhegel-<goos>-<goarch>.<ext>` and a matching
-`.sha256` sidecar for `linux/amd64`, `linux/arm64`, `darwin/amd64`,
-`darwin/arm64`, `windows/amd64`, and `windows/arm64`.
+`.sha256` sidecar for `linux/amd64`, `linux/arm64`, `darwin/arm64`,
+`windows/amd64`, and `windows/arm64`. Intel macOS (`darwin/amd64`) is not
+published; build the crate yourself if you need it.


### PR DESCRIPTION
Drop the Intel-macOS (`darwin-amd64`) `libhegel` release build. The `macos-13` (x86_64) GitHub-hosted runners are scarce and routinely leave the `release-binaries` job stuck for hours waiting for a run.

The library should still build locally and users who want intel mac support are encouraged to build it themselves.