### PR TITLE
Speed up Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,15 @@ jobs:
         with:
           tools: just
 
+      # Windows Defender real-time scanning of every .obj/.exe/.pdb cargo
+      # writes (and of each test binary on execution) is a large tax on the
+      # subprocess-heavy integration tests. Excluding the workspace from
+      # real-time scanning removes it. No-op on non-Windows runners.
+      - name: Exclude workspace from Windows Defender
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: Add-MpPreference -ExclusionPath "${{ github.workspace }}"
+
       - name: Run tests
         run: just check-tests
 
@@ -107,6 +116,13 @@ jobs:
         with:
           tools: just
 
+      # See the note in the `test` job: exclude the workspace from Windows
+      # Defender real-time scanning to drop the AV tax on subprocess builds.
+      - name: Exclude workspace from Windows Defender
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: Add-MpPreference -ExclusionPath "${{ github.workspace }}"
+
       - name: Run tests
         run: just ${{ matrix.recipe }}
 
@@ -140,6 +156,13 @@ jobs:
       - uses: ./.github/actions/install-tools
         with:
           tools: just
+
+      # See the note in the `test` job: exclude the workspace from Windows
+      # Defender real-time scanning to drop the AV tax on subprocess builds.
+      - name: Exclude workspace from Windows Defender
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: Add-MpPreference -ExclusionPath "${{ github.workspace }}"
 
       - name: Run C bindings test recipe
         run: just c-test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,21 @@ serde_json_raw_value = ["serde_json", "serde_json/raw_value"]
 # public API; depend on at your peril.
 __bench = []
 
+# Trim debuginfo on dev/test builds. The default dev profile emits full
+# DWARF/PDB debuginfo, which dominates link time — especially on Windows,
+# where `link.exe` is slow and the fat `.pdb` it produces is the bottleneck.
+# `line-tables-only` keeps file/line info for panic backtraces (which tests
+# rely on) while dropping the heavy variable/type debuginfo. `test` inherits
+# this from `dev`.
+#
+# NOTE: this only affects the *main* build (the hegeltest lib + the test
+# binaries themselves). The integration tests that spawn `cargo` subprocesses
+# build standalone temp crates with their own profile — those are sped up
+# separately via the `CARGO_PROFILE_*_DEBUG` env vars set in
+# `tests/common/project.rs`.
+[profile.dev]
+debug = "line-tables-only"
+
 [package.metadata.docs.rs]
 all-features = true
 # -D warnings means "deny warnings", which actually means "turn warnings into errors". Have

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,32 +95,30 @@ serde_json_raw_value = ["serde_json", "serde_json/raw_value"]
 # public API; depend on at your peril.
 __bench = []
 
-# Trim debuginfo on dev/test builds. The default dev profile emits full
-# DWARF/PDB debuginfo, which dominates link time — especially on Windows,
-# where `link.exe` is slow and the fat `.pdb` it produces is the bottleneck.
-# `line-tables-only` keeps file/line info for panic backtraces (which tests
-# rely on) while dropping the heavy variable/type debuginfo. `test` inherits
-# this from `dev`.
+# Tune the dev/test profile for CI speed.
 #
-# NOTE: this only affects the *main* build (the hegeltest lib + the test
-# binaries themselves). The integration tests that spawn `cargo` subprocesses
-# build standalone temp crates with their own profile — those are sped up
-# separately via the `CARGO_PROFILE_*_DEBUG` env vars set in
+# `opt-level = 1`: the native engine is compute-heavy, and running it
+# unoptimized makes the property-test suites dominate CI wall-clock — far
+# worse on Windows. opt-level 1 recovers most of the speed at modest compile
+# cost. Kept as a *whole-profile* setting (not per-package) specifically so
+# the coverage build can override it back to 0 via `CARGO_PROFILE_DEV_OPT_LEVEL`:
+# `cargo llvm-cov` needs unoptimized code for accurate line attribution
+# (optimization inlines small functions and drops their coverage regions).
+# See the `check-coverage` recipe in the justfile.
+#
+# `debug = "line-tables-only"`: the default dev profile emits full DWARF/PDB
+# debuginfo, which dominates link time — especially on Windows, where
+# `link.exe` is slow and the fat `.pdb` is the bottleneck. line-tables-only
+# keeps file/line info for panic backtraces (which tests rely on) while
+# dropping the heavy variable/type debuginfo.
+#
+# Both settings affect only the *main* build. Integration tests that spawn
+# `cargo` subprocesses build standalone temp crates with their own profile;
+# those are tuned separately via the `CARGO_PROFILE_*` env vars in
 # `tests/common/project.rs`.
 [profile.dev]
+opt-level = 1
 debug = "line-tables-only"
-
-# The native engine (in this crate) and its deps are compute- and
-# allocation-heavy; running them unoptimized makes the property-test suites
-# dominate CI wall-clock, and the penalty is far worse on Windows (~14x the
-# Linux runtime). Optimize the library and dependencies while leaving the
-# thin integration-test crates unoptimized, so the hot code runs fast without
-# inflating compile time across the ~40 test binaries.
-[profile.dev.package.hegeltest]
-opt-level = 2
-
-[profile.dev.package."*"]
-opt-level = 2
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,18 @@ __bench = []
 [profile.dev]
 debug = "line-tables-only"
 
+# The native engine (in this crate) and its deps are compute- and
+# allocation-heavy; running them unoptimized makes the property-test suites
+# dominate CI wall-clock, and the penalty is far worse on Windows (~14x the
+# Linux runtime). Optimize the library and dependencies while leaving the
+# thin integration-test crates unoptimized, so the hot code runs fast without
+# inflating compile time across the ~40 test binaries.
+[profile.dev.package.hegeltest]
+opt-level = 2
+
+[profile.dev.package."*"]
+opt-level = 2
+
 [package.metadata.docs.rs]
 all-features = true
 # -D warnings means "deny warnings", which actually means "turn warnings into errors". Have

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,4 @@
 RELEASE_TYPE: patch
 
-This patch improves the performance of shrinking a failing test when running with `RUST_BACKTRACE` set (for example, on CI).
-
-Hegel's panic hook previously captured a stack backtrace for every panic raised while running your test body — including the many failing examples explored during shrinking, whose backtraces are never shown. With `RUST_BACKTRACE` set, capturing and symbolizing those discarded backtraces dominated the cost of shrinking a failing property, and was especially slow on Windows. Hegel now captures a backtrace only for a failure it is actually going to report (and, in verbose mode, for each example it prints). The backtrace shown on the reported failure is unchanged.
+This patch improves the performance of shrinking a failing test when running with `RUST_BACKTRACE` set. Hegel would previously
+capture the stack backtrace for every panic raised while running your test body even when that backtrace was never shown. This could be a significant performance hit, especially on Windows. Hegel now captures only backtraces it needs to print. This should be a significant performance improvement in some workloads, and otherwise have no user-visible effect.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch improves the performance of shrinking a failing test when running with `RUST_BACKTRACE` set (for example, on CI).
+
+Hegel's panic hook previously captured a stack backtrace for every panic raised while running your test body — including the many failing examples explored during shrinking, whose backtraces are never shown. With `RUST_BACKTRACE` set, capturing and symbolizing those discarded backtraces dominated the cost of shrinking a failing property, and was especially slow on Windows. Hegel now captures a backtrace only for a failure it is actually going to report (and, in verbose mode, for each example it prints). The backtrace shown on the reported failure is unchanged.

--- a/justfile
+++ b/justfile
@@ -54,7 +54,10 @@ check-lint: check-format check-clippy check-nocov-style check-test-modules
 
 check-coverage:
     # requires cargo-llvm-cov and llvm-tools-preview
-    scripts/check-coverage.py
+    # Force opt-level 0 (overriding `[profile.dev] opt-level` in Cargo.toml):
+    # cargo-llvm-cov needs unoptimized code for accurate line attribution, as
+    # optimization inlines small functions and drops their coverage regions.
+    CARGO_PROFILE_DEV_OPT_LEVEL=0 scripts/check-coverage.py
 
 # Build the libhegel C shared library + checked-in C header.
 c-build:

--- a/src/run_lifecycle.rs
+++ b/src/run_lifecycle.rs
@@ -14,7 +14,7 @@
 //! re-raise.
 
 use std::backtrace::{Backtrace, BacktraceStatus};
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::panic::{self, AssertUnwindSafe, catch_unwind};
 use std::sync::Once;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -36,19 +36,46 @@ thread_local! {
     /// [`take_panic_info`] right after `catch_unwind` returns.
     static LAST_PANIC_INFO: RefCell<Option<(String, String, String, Backtrace)>> =
         const { RefCell::new(None) };
+
+    /// Whether the panic hook should pay to capture a backtrace for the next
+    /// panic on this thread. Set by [`run_test_case`] to `should_emit`
+    /// (`is_final || verbose`) — i.e. only when the resulting diagnostic will
+    /// actually be shown. Capturing (and, under `RUST_BACKTRACE`, symbolizing)
+    /// a backtrace for every discarded shrink probe is the dominant cost of
+    /// failing-heavy property runs, and is far worse on Windows.
+    static CAPTURE_BACKTRACE: Cell<bool> = const { Cell::new(false) };
 }
 
 fn take_panic_info() -> Option<(String, String, String, Backtrace)> {
     LAST_PANIC_INFO.with(|info| info.borrow_mut().take())
 }
 
+/// Control-flow panics (a failed `assume`, `stop_test`, loop-done, or an
+/// invalid-argument usage error) are caught and classified by
+/// [`run_test_case`] without ever rendering a backtrace, so the hook must not
+/// pay to capture one for them — they are common on the generation hot path.
+fn is_control_panic(payload: &(dyn std::any::Any + Send)) -> bool {
+    let msg = payload
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| payload.downcast_ref::<String>().map(String::as_str));
+    msg.is_some_and(|m| {
+        m == ASSUME_FAIL_STRING
+            || m == STOP_TEST_STRING
+            || m == LOOP_DONE_STRING
+            || m.starts_with(INVALID_ARGUMENT_PREFIX)
+    })
+}
+
 /// Install the cross-backend panic hook on first call.
 ///
-/// Idempotent across all backends: the hook captures location + backtrace
-/// for any panic raised inside a test context (so [`run_test_case`] can read
-/// the location after `catch_unwind`), and forwards everything else to the
-/// previous hook unchanged. Without the suppression, every shrinker probe
-/// would print a `thread 'main' panicked` line to stderr and the user-visible
+/// Idempotent across all backends: the hook captures the location for any
+/// panic raised inside a test context (so [`run_test_case`] can read it after
+/// `catch_unwind`), and forwards everything else to the previous hook
+/// unchanged. A backtrace is captured only when [`CAPTURE_BACKTRACE`] is set
+/// and the panic is a genuine failure (not a control-flow panic) — see
+/// [`is_control_panic`]. Without the suppression, every shrinker probe would
+/// print a `thread 'main' panicked` line to stderr and the user-visible
 /// output would be unreadable.
 pub(crate) fn init_panic_hook() {
     PANIC_HOOK_INIT.call_once(|| {
@@ -69,7 +96,13 @@ pub(crate) fn init_panic_hook() {
                 .location()
                 .map(|loc| format!("{}:{}:{}", loc.file(), loc.line(), loc.column()))
                 .unwrap_or_else(|| "<unknown>".to_string());
-            let backtrace = Backtrace::capture();
+            // Only capture (and symbolize) a backtrace when the diagnostic
+            // will actually be shown and the panic is a genuine failure.
+            let backtrace = if CAPTURE_BACKTRACE.get() && !is_control_panic(info.payload()) {
+                Backtrace::capture()
+            } else {
+                Backtrace::disabled()
+            };
 
             LAST_PANIC_INFO
                 .with(|l| *l.borrow_mut() = Some((thread_name, thread_id, location, backtrace)));
@@ -210,6 +243,12 @@ pub(crate) fn run_test_case(
         verbosity,
         crate::runner::Verbosity::Verbose | crate::runner::Verbosity::Debug
     );
+    // `should_emit` mirrors `TestCase`'s own gate: the diagnostic is only
+    // shown for the final replay or, in verbose mode, every interesting case.
+    // Tell the panic hook to capture a backtrace only when it will be shown.
+    let should_emit = is_final || verbose;
+    CAPTURE_BACKTRACE.with(|c| c.set(should_emit));
+
     let tc = TestCase::new(data_source, is_final, mode, verbose);
     let result = with_test_context(|| catch_unwind(AssertUnwindSafe(|| test_fn(tc.clone()))));
 

--- a/tests/common/project.rs
+++ b/tests/common/project.rs
@@ -318,6 +318,17 @@ hegeltest = {{ path = "{path}"{features} }}
             .current_dir(&self.project.project_path)
             .env("CARGO_TARGET_DIR", shared_target_dir());
 
+        // Trim debuginfo on the spawned subprocess builds. These standalone
+        // temp crates don't inherit the main workspace's `[profile.dev]`, so
+        // the override has to be passed explicitly. Full debuginfo dominates
+        // link time — most acutely on Windows, where `link.exe` is slow and
+        // writing the fat `.pdb` is the bottleneck. `line-tables-only` keeps
+        // panic-backtrace line numbers while dropping the heavy debuginfo.
+        // `cargo run` uses the dev profile and `cargo test` the test profile
+        // (which inherits dev's `debug`), so set both for robustness.
+        cmd.env("CARGO_PROFILE_DEV_DEBUG", "line-tables-only")
+            .env("CARGO_PROFILE_TEST_DEBUG", "line-tables-only");
+
         if use_coverage {
             // cargo-llvm-cov's RUSTC_WRAPPER only instruments crates listed in
             // __CARGO_LLVM_COV_RUSTC_WRAPPER_CRATE_NAMES. Append this temp

--- a/tests/embedded/run_lifecycle_tests.rs
+++ b/tests/embedded/run_lifecycle_tests.rs
@@ -1,6 +1,8 @@
 //! Embedded tests for `src/run_lifecycle.rs`.
 
 use super::*;
+use crate::backend::DataSourceError;
+use ciborium::Value;
 
 // `panic_message` downcasts the panic payload to `&str` or `String`; for
 // any other type it falls through to the `"Unknown panic"` branch.  Real
@@ -263,6 +265,155 @@ fn drive_multiple_failures_prints_each_reproducer_and_panics() {
     assert!(
         msg.contains("2 distinct failures"),
         "unexpected panic message: {msg}"
+    );
+}
+
+// ── run_lifecycle: backtrace capture is gated to where it is shown ───────
+//
+// The panic hook captures a backtrace for every panic raised in a test
+// context, but the only backtraces that are ever shown belong to failures
+// whose diagnostic is emitted — the final replay (`is_final`) or, in
+// verbose mode, every interesting case. Capturing (and, under
+// `RUST_BACKTRACE`, symbolizing) one for each discarded shrink probe is the
+// dominant cost of failing-heavy property runs. These tests pin the gating:
+// they are meaningful when the process has backtraces enabled (e.g. CI runs
+// with `RUST_BACKTRACE=1`) and harmless otherwise.
+
+/// A no-op `DataSource` for driving `run_test_case` with a body that panics
+/// before it draws. Only `mark_complete` is reached.
+struct BtStubDataSource;
+
+impl crate::backend::DataSource for BtStubDataSource {
+    fn generate(&self, _schema: &Value) -> Result<Value, DataSourceError> {
+        unimplemented!()
+    }
+    fn start_span(&self, _label: u64) -> Result<(), DataSourceError> {
+        unimplemented!()
+    }
+    fn stop_span(&self, _discard: bool) -> Result<(), DataSourceError> {
+        unimplemented!()
+    }
+    fn new_collection(&self, _min: u64, _max: Option<u64>) -> Result<i64, DataSourceError> {
+        unimplemented!()
+    }
+    fn collection_more(&self, _id: i64) -> Result<bool, DataSourceError> {
+        unimplemented!()
+    }
+    fn collection_reject(&self, _id: i64, _why: Option<&str>) -> Result<(), DataSourceError> {
+        unimplemented!()
+    }
+    fn new_pool(&self) -> Result<i64, DataSourceError> {
+        unimplemented!()
+    }
+    fn pool_add(&self, _pool_id: i64) -> Result<i64, DataSourceError> {
+        unimplemented!()
+    }
+    fn pool_generate(&self, _pool_id: i64, _consume: bool) -> Result<i64, DataSourceError> {
+        unimplemented!()
+    }
+    fn target_observation(&self, _score: f64, _label: &str) {
+        unimplemented!()
+    }
+    fn mark_complete(&self, _result: &TestCaseResult) {}
+}
+
+fn run_case_capturing(
+    is_final: bool,
+    verbosity: crate::runner::Verbosity,
+    body: &mut dyn FnMut(TestCase),
+) -> TestCaseResult {
+    init_panic_hook();
+    run_test_case(
+        Box::new(BtStubDataSource),
+        body,
+        is_final,
+        crate::runner::Mode::TestRun,
+        verbosity,
+    )
+}
+
+fn interesting_diagnostic(result: &TestCaseResult) -> String {
+    match result {
+        TestCaseResult::Interesting(failure) => failure.diagnostic.clone(),
+        other => panic!("expected an Interesting result, got {other:?}"),
+    }
+}
+
+fn backtraces_enabled() -> bool {
+    matches!(
+        Backtrace::capture().status(),
+        std::backtrace::BacktraceStatus::Captured
+    )
+}
+
+#[test]
+fn discarded_failures_skip_backtrace_capture() {
+    // Non-final, non-verbose: `should_emit` is false, so the diagnostic is
+    // thrown away — no backtrace should be captured, even with backtraces
+    // enabled. This is the shrinker hot path.
+    let result = run_case_capturing(false, crate::runner::Verbosity::Normal, &mut |_tc| {
+        panic!("{}", "boom")
+    });
+    let diagnostic = interesting_diagnostic(&result);
+    assert!(
+        !diagnostic.contains("stack backtrace"),
+        "a discarded (non-final) failure must not capture a backtrace; got:\n{diagnostic}"
+    );
+}
+
+#[test]
+fn shown_failures_capture_backtrace_when_enabled() {
+    // Final replay: `should_emit` is true, so the diagnostic is shown and
+    // should carry a backtrace exactly when the process has them enabled.
+    let result = run_case_capturing(true, crate::runner::Verbosity::Normal, &mut |_tc| {
+        panic!("{}", "boom")
+    });
+    let diagnostic = interesting_diagnostic(&result);
+    assert_eq!(
+        diagnostic.contains("stack backtrace"),
+        backtraces_enabled(),
+        "a shown (final) failure should carry a backtrace exactly when enabled; got:\n{diagnostic}"
+    );
+}
+
+#[test]
+fn verbose_mode_captures_backtrace_for_non_final_failures() {
+    // Verbose mode emits every interesting case's diagnostic live, so
+    // `should_emit` is true even when not final — the backtrace must be
+    // captured (when enabled) so the live output matches a real failure.
+    let result = run_case_capturing(false, crate::runner::Verbosity::Verbose, &mut |_tc| {
+        panic!("{}", "boom")
+    });
+    let diagnostic = interesting_diagnostic(&result);
+    assert_eq!(
+        diagnostic.contains("stack backtrace"),
+        backtraces_enabled(),
+        "verbose mode should capture a backtrace for non-final failures; got:\n{diagnostic}"
+    );
+}
+
+#[test]
+fn control_flow_panics_never_capture_a_backtrace() {
+    use std::backtrace::BacktraceStatus;
+    // An assume-style control panic is classified as `Invalid` and its
+    // captured info is discarded — so it must never pay to capture a
+    // backtrace, even on the final replay where `should_emit` is true.
+    init_panic_hook();
+    let result = run_test_case(
+        Box::new(BtStubDataSource),
+        &mut |_tc| std::panic::panic_any(crate::test_case::ASSUME_FAIL_STRING),
+        true,
+        crate::runner::Mode::TestRun,
+        crate::runner::Verbosity::Normal,
+    );
+    assert!(matches!(result, TestCaseResult::Invalid));
+    // The hook recorded the control panic but the `Invalid` branch left the
+    // info unconsumed; confirm no backtrace was captured for it.
+    let (_, _, _, backtrace) = take_panic_info().expect("hook recorded the control panic");
+    assert_eq!(
+        backtrace.status(),
+        BacktraceStatus::Disabled,
+        "control-flow panics must not capture a backtrace"
     );
 }
 


### PR DESCRIPTION
<!-- Human: please replace this line with the title and a short description. -->

<details>
<summary>AI-generated implementation notes</summary>

**Problem.** The Windows `test` jobs run ~5–10× slower than Linux/macOS.

**Root cause (found via step-level CI timing).** Not the `cargo`-subprocess compile/link path I first guessed (compile is only ~75s). The dominant cost is the in-process property-test suites, which run *failing* tests to exercise shrinking. The cross-backend panic hook captured a backtrace on **every** caught panic; during shrinking the engine runs the failing body hundreds of times, each panicking, but only the final replay's diagnostic is shown. With `RUST_BACKTRACE=1` (which CI sets) each capture also **symbolizes the stack** — and symbolization is far slower on Windows (DbgHelp/PDB). Measured: `test_quality` is **0.79s without** `RUST_BACKTRACE` vs **18.34s with** it.

| Suite | Linux | Windows | Ratio |
|---|---|---|---|
| test_quality | 25.8s | 380s | 14.7× |
| test_shrink_quality | 15.6s | 290s | 18.6× |
| test_collections | 13.8s | 198s | 14.3× |
| test_integers | 11.8s | 152s | 12.9× |

**Changes.**
1. **Gate backtrace capture (the fix).** Capture a backtrace only when the diagnostic will actually be shown — `should_emit` (`is_final || verbose`), the same condition `TestCase` uses — via a thread-local flag the panic hook reads. Also skip capture for control-flow panics (assume / stop_test / loop-done / invalid-argument), which never render a backtrace. Both new pieces of state are thread-local (matching the existing `LAST_PANIC_INFO` / `IN_TEST_CONTEXT`), so concurrent test threads stay isolated. With `RUST_BACKTRACE=1`, `test_quality` drops **18.34s → 0.93s** locally (~20×); larger on Windows. Backtraces on the reported failure are unchanged. This also speeds shrinking for any user who runs with `RUST_BACKTRACE` set. Regression tests added (TDD: confirmed red→green under `RUST_BACKTRACE=1`).
2. **Optimize the library + deps in the dev profile** (`opt-level = 2` for `hegeltest` and deps, test crates left at 0). Speeds the compute portion of the engine; one-time cold-rebuild cost on the first run, then cached.
3. **Trim debuginfo to `line-tables-only`** (`[profile.dev]` + `CARGO_PROFILE_*_DEBUG` for subprocess builds). Faster linking, keeps panic-backtrace line numbers.
4. **Exclude the workspace from Windows Defender** real-time scanning in the three Windows jobs.

Full default-feature suite stays green under `RUST_BACKTRACE=1` (52 suites, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>