### PR TITLE
Add slow shrinking timeout to native mode

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+The native engine now bounds the shrinking phase by wall-clock time. If shrinking a failing example runs for more than five minutes it stops, reports the smallest counterexample found so far, and prints a warning, instead of potentially running for a very long time on tests whose body is slow to execute. Re-running resumes shrinking from the saved example. This mirrors Hypothesis's `MAX_SHRINKING_SECONDS` safety valve.

--- a/src/native/core/mod.rs
+++ b/src/native/core/mod.rs
@@ -27,3 +27,10 @@ pub const BOUNDARY_PROBABILITY: f64 = 0.01;
 /// short-circuit so the runner doesn't get stuck chasing diminishing
 /// returns on pathological inputs.
 pub const MAX_SHRINKS: usize = 500;
+
+/// Wall-clock ceiling on the whole shrinking phase. Once shrinking has run
+/// for this long it stops and reports the smallest counterexample found so
+/// far, rather than blocking the run indefinitely on a test whose body is
+/// slow to execute (where the per-step `MAX_SHRINKS` / stall caps don't bound
+/// total time). Mirrors Hypothesis's `MAX_SHRINKING_SECONDS` safety valve.
+pub const MAX_SHRINKING_SECONDS: u64 = 300;

--- a/src/native/shrinker/bytes.rs
+++ b/src/native/shrinker/bytes.rs
@@ -7,10 +7,10 @@ use std::collections::HashMap;
 
 use crate::native::core::{BytesChoice, ChoiceKind, ChoiceValue};
 
-use super::{Shrinker, bin_search_down};
+use super::{ShrinkResult, Shrinker, bin_search_down_r};
 
 impl<'a> Shrinker<'a> {
-    pub(super) fn shrink_bytes(&mut self) {
+    pub(super) fn shrink_bytes(&mut self) -> ShrinkResult<()> {
         let mut i = 0;
         while i < self.current_nodes.len() {
             let (min_size, current) = match (
@@ -27,18 +27,18 @@ impl<'a> Shrinker<'a> {
             // Try the simplest (min_size zeros) first.
             let simplest = vec![0u8; min_size];
             if simplest != current {
-                self.replace(&HashMap::from([(i, ChoiceValue::Bytes(simplest))]));
+                self.replace(&HashMap::from([(i, ChoiceValue::Bytes(simplest))]))?;
             }
 
             // Shorten via binary search.
             let cur_len = self.current_byte_value(i).len();
             if cur_len > min_size {
                 let captured = self.current_byte_value(i);
-                bin_search_down(min_size as i128, cur_len as i128, &mut |sz| {
+                bin_search_down_r(min_size as i128, cur_len as i128, &mut |sz| {
                     let sz = sz as usize;
                     let cand = captured[..sz].to_vec();
                     self.replace(&HashMap::from([(i, ChoiceValue::Bytes(cand))]))
-                });
+                })?;
             }
 
             // Linear scan small lengths (non-monotonic fallback).
@@ -50,7 +50,7 @@ impl<'a> Shrinker<'a> {
                     break;
                 }
                 let cand = cur[..sz].to_vec();
-                self.replace(&HashMap::from([(i, ChoiceValue::Bytes(cand))]));
+                self.replace(&HashMap::from([(i, ChoiceValue::Bytes(cand))]))?;
             }
 
             // Delete individual elements, from right to left.
@@ -63,7 +63,7 @@ impl<'a> Shrinker<'a> {
                 }
                 let mut cand = cur.clone();
                 cand.remove(j);
-                self.replace(&HashMap::from([(i, ChoiceValue::Bytes(cand))]));
+                self.replace(&HashMap::from([(i, ChoiceValue::Bytes(cand))]))?;
             }
 
             // Reduce each byte toward 0, from right to left.
@@ -75,11 +75,11 @@ impl<'a> Shrinker<'a> {
                     continue;
                 }
                 let hi = cur[j] as i128;
-                bin_search_down(0, hi, &mut |e| {
+                bin_search_down_r(0, hi, &mut |e| {
                     let mut cand = self.current_byte_value(i);
                     cand[j] = e as u8;
                     self.replace(&HashMap::from([(i, ChoiceValue::Bytes(cand))]))
-                });
+                })?;
             }
 
             // Insertion-sort pass: swap adjacent out-of-order bytes.
@@ -97,7 +97,7 @@ impl<'a> Shrinker<'a> {
                     }
                     let mut swapped = cur.clone();
                     swapped.swap(j - 1, j);
-                    if self.replace(&HashMap::from([(i, ChoiceValue::Bytes(swapped))])) {
+                    if self.replace(&HashMap::from([(i, ChoiceValue::Bytes(swapped))]))? {
                         j -= 1;
                     } else {
                         break;
@@ -108,6 +108,7 @@ impl<'a> Shrinker<'a> {
 
             i += 1;
         }
+        Ok(())
     }
 
     fn current_byte_value(&self, i: usize) -> Vec<u8> {
@@ -124,7 +125,7 @@ impl<'a> Shrinker<'a> {
     /// Useful for tests with a total-length constraint across two bytes
     /// values, where the minimal counterexample has the first as short
     /// as possible.
-    pub(super) fn redistribute_bytes_pairs(&mut self) {
+    pub(super) fn redistribute_bytes_pairs(&mut self) -> ShrinkResult<()> {
         for gap in 1..3usize {
             let mut idx = 0;
             loop {
@@ -134,10 +135,11 @@ impl<'a> Shrinker<'a> {
                 }
                 let i = indices[idx];
                 let j = indices[idx + gap];
-                self.redistribute_bytes_pair(i, j);
+                self.redistribute_bytes_pair(i, j)?;
                 idx += 1;
             }
         }
+        Ok(())
     }
 
     fn bytes_indices(&self) -> Vec<usize> {
@@ -151,7 +153,7 @@ impl<'a> Shrinker<'a> {
             .collect()
     }
 
-    fn redistribute_bytes_pair(&mut self, i: usize, j: usize) {
+    fn redistribute_bytes_pair(&mut self, i: usize, j: usize) -> ShrinkResult<()> {
         let s = self.current_byte_value(i);
         let t = self.current_byte_value(j);
         let kind_j = match self.current_nodes[j].kind.as_ref() {
@@ -160,13 +162,13 @@ impl<'a> Shrinker<'a> {
         };
 
         if s.is_empty() {
-            return;
+            return Ok(());
         }
 
         // Try moving everything from s to t.
         let combined: Vec<u8> = s.iter().copied().chain(t.iter().copied()).collect();
-        if self.try_redistribute_bytes(i, j, Vec::new(), combined, &kind_j) {
-            return;
+        if self.try_redistribute_bytes(i, j, Vec::new(), combined, &kind_j)? {
+            return Ok(());
         }
 
         // Try moving the last byte of s to the start of t.
@@ -174,19 +176,20 @@ impl<'a> Shrinker<'a> {
         let mut t_prepended = Vec::with_capacity(t.len() + 1);
         t_prepended.push(*last);
         t_prepended.extend_from_slice(&t);
-        if !self.try_redistribute_bytes(i, j, s_init.to_vec(), t_prepended, &kind_j) {
-            return;
+        if !self.try_redistribute_bytes(i, j, s_init.to_vec(), t_prepended, &kind_j)? {
+            return Ok(());
         }
 
         // Binary search for the longest suffix of s that can be moved.
         let s_len = s.len();
-        bin_search_down(1, s_len as i128, &mut |n| {
+        bin_search_down_r(1, s_len as i128, &mut |n| {
             let n = n as usize;
             let new_s = s[..s_len - n].to_vec();
             let mut new_t = s[s_len - n..].to_vec();
             new_t.extend_from_slice(&t);
             self.try_redistribute_bytes(i, j, new_s, new_t, &kind_j)
-        });
+        })?;
+        Ok(())
     }
 
     fn try_redistribute_bytes(
@@ -196,9 +199,9 @@ impl<'a> Shrinker<'a> {
         new_s: Vec<u8>,
         new_t: Vec<u8>,
         kind_j: &BytesChoice,
-    ) -> bool {
+    ) -> ShrinkResult<bool> {
         if !kind_j.validate(&new_t) {
-            return false;
+            return Ok(false);
         }
         self.replace(&HashMap::from([
             (i, ChoiceValue::Bytes(new_s)),

--- a/src/native/shrinker/coarse.rs
+++ b/src/native/shrinker/coarse.rs
@@ -10,14 +10,14 @@
 use crate::native::bignum::BigInt;
 use crate::native::core::{ChoiceKind, ChoiceValue};
 
-use super::{ShrinkRun, Shrinker};
+use super::{ShrinkResult, ShrinkRun, Shrinker};
 
 impl<'a> Shrinker<'a> {
     /// Coarse pre-shrink reductions that need their own phase because
     /// they can re-randomise (and thus enlarge) the test case.  Called
     /// from `test_runner.rs` once, before the main `shrink()` loop.
-    pub(crate) fn initial_coarse_reduction(&mut self) {
-        self.reduce_each_alternative();
+    pub(crate) fn initial_coarse_reduction(&mut self) -> ShrinkResult<()> {
+        self.reduce_each_alternative()
     }
 
     /// Walk small non-negative integer nodes and try to lower them as
@@ -30,7 +30,7 @@ impl<'a> Shrinker<'a> {
     /// 2. Otherwise, try `try_lower_node_as_alternative(i, v)` for
     ///    each smaller candidate `v < node.value`, stopping at the
     ///    first success.
-    fn reduce_each_alternative(&mut self) {
+    fn reduce_each_alternative(&mut self) -> ShrinkResult<()> {
         let mut i = 0;
         while i < self.current_nodes.len() {
             let node = self.current_nodes[i].clone();
@@ -54,7 +54,7 @@ impl<'a> Shrinker<'a> {
                 .expect("0 fits a min==0 integer choice");
             let mut zeroed = self.current_nodes.clone();
             zeroed[i] = zeroed[i].with_value(ChoiceValue::Integer(zero_val));
-            let (_, zero_actual, _) = (self.test_fn)(ShrinkRun::Full(&zeroed));
+            let (_, zero_actual, _) = self.run_test_fn(ShrinkRun::Full(&zeroed))?;
             let shape_changed = zero_actual.len() != self.current_nodes.len()
                 || (i + 1..self.current_nodes.len()).any(|j| {
                     j >= zero_actual.len()
@@ -64,7 +64,7 @@ impl<'a> Shrinker<'a> {
             if shape_changed {
                 let mut v = BigInt::from(0);
                 while v < current_val {
-                    if self.try_lower_node_as_alternative(i, &v) {
+                    if self.try_lower_node_as_alternative(i, &v)? {
                         break;
                     }
                     v += 1;
@@ -72,17 +72,18 @@ impl<'a> Shrinker<'a> {
             }
             i += 1;
         }
+        Ok(())
     }
 
     /// Lower the integer at `i` to `v`, retrying the suffix as random
     /// continuations to repair any shape changes the lower caused.
-    fn try_lower_node_as_alternative(&mut self, i: usize, v: &BigInt) -> bool {
+    fn try_lower_node_as_alternative(&mut self, i: usize, v: &BigInt) -> ShrinkResult<bool> {
         // Callers iterate `i < self.current_nodes.len()`, so this is a
         // documented precondition.
         debug_assert!(i < self.current_nodes.len());
         // First try the bare lowering.
-        if self.replace_int(i, v) {
-            return true;
+        if self.replace_int(i, v)? {
+            return Ok(true);
         }
         // Couldn't lower directly; re-randomise the suffix via `probe`.
         // Use the lowered prefix as the probe's prefix and let the engine pick
@@ -96,12 +97,12 @@ impl<'a> Shrinker<'a> {
         let max_size = self.current_nodes.len() + 16;
         let epoch = self.improvements;
         for seed in 0..3u64 {
-            self.probe(&prefix, seed, max_size);
+            self.probe(&prefix, seed, max_size)?;
             if self.improvements > epoch {
-                return true;
+                return Ok(true);
             }
         }
-        false
+        Ok(false)
     }
 }
 

--- a/src/native/shrinker/deletion.rs
+++ b/src/native/shrinker/deletion.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use crate::native::bignum::BigInt;
 use crate::native::core::{ChoiceKind, ChoiceNode, ChoiceValue};
 
-use super::{Shrinker, bin_search_down_big, find_integer};
+use super::{ShrinkResult, Shrinker, bin_search_down_big_r, find_integer_r};
 
 impl<'a> Shrinker<'a> {
     /// Try deleting chunks of choices from the sequence.
@@ -14,7 +14,7 @@ impl<'a> Shrinker<'a> {
     /// Longer chunks allow deleting composite elements (e.g. a list element
     /// requires deleting both the "include?" choice and the element itself).
     /// Iterates backwards since later choices tend to depend on earlier ones.
-    pub(super) fn delete_chunks(&mut self) {
+    pub(super) fn delete_chunks(&mut self) -> ShrinkResult<()> {
         let mut k: usize = 8;
         while k > 0 {
             let mut i = self.current_nodes.len().saturating_sub(k + 1);
@@ -29,7 +29,7 @@ impl<'a> Shrinker<'a> {
                 attempt.extend_from_slice(&self.current_nodes[end..]);
                 assert!(attempt.len() < self.current_nodes.len());
 
-                if !self.consider(&attempt) && i > 0 {
+                if !self.consider(&attempt)? && i > 0 {
                     // Try decrementing the preceding choice (helps with
                     // collection length counters).
                     let prev = &attempt[i - 1];
@@ -48,7 +48,7 @@ impl<'a> Shrinker<'a> {
                     if let Some(new_value) = decremented {
                         let mut modified = attempt.clone();
                         modified[i - 1] = modified[i - 1].with_value(new_value);
-                        self.consider(&modified);
+                        self.consider(&modified)?;
                     }
                 }
                 if i == 0 {
@@ -58,13 +58,14 @@ impl<'a> Shrinker<'a> {
             }
             k -= 1;
         }
+        Ok(())
     }
 
     /// When a value controls the length of a downstream sequence (e.g.
     /// via flat_map), reducing that value may shorten the test case without
     /// keeping the result interesting. This pass detects that situation and
     /// tries deleting the now-excess choices to recover an interesting result.
-    pub(super) fn bind_deletion(&mut self) {
+    pub(super) fn bind_deletion(&mut self) -> ShrinkResult<()> {
         let mut i = 0;
         while i < self.current_nodes.len() {
             let node = self.current_nodes[i].clone();
@@ -89,14 +90,14 @@ impl<'a> Shrinker<'a> {
             // Binary-search smaller integer values; for each candidate, try
             // replace-with-deletion. `try_replace_with_deletion` only deletes
             // nodes *after* `i`, so `i` stays in range across probes.
-            let changed = bin_search_down_big(simplest, current_val, &mut |v| {
+            bin_search_down_big_r(simplest, current_val, &mut |v| {
                 let value = self.int_replacement(i, v);
                 self.try_replace_with_deletion(i, value, expected_len)
-            });
-            let _ = changed;
+            })?;
 
             i += 1;
         }
+        Ok(())
     }
 
     /// Try replacing the value at `idx`. If the result is interesting, done.
@@ -107,11 +108,11 @@ impl<'a> Shrinker<'a> {
         idx: usize,
         value: ChoiceValue,
         expected_len: usize,
-    ) -> bool {
+    ) -> ShrinkResult<bool> {
         // First try a straight replace. consider() already calls test_fn and
         // records the interesting case; we'd just duplicate work by retrying.
-        if self.replace(&HashMap::from([(idx, value.clone())])) {
-            return true;
+        if self.replace(&HashMap::from([(idx, value.clone())]))? {
+            return Ok(true);
         }
 
         // The replace couldn't narrow the result directly. Re-run the test to
@@ -122,9 +123,9 @@ impl<'a> Shrinker<'a> {
         let mut attempt = self.current_nodes.clone();
         attempt[idx] = attempt[idx].with_value(value);
 
-        let (_, actual_nodes, _) = (self.test_fn)(super::ShrinkRun::Full(&attempt));
+        let (_, actual_nodes, _) = self.run_test_fn(super::ShrinkRun::Full(&attempt))?;
         if actual_nodes.len() >= expected_len {
-            return false;
+            return Ok(false);
         }
 
         // The test used fewer nodes. Try deleting regions after idx.
@@ -137,12 +138,12 @@ impl<'a> Shrinker<'a> {
             for j in (idx + 1..=start).rev() {
                 let mut candidate = attempt[..j].to_vec();
                 candidate.extend_from_slice(&attempt[j + size..]);
-                if self.consider(&candidate) {
-                    return true;
+                if self.consider(&candidate)? {
+                    return Ok(true);
                 }
             }
         }
-        false
+        Ok(false)
     }
 
     /// Per-node minimization with size-dependency deletion fallback.
@@ -157,7 +158,7 @@ impl<'a> Shrinker<'a> {
     ///
     /// Non-integer nodes are deferred to the existing per-type passes —
     /// the unified driver only adds value for integers.
-    pub(crate) fn minimize_individual_choices(&mut self) {
+    pub(crate) fn minimize_individual_choices(&mut self) -> ShrinkResult<()> {
         let mut i = 0;
         while i < self.current_nodes.len() {
             let node = self.current_nodes[i].clone();
@@ -186,9 +187,9 @@ impl<'a> Shrinker<'a> {
             // (see `accept_improvement`), so its delta is "did we shrink?"
             // without needing a snapshot of the prior sort_key.
             let epoch_phase1 = self.improvements;
-            bin_search_down_big(simplest.clone(), current_val.clone(), &mut |v| {
+            bin_search_down_big_r(simplest.clone(), current_val.clone(), &mut |v| {
                 self.replace_int(i, v)
-            });
+            })?;
             if self.improvements > epoch_phase1 {
                 // Made progress; move on.
                 i += 1;
@@ -216,7 +217,8 @@ impl<'a> Shrinker<'a> {
             let mut lowered = self.current_nodes.clone();
             lowered[i] = lowered[i].with_value(towards_value);
 
-            let (_, actual_nodes, actual_spans) = (self.test_fn)(super::ShrinkRun::Full(&lowered));
+            let (_, actual_nodes, actual_spans) =
+                self.run_test_fn(super::ShrinkRun::Full(&lowered))?;
 
             // Misalignment-truncation retry. Even when the sequence
             // length didn't change, the realised draw of a string/bytes
@@ -243,7 +245,7 @@ impl<'a> Shrinker<'a> {
                 if let Some(rv) = retry_value {
                     let mut candidate = lowered.clone();
                     candidate[k] = candidate[k].with_value(rv);
-                    if self.consider(&candidate) && self.improvements > epoch_phase1 {
+                    if self.consider(&candidate)? && self.improvements > epoch_phase1 {
                         misalignment_handled = true;
                         break;
                     }
@@ -270,7 +272,7 @@ impl<'a> Shrinker<'a> {
                 }
                 let mut candidate: Vec<_> = actual_nodes[..span.start].to_vec();
                 candidate.extend_from_slice(&actual_nodes[span.end..]);
-                if self.consider(&candidate) && self.improvements > epoch_phase1 {
+                if self.consider(&candidate)? && self.improvements > epoch_phase1 {
                     shrank = true;
                     break;
                 }
@@ -281,13 +283,14 @@ impl<'a> Shrinker<'a> {
                 for j in i + 1..actual_nodes.len() {
                     let mut candidate: Vec<_> = actual_nodes[..j].to_vec();
                     candidate.extend_from_slice(&actual_nodes[j + 1..]);
-                    if self.consider(&candidate) && self.improvements > epoch_phase1 {
+                    if self.consider(&candidate)? && self.improvements > epoch_phase1 {
                         break;
                     }
                 }
             }
             i += 1;
         }
+        Ok(())
     }
 
     /// Adaptively delete `n` consecutive nodes at every position, with
@@ -306,16 +309,16 @@ impl<'a> Shrinker<'a> {
     /// each `n in 1..=5` — and gives O(log k) test-function calls when
     /// a long deletable region exists, vs. the linear O(k) of the legacy
     /// loop. `delete_chunks` is kept alongside as the native fallback.
-    pub(crate) fn node_program(&mut self, n: usize) {
+    pub(crate) fn node_program(&mut self, n: usize) -> ShrinkResult<()> {
         if n == 0 {
-            return;
+            return Ok(());
         }
         let mut i = 0;
         while i + n <= self.current_nodes.len() {
             // First try a single application at i against the current
             // snapshot.
             let snapshot = self.current_nodes.clone();
-            if !self.run_node_program(&snapshot, i, n, 1) {
+            if !self.run_node_program(&snapshot, i, n, 1)? {
                 i += 1;
                 continue;
             }
@@ -324,24 +327,25 @@ impl<'a> Shrinker<'a> {
             // sequence).
             let snapshot = self.current_nodes.clone();
             let starting = i.min(snapshot.len());
-            let left_offset = find_integer(|k| {
+            let left_offset = find_integer_r(|k| {
                 if k * n > starting {
-                    return false;
+                    return Ok(false);
                 }
                 let pos = starting - k * n;
                 self.run_node_program(&snapshot, pos, n, 1)
-            });
+            })?;
             let start = starting.saturating_sub(left_offset * n);
 
             // Adaptively grow the repeat count from `start`, again
             // against a fresh snapshot.
             let snapshot = self.current_nodes.clone();
-            find_integer(|k| self.run_node_program(&snapshot, start, n, k));
+            find_integer_r(|k| self.run_node_program(&snapshot, start, n, k))?;
 
             // Advance past the region we just consumed.  Moving forward
             // by `n` guarantees progress on the next outer iteration.
             i = start.saturating_add(n);
         }
+        Ok(())
     }
 
     /// Apply the "delete n consecutive nodes" program `repeats` times at
@@ -357,19 +361,19 @@ impl<'a> Shrinker<'a> {
         i: usize,
         program_len: usize,
         repeats: usize,
-    ) -> bool {
+    ) -> ShrinkResult<bool> {
         // `find_integer` starts probing at `n = 1`, so callers never
         // ask for zero-repeat applications.  A debug_assert documents
         // the precondition.
         debug_assert!(repeats > 0);
         let total_delete = program_len.saturating_mul(repeats);
         if i + total_delete > original.len() {
-            return false;
+            return Ok(false);
         }
         let mut attempt = original[..i].to_vec();
         attempt.extend_from_slice(&original[i + total_delete..]);
         let epoch = self.improvements;
-        self.consider(&attempt) && self.improvements > epoch
+        Ok(self.consider(&attempt)? && self.improvements > epoch)
     }
 }
 

--- a/src/native/shrinker/floats.rs
+++ b/src/native/shrinker/floats.rs
@@ -12,7 +12,7 @@ use crate::native::core::{
     ChoiceKind, ChoiceNode, ChoiceValue, FloatChoice, float_to_index, index_to_float, sort_key,
 };
 
-use super::{ShrinkRun, Shrinker, bin_search_down, find_integer};
+use super::{ShrinkResult, ShrinkRun, Shrinker, bin_search_down_r, find_integer_r};
 
 /// Largest `f64` for which `n + 1.0 != n` holds — i.e., `2^53`. Above
 /// this magnitude consecutive integers stop being individually
@@ -68,7 +68,7 @@ impl<'a> Shrinker<'a> {
     ///    zero while holding the fractional remainder r/n fixed. Catches
     ///    shrinks like 2.5 → 1.5 under predicates that constrain the
     ///    fractional part.
-    pub(super) fn shrink_floats(&mut self) {
+    pub(super) fn shrink_floats(&mut self) -> ShrinkResult<()> {
         let mut i = 0;
         while i < self.current_nodes.len() {
             let node = &self.current_nodes[i];
@@ -81,7 +81,7 @@ impl<'a> Shrinker<'a> {
                 // Try simplest.
                 let s = fc.simplest();
                 if ChoiceValue::Float(s) != ChoiceValue::Float(v) {
-                    self.replace(&HashMap::from([(i, ChoiceValue::Float(s))]));
+                    self.replace(&HashMap::from([(i, ChoiceValue::Float(s))]))?;
                 }
 
                 let v = self.float_at(i);
@@ -89,13 +89,13 @@ impl<'a> Shrinker<'a> {
                 // Special-value transitions out of ±inf.
                 if v.is_infinite() {
                     if v < 0.0 && fc.validate(f64::INFINITY) {
-                        self.replace(&HashMap::from([(i, ChoiceValue::Float(f64::INFINITY))]));
+                        self.replace(&HashMap::from([(i, ChoiceValue::Float(f64::INFINITY))]))?;
                     }
                     let v = self.float_at(i);
                     if v.is_infinite() {
                         let cand = if v > 0.0 { f64::MAX } else { -f64::MAX };
                         if fc.validate(cand) {
-                            self.replace(&HashMap::from([(i, ChoiceValue::Float(cand))]));
+                            self.replace(&HashMap::from([(i, ChoiceValue::Float(cand))]))?;
                         }
                     }
                 }
@@ -117,7 +117,7 @@ impl<'a> Shrinker<'a> {
                     let mut stepped = false;
                     for cand in [f64::MAX, f64::INFINITY] {
                         if fc.validate(cand)
-                            && self.replace(&HashMap::from([(i, ChoiceValue::Float(cand))]))
+                            && self.replace(&HashMap::from([(i, ChoiceValue::Float(cand))]))?
                         {
                             stepped = true;
                             break;
@@ -127,7 +127,7 @@ impl<'a> Shrinker<'a> {
                         let mut attempt: Vec<ChoiceNode> = self.current_nodes.clone();
                         attempt[i] = attempt[i].with_value(ChoiceValue::Float(f64::NAN));
                         let (is_interesting, actual_nodes, actual_spans) =
-                            (self.test_fn)(ShrinkRun::Full(&attempt));
+                            self.run_test_fn(ShrinkRun::Full(&attempt))?;
                         // Accept as a lateral move: all NaN bit patterns
                         // share sort_key so `<` alone would reject, but
                         // guard against a (hypothetical) test that
@@ -155,7 +155,7 @@ impl<'a> Shrinker<'a> {
                 if v.is_sign_negative() {
                     let neg = -v;
                     if fc.validate(neg) {
-                        self.replace(&HashMap::from([(i, ChoiceValue::Float(neg))]));
+                        self.replace(&HashMap::from([(i, ChoiceValue::Float(neg))]))?;
                     }
                 }
 
@@ -195,10 +195,10 @@ impl<'a> Shrinker<'a> {
                     let fc_capture = fc.clone();
                     // shift_right: find the largest k where base >> k
                     // still satisfies fc.validate and the predicate.
-                    find_integer(|k| {
+                    find_integer_r(|k| {
                         if k >= 127 {
                             // i128 shifts >= 127 produce 0 (or are UB).
-                            return false;
+                            return Ok(false);
                         }
                         let shifted = base >> k;
                         let candidate_mag = shifted as f64;
@@ -208,10 +208,10 @@ impl<'a> Shrinker<'a> {
                             candidate_mag
                         };
                         if !fc_capture.validate(candidate) {
-                            return false;
+                            return Ok(false);
                         }
                         self.replace(&HashMap::from([(i_capture, ChoiceValue::Float(candidate))]))
-                    });
+                    })?;
                     // shrink_by_multiples(2) and (1) — peel off the
                     // last few integer steps after the shift descent
                     // overshot.
@@ -234,10 +234,10 @@ impl<'a> Shrinker<'a> {
                         };
                         for step in [2i128, 1] {
                             let i_capture = i;
-                            find_integer(|n| {
+                            find_integer_r(|n| {
                                 let attempt = base_after - step * (n as i128);
                                 if attempt < lo {
-                                    return false;
+                                    return Ok(false);
                                 }
                                 let candidate_mag = attempt as f64;
                                 let candidate = if is_neg {
@@ -251,7 +251,7 @@ impl<'a> Shrinker<'a> {
                                     i_capture,
                                     ChoiceValue::Float(candidate),
                                 )]))
-                            });
+                            })?;
                         }
                     }
                 } else if v_abs.is_finite() && v_abs > 0.0 {
@@ -284,7 +284,7 @@ impl<'a> Shrinker<'a> {
                                 candidate_mag
                             };
                             if fc.validate(candidate) {
-                                self.replace(&HashMap::from([(i, ChoiceValue::Float(candidate))]));
+                                self.replace(&HashMap::from([(i, ChoiceValue::Float(candidate))]))?;
                             }
                         }
                     }
@@ -297,7 +297,7 @@ impl<'a> Shrinker<'a> {
                 let current_idx = float_to_index(v_abs);
                 let is_neg = v.is_sign_negative();
                 if current_idx > 0 {
-                    bin_search_down(0, current_idx as i128, &mut |idx| {
+                    bin_search_down_r(0, current_idx as i128, &mut |idx| {
                         let candidate_mag = index_to_float(idx as u64);
                         let candidate = if is_neg {
                             -candidate_mag
@@ -307,9 +307,9 @@ impl<'a> Shrinker<'a> {
                         if fc.validate(candidate) {
                             self.replace(&HashMap::from([(i, ChoiceValue::Float(candidate))]))
                         } else {
-                            false
+                            Ok(false)
                         }
-                    });
+                    })?;
                 }
 
                 // Step 5: Integer-ratio numeric reduction.
@@ -337,7 +337,7 @@ impl<'a> Shrinker<'a> {
                         let k_init = m / n;
                         let r = m % n;
                         if k_init > 0 {
-                            bin_search_down(0, k_init as i128, &mut |k| {
+                            bin_search_down_r(0, k_init as i128, &mut |k| {
                                 let num_sum = (k as u128) * n + r;
                                 let candidate_abs = (num_sum as f64) / (n as f64);
                                 let candidate = if is_neg {
@@ -346,18 +346,19 @@ impl<'a> Shrinker<'a> {
                                     candidate_abs
                                 };
                                 if !fc.validate(candidate) {
-                                    return false;
+                                    return Ok(false);
                                 }
                                 let epoch = self.improvements;
-                                self.replace(&HashMap::from([(i, ChoiceValue::Float(candidate))]));
-                                self.improvements > epoch
-                            });
+                                self.replace(&HashMap::from([(i, ChoiceValue::Float(candidate))]))?;
+                                Ok(self.improvements > epoch)
+                            })?;
                         }
                     }
                 }
             }
             i += 1;
         }
+        Ok(())
     }
 
     fn float_at(&self, i: usize) -> f64 {
@@ -381,7 +382,7 @@ impl<'a> Shrinker<'a> {
     /// [`Shrinker::redistribute_integers`] — this pass complements it by
     /// covering Float-Float, Float-Integer, and Integer-Float pairs that
     /// the integer-only pass skips.
-    pub(super) fn redistribute_numeric_pairs(&mut self) {
+    pub(super) fn redistribute_numeric_pairs(&mut self) -> ShrinkResult<()> {
         let len = self.current_nodes.len();
         for i in 0..len {
             for gap in 1..=4 {
@@ -418,9 +419,10 @@ impl<'a> Shrinker<'a> {
                 if is_trivial(&self.current_nodes[i]) {
                     continue;
                 }
-                redistribute_pair(self, i, j);
+                redistribute_pair(self, i, j)?;
             }
         }
+        Ok(())
     }
 }
 
@@ -469,7 +471,7 @@ fn bigint_as_f64(n: &BigInt) -> f64 {
 /// `v_i` is reduced toward its shrink target (0 for floats, simplest() for
 /// integers); the matching adjustment to `v_j` raises it. If `v_i` is
 /// already below its shrink target, both deltas flip sign.
-fn redistribute_pair(shrinker: &mut Shrinker<'_>, i: usize, j: usize) {
+fn redistribute_pair(shrinker: &mut Shrinker<'_>, i: usize, j: usize) -> ShrinkResult<()> {
     // Snapshot the original values; find_integer will probe larger and
     // larger `k` and the kept candidate updates current_nodes in place.
     // Caller has already filtered to Integer/Float pairs via
@@ -514,16 +516,17 @@ fn redistribute_pair(shrinker: &mut Shrinker<'_>, i: usize, j: usize) {
     // check in `consider`/`replace` rejects any candidate whose
     // `|cand_i|` grows beyond the prior accept, which always trips well
     // before `cand_j` reaches `2^53`.
-    find_integer(|k| {
+    find_integer_r(|k| {
         let (cand_i, cand_j) = apply_delta(&v_i, &v_j, k as i128, dir);
         let Some(val_i) = build_value(&kind_i, cand_i) else {
-            return false;
+            return Ok(false);
         };
         let Some(val_j) = build_value(&kind_j, cand_j) else {
-            return false;
+            return Ok(false);
         };
         shrinker.replace(&HashMap::from([(i, val_i), (j, val_j)]))
-    });
+    })?;
+    Ok(())
 }
 
 #[derive(Clone, Copy)]

--- a/src/native/shrinker/index_passes.rs
+++ b/src/native/shrinker/index_passes.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use crate::native::bignum::{BigInt, BigUint, Zero};
 use crate::native::core::{ChoiceKind, ChoiceValue};
 
-use super::Shrinker;
+use super::{ShrinkResult, Shrinker};
 
 fn is_sequence(kind: &std::sync::Arc<ChoiceKind>) -> bool {
     matches!(**kind, ChoiceKind::Bytes(_) | ChoiceKind::String(_))
@@ -21,7 +21,7 @@ impl<'a> Shrinker<'a> {
     /// Value punning (via `with_value` + `for_choices` with `prefix_nodes`)
     /// handles the case where decrementing changes the kind at position
     /// `j` (e.g. a `one_of` branch switch).
-    pub(super) fn lower_and_bump(&mut self) {
+    pub(super) fn lower_and_bump(&mut self) -> ShrinkResult<()> {
         let max_gap = std::cmp::min(self.current_nodes.len(), 4);
         for gap in 1..max_gap {
             let mut idx = 0;
@@ -76,14 +76,14 @@ impl<'a> Shrinker<'a> {
                     // to smaller interesting results).
                     let mut attempt = self.current_nodes.clone();
                     attempt[i] = attempt[i].with_value(new_val.clone());
-                    self.consider(&attempt);
+                    self.consider(&attempt)?;
 
                     let mut zeroed = attempt.clone();
                     for node in &mut zeroed[i + 1..] {
                         let s = node.kind.simplest();
                         *node = node.with_value(s);
                     }
-                    self.consider(&zeroed);
+                    self.consider(&zeroed)?;
 
                     // Try bumping node `j` at relative and absolute index
                     // offsets — replace-with-validate skips when the
@@ -97,7 +97,7 @@ impl<'a> Shrinker<'a> {
                         for bump in [1u32, 2, 4] {
                             let candidate_idx = &target_idx + BigUint::from(bump);
                             if let Some(bumped) = kind_j.from_index(candidate_idx) {
-                                if try_bump_ij(self, i, new_val, j, &bumped) {
+                                if try_bump_ij(self, i, new_val, j, &bumped)? {
                                     bumped_any_relative = true;
                                     break;
                                 }
@@ -112,10 +112,10 @@ impl<'a> Shrinker<'a> {
                                 }
                                 let p_minus_one = &p - BigUint::from(1u32);
                                 if let Some(v) = kind_j.from_index(p_minus_one) {
-                                    try_bump_ij(self, i, new_val, j, &v);
+                                    try_bump_ij(self, i, new_val, j, &v)?;
                                 }
                                 if let Some(v) = kind_j.from_index(p.clone()) {
-                                    try_bump_ij(self, i, new_val, j, &v);
+                                    try_bump_ij(self, i, new_val, j, &v)?;
                                 }
                                 p *= BigUint::from(2u32);
                             }
@@ -125,6 +125,7 @@ impl<'a> Shrinker<'a> {
                 idx += 1;
             }
         }
+        Ok(())
     }
 
     /// For each indexed node, try *incrementing* its index to see if the test
@@ -133,7 +134,7 @@ impl<'a> Shrinker<'a> {
     /// A value shrinker can only make values simpler; sometimes making a
     /// value *less* simple (e.g. `false → true`) causes an earlier exit,
     /// producing a shorter and thus overall simpler choice sequence.
-    pub(super) fn try_shortening_via_increment(&mut self) {
+    pub(super) fn try_shortening_via_increment(&mut self) -> ShrinkResult<()> {
         let mut i = 0;
         while i < self.current_nodes.len() {
             let node = self.current_nodes[i].clone();
@@ -195,10 +196,11 @@ impl<'a> Shrinker<'a> {
                     let s = node.kind.simplest();
                     *node = node.with_value(s);
                 }
-                self.consider(&zeroed);
+                self.consider(&zeroed)?;
             }
             i += 1;
         }
+        Ok(())
     }
 }
 
@@ -211,7 +213,7 @@ pub(super) fn try_bump_ij(
     new_val: &ChoiceValue,
     j: usize,
     bump_val: &ChoiceValue,
-) -> bool {
+) -> ShrinkResult<bool> {
     // `replace` checks `j < len` (via its `i >= attempt.len()`
     // short-circuit) and `kind.validate(bump_val)` itself, so the
     // pre-checks here would be redundant.  Let `replace` reject

--- a/src/native/shrinker/integers.rs
+++ b/src/native/shrinker/integers.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 use crate::native::bignum::{BigInt, Sign, Signed, ToPrimitive};
 use crate::native::core::{ChoiceKind, ChoiceValue};
 
-use super::{Shrinker, bin_search_down_big, find_integer};
+use super::{ShrinkResult, Shrinker, bin_search_down_big_r, find_integer_r};
 
 impl<'a> Shrinker<'a> {
     /// Current integer value at node `i` as a [`BigInt`].
@@ -42,7 +42,7 @@ impl<'a> Shrinker<'a> {
     /// [`Shrinker::replace`], which range-checks it and coerces it to the
     /// node's width (rejecting out-of-range candidates), so this stays correct
     /// for any node width.
-    pub(super) fn replace_int(&mut self, i: usize, candidate: &BigInt) -> bool {
+    pub(super) fn replace_int(&mut self, i: usize, candidate: &BigInt) -> ShrinkResult<bool> {
         self.replace(&HashMap::from([(
             i,
             ChoiceValue::Integer(candidate.clone()),
@@ -51,7 +51,13 @@ impl<'a> Shrinker<'a> {
 
     /// Attempt to replace two integer nodes simultaneously; `replace`
     /// range-checks and width-coerces each candidate.
-    pub(super) fn replace_two(&mut self, i: usize, vi: &BigInt, j: usize, vj: &BigInt) -> bool {
+    pub(super) fn replace_two(
+        &mut self,
+        i: usize,
+        vi: &BigInt,
+        j: usize,
+        vj: &BigInt,
+    ) -> ShrinkResult<bool> {
         self.replace(&HashMap::from([
             (i, ChoiceValue::Integer(vi.clone())),
             (j, ChoiceValue::Integer(vj.clone())),
@@ -59,7 +65,7 @@ impl<'a> Shrinker<'a> {
     }
 
     /// Replace blocks of choices with their simplest values.
-    pub(super) fn zero_choices(&mut self) {
+    pub(super) fn zero_choices(&mut self) -> ShrinkResult<()> {
         let mut k = self.current_nodes.len();
         while k > 0 {
             let mut i = 0;
@@ -71,16 +77,17 @@ impl<'a> Shrinker<'a> {
                     let replacements: HashMap<usize, ChoiceValue> = (i..i + k)
                         .map(|j| (j, self.current_nodes[j].kind.simplest()))
                         .collect();
-                    self.replace(&replacements);
+                    self.replace(&replacements)?;
                     i += k;
                 }
             }
             k /= 2;
         }
+        Ok(())
     }
 
     /// For integer choices: try simplest, then flip negative to positive.
-    pub(super) fn swap_integer_sign(&mut self) {
+    pub(super) fn swap_integer_sign(&mut self) -> ShrinkResult<()> {
         let mut i = 0;
         while i < self.current_nodes.len() {
             if let (ChoiceKind::Integer(ic), ChoiceValue::Integer(v)) = (
@@ -90,20 +97,21 @@ impl<'a> Shrinker<'a> {
                 let v = v.clone();
                 let simplest = ic.simplest();
                 if v != ic.simplest() {
-                    self.replace(&HashMap::from([(i, ChoiceValue::Integer(simplest))]));
+                    self.replace(&HashMap::from([(i, ChoiceValue::Integer(simplest))]))?;
                 }
                 // Re-read in case the replace changed things.
                 if i < self.current_nodes.len() {
                     if let ChoiceValue::Integer(v) = &self.current_nodes[i].value {
                         let v = v.clone();
                         if v.sign() == Sign::Minus {
-                            self.replace_int(i, &(-&v));
+                            self.replace_int(i, &(-&v))?;
                         }
                     }
                 }
             }
             i += 1;
         }
+        Ok(())
     }
 
     /// Binary search integer values toward zero.
@@ -111,7 +119,7 @@ impl<'a> Shrinker<'a> {
     /// Includes a linear scan of small values after binary search to
     /// handle non-monotonic functions (e.g. sampled_from or test functions
     /// that panic on boundary values).
-    pub(super) fn binary_search_integer_towards_zero(&mut self) {
+    pub(super) fn binary_search_integer_towards_zero(&mut self) -> ShrinkResult<()> {
         let mut i = 0;
         while i < self.current_nodes.len() {
             let ic = match self.current_nodes[i].kind.as_ref() {
@@ -132,10 +140,10 @@ impl<'a> Shrinker<'a> {
                 let dist = &v - &lo;
                 if dist.sign() == Sign::Plus {
                     let max_shift = dist.bits() as usize + 1;
-                    find_integer(|k| {
+                    find_integer_r(|k| {
                         let candidate = &lo + (&dist >> k.min(max_shift));
                         self.replace_int(i, &candidate)
-                    });
+                    })?;
                 }
                 // Linear scan small values for non-monotonic functions.
                 let scan_count: i64 = if range_size <= BigInt::from(128) {
@@ -147,7 +155,7 @@ impl<'a> Shrinker<'a> {
                 let scan_hi = (&lo + BigInt::from(scan_count)).min(cur_v);
                 let mut c = lo.clone();
                 while c < scan_hi {
-                    self.replace_int(i, &c);
+                    self.replace_int(i, &c)?;
                     c += 1;
                 }
                 // shrink_by_multiples(2) / (1): with a non-monotonic predicate
@@ -157,17 +165,17 @@ impl<'a> Shrinker<'a> {
                 // to `(m, m-1)` at the cost of one extra probe.
                 let base = self.int_value_bigint(i);
                 if base > lo {
-                    find_integer(|n| {
+                    find_integer_r(|n| {
                         let attempt = &base - BigInt::from(2u64 * n as u64);
                         if attempt < lo {
-                            return false;
+                            return Ok(false);
                         }
                         self.replace_int(i, &attempt)
-                    });
+                    })?;
                 }
                 let base = self.int_value_bigint(i);
                 if base > lo {
-                    find_integer(|n| {
+                    find_integer_r(|n| {
                         let attempt = &base - BigInt::from(n as u64);
                         if attempt < lo {
                             // Unreachable: a step-1 probe reaches `attempt < lo`
@@ -179,7 +187,7 @@ impl<'a> Shrinker<'a> {
                             unreachable!("step-1 descent cannot cross below `lo`");
                         }
                         self.replace_int(i, &attempt)
-                    });
+                    })?;
                 }
                 // Also try negative values with smaller absolute value (simpler).
                 if ic.min_value.clone().sign() == Sign::Minus {
@@ -189,15 +197,15 @@ impl<'a> Shrinker<'a> {
                         if upper >= BigInt::from(1) {
                             // Seed at -upper, then shift-right-descend the
                             // absolute value toward 1 via find_integer.
-                            self.replace_int(i, &(-&upper));
+                            self.replace_int(i, &(-&upper))?;
                             let dist = &upper - BigInt::from(1);
                             if dist.sign() == Sign::Plus {
                                 let max_shift = dist.bits() as usize + 1;
-                                find_integer(|k| {
+                                find_integer_r(|k| {
                                     let candidate_abs =
                                         BigInt::from(1) + (&dist >> k.min(max_shift));
                                     self.replace_int(i, &(-&candidate_abs))
-                                });
+                                })?;
                             }
                         }
                     }
@@ -210,10 +218,10 @@ impl<'a> Shrinker<'a> {
                 let dist = ((-&v) - &lo).max(BigInt::from(0));
                 if dist.sign() == Sign::Plus {
                     let max_shift = dist.bits() as usize + 1;
-                    find_integer(|k| {
+                    find_integer_r(|k| {
                         let candidate_abs = &lo + (&dist >> k.min(max_shift));
                         self.replace_int(i, &(-&candidate_abs))
-                    });
+                    })?;
                 }
                 // Linear scan small negative values for non-monotonic functions.
                 let neg_scan: i64 = if range_size <= BigInt::from(128) {
@@ -223,7 +231,7 @@ impl<'a> Shrinker<'a> {
                 };
                 let mut c: i64 = 1;
                 while c < neg_scan {
-                    self.replace_int(i, &BigInt::from(-c));
+                    self.replace_int(i, &BigInt::from(-c))?;
                     c += 1;
                 }
                 // shrink_by_multiples for the negative branch: probe
@@ -231,17 +239,17 @@ impl<'a> Shrinker<'a> {
                 let base = self.int_value_bigint(i);
                 let neg_hi = -&lo;
                 if base < neg_hi {
-                    find_integer(|n| {
+                    find_integer_r(|n| {
                         let attempt = &base + BigInt::from(2u64 * n as u64);
                         if attempt > neg_hi {
-                            return false;
+                            return Ok(false);
                         }
                         self.replace_int(i, &attempt)
-                    });
+                    })?;
                 }
                 let base = self.int_value_bigint(i);
                 if base < neg_hi {
-                    find_integer(|n| {
+                    find_integer_r(|n| {
                         let attempt = &base + BigInt::from(n as u64);
                         if attempt > neg_hi {
                             // Unreachable for the same reason as the positive
@@ -251,7 +259,7 @@ impl<'a> Shrinker<'a> {
                             unreachable!("step-1 descent cannot cross past `neg_hi`");
                         }
                         self.replace_int(i, &attempt)
-                    });
+                    })?;
                 }
                 // Also try positive values with smaller absolute value (simpler).
                 if ic.max_value.clone().sign() == Sign::Plus {
@@ -261,15 +269,15 @@ impl<'a> Shrinker<'a> {
                         if upper >= BigInt::from(1) {
                             // Seed at +upper, then shift-right-descend toward
                             // lo_pos via find_integer.
-                            self.replace_int(i, &upper);
+                            self.replace_int(i, &upper)?;
                             let lo_pos = ic.simplest().max(BigInt::from(0));
                             let dist = &upper - &lo_pos;
                             if dist.sign() == Sign::Plus {
                                 let max_shift = dist.bits() as usize + 1;
-                                find_integer(|k| {
+                                find_integer_r(|k| {
                                     let candidate = &lo_pos + (&dist >> k.min(max_shift));
                                     self.replace_int(i, &candidate)
-                                });
+                                })?;
                             }
                             // Linear scan positive values.
                             let scan_count: i64 = if range_size <= BigInt::from(128) {
@@ -281,7 +289,7 @@ impl<'a> Shrinker<'a> {
                                 (&lo_pos + BigInt::from(scan_count)).min(&upper + BigInt::from(1));
                             let mut c = lo_pos.clone();
                             while c < scan_hi {
-                                self.replace_int(i, &c);
+                                self.replace_int(i, &c)?;
                                 c += 1;
                             }
                         }
@@ -290,6 +298,7 @@ impl<'a> Shrinker<'a> {
             }
             i += 1;
         }
+        Ok(())
     }
 
     /// Try redistributing value between pairs of integer choices.
@@ -298,7 +307,7 @@ impl<'a> Shrinker<'a> {
     /// value from i to j (or vice versa) while keeping the total sum
     /// constant. Useful for sum-type constraints where the minimal
     /// counterexample has one small and one large value.
-    pub(super) fn redistribute_integers(&mut self) {
+    pub(super) fn redistribute_integers(&mut self) -> ShrinkResult<()> {
         let int_indices: Vec<usize> = self
             .current_nodes
             .iter()
@@ -356,17 +365,17 @@ impl<'a> Shrinker<'a> {
 
                 if prev_i != simplest_i {
                     if prev_i.sign() == Sign::Plus {
-                        bin_search_down_big(BigInt::from(0), prev_i.clone(), &mut |v| {
+                        bin_search_down_big_r(BigInt::from(0), prev_i.clone(), &mut |v| {
                             let new_j = &prev_j + (&prev_i - v);
                             self.replace_two(i, v, j, &new_j)
-                        });
+                        })?;
                     } else if prev_i.sign() == Sign::Minus {
-                        bin_search_down_big(BigInt::from(0), -&prev_i, &mut |a| {
+                        bin_search_down_big_r(BigInt::from(0), -&prev_i, &mut |a| {
                             // delta = prev_i + a = -(|prev_i| - a)
                             let new_i = -a;
                             let new_j = &prev_j + (&prev_i + a);
                             self.replace_two(i, &new_i, j, &new_j)
-                        });
+                        })?;
                     }
                 }
 
@@ -376,6 +385,7 @@ impl<'a> Shrinker<'a> {
                 pair_idx -= 1;
             }
         }
+        Ok(())
     }
 
     /// Lower pairs of nearby integer choices by the same amount
@@ -386,7 +396,7 @@ impl<'a> Shrinker<'a> {
     /// shrinker falls into a zig-zag trap. By probing `(v_i - k, v_j - k)` for
     /// geometrically growing `k` via `find_integer`, this pass reaches the
     /// minimum in `O(log k)` probes.
-    pub(super) fn lower_integers_together(&mut self) {
+    pub(super) fn lower_integers_together(&mut self) -> ShrinkResult<()> {
         let int_indices: Vec<usize> = self
             .current_nodes
             .iter()
@@ -440,33 +450,34 @@ impl<'a> Shrinker<'a> {
                 // `v_i - st_i` (the i-th's distance to st).
                 if v_i > st_i {
                     let max_k = &v_i - &st_i;
-                    find_integer(|n| {
+                    find_integer_r(|n| {
                         let k = BigInt::from(n as u64);
                         if k > max_k {
-                            return false;
+                            return Ok(false);
                         }
                         let new_i = &v_i - &k;
                         let new_j = &v_j - &k;
                         self.replace_two(i, &new_i, j, &new_j)
-                    });
+                    })?;
                 }
 
                 // Raise direction: run when v_i < st_i. Largest useful k:
                 // `st_i - v_i`.
                 if v_i < st_i {
                     let max_k = &st_i - &v_i;
-                    find_integer(|n| {
+                    find_integer_r(|n| {
                         let k = BigInt::from(n as u64);
                         if k > max_k {
-                            return false;
+                            return Ok(false);
                         }
                         let new_i = &v_i + &k;
                         let new_j = &v_j + &k;
                         self.replace_two(i, &new_i, j, &new_j)
-                    });
+                    })?;
                 }
             }
         }
+        Ok(())
     }
 
     /// Try shrinking duplicate integer values simultaneously.
@@ -479,7 +490,7 @@ impl<'a> Shrinker<'a> {
     /// All five choice kinds participate: every group tries the
     /// kind-simplest replacement, and integer groups additionally drive
     /// a binary search across all members at once.
-    pub(super) fn shrink_duplicates(&mut self) {
+    pub(super) fn shrink_duplicates(&mut self) -> ShrinkResult<()> {
         // Group nodes by (kind discriminant, value).  The discriminant
         // gate keeps an Integer and a Bytes that happen to coexist with
         // the same numeric payload apart.
@@ -528,7 +539,7 @@ impl<'a> Shrinker<'a> {
             if simplest != *group_value {
                 let replacements: HashMap<usize, ChoiceValue> =
                     valid.iter().map(|&i| (i, simplest.clone())).collect();
-                self.replace(&replacements);
+                self.replace(&replacements)?;
             }
         }
         // The remainder of this function is the legacy integer-only
@@ -580,7 +591,7 @@ impl<'a> Shrinker<'a> {
                     .iter()
                     .map(|&i| (i, ChoiceValue::Integer(simplest.clone())))
                     .collect();
-                self.replace(&replacements);
+                self.replace(&replacements)?;
             }
 
             // Re-read current value after possible replacement.
@@ -591,14 +602,14 @@ impl<'a> Shrinker<'a> {
             // boundary. Each probe re-reads the current value of `valid[0]`
             // so the descent starts from the live shrink target.
             let valid_capture = valid.clone();
-            let group_replace = |sh: &mut Shrinker<'_>, candidate: &BigInt| -> bool {
+            let group_replace = |sh: &mut Shrinker<'_>, candidate: &BigInt| -> ShrinkResult<bool> {
                 let current_valid: Vec<usize> = valid_capture
                     .iter()
                     .copied()
                     .filter(|&i| i < sh.current_nodes.len())
                     .collect();
                 if current_valid.len() < 2 {
-                    return false;
+                    return Ok(false);
                 }
                 let replacements: HashMap<usize, ChoiceValue> = current_valid
                     .iter()
@@ -617,48 +628,49 @@ impl<'a> Shrinker<'a> {
                 let dist = &cur_value - &lo;
                 if dist.sign() == Sign::Plus {
                     let max_shift = dist.bits() as usize + 1;
-                    find_integer(|k| {
+                    find_integer_r(|k| {
                         let candidate = &lo + (&dist >> k.min(max_shift));
                         group_replace(self, &candidate)
-                    });
+                    })?;
                 }
                 if live_base(self) > lo {
-                    find_integer(|n| {
+                    find_integer_r(|n| {
                         let attempt = live_base(self) - BigInt::from(2u64 * n as u64);
                         group_replace(self, &attempt)
-                    });
+                    })?;
                 }
                 if live_base(self) > lo {
-                    find_integer(|n| {
+                    find_integer_r(|n| {
                         let attempt = live_base(self) - BigInt::from(n as u64);
                         group_replace(self, &attempt)
-                    });
+                    })?;
                 }
             } else if cur_value.sign() == Sign::Minus {
                 let lo = (-ic.simplest()).max(BigInt::from(0));
                 let dist = ((-&cur_value) - &lo).max(BigInt::from(0));
                 if dist.sign() == Sign::Plus {
                     let max_shift = dist.bits() as usize + 1;
-                    find_integer(|k| {
+                    find_integer_r(|k| {
                         let candidate_abs = &lo + (&dist >> k.min(max_shift));
                         group_replace(self, &(-&candidate_abs))
-                    });
+                    })?;
                 }
                 let neg_hi = -&lo;
                 if live_base(self) < neg_hi {
-                    find_integer(|n| {
+                    find_integer_r(|n| {
                         let attempt = live_base(self) + BigInt::from(2u64 * n as u64);
                         group_replace(self, &attempt)
-                    });
+                    })?;
                 }
                 if live_base(self) < neg_hi {
-                    find_integer(|n| {
+                    find_integer_r(|n| {
                         let attempt = live_base(self) + BigInt::from(n as u64);
                         group_replace(self, &attempt)
-                    });
+                    })?;
                 }
             }
         }
+        Ok(())
     }
 
     /// Break the zig-zag trap by lowering a common offset across every
@@ -673,13 +685,13 @@ impl<'a> Shrinker<'a> {
     ///
     /// Always called after a successful pass that may have changed
     /// integer values; clears the change-tracking set on exit.
-    pub(crate) fn lower_common_node_offset(&mut self) {
+    pub(crate) fn lower_common_node_offset(&mut self) -> ShrinkResult<()> {
         let mut changed: Vec<usize> = self.changed_nodes().iter().copied().collect();
         // `changed_nodes` is a `HashSet`; sort for a deterministic, run-to-run
         // stable iteration order.
         changed.sort_unstable();
         if changed.len() <= 1 {
-            return;
+            return Ok(());
         }
         let mut indices: Vec<usize> = Vec::new();
         let mut ic_targets: Vec<BigInt> = Vec::new();
@@ -706,7 +718,7 @@ impl<'a> Shrinker<'a> {
             ic_targets.push(target);
         }
         if indices.len() <= 1 {
-            return;
+            return Ok(());
         }
         let offset = distances
             .iter()
@@ -741,10 +753,10 @@ impl<'a> Shrinker<'a> {
 
         // Try lowering by an additional `n` units in both directions.
         for sign_multiplier in [1i128, -1] {
-            find_integer(|n| {
+            find_integer_r(|n| {
                 let n_big = BigInt::from(n as u64);
                 if n_big > offset {
-                    return false;
+                    return Ok(false);
                 }
                 let new_offset = &offset - &n_big;
                 let mut replacements: HashMap<usize, ChoiceValue> = HashMap::new();
@@ -759,9 +771,10 @@ impl<'a> Shrinker<'a> {
                     replacements.insert(indices[k], ChoiceValue::Integer(new_value));
                 }
                 self.replace(&replacements)
-            });
+            })?;
         }
         self.clear_change_tracking();
+        Ok(())
     }
 }
 

--- a/src/native/shrinker/mod.rs
+++ b/src/native/shrinker/mod.rs
@@ -26,6 +26,7 @@ mod strings;
 pub use scheduling::ShrinkPass;
 
 use std::collections::{HashMap, HashSet};
+use std::time::Instant;
 
 use crate::native::bignum::BigInt;
 use crate::native::core::{
@@ -129,6 +130,16 @@ pub struct Shrinker<'a> {
     /// end-of-shrink "Shrink pass profiling" report. Wired by the test
     /// runner at `Verbosity::Debug`; unused otherwise.
     pub(super) debug: Option<Box<DebugFn<'a>>>,
+    /// Wall-clock deadline after which `consider` / `probe` short-circuit and
+    /// the pass scheduler bails, leaving `current_nodes` at the best example
+    /// found so far. `None` (the default) disables the bound; the runner sets
+    /// it to `now + MAX_SHRINKING_SECONDS` before driving a shrink. Mirrors
+    /// Hypothesis's `finish_shrinking_deadline` (engine.py). Tests set a past
+    /// instant to exercise the timeout path without waiting.
+    pub deadline: Option<Instant>,
+    /// Latched once `deadline` is first observed to have passed. The runner
+    /// reads it after `shrink()` to emit the slow-shrink warning.
+    pub timed_out: bool,
 }
 
 /// One-byte tag identifying a `ChoiceKind` variant — used by
@@ -169,7 +180,25 @@ impl<'a> Shrinker<'a> {
             all_changed_nodes: HashSet::new(),
             consider_cache: HashSet::new(),
             debug: None,
+            deadline: None,
+            timed_out: false,
         }
+    }
+
+    /// Returns `true` once the wall-clock [`Shrinker::deadline`] has passed,
+    /// latching [`Shrinker::timed_out`]. A cheap no-op when no deadline is set
+    /// (the common case in unit tests that drive passes directly).
+    pub(super) fn past_deadline(&mut self) -> bool {
+        if self.timed_out {
+            return true;
+        }
+        if let Some(deadline) = self.deadline
+            && Instant::now() >= deadline
+        {
+            self.timed_out = true;
+            return true;
+        }
+        false
     }
 
     /// Install a debug callback.  Each emitted message corresponds to
@@ -214,6 +243,11 @@ impl<'a> Shrinker<'a> {
             }
         }
         if self.improvements >= self.max_improvements {
+            return false;
+        }
+        // Wall-clock guard: once the shrink deadline has passed, stop
+        // considering new candidates and keep the best example so far.
+        if self.past_deadline() {
             return false;
         }
         // Only enforce the stall guard once we've found at least one
@@ -264,6 +298,9 @@ impl<'a> Shrinker<'a> {
     /// `current_nodes`, update `current_nodes`.
     pub(super) fn probe(&mut self, prefix: &[ChoiceValue], seed: u64, max_size: usize) {
         if self.improvements >= self.max_improvements {
+            return;
+        }
+        if self.past_deadline() {
             return;
         }
         if self.calls.saturating_sub(self.calls_at_last_shrink) >= self.max_stall {

--- a/src/native/shrinker/mod.rs
+++ b/src/native/shrinker/mod.rs
@@ -60,6 +60,20 @@ pub type TestFn<'a> = dyn FnMut(ShrinkRun) -> (bool, Vec<ChoiceNode>, Spans) + '
 /// end-of-shrink profiling report).  Wired only at `Verbosity::Debug`.
 pub type DebugFn<'a> = dyn FnMut(&str) + 'a;
 
+/// Sentinel signalling that the wall-clock shrink deadline has passed.
+///
+/// Every shrinker execution method ([`Shrinker::run_test_fn`] and the
+/// `consider` / `probe` / `replace` built on it) returns this — instead of
+/// running the test function — once the deadline is exceeded, and passes
+/// propagate it with `?`. Shrinking therefore unwinds promptly, even
+/// mid-pass, keeping the best example found so far. This is the Rust analogue
+/// of Hypothesis's `RunIsComplete` unwind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ShrinkStop;
+
+/// Result of a shrinker operation that the deadline may cut short.
+pub(crate) type ShrinkResult<T = ()> = Result<T, ShrinkStop>;
+
 pub struct Shrinker<'a> {
     test_fn: Box<TestFn<'a>>,
     pub current_nodes: Vec<ChoiceNode>,
@@ -223,9 +237,9 @@ impl<'a> Shrinker<'a> {
     /// exits early (actual is shorter than candidate) or when value
     /// punning replaces values that no longer fit the kind at that
     /// position after a one_of branch switch.
-    pub fn consider(&mut self, nodes: &[ChoiceNode]) -> bool {
+    pub fn consider(&mut self, nodes: &[ChoiceNode]) -> ShrinkResult<bool> {
         if sort_key(nodes) == sort_key(&self.current_nodes) {
-            return true;
+            return Ok(true);
         }
         // Forced-node guard: a candidate may not differ from the
         // current shrink target at any index marked `was_forced`.
@@ -239,16 +253,11 @@ impl<'a> Shrinker<'a> {
             .take(nodes.len().min(self.current_nodes.len()))
         {
             if self.current_nodes[i].was_forced && candidate.value != self.current_nodes[i].value {
-                return false;
+                return Ok(false);
             }
         }
         if self.improvements >= self.max_improvements {
-            return false;
-        }
-        // Wall-clock guard: once the shrink deadline has passed, stop
-        // considering new candidates and keep the best example so far.
-        if self.past_deadline() {
-            return false;
+            return Ok(false);
         }
         // Only enforce the stall guard once we've found at least one
         // improvement.  Without warmup, predicates that need many calls
@@ -258,7 +267,7 @@ impl<'a> Shrinker<'a> {
         if self.improvements > 0
             && self.calls.saturating_sub(self.calls_at_last_shrink) >= self.max_stall
         {
-            return false;
+            return Ok(false);
         }
         // Negative-result cache: if we already asked the closure about a
         // candidate with this sort_key and it was uninteresting,
@@ -274,47 +283,68 @@ impl<'a> Shrinker<'a> {
             .map(|node| (kind_tag(&node.kind), node.sort_key()))
             .collect();
         if self.consider_cache.contains(&cache_key) {
-            return false;
+            return Ok(false);
         }
 
+        // The wall-clock guard lives in `run_test_fn`: it errors out before
+        // touching the test function once the deadline has passed.
+        let (is_interesting, actual_nodes, actual_spans) =
+            self.run_test_fn(ShrinkRun::Full(nodes))?;
         self.calls += 1;
-        let (is_interesting, actual_nodes, actual_spans) = (self.test_fn)(ShrinkRun::Full(nodes));
-        // Bounded cache with FIFO eviction: drop the oldest entry once
-        // we exceed 4096.  Insertion-order is recorded explicitly in
-        // `consider_cache_order` — `HashSet::iter` makes no order
-        // guarantee, so the previous version was effectively random.
         if !is_interesting {
             self.consider_cache.insert(cache_key);
         }
         if is_interesting && sort_key(&actual_nodes) < sort_key(&self.current_nodes) {
             self.accept_improvement(actual_nodes, actual_spans);
         }
-        is_interesting
+        Ok(is_interesting)
+    }
+
+    /// Run the test function for `run`, or return [`ShrinkStop`] immediately —
+    /// without touching the test function — once the wall-clock deadline has
+    /// passed (latching `timed_out`).
+    ///
+    /// This is the single execution choke point: `consider`, `probe`,
+    /// `replace`, and the inspection re-runs in individual passes all funnel
+    /// through it, so a passed deadline stops every further test-body run and
+    /// the `?` operator unwinds the current pass.
+    pub(super) fn run_test_fn(
+        &mut self,
+        run: ShrinkRun,
+    ) -> ShrinkResult<(bool, Vec<ChoiceNode>, Spans)> {
+        if self.past_deadline() {
+            return Err(ShrinkStop);
+        }
+        Ok((self.test_fn)(run))
     }
 
     /// Run a probe: replay `prefix` then continue with random draws from a
     /// deterministic RNG seeded by `seed`, capped at `max_size` choices. If
     /// the resulting run is interesting and shortlex-smaller than
     /// `current_nodes`, update `current_nodes`.
-    pub(super) fn probe(&mut self, prefix: &[ChoiceValue], seed: u64, max_size: usize) {
+    pub(super) fn probe(
+        &mut self,
+        prefix: &[ChoiceValue],
+        seed: u64,
+        max_size: usize,
+    ) -> ShrinkResult<()> {
         if self.improvements >= self.max_improvements {
-            return;
-        }
-        if self.past_deadline() {
-            return;
+            return Ok(());
         }
         if self.calls.saturating_sub(self.calls_at_last_shrink) >= self.max_stall {
-            return;
+            return Ok(());
         }
-        self.calls += 1;
-        let (is_interesting, actual_nodes, actual_spans) = (self.test_fn)(ShrinkRun::Probe {
+        // The wall-clock guard lives in `run_test_fn`.
+        let (is_interesting, actual_nodes, actual_spans) = self.run_test_fn(ShrinkRun::Probe {
             prefix,
             seed,
             max_size,
-        });
+        })?;
+        self.calls += 1;
         if is_interesting && sort_key(&actual_nodes) < sort_key(&self.current_nodes) {
             self.accept_improvement(actual_nodes, actual_spans);
         }
+        Ok(())
     }
 
     /// Common bookkeeping when a candidate becomes the new shrink target:
@@ -392,18 +422,18 @@ impl<'a> Shrinker<'a> {
     /// as a failed replacement (rather than panicking later in `sort_key`)
     /// matches the semantic invariant: a value that doesn't fit the node's
     /// schema can't be assigned to it.
-    pub fn replace(&mut self, values: &HashMap<usize, ChoiceValue>) -> bool {
+    pub fn replace(&mut self, values: &HashMap<usize, ChoiceValue>) -> ShrinkResult<bool> {
         let mut attempt: Vec<ChoiceNode> = self.current_nodes.clone();
         for (&i, v) in values {
             if i >= attempt.len() {
-                return false;
+                return Ok(false);
             }
             if attempt[i].was_forced {
                 // Forced choices stay put.
-                return false;
+                return Ok(false);
             }
             if !attempt[i].kind.validate(v) {
-                return false;
+                return Ok(false);
             }
             // Integer values must be expressed in the target node's width — a
             // pass may move a value between integer nodes of different widths
@@ -496,9 +526,7 @@ impl<'a> Shrinker<'a> {
             // can't see, run ahead of them.
             ShrinkPass::new(
                 "remove_discarded",
-                Box::new(|sh| {
-                    sh.remove_discarded();
-                }),
+                Box::new(|sh| sh.remove_discarded().map(|_| ())),
             ),
             ShrinkPass::new("try_trivial_spans", Box::new(|sh| sh.try_trivial_spans())),
             ShrinkPass::new("pass_to_descendant", Box::new(|sh| sh.pass_to_descendant())),
@@ -572,7 +600,10 @@ impl<'a> Shrinker<'a> {
         ];
         let initial_size = self.current_nodes.len();
         let initial_calls = self.calls;
-        self.fixate_shrink_passes(&mut passes);
+        // A `ShrinkStop` just means the wall-clock budget ran out; the best
+        // example so far is already in `current_nodes` and `timed_out` is
+        // latched, so there is nothing more to do here.
+        let _ = self.fixate_shrink_passes(&mut passes);
         self.emit_profile_report(&passes, initial_size, initial_calls);
     }
 }
@@ -581,9 +612,18 @@ impl<'a> Shrinker<'a> {
 ///
 /// Assumes f(hi) is true (not checked). Returns lo if f(lo) is true,
 /// otherwise finds a locally minimal true value.
-pub(super) fn bin_search_down(lo: i128, hi: i128, f: &mut impl FnMut(i128) -> bool) -> i128 {
-    if f(lo) {
-        return lo;
+///
+/// The probe returns `Result<bool, E>` so a shrink pass can abort the search
+/// by returning `Err` (a [`ShrinkStop`]); the error is propagated with `?` on
+/// the same line as the probe, so no extra branch is introduced. The plain
+/// `bool` [`bin_search_down`] below is the infallible form used by targeting.
+pub(super) fn bin_search_down_r<E>(
+    lo: i128,
+    hi: i128,
+    f: &mut impl FnMut(i128) -> Result<bool, E>,
+) -> Result<i128, E> {
+    if f(lo)? {
+        return Ok(lo);
     }
     let mut lo = lo;
     let mut hi = hi;
@@ -594,38 +634,38 @@ pub(super) fn bin_search_down(lo: i128, hi: i128, f: &mut impl FnMut(i128) -> bo
     // `i128::MAX`), so bail with `hi`.
     while lo.checked_add(1).is_some_and(|n| n < hi) {
         let mid = lo + (hi - lo) / 2;
-        if f(mid) {
+        if f(mid)? {
             hi = mid;
         } else {
             lo = mid;
         }
     }
-    hi
+    Ok(hi)
 }
 
 /// [`BigInt`] counterpart of [`bin_search_down`], used by the integer shrink
 /// passes which now carry values as arbitrary-precision integers. Same
 /// contract: assumes `f(hi)` is true, returns the smallest locally-true value
 /// in `[lo, hi]`.
-pub(super) fn bin_search_down_big(
+pub(super) fn bin_search_down_big_r<E>(
     lo: BigInt,
     hi: BigInt,
-    f: &mut impl FnMut(&BigInt) -> bool,
-) -> BigInt {
-    if f(&lo) {
-        return lo;
+    f: &mut impl FnMut(&BigInt) -> Result<bool, E>,
+) -> Result<BigInt, E> {
+    if f(&lo)? {
+        return Ok(lo);
     }
     let mut lo = lo;
     let mut hi = hi;
     while &lo + 1 < hi {
         let mid = &lo + (&hi - &lo) / 2;
-        if f(&mid) {
+        if f(&mid)? {
             hi = mid;
         } else {
             lo = mid;
         }
     }
-    hi
+    Ok(hi)
 }
 
 /// Finds a (hopefully large) integer `n >= 0` such that `f(n)` is true and
@@ -639,30 +679,38 @@ pub(super) fn bin_search_down_big(
 /// the binary-search midpoint: a predicate that accepts an unbounded range
 /// (e.g. a `lower_integers_together` pass over full-range `i128` nodes)
 /// would otherwise walk `hi` off the end of `usize`.
-pub(crate) fn find_integer(mut f: impl FnMut(usize) -> bool) -> usize {
+pub(crate) fn find_integer_r<E>(mut f: impl FnMut(usize) -> Result<bool, E>) -> Result<usize, E> {
     for i in 1..5 {
-        if !f(i) {
-            return i - 1;
+        if !f(i)? {
+            return Ok(i - 1);
         }
     }
     let mut lo = 4;
     let mut hi = 5;
-    while f(hi) {
+    while f(hi)? {
         lo = hi;
         let Some(next) = hi.checked_mul(2) else {
-            return lo;
+            return Ok(lo);
         };
         hi = next;
     }
     while lo + 1 < hi {
         let mid = lo + (hi - lo) / 2;
-        if f(mid) {
+        if f(mid)? {
             lo = mid;
         } else {
             hi = mid;
         }
     }
-    lo
+    Ok(lo)
+}
+
+/// Infallible `bool` form of [`find_integer_r`], used by the targeting
+/// hill-climber.
+pub(crate) fn find_integer(mut f: impl FnMut(usize) -> bool) -> usize {
+    match find_integer_r(|x| Ok::<bool, std::convert::Infallible>(f(x))) {
+        Ok(v) => v,
+    }
 }
 
 #[cfg(test)]

--- a/src/native/shrinker/mod.rs
+++ b/src/native/shrinker/mod.rs
@@ -89,9 +89,9 @@ pub struct Shrinker<'a> {
     /// secondary key.
     pub downgraded: Vec<Vec<ChoiceValue>>,
     /// Cap on `improvements`. Once `improvements >= max_improvements`,
-    /// `consider` and `probe` short-circuit so the runner doesn't get
-    /// stuck chasing diminishing returns. Defaults to [`MAX_SHRINKS`];
-    /// tests can lower it for controlled-budget assertions.
+    /// `consider` and `probe` return [`ShrinkStop`] to end the shrink, so the
+    /// runner doesn't get stuck chasing diminishing returns. Defaults to
+    /// [`MAX_SHRINKS`]; tests can lower it for controlled-budget assertions.
     pub max_improvements: usize,
     /// Total number of times the test closure has been invoked through
     /// `consider` or `probe`.  Used together with `calls_at_last_shrink`
@@ -206,11 +206,13 @@ impl<'a> Shrinker<'a> {
         if self.timed_out {
             return true;
         }
-        if let Some(deadline) = self.deadline
-            && Instant::now() >= deadline
-        {
-            self.timed_out = true;
-            return true;
+        // Spelled out as nested `if let` rather than an `if let … &&` chain,
+        // which isn't stable on the 1.86 MSRV.
+        if let Some(deadline) = self.deadline {
+            if Instant::now() >= deadline {
+                self.timed_out = true;
+                return true;
+            }
         }
         false
     }
@@ -256,8 +258,12 @@ impl<'a> Shrinker<'a> {
                 return Ok(false);
             }
         }
+        // The improvement cap is a *global* stop, not a per-candidate reject:
+        // once `MAX_SHRINKS` strict shrinks have been accepted, no further
+        // shrinking can help, so stop the whole shrink (like the deadline)
+        // instead of returning "not interesting" for every remaining candidate.
         if self.improvements >= self.max_improvements {
-            return Ok(false);
+            return Err(ShrinkStop);
         }
         // Only enforce the stall guard once we've found at least one
         // improvement.  Without warmup, predicates that need many calls
@@ -328,8 +334,9 @@ impl<'a> Shrinker<'a> {
         seed: u64,
         max_size: usize,
     ) -> ShrinkResult<()> {
+        // Global stop once the improvement cap is reached (see `consider`).
         if self.improvements >= self.max_improvements {
-            return Ok(());
+            return Err(ShrinkStop);
         }
         if self.calls.saturating_sub(self.calls_at_last_shrink) >= self.max_stall {
             return Ok(());

--- a/src/native/shrinker/mutation.rs
+++ b/src/native/shrinker/mutation.rs
@@ -12,7 +12,7 @@
 use crate::native::bignum::BigUint;
 use crate::native::core::ChoiceValue;
 
-use super::Shrinker;
+use super::{ShrinkResult, Shrinker};
 
 /// Number of random continuations to try per mutation.
 const RANDOM_ATTEMPTS: u64 = 3;
@@ -24,9 +24,9 @@ impl<'a> Shrinker<'a> {
     /// Try random mutations of a few positions to escape local optima.
     ///
     /// Port of Hypothesis's `shrinking/mutation.py::mutate_and_shrink`.
-    pub(super) fn mutate_and_shrink(&mut self) {
+    pub(super) fn mutate_and_shrink(&mut self) -> ShrinkResult<()> {
         if self.current_nodes.len() > MAX_MUTATE_NODES {
-            return;
+            return Ok(());
         }
         let mut i = 0;
         while i < self.current_nodes.len() {
@@ -69,10 +69,10 @@ impl<'a> Shrinker<'a> {
 
                 // Probe with a fixed seed (matches Hypothesis's `Random(0)`),
                 // then RANDOM_ATTEMPTS random continuations.
-                self.probe(&prefix, 0, max_size);
+                self.probe(&prefix, 0, max_size)?;
                 for attempt in 0..RANDOM_ATTEMPTS {
                     let seed = (i as u64).wrapping_mul(1000).wrapping_add(attempt);
-                    self.probe(&prefix, seed, max_size);
+                    self.probe(&prefix, seed, max_size)?;
                 }
 
                 // Also try setting each of the next few positions to the
@@ -103,12 +103,13 @@ impl<'a> Shrinker<'a> {
                             .wrapping_mul(1000)
                             .wrapping_add((j_offset as u64).wrapping_mul(100))
                             .wrapping_add(attempt);
-                        self.probe(&two_prefix, seed, max_size);
+                        self.probe(&two_prefix, seed, max_size)?;
                     }
                 }
             }
             i += 1;
         }
+        Ok(())
     }
 }
 

--- a/src/native/shrinker/ordering.rs
+++ b/src/native/shrinker/ordering.rs
@@ -18,7 +18,7 @@
 //! the new shrink target (and is now reflected in `current`), `false`
 //! otherwise.
 
-use super::find_integer;
+use super::{ShrinkResult, find_integer_r};
 
 /// Run the ordering shrinker over a permutation of `[0..n)`.
 ///
@@ -33,14 +33,14 @@ use super::find_integer;
 /// returns `true`, the caller has presumably updated whatever underlying
 /// state corresponds to that permutation; the function refreshes its
 /// `current` from the new ordering.
-pub(super) fn shrink_ordering<T, K, F>(n: usize, mut keys: K, mut accept: F)
+pub(super) fn shrink_ordering<T, K, F>(n: usize, mut keys: K, mut accept: F) -> ShrinkResult<()>
 where
     T: Ord,
     K: FnMut(usize) -> T,
-    F: FnMut(&[usize]) -> bool,
+    F: FnMut(&[usize]) -> ShrinkResult<bool>,
 {
     if n <= 1 {
-        return;
+        return Ok(());
     }
     let mut current: Vec<usize> = (0..n).collect();
 
@@ -51,11 +51,11 @@ where
         p.sort_by_key(|&i| keys(i));
         p
     };
-    if sorted_candidate != current && accept(&sorted_candidate) {
+    if sorted_candidate != current && accept(&sorted_candidate)? {
         // A full sort is the global optimum under shortlex key
         // ordering, so there's nothing more to do.  No need to update
         // `current` because we return.
-        return;
+        return Ok(());
     }
 
     // sort_regions: walk from i=0, finding the largest k where sorting
@@ -66,9 +66,9 @@ where
         let prefix: Vec<usize> = snapshot[..i].to_vec();
         let len = snapshot.len();
         let mut best: Vec<usize> = Vec::new();
-        let k = find_integer(|k| {
+        let k = find_integer_r(|k| {
             if i + k > len {
-                return false;
+                return Ok(false);
             }
             let mut region: Vec<usize> = snapshot[i..i + k].to_vec();
             region.sort_by_key(|&j| keys(j));
@@ -78,15 +78,15 @@ where
             if attempt == snapshot {
                 // No actual reordering; treat as a no-op success so the
                 // exponential probe keeps growing.
-                return true;
+                return Ok(true);
             }
-            if accept(&attempt) {
+            if accept(&attempt)? {
                 best = attempt;
-                true
+                Ok(true)
             } else {
-                false
+                Ok(false)
             }
-        });
+        })?;
         if !best.is_empty() {
             current = best;
         }
@@ -98,7 +98,7 @@ where
     // (centre excluded) is no longer accepted.
     let len = current.len();
     if len < 3 {
-        return;
+        return Ok(());
     }
     for i in 1..len - 1 {
         // Skip already-locally-sorted positions
@@ -111,9 +111,9 @@ where
         let mut right = i + 1;
         let snapshot_r = current.clone();
         let i_fixed = i;
-        let k_r = find_integer(|k| {
+        let k_r = find_integer_r(|k| {
             if right + k > snapshot_r.len() {
-                return false;
+                return Ok(false);
             }
             try_sort_around(
                 &snapshot_r,
@@ -123,14 +123,14 @@ where
                 &mut keys,
                 &mut accept,
             )
-        });
+        })?;
         right += k_r;
         // Expand left.  The return value is discarded because `left`
         // is re-initialised at the start of the next iteration.
         let snapshot_l = current.clone();
-        find_integer(|k| {
+        find_integer_r(|k| {
             if k > left {
-                return false;
+                return Ok(false);
             }
             try_sort_around(
                 &snapshot_l,
@@ -140,8 +140,9 @@ where
                 &mut keys,
                 &mut accept,
             )
-        });
+        })?;
     }
+    Ok(())
 }
 
 fn try_sort_around<T, K, F>(
@@ -151,11 +152,11 @@ fn try_sort_around<T, K, F>(
     centre: usize,
     keys: &mut K,
     accept: &mut F,
-) -> bool
+) -> ShrinkResult<bool>
 where
     T: Ord,
     K: FnMut(usize) -> T,
-    F: FnMut(&[usize]) -> bool,
+    F: FnMut(&[usize]) -> ShrinkResult<bool>,
 {
     // `a <= centre < b` allows the boundary case `a == centre`
     // (sort only the right side, with `split = 0`). Callers guarantee
@@ -171,7 +172,7 @@ where
     attempt.extend_from_slice(&sides[split..]);
     attempt.extend_from_slice(&snapshot[b..]);
     if attempt == snapshot {
-        return true;
+        return Ok(true);
     }
     accept(&attempt)
 }

--- a/src/native/shrinker/scheduling.rs
+++ b/src/native/shrinker/scheduling.rs
@@ -81,6 +81,11 @@ impl<'a> Shrinker<'a> {
         let mut any_ran = true;
         let mut shuffle_state: u64 = 0x9E3779B97F4A7C15;
         while any_ran {
+            // Stop the whole schedule once the wall-clock shrink budget is
+            // spent, keeping the best example found so far.
+            if self.past_deadline() {
+                break;
+            }
             any_ran = false;
             // Try the cleanup pass once at the start of each loop.
             let mut can_discard = self.remove_discarded();

--- a/src/native/shrinker/scheduling.rs
+++ b/src/native/shrinker/scheduling.rs
@@ -10,7 +10,11 @@
 //! finer-grained step is a future refinement; the scheduling skeleton
 //! here stays the same either way.
 
-use super::Shrinker;
+use super::{ShrinkResult, Shrinker};
+
+/// A boxed shrink-pass step. Returns [`ShrinkStop`](super::ShrinkStop) once the
+/// shrink deadline has passed so the scheduler unwinds promptly.
+pub type ShrinkPassFn<'a> = Box<dyn FnMut(&mut Shrinker<'a>) -> ShrinkResult<()> + 'a>;
 
 /// SplitMix64 step — used as a deterministic, dependency-free RNG to
 /// scramble pass ordering when `fixate_shrink_passes` falls into the
@@ -35,7 +39,7 @@ pub struct ShrinkPass<'a> {
     /// `Shrinker::shrink`'s end-of-run profile report.
     pub name: &'static str,
     /// The callable to run.
-    pub run: Box<dyn FnMut(&mut Shrinker<'a>) + 'a>,
+    pub run: ShrinkPassFn<'a>,
     /// Total times this pass has been stepped.
     pub calls: usize,
     /// Times the pass step strictly improved the shrink target.
@@ -46,7 +50,7 @@ pub struct ShrinkPass<'a> {
 
 impl<'a> ShrinkPass<'a> {
     /// Construct a named pass from a closure.
-    pub fn new(name: &'static str, run: Box<dyn FnMut(&mut Shrinker<'a>) + 'a>) -> Self {
+    pub fn new(name: &'static str, run: ShrinkPassFn<'a>) -> Self {
         ShrinkPass {
             name,
             run,
@@ -76,26 +80,21 @@ impl<'a> Shrinker<'a> {
     ///
     /// Returns when no pass made any progress over a full outer
     /// iteration. Called by [`Shrinker::shrink`].
-    pub fn fixate_shrink_passes(&mut self, passes: &mut [ShrinkPass<'a>]) {
+    pub fn fixate_shrink_passes(&mut self, passes: &mut [ShrinkPass<'a>]) -> ShrinkResult<()> {
         const MAX_FAILURES: usize = 20;
         let mut any_ran = true;
         let mut shuffle_state: u64 = 0x9E3779B97F4A7C15;
         while any_ran {
-            // Stop the whole schedule once the wall-clock shrink budget is
-            // spent, keeping the best example found so far.
-            if self.past_deadline() {
-                break;
-            }
             any_ran = false;
             // Try the cleanup pass once at the start of each loop.
-            let mut can_discard = self.remove_discarded();
+            let mut can_discard = self.remove_discarded()?;
             let calls_at_loop_start = self.calls;
             let mut max_calls_per_failing_step: usize = 1;
             let mut reorder_keys: Vec<i32> = vec![0; passes.len()];
             let mut shuffle_requested = false;
             for idx in 0..passes.len() {
                 if can_discard {
-                    can_discard = self.remove_discarded();
+                    can_discard = self.remove_discarded()?;
                 }
                 let before_nodes_len = self.current_nodes.len();
                 let epoch_before_pass = self.improvements;
@@ -132,7 +131,7 @@ impl<'a> Shrinker<'a> {
                     passes[idx].calls += 1;
                     let epoch_before_iter = self.improvements;
                     let initial_calls = self.calls;
-                    (passes[idx].run)(self);
+                    (passes[idx].run)(self)?;
                     if self.improvements > epoch_before_iter {
                         passes[idx].shrinks += 1;
                         if self.current_nodes.len() < before_nodes_len {
@@ -185,13 +184,14 @@ impl<'a> Shrinker<'a> {
                 new_order[dest] = Some(std::mem::replace(
                     &mut passes[src],
                     // Temporarily fill with a noop placeholder.
-                    ShrinkPass::new("__placeholder__", Box::new(|_| {})),
+                    ShrinkPass::new("__placeholder__", Box::new(|_| Ok(()))),
                 ));
             }
             for (dest, slot) in new_order.into_iter().enumerate() {
                 passes[dest] = slot.expect("permutation fills every slot");
             }
         }
+        Ok(())
     }
 
     /// Read-only access to per-pass stats; used by `shrink`'s profile

--- a/src/native/shrinker/sequence.rs
+++ b/src/native/shrinker/sequence.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use crate::native::core::{ChoiceKind, ChoiceValue};
 
-use super::Shrinker;
+use super::{ShrinkResult, Shrinker};
 
 impl<'a> Shrinker<'a> {
     /// Try sorting groups of same-type choices by sort key.
@@ -17,22 +17,22 @@ impl<'a> Shrinker<'a> {
     /// matters when earlier swaps cause structural changes (e.g. value
     /// punning on collection-bearing kinds) that would make the full
     /// sort's replace unreachable.
-    pub(super) fn sort_values(&mut self) {
+    pub(super) fn sort_values(&mut self) -> ShrinkResult<()> {
         // Sort integer choices by absolute value.
-        self.sort_values_integers();
+        self.sort_values_integers()?;
         // Sort boolean choices: false (0) before true (1).
-        self.sort_values_booleans();
+        self.sort_values_booleans()
     }
 
-    pub(super) fn sort_values_integers(&mut self) {
-        self.try_sort_group(|k| matches!(k, ChoiceKind::Integer(_)));
+    pub(super) fn sort_values_integers(&mut self) -> ShrinkResult<()> {
+        self.try_sort_group(|k| matches!(k, ChoiceKind::Integer(_)))
     }
 
-    pub(super) fn sort_values_booleans(&mut self) {
-        self.try_sort_group(|k| matches!(k, ChoiceKind::Boolean(_)));
+    pub(super) fn sort_values_booleans(&mut self) -> ShrinkResult<()> {
+        self.try_sort_group(|k| matches!(k, ChoiceKind::Boolean(_)))
     }
 
-    fn try_sort_group<F>(&mut self, matches_kind: F)
+    fn try_sort_group<F>(&mut self, matches_kind: F) -> ShrinkResult<()>
     where
         F: Fn(&ChoiceKind) -> bool,
     {
@@ -50,7 +50,7 @@ impl<'a> Shrinker<'a> {
             .collect();
 
         if indices.len() < 2 {
-            return;
+            return Ok(());
         }
 
         let values: Vec<ChoiceValue> = indices
@@ -75,8 +75,8 @@ impl<'a> Shrinker<'a> {
                 .zip(sorted_values.iter())
                 .map(|(&i, v)| (i, v.clone()))
                 .collect();
-            if self.replace(&replacements) {
-                return;
+            if self.replace(&replacements)? {
+                return Ok(());
             }
         }
 
@@ -108,13 +108,14 @@ impl<'a> Shrinker<'a> {
                 let mut swap = HashMap::new();
                 swap.insert(idx_prev, v_j);
                 swap.insert(idx_j, v_prev);
-                if self.replace(&swap) {
+                if self.replace(&swap)? {
                     j -= 1;
                     continue;
                 }
                 break;
             }
         }
+        Ok(())
     }
 
     /// For each block size 2..=8, tries swapping adjacent blocks of the
@@ -122,7 +123,7 @@ impl<'a> Shrinker<'a> {
     /// cases like list entries where each entry spans multiple choices
     /// (e.g. [continue, value]) and the sorting pass can't swap
     /// individual values without breaking structure.
-    pub(super) fn swap_adjacent_blocks(&mut self) {
+    pub(super) fn swap_adjacent_blocks(&mut self) -> ShrinkResult<()> {
         for block_size in 2usize..=8 {
             let mut i = 0;
             while i + 2 * block_size <= self.current_nodes.len() {
@@ -159,10 +160,11 @@ impl<'a> Shrinker<'a> {
                     swap.insert(i + k, block_b[k].clone());
                     swap.insert(j + k, block_a[k].clone());
                 }
-                self.replace(&swap);
+                self.replace(&swap)?;
                 i += 1;
             }
         }
+        Ok(())
     }
 }
 

--- a/src/native/shrinker/spans.rs
+++ b/src/native/shrinker/spans.rs
@@ -5,7 +5,7 @@
 //! nodes.
 
 use super::ordering::shrink_ordering;
-use super::{ShrinkRun, Shrinker};
+use super::{ShrinkResult, ShrinkRun, Shrinker};
 use crate::native::core::sort_key;
 
 impl<'a> Shrinker<'a> {
@@ -19,7 +19,7 @@ impl<'a> Shrinker<'a> {
     /// (b) the deletion attempts succeeded.  Returns `false` when the
     /// shrinker has discarded data that can't be removed (a follow-up
     /// pass shouldn't try this work again on the same target).
-    pub(crate) fn remove_discarded(&mut self) -> bool {
+    pub(crate) fn remove_discarded(&mut self) -> ShrinkResult<bool> {
         loop {
             // Gather the outermost discarded spans in source order.  A span
             // nested inside an already-collected discarded region is skipped
@@ -36,7 +36,7 @@ impl<'a> Shrinker<'a> {
                 }
             }
             if discarded.is_empty() {
-                return true;
+                return Ok(true);
             }
 
             let mut attempt = self.current_nodes.clone();
@@ -44,8 +44,8 @@ impl<'a> Shrinker<'a> {
                 attempt.drain(u..v);
             }
 
-            if !self.consider(&attempt) {
-                return false;
+            if !self.consider(&attempt)? {
+                return Ok(false);
             }
             // If `consider` accepted but the actual run produced no new
             // discards, the next loop iteration will find an empty
@@ -62,7 +62,7 @@ impl<'a> Shrinker<'a> {
     /// structures whose simplest form is shape-dependent (e.g. an
     /// inner span that becomes shorter under simplest values) still
     /// converge.
-    pub(crate) fn try_trivial_spans(&mut self) {
+    pub(crate) fn try_trivial_spans(&mut self) -> ShrinkResult<()> {
         let mut i = 0;
         while i < self.current_spans.len() {
             // Capture the shrink epoch before any mutation so we can
@@ -98,7 +98,7 @@ impl<'a> Shrinker<'a> {
             // improvement — we retry with the realised span content
             // below.
             let (is_interesting, actual_nodes, actual_spans) =
-                (self.test_fn)(ShrinkRun::Full(&attempt));
+                self.run_test_fn(ShrinkRun::Full(&attempt))?;
             if is_interesting && sort_key(&actual_nodes) < sort_key(&self.current_nodes) {
                 self.accept_improvement(actual_nodes, actual_spans);
                 i += 1;
@@ -118,12 +118,13 @@ impl<'a> Shrinker<'a> {
                         let mut spliced = self.current_nodes[..span.start].to_vec();
                         spliced.extend_from_slice(&actual_nodes[new_span.start..new_span.end]);
                         spliced.extend_from_slice(&self.current_nodes[span.end..]);
-                        self.consider(&spliced);
+                        self.consider(&spliced)?;
                     }
                 }
             }
             i += 1;
         }
+        Ok(())
     }
 
     /// Replace each span with one of its same-label descendants.
@@ -136,7 +137,7 @@ impl<'a> Shrinker<'a> {
     /// the descendant is strictly contained in the ancestor and is
     /// strictly shorter, we splice the descendant's nodes in place of the
     /// ancestor's and ask the predicate whether that's still interesting.
-    pub(crate) fn pass_to_descendant(&mut self) {
+    pub(crate) fn pass_to_descendant(&mut self) -> ShrinkResult<()> {
         // Snapshot (start, end, label) tuples up front. Each consider()
         // may rebuild current_spans, which would invalidate live indices
         // — re-reading from the snapshot after every consider would mean
@@ -193,10 +194,11 @@ impl<'a> Shrinker<'a> {
                     let mut attempt = self.current_nodes[..a_start].to_vec();
                     attempt.extend_from_slice(&self.current_nodes[d_start..d_end]);
                     attempt.extend_from_slice(&self.current_nodes[a_end..]);
-                    self.consider(&attempt);
+                    self.consider(&attempt)?;
                 }
             }
         }
+        Ok(())
     }
 
     /// Reorder same-label sibling spans into a more-sorted permutation.
@@ -211,7 +213,7 @@ impl<'a> Shrinker<'a> {
     /// position. This is the pass that ensures `test_not_equal(x, y)`
     /// collapses to a canonical `(x="", y="0")` rather than the
     /// symmetric alternative.
-    pub(crate) fn reorder_spans(&mut self) {
+    pub(crate) fn reorder_spans(&mut self) -> ShrinkResult<()> {
         let parents: Vec<Option<usize>> = {
             // Build the set of parent indices that have direct children
             // (including the implicit root, parent == None).
@@ -281,7 +283,7 @@ impl<'a> Shrinker<'a> {
                 shrink_ordering::<crate::native::core::NodesSortKey<'_>, _, _>(
                     n,
                     |i| cached_keys[i],
-                    |permutation| {
+                    |permutation| -> ShrinkResult<bool> {
                         // Build the candidate by interleaving the
                         // permuted slices with the unchanged regions
                         // between sibling endpoints.  shrink_ordering
@@ -305,9 +307,10 @@ impl<'a> Shrinker<'a> {
                         }
                         self.consider(&attempt)
                     },
-                );
+                )?;
             }
         }
+        Ok(())
     }
 }
 

--- a/src/native/shrinker/strings.rs
+++ b/src/native/shrinker/strings.rs
@@ -16,10 +16,10 @@ use std::collections::HashMap;
 use crate::native::core::{ChoiceKind, ChoiceValue, StringChoice};
 use crate::unicodedata;
 
-use super::{Shrinker, bin_search_down};
+use super::{ShrinkResult, Shrinker, bin_search_down_r};
 
 impl<'a> Shrinker<'a> {
-    pub(super) fn shrink_strings(&mut self) {
+    pub(super) fn shrink_strings(&mut self) -> ShrinkResult<()> {
         let mut i = 0;
         while i < self.current_nodes.len() {
             let (kind, current) = match (
@@ -36,7 +36,7 @@ impl<'a> Shrinker<'a> {
             // Try simplest.
             let simplest = kind.simplest();
             if simplest != current {
-                self.replace(&HashMap::from([(i, ChoiceValue::String(simplest))]));
+                self.replace(&HashMap::from([(i, ChoiceValue::String(simplest))]))?;
             }
 
             // Shorten via linear scan up from min_size. For strings the
@@ -47,7 +47,7 @@ impl<'a> Shrinker<'a> {
             if cur_len > kind.min_size {
                 for target_len in kind.min_size..cur_len {
                     let cand: Vec<u32> = self.current_string(i)[..target_len].to_vec();
-                    if self.replace(&HashMap::from([(i, ChoiceValue::String(cand))])) {
+                    if self.replace(&HashMap::from([(i, ChoiceValue::String(cand))]))? {
                         break;
                     }
                 }
@@ -63,7 +63,7 @@ impl<'a> Shrinker<'a> {
                 }
                 let mut cand = cur.clone();
                 cand.remove(j);
-                self.replace(&HashMap::from([(i, ChoiceValue::String(cand))]));
+                self.replace(&HashMap::from([(i, ChoiceValue::String(cand))]))?;
             }
 
             // Shrink duplicated codepoints simultaneously.
@@ -97,7 +97,7 @@ impl<'a> Shrinker<'a> {
                     continue;
                 }
 
-                let try_replace_all = |sh: &mut Shrinker<'_>, cand_cp: u32| -> bool {
+                let try_replace_all = |sh: &mut Shrinker<'_>, cand_cp: u32| -> ShrinkResult<bool> {
                     let mut new_str = sh.current_string(i);
                     let mut changed = false;
                     for c in new_str.iter_mut() {
@@ -107,7 +107,7 @@ impl<'a> Shrinker<'a> {
                         }
                     }
                     if !changed {
-                        return false;
+                        return Ok(false);
                     }
                     sh.replace(&HashMap::from([(i, ChoiceValue::String(new_str))]))
                 };
@@ -115,7 +115,7 @@ impl<'a> Shrinker<'a> {
                 for cand_cp in semantic_candidates(val, &kind) {
                     // `semantic_candidates` only returns codepoints with
                     // strictly smaller shrink-key than `val`.
-                    try_replace_all(self, cand_cp);
+                    try_replace_all(self, cand_cp)?;
                     if !self.current_string(i).contains(&val) {
                         break;
                     }
@@ -124,7 +124,7 @@ impl<'a> Shrinker<'a> {
                 if self.current_string(i).contains(&val) {
                     let cur_key = kind.codepoint_key(val);
                     if cur_key > 0 {
-                        bin_search_down(0, cur_key as i128, &mut |k| {
+                        bin_search_down_r(0, cur_key as i128, &mut |k| {
                             // `key_to_codepoint(k)` is `Some` for every
                             // `k < alpha_size`, and our upper bound `cur_key`
                             // is itself a valid position in the alphabet.
@@ -132,7 +132,7 @@ impl<'a> Shrinker<'a> {
                                 .key_to_codepoint(k as u32)
                                 .expect("bin_search probe stays within alpha_size");
                             try_replace_all(self, cp)
-                        });
+                        })?;
                     }
                 }
             }
@@ -170,19 +170,19 @@ impl<'a> Shrinker<'a> {
                     }
                     let mut cand = self.current_string(i);
                     cand[j] = cand_cp;
-                    self.replace(&HashMap::from([(i, ChoiceValue::String(cand))]));
+                    self.replace(&HashMap::from([(i, ChoiceValue::String(cand))]))?;
                 }
 
                 let cur_key = kind.codepoint_key(self.current_string(i)[j]);
                 if cur_key > 0 {
-                    bin_search_down(0, cur_key as i128, &mut |k| {
+                    bin_search_down_r(0, cur_key as i128, &mut |k| {
                         let cp = kind
                             .key_to_codepoint(k as u32)
                             .expect("bin_search probe stays within alpha_size");
                         let mut cand = self.current_string(i);
                         cand[j] = cp;
                         self.replace(&HashMap::from([(i, ChoiceValue::String(cand))]))
-                    });
+                    })?;
                 }
             }
 
@@ -204,7 +204,7 @@ impl<'a> Shrinker<'a> {
                     }
                     let mut swapped = cur.clone();
                     swapped.swap(j - 1, j);
-                    if self.replace(&HashMap::from([(i, ChoiceValue::String(swapped))])) {
+                    if self.replace(&HashMap::from([(i, ChoiceValue::String(swapped))]))? {
                         j -= 1;
                     } else {
                         break;
@@ -215,6 +215,7 @@ impl<'a> Shrinker<'a> {
 
             i += 1;
         }
+        Ok(())
     }
 
     fn current_string(&self, i: usize) -> Vec<u32> {
@@ -230,7 +231,7 @@ impl<'a> Shrinker<'a> {
     /// useful for tests with a total-length constraint across two strings,
     /// where the minimal counterexample has the first string as short as
     /// possible.
-    pub(super) fn redistribute_string_pairs(&mut self) {
+    pub(super) fn redistribute_string_pairs(&mut self) -> ShrinkResult<()> {
         for gap in 1..3usize {
             let mut idx = 0;
             loop {
@@ -240,10 +241,11 @@ impl<'a> Shrinker<'a> {
                 }
                 let i = indices[idx];
                 let j = indices[idx + gap];
-                self.redistribute_string_pair(i, j);
+                self.redistribute_string_pair(i, j)?;
                 idx += 1;
             }
         }
+        Ok(())
     }
 
     fn string_indices(&self) -> Vec<usize> {
@@ -257,7 +259,7 @@ impl<'a> Shrinker<'a> {
             .collect()
     }
 
-    fn redistribute_string_pair(&mut self, i: usize, j: usize) {
+    fn redistribute_string_pair(&mut self, i: usize, j: usize) -> ShrinkResult<()> {
         let s = self.current_string(i);
         let t = self.current_string(j);
         let kind_j = match self.current_nodes[j].kind.as_ref() {
@@ -266,13 +268,13 @@ impl<'a> Shrinker<'a> {
         };
 
         if s.is_empty() {
-            return;
+            return Ok(());
         }
 
         // Try moving everything from s to t.
         let combined: Vec<u32> = s.iter().copied().chain(t.iter().copied()).collect();
-        if self.try_redistribute(i, j, Vec::new(), combined, &kind_j) {
-            return;
+        if self.try_redistribute(i, j, Vec::new(), combined, &kind_j)? {
+            return Ok(());
         }
 
         // Try moving the last codepoint of s to the start of t.
@@ -280,19 +282,20 @@ impl<'a> Shrinker<'a> {
         let mut t_prepended = Vec::with_capacity(t.len() + 1);
         t_prepended.push(*last);
         t_prepended.extend_from_slice(&t);
-        if !self.try_redistribute(i, j, s_init.to_vec(), t_prepended, &kind_j) {
-            return;
+        if !self.try_redistribute(i, j, s_init.to_vec(), t_prepended, &kind_j)? {
+            return Ok(());
         }
 
         // Binary search for the longest suffix of s that can be moved.
         let s_len = s.len();
-        bin_search_down(1, s_len as i128, &mut |n| {
+        bin_search_down_r(1, s_len as i128, &mut |n| {
             let n = n as usize;
             let new_s = s[..s_len - n].to_vec();
             let mut new_t = s[s_len - n..].to_vec();
             new_t.extend_from_slice(&t);
             self.try_redistribute(i, j, new_s, new_t, &kind_j)
-        });
+        })?;
+        Ok(())
     }
 
     fn try_redistribute(
@@ -302,9 +305,9 @@ impl<'a> Shrinker<'a> {
         new_s: Vec<u32>,
         new_t: Vec<u32>,
         kind_j: &StringChoice,
-    ) -> bool {
+    ) -> ShrinkResult<bool> {
         if !kind_j.validate(&new_t) {
-            return false;
+            return Ok(false);
         }
         self.replace(&HashMap::from([
             (i, ChoiceValue::String(new_s)),
@@ -319,7 +322,7 @@ impl<'a> Shrinker<'a> {
     /// character but the actual character value is free — we want to
     /// drive both occurrences toward the alphabet's smallest member at
     /// once.
-    pub(crate) fn lower_duplicated_characters(&mut self) {
+    pub(crate) fn lower_duplicated_characters(&mut self) -> ShrinkResult<()> {
         let len = self.current_nodes.len();
         for i in 0..len {
             for j in (i + 1)..(i + 1 + 4).min(len) {
@@ -347,7 +350,7 @@ impl<'a> Shrinker<'a> {
                     if original_key == 0 {
                         continue;
                     }
-                    super::bin_search_down(0, original_key as i128, &mut |new_key| {
+                    bin_search_down_r(0, original_key as i128, &mut |new_key| {
                         // `key_to_codepoint(new_key)` is `Some` for
                         // every key in `0..alpha_size`, and our search
                         // upper bound is `original_key` which is itself
@@ -373,10 +376,11 @@ impl<'a> Shrinker<'a> {
                             (i, ChoiceValue::String(new_i)),
                             (j, ChoiceValue::String(new_j)),
                         ]))
-                    });
+                    })?;
                 }
             }
         }
+        Ok(())
     }
 
     /// Walk every string node and try replacing each codepoint with one
@@ -385,7 +389,7 @@ impl<'a> Shrinker<'a> {
     /// Complements `shrink_strings`' per-position search by trying the
     /// semantically obvious replacements that lex-index bisection can
     /// skip over.
-    pub(crate) fn normalize_unicode_chars(&mut self) {
+    pub(crate) fn normalize_unicode_chars(&mut self) -> ShrinkResult<()> {
         let mut i = 0;
         while i < self.current_nodes.len() {
             let (kind, value) = match (
@@ -420,13 +424,14 @@ impl<'a> Shrinker<'a> {
                     // single-char replacements at fixed-length —
                     // therefore the candidate is always valid.
                     debug_assert!(kind.validate(&new_value));
-                    if self.replace(&HashMap::from([(i, ChoiceValue::String(new_value))])) {
+                    if self.replace(&HashMap::from([(i, ChoiceValue::String(new_value))]))? {
                         break;
                     }
                 }
             }
             i += 1;
         }
+        Ok(())
     }
 }
 

--- a/src/native/test_runner.rs
+++ b/src/native/test_runner.rs
@@ -18,7 +18,8 @@ use rand::RngExt;
 
 use crate::backend::{DataSource, Failure, TestCaseResult, TestRunResult, TestRunner};
 use crate::native::core::{
-    BUFFER_SIZE, ChoiceNode, ChoiceValue, NativeTestCase, Span, Spans, Status, sort_key,
+    BUFFER_SIZE, ChoiceNode, ChoiceValue, MAX_SHRINKING_SECONDS, NativeTestCase, Span, Spans,
+    Status, sort_key,
 };
 use crate::native::data_source::NativeDataSource;
 use crate::native::database::{
@@ -96,7 +97,13 @@ impl TestRunner for NativeTestRunner {
         if settings.mode == Mode::SingleTestCase {
             return run_single(settings, run_case);
         }
-        run_main(settings, database_key, run_case, TOO_SLOW_THRESHOLD)
+        run_main(
+            settings,
+            database_key,
+            run_case,
+            TOO_SLOW_THRESHOLD,
+            std::time::Duration::from_secs(MAX_SHRINKING_SECONDS),
+        )
     }
 }
 
@@ -206,6 +213,10 @@ fn run_main(
     // Injected (rather than read from the `TOO_SLOW_THRESHOLD` constant) so a
     // test can trip the TooSlow check deterministically without a 30s sleep.
     too_slow_threshold: std::time::Duration,
+    // Wall-clock budget for the whole shrinking phase. Injected (rather than
+    // read from `MAX_SHRINKING_SECONDS`) so a test can trip the slow-shrink
+    // cutoff deterministically with a zero budget instead of a 5-minute wait.
+    shrink_budget: std::time::Duration,
 ) -> TestRunResult {
     let mut rng = create_rng(settings, database_key);
     let max_test_cases = settings.test_cases;
@@ -604,6 +615,10 @@ fn run_main(
         // order is randomised per process, and each origin's shrink shares the
         // run-level call budget.
         origins.sort();
+        // One wall-clock deadline shared across every origin's shrink, matching
+        // Hypothesis's single `finish_shrinking_deadline` for the whole phase.
+        let shrink_deadline = std::time::Instant::now() + shrink_budget;
+        let mut shrink_timed_out = false;
         for origin in origins {
             let initial = interesting.get(&origin).cloned().unwrap_or_default();
 
@@ -649,6 +664,7 @@ fn run_main(
                     verify.nodes,
                     initial_spans,
                 );
+                shrinker.deadline = Some(shrink_deadline);
                 // Pre-shrink coarse reduction — runs once before the
                 // main shrink loop to rerandomise small one_of-style
                 // branch selectors.
@@ -657,9 +673,17 @@ fn run_main(
                     shrinker.set_debug(|msg| eprintln!("{msg}"));
                 }
                 shrinker.shrink();
+                shrink_timed_out |= shrinker.timed_out;
                 shrinker.current_nodes
             };
             interesting.insert(origin, shrunk);
+        }
+
+        // The shrink phase ran past its wall-clock budget and bailed with the
+        // best example so far. Warn unless output is suppressed, mirroring
+        // Hypothesis's slow-shrink notice.
+        if shrink_timed_out && verbosity != Verbosity::Quiet {
+            eprintln!("{}", slow_shrink_warning());
         }
 
         if verbosity == Verbosity::Debug {
@@ -879,6 +903,20 @@ pub(crate) fn flaky_diagnostic() -> String {
      This usually means your test depends on external state such as \
      global variables, system time, or external random number generators."
         .to_string()
+}
+
+/// Warning emitted when shrinking exhausts its wall-clock budget
+/// ([`MAX_SHRINKING_SECONDS`]) and stops early. Unlike a health-check
+/// failure this is not a failure: the smallest counterexample found so far is
+/// still reported. Returned as a string (rather than printed inline) so it can
+/// be asserted directly in tests. Mirrors Hypothesis's slow-shrink notice.
+pub(crate) fn slow_shrink_warning() -> String {
+    format!(
+        "WARNING: Shrinking has been running for more than {MAX_SHRINKING_SECONDS} seconds \
+         and is making very slow progress, so it has been stopped. The smallest failing \
+         example found so far will be reported. Re-running the test will resume shrinking \
+         from there, and may take this long again before stopping."
+    )
 }
 
 /// Build a failing [`TestRunResult`] from a health-check diagnostic.

--- a/src/native/test_runner.rs
+++ b/src/native/test_runner.rs
@@ -667,8 +667,10 @@ fn run_main(
                 shrinker.deadline = Some(shrink_deadline);
                 // Pre-shrink coarse reduction — runs once before the
                 // main shrink loop to rerandomise small one_of-style
-                // branch selectors.
-                shrinker.initial_coarse_reduction();
+                // branch selectors. A `ShrinkStop` here just means the
+                // deadline passed; `shrink()` below is a no-op in that case
+                // and `timed_out` is already latched.
+                let _ = shrinker.initial_coarse_reduction();
                 if verbosity == Verbosity::Debug {
                     shrinker.set_debug(|msg| eprintln!("{msg}"));
                 }

--- a/tests/embedded/native/shrinker_bytes_tests.rs
+++ b/tests/embedded/native/shrinker_bytes_tests.rs
@@ -28,7 +28,7 @@ fn shrink_bytes_collapses_accepting_run_to_simplest() {
     // surrounding loop structure.
     let initial = vec![bytes_node(vec![3, 1, 4, 1], 1, 10)];
     let mut shrinker = accepting_shrinker(initial);
-    shrinker.shrink_bytes();
+    shrinker.shrink_bytes().unwrap();
     let v = match &shrinker.current_nodes[0].value {
         ChoiceValue::Bytes(v) => v.clone(),
         _ => unreachable!(),
@@ -63,7 +63,7 @@ fn shrink_bytes_linear_scan_breaks_when_replace_shortens_below_sz() {
         initial,
         Spans::new(),
     );
-    shrinker.shrink_bytes();
+    shrinker.shrink_bytes().unwrap();
     match &shrinker.current_nodes[0].value {
         ChoiceValue::Bytes(v) => assert_eq!(v, &vec![7u8]),
         _ => unreachable!(),
@@ -100,7 +100,7 @@ fn redistribute_bytes_pair_partial_move_triggers_bin_search() {
         initial,
         Spans::new(),
     );
-    shrinker.redistribute_bytes_pairs();
+    shrinker.redistribute_bytes_pairs().unwrap();
     match &shrinker.current_nodes[1].value {
         ChoiceValue::Bytes(b) => assert!(b.len() <= 3, "t exceeded 3 bytes: {b:?}"),
         _ => unreachable!(),
@@ -117,7 +117,7 @@ fn redistribute_bytes_pair_moves_entire_value_when_accepted() {
         bytes_node(vec![4, 5], 0, 10),
     ];
     let mut shrinker = accepting_shrinker(initial);
-    shrinker.redistribute_bytes_pairs();
+    shrinker.redistribute_bytes_pairs().unwrap();
     let (a, b) = match (
         &shrinker.current_nodes[0].value,
         &shrinker.current_nodes[1].value,

--- a/tests/embedded/native/shrinker_cache_tests.rs
+++ b/tests/embedded/native/shrinker_cache_tests.rs
@@ -50,7 +50,7 @@ fn replace_rejects_index_past_end_of_current_nodes() {
     );
     let mut values = HashMap::new();
     values.insert(99, ChoiceValue::Integer(BigInt::from(0)));
-    assert!(!shrinker.replace(&values));
+    assert!(!shrinker.replace(&values).unwrap());
 }
 
 #[test]
@@ -69,7 +69,7 @@ fn replace_rejects_value_that_fails_kind_validate() {
     );
     let mut values = HashMap::new();
     values.insert(0, ChoiceValue::Integer(BigInt::from(42)));
-    assert!(!shrinker.replace(&values));
+    assert!(!shrinker.replace(&values).unwrap());
 }
 
 #[test]
@@ -116,13 +116,13 @@ fn consider_cache_short_circuits_repeat_lookups() {
 
     // First wave: each unique value runs the closure.
     for v in 1..=200_i128 {
-        shrinker.consider(&[int_node(v)]);
+        shrinker.consider(&[int_node(v)]).unwrap();
     }
     assert_eq!(seen.borrow().len(), 200);
 
     // Second wave: every lookup hits the cache.
     for v in 1..=200_i128 {
-        shrinker.consider(&[int_node(v)]);
+        shrinker.consider(&[int_node(v)]).unwrap();
     }
     assert_eq!(seen.borrow().len(), 200, "cache short-circuit failed");
 }
@@ -154,8 +154,8 @@ fn consider_cache_distinguishes_kind_punned_candidates() {
         Spans::new(),
     );
     shrinker.max_stall = usize::MAX;
-    shrinker.consider(&[bool_node(false)]);
-    shrinker.consider(&[int_node(0)]);
+    shrinker.consider(&[bool_node(false)]).unwrap();
+    shrinker.consider(&[int_node(0)]).unwrap();
     // Both should reach the closure: distinct kinds = distinct cache keys.
     assert_eq!(seen.borrow().as_slice(), &["bool", "int"]);
 }

--- a/tests/embedded/native/shrinker_coarse_tests.rs
+++ b/tests/embedded/native/shrinker_coarse_tests.rs
@@ -50,7 +50,7 @@ fn initial_coarse_reduction_no_op_when_shape_stable() {
         initial,
         Spans::new(),
     );
-    shrinker.initial_coarse_reduction();
+    shrinker.initial_coarse_reduction().unwrap();
     assert_eq!(int_value(&shrinker.current_nodes[0]), 5);
 }
 
@@ -80,7 +80,7 @@ fn initial_coarse_reduction_lowers_when_shape_depends_on_value() {
         initial,
         Spans::new(),
     );
-    shrinker.initial_coarse_reduction();
+    shrinker.initial_coarse_reduction().unwrap();
     // The shape-aware coarse pass should drop the integer.
     assert!(int_value(&shrinker.current_nodes[0]) < 3);
 }
@@ -97,7 +97,7 @@ fn initial_coarse_reduction_skips_large_values() {
         initial,
         Spans::new(),
     );
-    shrinker.initial_coarse_reduction();
+    shrinker.initial_coarse_reduction().unwrap();
     // Unchanged.
     assert_eq!(int_value(&shrinker.current_nodes[0]), 50);
 }
@@ -119,7 +119,7 @@ fn initial_coarse_reduction_skips_non_zero_min_value() {
         initial,
         Spans::new(),
     );
-    shrinker.initial_coarse_reduction();
+    shrinker.initial_coarse_reduction().unwrap();
     assert_eq!(int_value(&shrinker.current_nodes[0]), 3);
 }
 
@@ -136,7 +136,7 @@ fn initial_coarse_reduction_skips_forced_node() {
         initial,
         Spans::new(),
     );
-    shrinker.initial_coarse_reduction();
+    shrinker.initial_coarse_reduction().unwrap();
     assert_eq!(int_value(&shrinker.current_nodes[0]), 5);
 }
 
@@ -159,7 +159,7 @@ fn initial_coarse_reduction_keeps_same_shape_one_of() {
         initial,
         Spans::new(),
     );
-    shrinker.initial_coarse_reduction();
+    shrinker.initial_coarse_reduction().unwrap();
     // Sequence should remain (1, 0); coarse phase doesn't lower the
     // selector when there's no shape change to exploit.
     assert_eq!(shrinker.current_nodes.len(), 2);
@@ -226,7 +226,7 @@ fn initial_coarse_reduction_accepts_probe_when_direct_replace_fails() {
         initial,
         Spans::new(),
     );
-    shrinker.initial_coarse_reduction();
+    shrinker.initial_coarse_reduction().unwrap();
     assert!(probe_calls.get() > 0, "probe branch was never reached");
     assert_eq!(shrinker.current_nodes.len(), 2);
 }

--- a/tests/embedded/native/shrinker_defensive_branch_tests.rs
+++ b/tests/embedded/native/shrinker_defensive_branch_tests.rs
@@ -38,7 +38,7 @@ fn delete_chunks_handles_empty_initial_sequence() {
     // `i >= current_nodes.len()` (0 >= 0) is true on entry, hitting
     // the previously-nocov break.
     let mut shrinker = accepting_shrinker(vec![]);
-    shrinker.delete_chunks();
+    shrinker.delete_chunks().unwrap();
     assert!(shrinker.current_nodes.is_empty());
 }
 
@@ -48,7 +48,9 @@ fn try_replace_with_deletion_returns_true_on_early_success() {
     // simplest value succeeds straight through the early-success
     // path that the nocov masked.
     let mut shrinker = accepting_shrinker(vec![int_node(42), int_node(7)]);
-    let ok = shrinker.try_replace_with_deletion(0, ChoiceValue::Integer(BigInt::from(0)), 2);
+    let ok = shrinker
+        .try_replace_with_deletion(0, ChoiceValue::Integer(BigInt::from(0)), 2)
+        .unwrap();
     assert!(ok);
     match &shrinker.current_nodes[0].value {
         ChoiceValue::Integer(v) => assert_eq!(i128::try_from(v.clone()).unwrap(), 0),
@@ -86,7 +88,7 @@ fn sort_values_break_when_concurrent_shrink_drops_valid_indices() {
         vec![int_node(40), int_node(30), int_node(20), int_node(10)],
         Spans::new(),
     );
-    shrinker.sort_values();
+    shrinker.sort_values().unwrap();
     assert_eq!(shrinker.current_nodes.len(), 1);
 }
 
@@ -109,7 +111,7 @@ fn redistribute_integers_pair_idx_overshoots_after_concurrent_truncation() {
         vec![int_node(10), int_node(20), int_node(30), int_node(40)],
         Spans::new(),
     );
-    shrinker.redistribute_integers();
+    shrinker.redistribute_integers().unwrap();
     assert_eq!(shrinker.current_nodes.len(), 1);
 }
 
@@ -129,7 +131,7 @@ fn lower_integers_together_break_when_indices_outrun_current_nodes() {
         vec![int_node(10), int_node(20), int_node(30)],
         Spans::new(),
     );
-    shrinker.lower_integers_together();
+    shrinker.lower_integers_together().unwrap();
     assert!(shrinker.current_nodes.len() <= 3);
 }
 
@@ -157,7 +159,7 @@ fn lower_integers_together_skips_kind_punning() {
         vec![int_node(5), int_node(10)],
         Spans::new(),
     );
-    shrinker.lower_integers_together();
+    shrinker.lower_integers_together().unwrap();
 }
 
 #[test]
@@ -182,7 +184,7 @@ fn shrink_duplicates_skips_groups_whose_members_diverged() {
         vec![int_node(7), int_node(7), int_node(7)],
         Spans::new(),
     );
-    shrinker.shrink_duplicates();
+    shrinker.shrink_duplicates().unwrap();
 }
 
 #[test]
@@ -199,7 +201,7 @@ fn try_shortening_via_increment_break_on_concurrent_shrink() {
         vec![int_node(5), int_node(10), int_node(15)],
         Spans::new(),
     );
-    shrinker.try_shortening_via_increment();
+    shrinker.try_shortening_via_increment().unwrap();
     assert!(shrinker.current_nodes.is_empty());
 }
 
@@ -212,5 +214,5 @@ fn replace_short_circuits_on_index_past_end_of_attempt() {
     let mut values = HashMap::new();
     values.insert(0, ChoiceValue::Integer(BigInt::from(0)));
     values.insert(10, ChoiceValue::Integer(BigInt::from(0)));
-    assert!(!shrinker.replace(&values));
+    assert!(!shrinker.replace(&values).unwrap());
 }

--- a/tests/embedded/native/shrinker_floats_tests.rs
+++ b/tests/embedded/native/shrinker_floats_tests.rs
@@ -59,7 +59,7 @@ fn redistribute_pair_below_shrink_target_uses_raise_left_direction() {
         initial,
         Spans::new(),
     );
-    shrinker.redistribute_numeric_pairs();
+    shrinker.redistribute_numeric_pairs().unwrap();
     let (a, b) = match (
         &shrinker.current_nodes[0].value,
         &shrinker.current_nodes[1].value,
@@ -82,7 +82,7 @@ fn redistribute_pair_bails_when_int_candidate_leaves_validate_range() {
         initial,
         Spans::new(),
     );
-    shrinker.redistribute_numeric_pairs();
+    shrinker.redistribute_numeric_pairs().unwrap();
     // Engine stayed within validate bounds despite the accepting test_fn.
     match (
         &shrinker.current_nodes[0].value,
@@ -133,7 +133,7 @@ fn shrink_floats_canonicalizes_nan_to_finite_when_predicate_admits() {
         initial,
         Spans::new(),
     );
-    shrinker.shrink_floats();
+    shrinker.shrink_floats().unwrap();
     // After canonicalization the node holds `f64::MAX` (first accepted
     // candidate in the iteration order) rather than the original NaN.
     match shrinker.current_nodes[0].value {
@@ -195,7 +195,7 @@ fn shrink_floats_negative_large_magnitude_uses_is_neg_branch() {
         initial,
         Spans::new(),
     );
-    shrinker.shrink_floats();
+    shrinker.shrink_floats().unwrap();
     match shrinker.current_nodes[0].value {
         ChoiceValue::Float(v) => assert!(v < -1.0 && v.is_finite()),
         _ => unreachable!(),
@@ -232,7 +232,7 @@ fn shrink_floats_negative_shrink_by_multiples_reaches_predicate_boundary() {
         initial,
         Spans::new(),
     );
-    shrinker.shrink_floats();
+    shrinker.shrink_floats().unwrap();
     match shrinker.current_nodes[0].value {
         ChoiceValue::Float(v) => assert_eq!(v, -3.0),
         _ => unreachable!(),

--- a/tests/embedded/native/shrinker_forced_node_tests.rs
+++ b/tests/embedded/native/shrinker_forced_node_tests.rs
@@ -74,14 +74,14 @@ fn assert_integer_at(shrinker: &Shrinker<'_>, idx: usize, expected: i128) {
 #[test]
 fn swap_integer_sign_skips_forced_node() {
     let mut shrinker = accepting_shrinker(vec![int_node(-10, true), int_node(-20, false)]);
-    shrinker.swap_integer_sign();
+    shrinker.swap_integer_sign().unwrap();
     assert_integer_at(&shrinker, 0, -10);
 }
 
 #[test]
 fn binary_search_integer_towards_zero_skips_forced_node() {
     let mut shrinker = accepting_shrinker(vec![int_node(1000, true), int_node(500, false)]);
-    shrinker.binary_search_integer_towards_zero();
+    shrinker.binary_search_integer_towards_zero().unwrap();
     assert_integer_at(&shrinker, 0, 1000);
 }
 
@@ -92,14 +92,14 @@ fn shrink_duplicates_skips_forced_member_of_group() {
         int_node(7, false),
         int_node(7, false),
     ]);
-    shrinker.shrink_duplicates();
+    shrinker.shrink_duplicates().unwrap();
     assert_integer_at(&shrinker, 0, 7);
 }
 
 #[test]
 fn redistribute_integers_skips_forced_node() {
     let mut shrinker = accepting_shrinker(vec![int_node(50, true), int_node(50, false)]);
-    shrinker.redistribute_integers();
+    shrinker.redistribute_integers().unwrap();
     assert_integer_at(&shrinker, 0, 50);
 }
 
@@ -109,7 +109,7 @@ fn shrink_bytes_skips_forced_node() {
         bytes_node(vec![9, 9, 9], true),
         bytes_node(vec![1, 2, 3], false),
     ]);
-    shrinker.shrink_bytes();
+    shrinker.shrink_bytes().unwrap();
     match &shrinker.current_nodes[0].value {
         ChoiceValue::Bytes(b) => assert_eq!(b, &vec![9, 9, 9]),
         _ => unreachable!(),
@@ -119,7 +119,7 @@ fn shrink_bytes_skips_forced_node() {
 #[test]
 fn shrink_floats_skips_forced_node() {
     let mut shrinker = accepting_shrinker(vec![float_node(123.5, true), float_node(7.5, false)]);
-    shrinker.shrink_floats();
+    shrinker.shrink_floats().unwrap();
     match shrinker.current_nodes[0].value {
         ChoiceValue::Float(v) => assert_eq!(v, 123.5),
         _ => unreachable!(),
@@ -133,14 +133,14 @@ fn try_shortening_via_increment_skips_forced_node() {
         int_node(3, false),
         int_node(2, false),
     ]);
-    shrinker.try_shortening_via_increment();
+    shrinker.try_shortening_via_increment().unwrap();
     assert_integer_at(&shrinker, 0, 5);
 }
 
 #[test]
 fn mutate_and_shrink_skips_forced_node() {
     let mut shrinker = accepting_shrinker(vec![int_node(99, true), bool_node(true, false)]);
-    shrinker.mutate_and_shrink();
+    shrinker.mutate_and_shrink().unwrap();
     assert_integer_at(&shrinker, 0, 99);
 }
 
@@ -178,7 +178,7 @@ fn redistribute_numeric_pairs_skips_forced_integer() {
         ],
         Spans::new(),
     );
-    shrinker.redistribute_numeric_pairs();
+    shrinker.redistribute_numeric_pairs().unwrap();
     assert_integer_at(&shrinker, 0, 15);
     assert_integer_at(&shrinker, 1, 10);
 }
@@ -207,7 +207,7 @@ fn normalize_unicode_chars_skips_forced_node() {
         false,
     );
     let mut shrinker = accepting_shrinker(vec![forced_str, other]);
-    shrinker.normalize_unicode_chars();
+    shrinker.normalize_unicode_chars().unwrap();
     match &shrinker.current_nodes[0].value {
         ChoiceValue::String(s) => assert_eq!(s, &vec![0xE9]),
         _ => unreachable!(),

--- a/tests/embedded/native/shrinker_lower_common_node_offset_tests.rs
+++ b/tests/embedded/native/shrinker_lower_common_node_offset_tests.rs
@@ -36,13 +36,15 @@ fn lower_common_node_offset_noop_when_fewer_than_two_changes() {
         Spans::new(),
     );
     // No changes at all → set is empty → return immediately.
-    shrinker.lower_common_node_offset();
+    shrinker.lower_common_node_offset().unwrap();
     assert!(shrinker.changed_nodes().is_empty());
 
     // Touch just one node.
-    shrinker.consider(&[int_node(3, 0), int_node(5, 0)]);
+    shrinker
+        .consider(&[int_node(3, 0), int_node(5, 0)])
+        .unwrap();
     assert_eq!(shrinker.changed_nodes().len(), 1);
-    shrinker.lower_common_node_offset();
+    shrinker.lower_common_node_offset().unwrap();
     // One-element set: pass should leave it alone (short-circuits at
     // `len <= 1`).
     assert_eq!(int_value(&shrinker.current_nodes[0]), 3);
@@ -78,9 +80,11 @@ fn lower_common_node_offset_collapses_zig_zag_pair() {
         Spans::new(),
     );
     // Touch both nodes so the change set has cardinality 2.
-    shrinker.consider(&[int_node(50, 0), int_node(51, 0)]);
+    shrinker
+        .consider(&[int_node(50, 0), int_node(51, 0)])
+        .unwrap();
     assert_eq!(shrinker.changed_nodes().len(), 2);
-    shrinker.lower_common_node_offset();
+    shrinker.lower_common_node_offset().unwrap();
     // Predicate accepts (1, 2): m = 1, n = 2, diff = 1.
     assert_eq!(int_value(&shrinker.current_nodes[0]), 1);
     assert_eq!(int_value(&shrinker.current_nodes[1]), 2);
@@ -107,9 +111,11 @@ fn lower_common_node_offset_handles_negative_shrink_target() {
         initial,
         Spans::new(),
     );
-    shrinker.consider(&[int_node(-9, -10), int_node(-11, -10)]);
+    shrinker
+        .consider(&[int_node(-9, -10), int_node(-11, -10)])
+        .unwrap();
     assert_eq!(shrinker.changed_nodes().len(), 2);
-    shrinker.lower_common_node_offset();
+    shrinker.lower_common_node_offset().unwrap();
     // Closest valid pair: distances (1, -1) under shrink_towards -10
     // ⇒ values (-9, -11) — but we want them as close to -10 as possible
     // with diff 2.  The algorithm probes the common offset down.
@@ -152,31 +158,33 @@ fn lower_common_node_offset_skips_non_integer_nodes() {
         Spans::new(),
     );
     // Manufacture a multi-index change set including the bool and float.
-    shrinker.consider(&[
-        int_node(3, 0),
-        ChoiceNode::new(
-            ChoiceKind::Boolean(BooleanChoice),
-            ChoiceValue::Boolean(false),
-            false,
-        ),
-        ChoiceNode::new(
-            ChoiceKind::Float(FloatChoice {
-                min_value: f64::NEG_INFINITY,
-                max_value: f64::INFINITY,
-                allow_nan: false,
-                allow_infinity: false,
-            }),
-            ChoiceValue::Float(0.0),
-            false,
-        ),
-        int_node(2, 0),
-    ]);
+    shrinker
+        .consider(&[
+            int_node(3, 0),
+            ChoiceNode::new(
+                ChoiceKind::Boolean(BooleanChoice),
+                ChoiceValue::Boolean(false),
+                false,
+            ),
+            ChoiceNode::new(
+                ChoiceKind::Float(FloatChoice {
+                    min_value: f64::NEG_INFINITY,
+                    max_value: f64::INFINITY,
+                    allow_nan: false,
+                    allow_infinity: false,
+                }),
+                ChoiceValue::Float(0.0),
+                false,
+            ),
+            int_node(2, 0),
+        ])
+        .unwrap();
     assert!(shrinker.changed_nodes().len() >= 3);
     // Only the two integer nodes participate in lowering.  After the
     // consider() above, distances from shrink_towards (0) are 3 and 2 —
     // their common offset is 2.  Lowering the offset to zero keeps the
     // residual `[1, 0]`, so the values end at 1 and 0.
-    shrinker.lower_common_node_offset();
+    shrinker.lower_common_node_offset().unwrap();
     assert_eq!(int_value(&shrinker.current_nodes[0]), 1);
     assert_eq!(int_value(&shrinker.current_nodes[3]), 0);
 }
@@ -203,9 +211,9 @@ fn index_passes_skip_sequence_nodes_without_blowup() {
         initial,
         Spans::new(),
     );
-    shrinker.lower_and_bump();
-    shrinker.try_shortening_via_increment();
-    shrinker.mutate_and_shrink();
+    shrinker.lower_and_bump().unwrap();
+    shrinker.try_shortening_via_increment().unwrap();
+    shrinker.mutate_and_shrink().unwrap();
     match &shrinker.current_nodes[0].value {
         ChoiceValue::Bytes(v) => assert_eq!(v.len(), 300, "long value should be left untouched"),
         other => panic!("expected bytes, got {other:?}"),

--- a/tests/embedded/native/shrinker_minimize_duplicated_choices_tests.rs
+++ b/tests/embedded/native/shrinker_minimize_duplicated_choices_tests.rs
@@ -79,7 +79,7 @@ fn accepting_shrinker(initial: Vec<ChoiceNode>) -> Shrinker<'static> {
 #[test]
 fn shrink_duplicates_collapses_paired_booleans_to_false() {
     let mut shrinker = accepting_shrinker(vec![bool_node(true), bool_node(true)]);
-    shrinker.shrink_duplicates();
+    shrinker.shrink_duplicates().unwrap();
     for n in &shrinker.current_nodes {
         match n.value {
             ChoiceValue::Boolean(b) => assert!(!b),
@@ -91,7 +91,7 @@ fn shrink_duplicates_collapses_paired_booleans_to_false() {
 #[test]
 fn shrink_duplicates_collapses_paired_floats_to_zero() {
     let mut shrinker = accepting_shrinker(vec![float_node(3.5), float_node(3.5)]);
-    shrinker.shrink_duplicates();
+    shrinker.shrink_duplicates().unwrap();
     for n in &shrinker.current_nodes {
         match n.value {
             ChoiceValue::Float(v) => assert_eq!(v, 0.0),
@@ -104,7 +104,7 @@ fn shrink_duplicates_collapses_paired_floats_to_zero() {
 fn shrink_duplicates_collapses_paired_bytes_to_empty() {
     let mut shrinker =
         accepting_shrinker(vec![bytes_node(vec![1, 2, 3]), bytes_node(vec![1, 2, 3])]);
-    shrinker.shrink_duplicates();
+    shrinker.shrink_duplicates().unwrap();
     for n in &shrinker.current_nodes {
         match &n.value {
             ChoiceValue::Bytes(b) => assert!(b.is_empty()),
@@ -119,7 +119,7 @@ fn shrink_duplicates_collapses_paired_strings_to_empty() {
         string_node(vec![b'a' as u32, b'b' as u32]),
         string_node(vec![b'a' as u32, b'b' as u32]),
     ]);
-    shrinker.shrink_duplicates();
+    shrinker.shrink_duplicates().unwrap();
     for n in &shrinker.current_nodes {
         match &n.value {
             ChoiceValue::String(s) => assert!(s.is_empty()),
@@ -135,7 +135,7 @@ fn shrink_duplicates_leaves_solo_nodes_alone() {
     // could fire, but each group has only one member.
     let mut shrinker =
         accepting_shrinker(vec![bool_node(true), float_node(3.0), bytes_node(vec![5])]);
-    shrinker.shrink_duplicates();
+    shrinker.shrink_duplicates().unwrap();
     match shrinker.current_nodes[0].value {
         ChoiceValue::Boolean(b) => assert!(b),
         _ => unreachable!(),
@@ -155,7 +155,7 @@ fn shrink_duplicates_keeps_distinct_values_separate() {
     // Three booleans, only two of them duplicates.  The duplicates
     // should be lowered together; the third value should be left alone.
     let mut shrinker = accepting_shrinker(vec![bool_node(true), bool_node(false), bool_node(true)]);
-    shrinker.shrink_duplicates();
+    shrinker.shrink_duplicates().unwrap();
     // After shrink: the two trues went to false, the original false
     // stayed.  Result: [false, false, false].
     for n in &shrinker.current_nodes {
@@ -204,7 +204,7 @@ fn shrink_duplicates_positive_descent_is_log_log() {
         .map(|_| integer_node(1_000_000_000_000_000, 0, i128::MAX))
         .collect();
     let mut shrinker = group_accepts_uniform_at_least(initial, 100);
-    shrinker.shrink_duplicates();
+    shrinker.shrink_duplicates().unwrap();
 
     for n in &shrinker.current_nodes {
         match &n.value {
@@ -247,7 +247,7 @@ fn shrink_duplicates_negative_descent_is_log_log() {
         initial,
         Spans::new(),
     );
-    shrinker.shrink_duplicates();
+    shrinker.shrink_duplicates().unwrap();
 
     for n in &shrinker.current_nodes {
         match &n.value {
@@ -288,7 +288,7 @@ fn shrink_duplicates_skips_group_invalidated_by_concurrent_shrink() {
         initial,
         Spans::new(),
     );
-    shrinker.shrink_duplicates();
+    shrinker.shrink_duplicates().unwrap();
 }
 
 /// Cover the `current_valid.len() < 2` return inside the
@@ -324,7 +324,7 @@ fn shrink_duplicates_group_replace_short_circuits_when_truncated() {
         initial,
         Spans::new(),
     );
-    shrinker.shrink_duplicates();
+    shrinker.shrink_duplicates().unwrap();
 }
 
 /// Cover the outer-loop `valid.len() < 2 continue` inside
@@ -374,6 +374,6 @@ fn shrink_duplicates_outer_skips_group_truncated_by_prior_group() {
         initial,
         Spans::new(),
     );
-    shrinker.shrink_duplicates();
+    shrinker.shrink_duplicates().unwrap();
     assert_eq!(shrinker.current_nodes.len(), 1);
 }

--- a/tests/embedded/native/shrinker_minimize_individual_choices_tests.rs
+++ b/tests/embedded/native/shrinker_minimize_individual_choices_tests.rs
@@ -43,7 +43,7 @@ fn minimize_individual_choices_drives_int_to_simplest_when_predicate_admits() {
         initial,
         Spans::new(),
     );
-    shrinker.minimize_individual_choices();
+    shrinker.minimize_individual_choices().unwrap();
     assert_eq!(int_value(&shrinker.current_nodes[0]), 0);
 }
 
@@ -58,7 +58,7 @@ fn minimize_individual_choices_skips_forced_nodes() {
         initial,
         Spans::new(),
     );
-    shrinker.minimize_individual_choices();
+    shrinker.minimize_individual_choices().unwrap();
     assert_eq!(int_value(&shrinker.current_nodes[0]), 7);
 }
 
@@ -108,7 +108,7 @@ fn minimize_individual_choices_invokes_span_delete_fallback() {
         initial,
         Spans::new(),
     );
-    shrinker.minimize_individual_choices();
+    shrinker.minimize_individual_choices().unwrap();
     // After convergence the integer is at its minimum admissible value
     // (1) and the trailing region is the matching size (1 item).
     assert_eq!(int_value(&shrinker.current_nodes[0]), 1);
@@ -171,7 +171,7 @@ fn minimize_individual_choices_truncates_misaligned_string() {
         initial,
         Spans::new(),
     );
-    shrinker.minimize_individual_choices();
+    shrinker.minimize_individual_choices().unwrap();
     // The misalignment retry should leave the integer lower than the
     // original 3 and the string truncated to match.
     assert!(int_value(&shrinker.current_nodes[0]) < 3);
@@ -219,7 +219,7 @@ fn minimize_individual_choices_size_dep_single_node_delete_succeeds() {
         initial,
         Spans::new(),
     );
-    shrinker.minimize_individual_choices();
+    shrinker.minimize_individual_choices().unwrap();
     assert_eq!(int_value(&shrinker.current_nodes[0]), 1);
     assert_eq!(shrinker.current_nodes.len(), 1);
 }
@@ -265,7 +265,7 @@ fn minimize_individual_choices_size_dep_span_delete_succeeds() {
         initial,
         Spans::new(),
     );
-    shrinker.minimize_individual_choices();
+    shrinker.minimize_individual_choices().unwrap();
     assert_eq!(int_value(&shrinker.current_nodes[0]), 1);
     assert_eq!(shrinker.current_nodes.len(), 1);
 }
@@ -312,7 +312,7 @@ fn minimize_individual_choices_truncates_misaligned_bytes() {
         initial,
         Spans::new(),
     );
-    shrinker.minimize_individual_choices();
+    shrinker.minimize_individual_choices().unwrap();
     assert!(int_value(&shrinker.current_nodes[0]) < 3);
     match &shrinker.current_nodes[1].value {
         ChoiceValue::Bytes(b) => {
@@ -333,7 +333,7 @@ fn minimize_individual_choices_no_op_on_already_simplest_node() {
         initial,
         Spans::new(),
     );
-    shrinker.minimize_individual_choices();
+    shrinker.minimize_individual_choices().unwrap();
     assert_eq!(int_value(&shrinker.current_nodes[0]), 0);
 }
 
@@ -365,6 +365,8 @@ fn try_replace_with_deletion_continues_past_sizes_reaching_into_idx() {
     );
     // idx = 2 (last index), len = 3: for every size in 1..=k the start index
     // is `3 - size <= 2 == idx`, so the loop `continue`s each time.
-    let deleted = shrinker.try_replace_with_deletion(2, ChoiceValue::Integer(BigInt::from(0)), 5);
+    let deleted = shrinker
+        .try_replace_with_deletion(2, ChoiceValue::Integer(BigInt::from(0)), 5)
+        .unwrap();
     assert!(!deleted);
 }

--- a/tests/embedded/native/shrinker_node_program_tests.rs
+++ b/tests/embedded/native/shrinker_node_program_tests.rs
@@ -30,7 +30,7 @@ fn node_program_one_deletes_single_node_at_a_time() {
         initial,
         Spans::new(),
     );
-    shrinker.node_program(1);
+    shrinker.node_program(1).unwrap();
     // All nodes deletable → result is empty.
     assert!(shrinker.current_nodes.is_empty());
 }
@@ -55,7 +55,7 @@ fn node_program_two_deletes_pairs_adaptively() {
         initial,
         Spans::new(),
     );
-    shrinker.node_program(2);
+    shrinker.node_program(2).unwrap();
     assert!(shrinker.current_nodes.is_empty());
 }
 
@@ -84,7 +84,7 @@ fn node_program_respects_predicate_rejecting_partial_deletes() {
             initial.clone(),
             Spans::new(),
         );
-        shrinker.node_program(1);
+        shrinker.node_program(1).unwrap();
         assert_eq!(shrinker.current_nodes.len(), 6);
     }
 
@@ -98,7 +98,7 @@ fn node_program_respects_predicate_rejecting_partial_deletes() {
             initial,
             Spans::new(),
         );
-        shrinker.node_program(2);
+        shrinker.node_program(2).unwrap();
         assert_eq!(shrinker.current_nodes.len(), 0);
     }
 }
@@ -114,7 +114,7 @@ fn node_program_no_op_on_empty_or_too_long() {
         Vec::new(),
         Spans::new(),
     );
-    shrinker.node_program(3);
+    shrinker.node_program(3).unwrap();
     assert_eq!(shrinker.current_nodes.len(), 0);
 
     // n == 0 should also be a no-op.
@@ -127,7 +127,7 @@ fn node_program_no_op_on_empty_or_too_long() {
         initial,
         Spans::new(),
     );
-    shrinker.node_program(0);
+    shrinker.node_program(0).unwrap();
     assert_eq!(shrinker.current_nodes.len(), 1);
 }
 
@@ -184,7 +184,7 @@ fn node_program_deletes_short_ranges() {
         Spans::new(),
     );
     for k in 1..=4 {
-        shrinker.node_program(k);
+        shrinker.node_program(k).unwrap();
     }
     // The minimum is the single 4-block: 5 nodes total ([4, 4, 4, 4, 4]).
     // The shrinker may converge faster or slower than that, but the
@@ -245,7 +245,7 @@ fn node_program_adaptively_deletes_long_false_run() {
         initial,
         Spans::new(),
     );
-    shrinker.node_program(1);
+    shrinker.node_program(1).unwrap();
     // The shrink target collapses to a single [true].
     assert_eq!(shrinker.current_nodes.len(), 1);
 }

--- a/tests/embedded/native/shrinker_ordering_tests.rs
+++ b/tests/embedded/native/shrinker_ordering_tests.rs
@@ -14,9 +14,10 @@ fn shrink_ordering_short_circuits_to_full_sort() {
         |i| keys[i],
         |perm| {
             accepted_perms.push(perm.to_vec());
-            true
+            Ok(true)
         },
-    );
+    )
+    .unwrap();
     // Exactly one accept: a fully sorted permutation (1, 1, 3, 4, 5).
     assert_eq!(accepted_perms.len(), 1);
     let sorted_keys: Vec<u32> = accepted_perms[0].iter().map(|&i| keys[i]).collect();
@@ -41,12 +42,13 @@ fn shrink_ordering_falls_back_to_region_sort_when_full_sort_rejected() {
             // improvement.
             let mapped: Vec<u32> = perm.iter().map(|&i| keys[i]).collect();
             if mapped == vec![1u32, 1, 2, 3] {
-                return false;
+                return Ok(false);
             }
             accepted.push(perm.to_vec());
-            true
+            Ok(true)
         },
-    );
+    )
+    .unwrap();
     // Some accept happened in the fallback phases.
     assert!(!accepted.is_empty());
 }
@@ -60,9 +62,10 @@ fn shrink_ordering_returns_early_on_trivial_input() {
         |_| 0u32,
         |_| {
             count += 1;
-            true
+            Ok(true)
         },
-    );
+    )
+    .unwrap();
     assert_eq!(count, 0);
     let mut count2 = 0;
     shrink_ordering(
@@ -70,9 +73,10 @@ fn shrink_ordering_returns_early_on_trivial_input() {
         |_| 0u32,
         |_| {
             count2 += 1;
-            true
+            Ok(true)
         },
-    );
+    )
+    .unwrap();
     assert_eq!(count2, 0);
 }
 
@@ -81,6 +85,6 @@ fn shrink_ordering_handles_predicate_that_never_accepts() {
     // No improvement: the algorithm tries a few permutations and gives
     // up without panicking.
     let keys = [5u32, 3, 1];
-    shrink_ordering(keys.len(), |i| keys[i], |_| false);
+    shrink_ordering(keys.len(), |i| keys[i], |_| Ok(false)).unwrap();
     // No assertion — just verify it terminates.
 }

--- a/tests/embedded/native/shrinker_pass_to_descendant_tests.rs
+++ b/tests/embedded/native/shrinker_pass_to_descendant_tests.rs
@@ -55,7 +55,7 @@ fn pass_to_descendant_replaces_outer_with_inner_same_label() {
         initial,
         spans,
     );
-    shrinker.pass_to_descendant();
+    shrinker.pass_to_descendant().unwrap();
 
     let values: Vec<_> = shrinker
         .current_nodes
@@ -85,7 +85,7 @@ fn pass_to_descendant_skips_different_labels() {
         initial,
         spans,
     );
-    shrinker.pass_to_descendant();
+    shrinker.pass_to_descendant().unwrap();
     // Nothing changed.
     assert_eq!(shrinker.current_nodes.len(), 3);
 }
@@ -108,7 +108,7 @@ fn pass_to_descendant_skips_equal_length_descendant() {
         initial,
         spans,
     );
-    shrinker.pass_to_descendant();
+    shrinker.pass_to_descendant().unwrap();
     assert_eq!(shrinker.current_nodes.len(), 2);
 }
 
@@ -139,7 +139,7 @@ fn pass_to_descendant_handles_multiple_descendants() {
         initial,
         spans,
     );
-    shrinker.pass_to_descendant();
+    shrinker.pass_to_descendant().unwrap();
     // The innermost span (length 1) gives prefix [] + [3] + suffix [] when
     // replacing the outermost; that's accepted (len 1 ≤ 2).
     assert!(shrinker.current_nodes.len() <= 2);
@@ -163,6 +163,6 @@ fn pass_to_descendant_safe_when_indices_outrange_after_shrink() {
         initial,
         spans,
     );
-    shrinker.pass_to_descendant();
+    shrinker.pass_to_descendant().unwrap();
     assert_eq!(shrinker.current_nodes.len(), 2);
 }

--- a/tests/embedded/native/shrinker_remove_discarded_tests.rs
+++ b/tests/embedded/native/shrinker_remove_discarded_tests.rs
@@ -57,7 +57,7 @@ fn remove_discarded_returns_true_when_no_discards() {
     let mut spans = Spans::new();
     spans.push(span(0, 2, false));
     let mut shrinker = Shrinker::with_probe(accepting_test_fn(Spans::new()), initial, spans);
-    assert!(shrinker.remove_discarded());
+    assert!(shrinker.remove_discarded().unwrap());
     assert_eq!(shrinker.current_nodes.len(), 2);
 }
 
@@ -69,7 +69,7 @@ fn remove_discarded_skips_zero_length_discarded_span() {
     let mut spans = Spans::new();
     spans.push(span(0, 0, true)); // zero-length discarded
     let mut shrinker = Shrinker::with_probe(accepting_test_fn(Spans::new()), initial, spans);
-    assert!(shrinker.remove_discarded());
+    assert!(shrinker.remove_discarded().unwrap());
     assert_eq!(shrinker.current_nodes.len(), 1);
 }
 
@@ -84,7 +84,7 @@ fn remove_discarded_deletes_a_single_discarded_region() {
     spans.push(span(1, 3, true));
 
     let mut shrinker = Shrinker::with_probe(accepting_test_fn(Spans::new()), initial, spans);
-    assert!(shrinker.remove_discarded());
+    assert!(shrinker.remove_discarded().unwrap());
     // Closure now returns no discards, so the next loop iteration finds
     // an empty list and exits.
     assert_eq!(shrinker.current_nodes.len(), 2);
@@ -119,7 +119,7 @@ fn remove_discarded_deletes_non_overlapping_regions_in_reverse() {
     spans.push(span(5, 7, true));
 
     let mut shrinker = Shrinker::with_probe(accepting_test_fn(Spans::new()), initial, spans);
-    assert!(shrinker.remove_discarded());
+    assert!(shrinker.remove_discarded().unwrap());
     let values: Vec<_> = shrinker
         .current_nodes
         .iter()
@@ -151,7 +151,7 @@ fn remove_discarded_skips_nested_discarded_spans() {
     spans.push(span(2, 3, true));
 
     let mut shrinker = Shrinker::with_probe(accepting_test_fn(Spans::new()), initial, spans);
-    assert!(shrinker.remove_discarded());
+    assert!(shrinker.remove_discarded().unwrap());
     let values: Vec<_> = shrinker
         .current_nodes
         .iter()
@@ -182,7 +182,7 @@ fn remove_discarded_returns_false_when_consider_rejects() {
         initial,
         spans,
     );
-    assert!(!shrinker.remove_discarded());
+    assert!(!shrinker.remove_discarded().unwrap());
     // The original sequence is preserved.
     assert_eq!(shrinker.current_nodes.len(), 2);
 }
@@ -221,7 +221,7 @@ fn remove_discarded_iterates_when_new_target_still_has_discards() {
         initial,
         spans,
     );
-    assert!(shrinker.remove_discarded());
+    assert!(shrinker.remove_discarded().unwrap());
     // First call removed [2..4); second iteration found [0..2) still
     // marked discarded and removed it too — leaving nothing.
     assert_eq!(shrinker.current_nodes.len(), 0);

--- a/tests/embedded/native/shrinker_reorder_spans_tests.rs
+++ b/tests/embedded/native/shrinker_reorder_spans_tests.rs
@@ -45,7 +45,7 @@ fn reorder_spans_sorts_same_label_siblings() {
         initial,
         spans,
     );
-    shrinker.reorder_spans();
+    shrinker.reorder_spans().unwrap();
     let values: Vec<_> = shrinker
         .current_nodes
         .iter()
@@ -55,6 +55,30 @@ fn reorder_spans_sorts_same_label_siblings() {
         })
         .collect();
     assert_eq!(values, vec![1, 3]);
+}
+
+#[test]
+fn reorder_spans_stops_when_deadline_passed() {
+    // With same-label siblings to reorder and an already-expired deadline,
+    // the first `consider` inside `shrink_ordering` errors out and the stop
+    // propagates back through `reorder_spans`.
+    use std::time::{Duration, Instant};
+    let initial = vec![int_node(3), int_node(1)];
+    let mut spans = Spans::new();
+    spans.push(sib(0, 1, "item", None));
+    spans.push(sib(1, 2, "item", None));
+
+    let mut shrinker = Shrinker::with_probe(
+        Box::new(|run| match run {
+            ShrinkRun::Full(nodes) => (true, nodes.to_vec(), Spans::new()),
+            ShrinkRun::Probe { .. } => (false, Vec::new(), Spans::new()),
+        }),
+        initial,
+        spans,
+    );
+    shrinker.deadline = Some(Instant::now() - Duration::from_secs(1));
+    assert!(shrinker.reorder_spans().is_err());
+    assert!(shrinker.timed_out);
 }
 
 #[test]
@@ -73,7 +97,7 @@ fn reorder_spans_skips_singleton_groups() {
         initial,
         spans,
     );
-    shrinker.reorder_spans();
+    shrinker.reorder_spans().unwrap();
     // Order unchanged.
     let values: Vec<_> = shrinker
         .current_nodes
@@ -112,7 +136,7 @@ fn reorder_spans_handles_multi_node_siblings() {
         initial,
         spans,
     );
-    shrinker.reorder_spans();
+    shrinker.reorder_spans().unwrap();
     let values: Vec<_> = shrinker
         .current_nodes
         .iter()
@@ -141,7 +165,7 @@ fn reorder_spans_safe_with_stale_endpoints() {
         initial,
         spans,
     );
-    shrinker.reorder_spans();
+    shrinker.reorder_spans().unwrap();
     // No panic; nothing changed.
     assert_eq!(shrinker.current_nodes.len(), 2);
 }

--- a/tests/embedded/native/shrinker_scheduling_tests.rs
+++ b/tests/embedded/native/shrinker_scheduling_tests.rs
@@ -32,7 +32,7 @@ fn fixate_shrink_passes_runs_passes_to_fixed_point() {
         "zero_choices",
         Box::new(|sh| sh.zero_choices()),
     )];
-    shrinker.fixate_shrink_passes(&mut passes);
+    shrinker.fixate_shrink_passes(&mut passes).unwrap();
     // Accepting predicate → integers driven to 0.
     let values: Vec<_> = shrinker
         .current_nodes
@@ -68,7 +68,7 @@ fn fixate_shrink_passes_records_deletion_stat_when_pass_shortens() {
         "delete_chunks",
         Box::new(|sh| sh.delete_chunks()),
     )];
-    shrinker.fixate_shrink_passes(&mut passes);
+    shrinker.fixate_shrink_passes(&mut passes).unwrap();
     assert!(shrinker.current_nodes.is_empty());
     let stats = shrinker.pass_stats(&passes);
     let (_, _, _, deletions) = stats[0];
@@ -103,13 +103,13 @@ fn consider_short_circuits_when_stalled() {
         Spans::new(),
     );
     // Seed one improvement so the stall guard's warmup is satisfied.
-    shrinker.consider(&[int_node(3)]);
+    shrinker.consider(&[int_node(3)]).unwrap();
     let baseline = counter.get();
     shrinker.max_stall = 10;
     // Reset calls_at_last_shrink so we measure the post-baseline budget.
     shrinker.calls_at_last_shrink = shrinker.calls;
     for v in 10..60 {
-        shrinker.consider(&[int_node(v)]);
+        shrinker.consider(&[int_node(v)]).unwrap();
     }
     // Post-baseline closure calls capped at max_stall.
     assert!(
@@ -143,16 +143,16 @@ fn max_stall_grows_after_shrink() {
     // hundreds of calls.
     shrinker.max_stall = 5;
     // Seed an improvement first to anchor calls_at_last_shrink.
-    let accepted_first = shrinker.consider(&[int_node(9)]);
+    let accepted_first = shrinker.consider(&[int_node(9)]).unwrap();
     assert!(accepted_first);
     let stall_after_first = shrinker.max_stall;
     // Burn 3 uninteresting calls (still within stall budget).
     for v in 11..14 {
-        shrinker.consider(&[int_node(v)]);
+        shrinker.consider(&[int_node(v)]).unwrap();
     }
     // Another improvement.  span = calls - calls_at_last_shrink ≈ 3;
     // grown = 6 > 5, so max_stall should grow.
-    shrinker.consider(&[int_node(5)]);
+    shrinker.consider(&[int_node(5)]).unwrap();
     assert!(
         shrinker.max_stall > stall_after_first,
         "max_stall failed to grow: {} -> {}",
@@ -223,7 +223,7 @@ fn fixate_passes_does_full_run_even_when_stalled() {
     let mut passes: Vec<ShrinkPass> = (1..=5)
         .map(|i| ShrinkPass::new("node_program", Box::new(move |sh| sh.node_program(i))))
         .collect();
-    shrinker.fixate_shrink_passes(&mut passes);
+    shrinker.fixate_shrink_passes(&mut passes).unwrap();
     // Every pass got at least one call — fixate didn't bail out
     // before running the full pass list.
     for sp in &passes {
@@ -245,13 +245,13 @@ fn fixate_shrink_passes_reorders_useful_passes_to_the_front() {
         Spans::new(),
     );
     let mut passes = vec![
-        ShrinkPass::new("useless", Box::new(|_| ())),
+        ShrinkPass::new("useless", Box::new(|_| Ok(()))),
         ShrinkPass::new(
             "useful",
             Box::new(|sh| sh.binary_search_integer_towards_zero()),
         ),
     ];
-    shrinker.fixate_shrink_passes(&mut passes);
+    shrinker.fixate_shrink_passes(&mut passes).unwrap();
     // After fixate the useful pass should sit at index 0 (key 0 < 1).
     assert_eq!(passes[0].name, "useful");
     assert_eq!(passes[1].name, "useless");
@@ -280,7 +280,7 @@ fn fixate_emits_debug_per_pass_step_when_debug_set() {
         "binary_search_integer_towards_zero",
         Box::new(|sh| sh.binary_search_integer_towards_zero()),
     )];
-    shrinker.fixate_shrink_passes(&mut passes);
+    shrinker.fixate_shrink_passes(&mut passes).unwrap();
     let messages = log.borrow();
     assert!(
         messages
@@ -309,7 +309,7 @@ fn fixate_emits_no_debug_when_no_callback_set() {
         "zero_choices",
         Box::new(|sh| sh.zero_choices()),
     )];
-    shrinker.fixate_shrink_passes(&mut passes);
+    shrinker.fixate_shrink_passes(&mut passes).unwrap();
     let v = match &shrinker.current_nodes[0].value {
         ChoiceValue::Integer(v) => i128::try_from(v).unwrap(),
         _ => unreachable!(),
@@ -483,11 +483,16 @@ fn past_deadline_latches_and_short_circuits_consider_and_probe() {
     );
     shrinker.deadline = Some(Instant::now() - Duration::from_secs(1));
     // First `consider` observes the expired deadline, latches `timed_out`, and
-    // rejects without invoking the closure.
-    assert!(!shrinker.consider(&[int_node(0)]));
+    // stops (returns `ShrinkStop`) without invoking the closure.
+    assert!(shrinker.consider(&[int_node(0)]).is_err());
     assert!(shrinker.timed_out);
-    // A second `consider` and a `probe` hit the already-latched fast path.
-    assert!(!shrinker.consider(&[int_node(0)]));
-    shrinker.probe(&[ChoiceValue::Integer(BigInt::from(0))], 0, 8);
+    // A second `consider` and a `probe` hit the already-latched fast path,
+    // which also stops.
+    assert!(shrinker.consider(&[int_node(0)]).is_err());
+    assert!(
+        shrinker
+            .probe(&[ChoiceValue::Integer(BigInt::from(0))], 0, 8)
+            .is_err()
+    );
     assert_eq!(shrinker.calls, 0, "nothing should have been executed");
 }

--- a/tests/embedded/native/shrinker_scheduling_tests.rs
+++ b/tests/embedded/native/shrinker_scheduling_tests.rs
@@ -471,6 +471,29 @@ fn shrink_completes_normally_with_a_future_deadline() {
 }
 
 #[test]
+fn consider_and_probe_stop_when_improvement_cap_reached() {
+    // The `MAX_SHRINKS` improvement cap is a global stop: once reached,
+    // `consider`/`probe` return `ShrinkStop` (like the deadline) rather than a
+    // per-candidate "not interesting".
+    let mut shrinker = Shrinker::with_probe(
+        Box::new(|run| match run {
+            ShrinkRun::Full(nodes) => (true, nodes.to_vec(), Spans::new()),
+            ShrinkRun::Probe { .. } => (false, Vec::new(), Spans::new()),
+        }),
+        vec![int_node(5)],
+        Spans::new(),
+    );
+    shrinker.max_improvements = 0;
+    assert!(shrinker.consider(&[int_node(0)]).is_err());
+    assert!(
+        shrinker
+            .probe(&[ChoiceValue::Integer(BigInt::from(0))], 0, 8)
+            .is_err()
+    );
+    assert_eq!(shrinker.calls, 0, "the cap stops before any execution");
+}
+
+#[test]
 fn past_deadline_latches_and_short_circuits_consider_and_probe() {
     use std::time::{Duration, Instant};
     let mut shrinker = Shrinker::with_probe(

--- a/tests/embedded/native/shrinker_scheduling_tests.rs
+++ b/tests/embedded/native/shrinker_scheduling_tests.rs
@@ -396,3 +396,98 @@ fn shrink_profile_reports_singular_call_unit() {
         combined
     );
 }
+
+#[test]
+fn shrink_stops_immediately_when_deadline_already_passed() {
+    use std::cell::Cell;
+    use std::rc::Rc;
+    use std::time::{Duration, Instant};
+    // A predicate that accepts everything and would otherwise drive the
+    // 50-node sequence down to zeros; with an already-expired deadline the
+    // scheduler must bail before running a single pass.
+    let calls = Rc::new(Cell::new(0usize));
+    let calls_clone = calls.clone();
+    let initial = vec![int_node(5); 50];
+    let mut shrinker = Shrinker::with_probe(
+        Box::new(move |run| match run {
+            ShrinkRun::Full(nodes) => {
+                calls_clone.set(calls_clone.get() + 1);
+                (true, nodes.to_vec(), Spans::new())
+            }
+            ShrinkRun::Probe { .. } => (false, Vec::new(), Spans::new()),
+        }),
+        initial,
+        Spans::new(),
+    );
+    shrinker.deadline = Some(Instant::now() - Duration::from_secs(1));
+    shrinker.shrink();
+    assert!(shrinker.timed_out, "expected the shrink to time out");
+    assert_eq!(
+        shrinker.calls, 0,
+        "no candidate should have been considered"
+    );
+    assert_eq!(calls.get(), 0, "the test fn must not have been invoked");
+    assert_eq!(
+        shrinker.current_nodes.len(),
+        50,
+        "the example must be left unshrunk when the deadline has passed"
+    );
+}
+
+#[test]
+fn shrink_completes_normally_with_a_future_deadline() {
+    use std::time::{Duration, Instant};
+    let initial = vec![int_node(10), int_node(20)];
+    let mut shrinker = Shrinker::with_probe(
+        // A realistic predicate: a draw is required, so an over-short sequence
+        // is "uninteresting" — mirroring the real engine, where replaying too
+        // few choices makes the body overrun rather than re-fail. The minimal
+        // interesting sequence is therefore a single zero node, not empty.
+        Box::new(|run| match run {
+            ShrinkRun::Full(nodes) => (!nodes.is_empty(), nodes.to_vec(), Spans::new()),
+            ShrinkRun::Probe { .. } => (false, Vec::new(), Spans::new()),
+        }),
+        initial,
+        Spans::new(),
+    );
+    // A deadline far in the future never trips, so shrinking proceeds to the
+    // fixed point exactly as it would with no deadline set.
+    shrinker.deadline = Some(Instant::now() + Duration::from_secs(300));
+    shrinker.shrink();
+    assert!(!shrinker.timed_out);
+    let values: Vec<_> = shrinker
+        .current_nodes
+        .iter()
+        .map(|n| match &n.value {
+            ChoiceValue::Integer(v) => i128::try_from(v).unwrap(),
+            _ => unreachable!(),
+        })
+        .collect();
+    assert_eq!(
+        values,
+        vec![0],
+        "should shrink to the minimal non-empty sequence"
+    );
+}
+
+#[test]
+fn past_deadline_latches_and_short_circuits_consider_and_probe() {
+    use std::time::{Duration, Instant};
+    let mut shrinker = Shrinker::with_probe(
+        Box::new(|run| match run {
+            ShrinkRun::Full(nodes) => (true, nodes.to_vec(), Spans::new()),
+            ShrinkRun::Probe { .. } => (false, Vec::new(), Spans::new()),
+        }),
+        vec![int_node(5)],
+        Spans::new(),
+    );
+    shrinker.deadline = Some(Instant::now() - Duration::from_secs(1));
+    // First `consider` observes the expired deadline, latches `timed_out`, and
+    // rejects without invoking the closure.
+    assert!(!shrinker.consider(&[int_node(0)]));
+    assert!(shrinker.timed_out);
+    // A second `consider` and a `probe` hit the already-latched fast path.
+    assert!(!shrinker.consider(&[int_node(0)]));
+    shrinker.probe(&[ChoiceValue::Integer(BigInt::from(0))], 0, 8);
+    assert_eq!(shrinker.calls, 0, "nothing should have been executed");
+}

--- a/tests/embedded/native/shrinker_sequence_tests.rs
+++ b/tests/embedded/native/shrinker_sequence_tests.rs
@@ -51,7 +51,7 @@ fn sort_values_takes_the_full_sort_when_accepted() {
         initial,
         Spans::new(),
     );
-    shrinker.sort_values_integers();
+    shrinker.sort_values_integers().unwrap();
     assert_eq!(int_values(&shrinker), vec![1, 3, 5]);
 }
 
@@ -67,7 +67,7 @@ fn sort_values_sorts_booleans() {
         initial,
         Spans::new(),
     );
-    shrinker.sort_values_booleans();
+    shrinker.sort_values_booleans().unwrap();
     let bools: Vec<bool> = shrinker
         .current_nodes
         .iter()

--- a/tests/embedded/native/shrinker_spans_tests.rs
+++ b/tests/embedded/native/shrinker_spans_tests.rs
@@ -72,7 +72,7 @@ fn consider_replaces_current_spans_on_improvement() {
     // A smaller candidate triggers `accept_improvement`, which swaps in the
     // closure-provided spans.
     let smaller = vec![int_node(0), int_node(0)];
-    assert!(shrinker.consider(&smaller));
+    assert!(shrinker.consider(&smaller).unwrap());
     assert_eq!(shrinker.current_spans.len(), 1);
     assert_eq!(shrinker.current_spans.get(0).unwrap().label, "updated");
 }
@@ -100,7 +100,7 @@ fn consider_leaves_current_spans_alone_when_candidate_not_smaller() {
     );
 
     // Same as current_nodes → fast-path returns true without calling test_fn.
-    assert!(shrinker.consider(&initial));
+    assert!(shrinker.consider(&initial).unwrap());
     assert_eq!(shrinker.current_spans.get(0).unwrap().label, "kept");
 
     // Non-improving (same sort_key, different values would have to be
@@ -108,7 +108,7 @@ fn consider_leaves_current_spans_alone_when_candidate_not_smaller() {
     // We instead pass a strictly larger candidate to verify the not-smaller
     // path leaves spans untouched.
     let larger = vec![int_node(7)];
-    shrinker.consider(&larger);
+    shrinker.consider(&larger).unwrap();
     assert_eq!(shrinker.current_spans.get(0).unwrap().label, "kept");
 }
 
@@ -128,12 +128,16 @@ fn changed_nodes_accumulates_diff_against_checkpoint() {
     assert!(shrinker.changed_nodes().is_empty());
 
     // Shrink node 0 → set should contain {0}.
-    shrinker.consider(&[int_node(0), int_node(10), int_node(10)]);
+    shrinker
+        .consider(&[int_node(0), int_node(10), int_node(10)])
+        .unwrap();
     assert_eq!(shrinker.changed_nodes().len(), 1);
     assert!(shrinker.changed_nodes().contains(&0));
 
     // Shrink node 2 → set should contain {0, 2}.
-    shrinker.consider(&[int_node(0), int_node(10), int_node(0)]);
+    shrinker
+        .consider(&[int_node(0), int_node(10), int_node(0)])
+        .unwrap();
     let changed = shrinker.changed_nodes();
     assert!(changed.contains(&0));
     assert!(changed.contains(&2));
@@ -155,11 +159,13 @@ fn changed_nodes_clears_on_shape_change() {
         Spans::new(),
     );
 
-    shrinker.consider(&[int_node(0), int_node(5), int_node(5)]);
+    shrinker
+        .consider(&[int_node(0), int_node(5), int_node(5)])
+        .unwrap();
     assert!(!shrinker.changed_nodes().is_empty());
 
     // A two-element candidate is strictly smaller and changes the shape.
-    shrinker.consider(&[int_node(0), int_node(0)]);
+    shrinker.consider(&[int_node(0), int_node(0)]).unwrap();
     assert!(shrinker.changed_nodes().is_empty());
 }
 
@@ -182,7 +188,7 @@ fn changed_nodes_clears_on_kind_change_in_place() {
         initial,
         Spans::new(),
     );
-    shrinker.consider(&[int_node(0), int_node(0)]);
+    shrinker.consider(&[int_node(0), int_node(0)]).unwrap();
     // Kind change → set cleared.
     assert!(shrinker.changed_nodes().is_empty());
 }
@@ -220,7 +226,7 @@ fn forced_nodes_survive_every_shrinker_pass() {
         ),
         ShrinkPass::new("shrink_duplicates", Box::new(|sh| sh.shrink_duplicates())),
     ];
-    shrinker.fixate_shrink_passes(&mut passes);
+    shrinker.fixate_shrink_passes(&mut passes).unwrap();
     let value = match &shrinker.current_nodes[snapshot_forced_idx].value {
         ChoiceValue::Integer(v) => i128::try_from(v).unwrap(),
         _ => unreachable!(),
@@ -248,13 +254,13 @@ fn consider_cache_evicts_when_over_capacity() {
     for v in 1..=4100i128 {
         // Each candidate has a distinct value → distinct sort_key →
         // distinct cache key.
-        shrinker.consider(&[int_node(v)]);
+        shrinker.consider(&[int_node(v)]).unwrap();
     }
     // No panic, no growth past the bound (we only assert the rough
     // upper bound — exact size depends on hashing).
     // The behaviour we care about is that `consider` keeps working
     // even after the bound is reached.
-    assert!(!shrinker.consider(&[int_node(99999)]));
+    assert!(!shrinker.consider(&[int_node(99999)]).unwrap());
 }
 
 #[test]
@@ -281,9 +287,9 @@ fn consider_cache_short_circuits_repeated_candidate() {
         Spans::new(),
     );
     let candidate = vec![int_node(7)];
-    shrinker.consider(&candidate);
-    shrinker.consider(&candidate);
-    shrinker.consider(&candidate);
+    shrinker.consider(&candidate).unwrap();
+    shrinker.consider(&candidate).unwrap();
+    shrinker.consider(&candidate).unwrap();
     assert_eq!(count.get(), 1);
 }
 
@@ -298,7 +304,7 @@ fn clear_change_tracking_rebaselines_and_empties_set() {
         initial,
         Spans::new(),
     );
-    shrinker.consider(&[int_node(0), int_node(10)]);
+    shrinker.consider(&[int_node(0), int_node(10)]).unwrap();
     assert!(shrinker.changed_nodes().contains(&0));
 
     shrinker.clear_change_tracking();
@@ -306,7 +312,7 @@ fn clear_change_tracking_rebaselines_and_empties_set() {
 
     // After clearing, the new baseline is the post-shrink state, so the
     // next diff is against `[0, 10]` rather than the original `[10, 10]`.
-    shrinker.consider(&[int_node(0), int_node(0)]);
+    shrinker.consider(&[int_node(0), int_node(0)]).unwrap();
     let changed = shrinker.changed_nodes();
     assert!(changed.contains(&1));
     assert!(!changed.contains(&0));

--- a/tests/embedded/native/shrinker_string_passes_tests.rs
+++ b/tests/embedded/native/shrinker_string_passes_tests.rs
@@ -35,7 +35,7 @@ fn lower_duplicated_characters_lowers_shared_codepoint_in_pair() {
         initial,
         Spans::new(),
     );
-    shrinker.lower_duplicated_characters();
+    shrinker.lower_duplicated_characters().unwrap();
     // The 'b' shared codepoint should be lowered to the smallest in the
     // shrink order ('a').
     if let ChoiceValue::String(s0) = &shrinker.current_nodes[0].value {
@@ -69,7 +69,7 @@ fn lower_duplicated_characters_skips_non_string_neighbour() {
         initial,
         Spans::new(),
     );
-    shrinker.lower_duplicated_characters();
+    shrinker.lower_duplicated_characters().unwrap();
     // No second string to pair with → no change.
     if let ChoiceValue::String(s) = &shrinker.current_nodes[0].value {
         assert_eq!(s, &vec![b'b' as u32]);
@@ -88,7 +88,7 @@ fn normalize_unicode_chars_replaces_accented_letter_with_base() {
         initial,
         Spans::new(),
     );
-    shrinker.normalize_unicode_chars();
+    shrinker.normalize_unicode_chars().unwrap();
     if let ChoiceValue::String(s) = &shrinker.current_nodes[0].value {
         // Either lowered to 'A' (NFD) or 'a' (case map) — both fine.
         assert!(s == &vec![b'A' as u32] || s == &vec![b'a' as u32]);
@@ -113,7 +113,7 @@ fn normalize_unicode_chars_skips_when_no_simpler_chars() {
         initial,
         Spans::new(),
     );
-    shrinker.normalize_unicode_chars();
+    shrinker.normalize_unicode_chars().unwrap();
     if let ChoiceValue::String(s) = &shrinker.current_nodes[0].value {
         assert_eq!(s, &vec![b'A' as u32]);
     } else {
@@ -147,7 +147,7 @@ fn normalize_unicode_chars_handles_string_truncated_by_closure() {
         initial,
         Spans::new(),
     );
-    shrinker.normalize_unicode_chars();
+    shrinker.normalize_unicode_chars().unwrap();
     // No panic on the second iteration; current_nodes converged on a
     // length-1 string.
     if let ChoiceValue::String(s) = &shrinker.current_nodes[0].value {
@@ -173,7 +173,7 @@ fn normalize_unicode_chars_does_nothing_on_non_string() {
         initial,
         Spans::new(),
     );
-    shrinker.normalize_unicode_chars();
+    shrinker.normalize_unicode_chars().unwrap();
     match shrinker.current_nodes[0].value {
         ChoiceValue::Boolean(b) => assert!(b),
         _ => unreachable!(),
@@ -194,7 +194,7 @@ fn normalize_unicode_chars_respects_intervals() {
         initial,
         Spans::new(),
     );
-    shrinker.normalize_unicode_chars();
+    shrinker.normalize_unicode_chars().unwrap();
     if let ChoiceValue::String(s) = &shrinker.current_nodes[0].value {
         // The 'A' base (0x41) sits outside the allowed range; 'À' (0xC0)
         // remains unchanged.

--- a/tests/embedded/native/shrinker_strings_tests.rs
+++ b/tests/embedded/native/shrinker_strings_tests.rs
@@ -39,7 +39,7 @@ fn redistribute_string_pair_moves_entire_value_when_accepted() {
         string_node(vec![b'd' as u32, b'e' as u32], 0, 0x10FFFF),
     ];
     let mut shrinker = accepting_shrinker(initial);
-    shrinker.redistribute_string_pairs();
+    shrinker.redistribute_string_pairs().unwrap();
     let (a, b) = match (
         &shrinker.current_nodes[0].value,
         &shrinker.current_nodes[1].value,
@@ -84,7 +84,7 @@ fn redistribute_string_pair_partial_move_triggers_bin_search() {
         initial,
         Spans::new(),
     );
-    shrinker.redistribute_string_pairs();
+    shrinker.redistribute_string_pairs().unwrap();
     match &shrinker.current_nodes[1].value {
         ChoiceValue::String(s) => assert!(s.len() <= 3, "t exceeded 3 cps: {s:?}"),
         _ => unreachable!(),
@@ -101,7 +101,7 @@ fn shrink_strings_collapses_accepting_run_toward_simplest() {
         b'z' as u32,
     )];
     let mut shrinker = accepting_shrinker(initial);
-    shrinker.shrink_strings();
+    shrinker.shrink_strings().unwrap();
     let v = match &shrinker.current_nodes[0].value {
         ChoiceValue::String(v) => v.clone(),
         _ => unreachable!(),
@@ -141,7 +141,7 @@ fn shrink_strings_duplicate_pass_bin_search_skips_after_val_eliminated() {
         initial,
         Spans::new(),
     );
-    shrinker.shrink_strings();
+    shrinker.shrink_strings().unwrap();
     match &shrinker.current_nodes[0].value {
         ChoiceValue::String(s) => assert_eq!(s, &vec![100u32, 100u32]),
         _ => unreachable!(),
@@ -171,7 +171,7 @@ fn shrink_strings_semantic_candidate_falls_back_to_nfd_base_in_range() {
         initial,
         Spans::new(),
     );
-    shrinker.shrink_strings();
+    shrinker.shrink_strings().unwrap();
     match &shrinker.current_nodes[0].value {
         ChoiceValue::String(s) => {
             assert_eq!(s.len(), 1);

--- a/tests/embedded/native/shrinker_try_trivial_spans_tests.rs
+++ b/tests/embedded/native/shrinker_try_trivial_spans_tests.rs
@@ -55,7 +55,7 @@ fn try_trivial_spans_zeroes_non_forced_children() {
         initial,
         spans,
     );
-    shrinker.try_trivial_spans();
+    shrinker.try_trivial_spans().unwrap();
     let values: Vec<_> = shrinker
         .current_nodes
         .iter()
@@ -89,7 +89,7 @@ fn try_trivial_spans_preserves_forced_children() {
         initial,
         spans,
     );
-    shrinker.try_trivial_spans();
+    shrinker.try_trivial_spans().unwrap();
     let values: Vec<_> = shrinker
         .current_nodes
         .iter()
@@ -125,7 +125,7 @@ fn try_trivial_spans_skips_already_trivial_span() {
         initial,
         spans,
     );
-    shrinker.try_trivial_spans();
+    shrinker.try_trivial_spans().unwrap();
     // No test invocations: the span was trivial up front.
     assert_eq!(calls.get(), 0);
 }
@@ -146,7 +146,7 @@ fn try_trivial_spans_handles_oversized_span_end() {
         initial,
         spans,
     );
-    shrinker.try_trivial_spans();
+    shrinker.try_trivial_spans().unwrap();
     // No change — the oversized span was skipped.
     assert_eq!(shrinker.current_nodes.len(), 1);
     match &shrinker.current_nodes[0].value {
@@ -194,7 +194,7 @@ fn try_trivial_spans_retries_with_realised_span_content() {
         initial,
         spans,
     );
-    shrinker.try_trivial_spans();
+    shrinker.try_trivial_spans().unwrap();
     assert_eq!(call_count.get(), 2);
     // Retry succeeded — the spliced sequence is now the current target.
     assert_eq!(shrinker.current_nodes.len(), 2);

--- a/tests/embedded/native/test_runner_tests.rs
+++ b/tests/embedded/native/test_runner_tests.rs
@@ -341,7 +341,13 @@ fn run_main_with_urandom_backend_generates_and_passes() {
         .test_cases(20)
         .database(None)
         .backend(crate::runner::Backend::Urandom);
-    let result = run_main(&settings, None, &mut run_case, Duration::from_secs(30));
+    let result = run_main(
+        &settings,
+        None,
+        &mut run_case,
+        Duration::from_secs(30),
+        Duration::from_secs(300),
+    );
     assert!(result.passed);
 }
 
@@ -362,10 +368,58 @@ fn run_main_with_urandom_backend_finds_counterexample() {
         .test_cases(20)
         .database(None)
         .backend(crate::runner::Backend::Urandom);
-    let result = run_main(&settings, None, &mut run_case, Duration::from_secs(30));
+    let result = run_main(
+        &settings,
+        None,
+        &mut run_case,
+        Duration::from_secs(30),
+        Duration::from_secs(300),
+    );
     assert!(!result.passed);
     assert!(
         result.failures[0].panic_message.contains("always fails"),
+        "{:?}",
+        result.failures
+    );
+}
+
+#[test]
+fn slow_shrink_warning_mentions_shrinking() {
+    let w = slow_shrink_warning();
+    assert!(w.contains("Shrinking"), "{w}");
+    assert!(w.contains("stopped"), "{w}");
+}
+
+#[test]
+fn run_main_stops_shrinking_when_budget_is_exhausted() {
+    // Drive `run_main` with a zero shrink budget so the wall-clock cutoff
+    // fires deterministically instead of after five minutes. The run must
+    // still surface the failure (with the best, un-shrunk example) rather
+    // than hang, and the slow-shrink warning path is exercised.
+    crate::run_lifecycle::init_panic_hook();
+    let mut test_fn = |tc: crate::TestCase| {
+        // A non-trivial counterexample so there is real shrinking work that
+        // the zero budget cuts short.
+        let v: Vec<i32> = tc.draw(crate::generators::vecs(crate::generators::integers()));
+        assert!(v.is_empty(), "non-empty vec");
+    };
+    let mut run_case = |ds: Box<dyn crate::backend::DataSource + Send + Sync>, is_final: bool| {
+        run_test_case(ds, &mut test_fn, is_final, Mode::TestRun, Verbosity::Normal);
+    };
+    let settings = Settings::new()
+        .test_cases(200)
+        .database(None)
+        .derandomize(true);
+    let result = run_main(
+        &settings,
+        None,
+        &mut run_case,
+        Duration::from_secs(30),
+        Duration::ZERO,
+    );
+    assert!(!result.passed, "the failure must still be reported");
+    assert!(
+        result.failures[0].panic_message.contains("non-empty vec"),
         "{:?}",
         result.failures
     );
@@ -385,7 +439,13 @@ fn run_main_reports_too_slow_at_call_site() {
         run_test_case(ds, &mut test_fn, is_final, Mode::TestRun, Verbosity::Normal);
     };
     let settings = Settings::new().test_cases(100).database(None);
-    let result = run_main(&settings, None, &mut run_case, Duration::ZERO);
+    let result = run_main(
+        &settings,
+        None,
+        &mut run_case,
+        Duration::ZERO,
+        Duration::from_secs(300),
+    );
     assert!(!result.passed);
     assert!(
         result.failures[0].panic_message.contains("TooSlow"),
@@ -516,7 +576,13 @@ fn discover_reproduce_blob() -> String {
     let mut run_case = |ds: Box<dyn crate::backend::DataSource + Send + Sync>, _is_final: bool| {
         mark_large_interesting(&*ds);
     };
-    let result = run_main(&settings, None, &mut run_case, Duration::from_secs(30));
+    let result = run_main(
+        &settings,
+        None,
+        &mut run_case,
+        Duration::from_secs(30),
+        Duration::from_secs(300),
+    );
     assert!(!result.passed, "property should have failed");
     result.failures[0]
         .reproduce_blob


### PR DESCRIPTION
Bounds the native engine's shrinking phase by wall-clock time, so a test whose body is slow to execute can no longer make shrinking run for an unbounded amount of time.

<details>
<summary>Implementation notes (AI-generated)</summary>

Previously the native shrinker was bounded only by step counts (`MAX_SHRINKS` and the per-pass stall guard). On a test with a slow body the shrink phase could run for a very long wall-clock time, whereas Hypothesis stops after `MAX_SHRINKING_SECONDS` (5 minutes) and reports the smallest example found so far.

This adds the same safety valve:

- `Shrinker` gains a `deadline: Option<Instant>` and a latching `timed_out` flag. A `past_deadline()` helper checks it in `consider`/`probe` (short-circuiting further candidates) and at the top of the pass scheduler's outer loop (stopping the schedule).
- The runner sets **one** deadline shared across every origin's shrink, matching Hypothesis's single `finish_shrinking_deadline` for the whole phase. On timeout it keeps the smallest example found so far and prints a warning (unless `Verbosity::Quiet`).
- The budget is injected into `run_main` (mirroring the existing `too_slow_threshold` parameter) so tests trip it deterministically with a zero budget rather than waiting 5 minutes.

The timeout only ever fires on pathologically slow runs, so normal (sub-300s) runs are unaffected and stay deterministic.

Tests: shrinker-level unit tests (deadline already passed → stops with the example unshrunk; future deadline → shrinks normally to the minimal example; latch + `consider`/`probe` short-circuit), a `run_main` integration test driving the zero-budget cutoff, and a direct assertion on the warning text.
</details>
