### PR TITLE
Fix broken release from switchover PR

### DIFF
--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -8,6 +8,18 @@ from pathlib import Path
 SOURCE_DIRS = ["src/", "hegel-macros/"]
 ROOT = Path(__file__).resolve().parent.parent.parent
 
+# Files the release commit reads, rewrites, and stages. These are validated by
+# `check` on every PR so removing one (as the conformance-test removal did with
+# tests/conformance/rust) fails fast instead of breaking the actual release —
+# which only ever runs the `release` subcommand on a push to main.
+RELEASE_PATHS = [
+    "Cargo.toml",
+    "Cargo.lock",
+    "hegel-macros/Cargo.toml",
+    "hegel-c/Cargo.toml",
+    "CHANGELOG.md",
+]
+
 
 def git(*args: str, cwd: Path | None = None) -> None:
     subprocess.run(["git", *args], check=True, cwd=cwd)
@@ -79,6 +91,13 @@ def add_changelog(path: Path, *, version: str, content: str) -> None:
 
 
 def check(base_ref: str) -> None:
+    missing = [rel for rel in RELEASE_PATHS if not (ROOT / rel).exists()]
+    if missing:
+        raise ValueError(
+            "release.py would fail: these paths it stages no longer exist: "
+            + ", ".join(missing)
+        )
+
     output = subprocess.check_output(
         ["git", "diff", "--name-only", f"origin/{base_ref}...HEAD"],
         text=True,
@@ -138,13 +157,8 @@ def release() -> None:
     set_dep_version(ROOT / "Cargo.toml", "hegeltest-macros", new_version)
     set_dep_version(ROOT / "hegel-c" / "Cargo.toml", "hegeltest", new_version)
 
-    # regenerate lockfiles after version bump
+    # regenerate the lockfile after version bump
     subprocess.run(["cargo", "update", "--workspace"], check=True, cwd=ROOT)
-    subprocess.run(
-        ["cargo", "update", "--workspace"],
-        check=True,
-        cwd=(ROOT / "tests" / "conformance" / "rust"),
-    )
 
     add_changelog(ROOT / "CHANGELOG.md", version=new_version, content=content)
 
@@ -159,16 +173,7 @@ def release() -> None:
         f"{bot_user_id}+{app_slug}[bot]@users.noreply.github.com",
         cwd=ROOT,
     )
-    git(
-        "add",
-        "Cargo.toml",
-        "Cargo.lock",
-        "hegel-macros/Cargo.toml",
-        "hegel-c/Cargo.toml",
-        "tests/conformance/rust/Cargo.lock",
-        "CHANGELOG.md",
-        cwd=ROOT,
-    )
+    git("add", *RELEASE_PATHS, cwd=ROOT)
     git("rm", "RELEASE.md", cwd=ROOT)
     git(
         "commit",


### PR DESCRIPTION
The switchover PR removed a bunch of files that our release script was checking for. This fixes that.

<details>
<summary>AI-generated implementation notes</summary>

The `release` job for the switchover failed ([run](https://github.com/hegeldev/hegel-rust/actions/runs/27200965899/job/80309041729)) with:

```
FileNotFoundError: [Errno 2] No such file or directory: .../tests/conformance/rust
```

Commit `1e634ed4` removed `tests/conformance/rust` (the conformance suite lost its `hegel-core` oracle when the server backend went away) but missed two references to it in `.github/scripts/release.py`:

1. A second `cargo update --workspace` run with `cwd=tests/conformance/rust`.
2. Staging `tests/conformance/rust/Cargo.lock` in the release commit.

The first aborted the job *before* any tag, publish, or push — so the failure was clean: `main` is still at `0.16.0`, `v0.16.0` is the latest tag, and `RELEASE.md` is still present on `main`. Merging this fix re-triggers the `release` job on `main`, which will cut `v0.17.0`.

**Changes:**
- Drop both `tests/conformance/rust` references from `release.py`.
- Add a `RELEASE_PATHS` constant (the files the release reads/rewrites/stages) and validate it in the `check` subcommand. `check` runs on every source-touching PR, whereas `release` only runs on a push to main — so this class of bug (a path the release depends on being removed elsewhere) now fails fast in pre-merge CI instead of breaking the actual release. This would have caught the switchover PR.
- `release`'s `git add` now uses `RELEASE_PATHS` so the staged set and the validated set can't drift.

**Other release surfaces investigated (no further breakage found):**
- Version-bump regexes in `set_version`/`set_dep_version` still match the current `Cargo.toml`, `hegel-macros/Cargo.toml`, `hegel-c/Cargo.toml`.
- crate publish order (`hegeltest-macros` → `hegeltest` → `hegeltest-c`) and the `=`-pinned path deps are intact.
- `release-binaries` / `release-binaries-verify` build and verify the `hegeltest-c` cdylib and are unaffected.
- Grep of `.github/`, `justfile`, `scripts/` for `conformance|hegel-core|server|socket|uv run` found no other stale references (remaining hits are unrelated Python helpers and the intended `uv` coverage shebang).
</details>