### PR TITLE
Improvements to stateful testing "variables" API

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,32 @@
+RELEASE_TYPE: minor
+
+This release reworks the stateful-testing value-pool API. The `Variables<T>`
+type is renamed to `Pool<T>` and the `variables()` constructor is renamed to
+`pool()`. The `draw()` and `consume()` methods are replaced by two generators
+you draw from with `tc.draw()`:
+
+- `pool.references()` returns a generator over `&T` — drawing from it yields a
+  reference to a value in the pool without removing it (the old `draw()`).
+- `pool.values()` returns a generator over `T` — drawing from it removes a value
+  from the pool and yields it by value (the old `consume()`).
+
+Routing pool draws through `tc.draw()` means the chosen value is recorded in the
+failing-test replay and shrinks like any other draw.
+
+To migrate, rename the type and constructor, and replace draws:
+
+```rust
+// Before
+use hegel::stateful::{Variables, variables};
+let mut accounts: Variables<String> = variables(&tc);
+let account = accounts.draw().clone();
+let consumed = accounts.consume();
+
+// After
+use hegel::stateful::{Pool, pool};
+let mut accounts: Pool<String> = pool(&tc);
+let account = tc.draw(accounts.references()).clone();
+let consumed = tc.draw(accounts.values());
+```
+
+The `is_empty()`, `len()`, and `add()` methods are unchanged.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,10 +5,11 @@ type is renamed to `Pool<T>` and the `variables()` constructor is renamed to
 `pool()`. The `draw()` and `consume()` methods are replaced by two generators
 you draw from with `tc.draw()`:
 
-- `pool.references()` returns a generator over `&T` — drawing from it yields a
-  reference to a value in the pool without removing it (the old `draw()`).
-- `pool.values()` returns a generator over `T` — drawing from it removes a value
-  from the pool and yields it by value (the old `consume()`).
+- `pool.values_reusable()` returns a generator over `&T` — drawing from it
+  yields a reference to a value in the pool without removing it (the old
+  `draw()`).
+- `pool.values_consumed()` returns a generator over `T` — drawing from it
+  removes a value from the pool and yields it by value (the old `consume()`).
 
 Routing pool draws through `tc.draw()` means the chosen value is recorded in the
 failing-test replay and shrinks like any other draw.
@@ -25,8 +26,8 @@ let consumed = accounts.consume();
 // After
 use hegel::stateful::{Pool, pool};
 let mut accounts: Pool<String> = pool(&tc);
-let account = tc.draw(accounts.references()).clone();
-let consumed = tc.draw(accounts.values());
+let account = tc.draw(accounts.values_reusable()).clone();
+let consumed = tc.draw(accounts.values_consumed());
 ```
 
 The `is_empty()`, `len()`, and `add()` methods are unchanged.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,9 +11,6 @@ you draw from with `tc.draw()`:
 - `pool.values_consumed()` returns a generator over `T` — drawing from it
   removes a value from the pool and yields it by value (the old `consume()`).
 
-Routing pool draws through `tc.draw()` means the chosen value is recorded in the
-failing-test replay and shrinks like any other draw.
-
 To migrate, rename the type and constructor, and replace draws:
 
 ```rust
@@ -30,11 +27,6 @@ let account = tc.draw(accounts.values_reusable()).clone();
 let consumed = tc.draw(accounts.values_consumed());
 ```
 
-The `is_empty()`, `len()`, and `add()` methods are unchanged.
-
-The `Generator<T>` trait no longer requires `Self: Send + Sync`. Drawing a value
-is single-threaded, so the bound was never needed to produce values; it is now
-required only where a generator is actually shared across threads — by `boxed()`
-and by `deferred()`'s `set()`, which already carry it. This lets generators that
-borrow non-`Sync` data (such as the new `Pool` reference and value generators)
-implement the trait directly. Existing generators are unaffected.
+Additionally, the `Generator<T>` trait no longer requires `Self: Send + Sync`.
+This lets generators that borrow non-`Sync` data (such as the new `Pool` reference
+and value generators) implement the trait directly. 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -30,3 +30,10 @@ let consumed = tc.draw(accounts.values());
 ```
 
 The `is_empty()`, `len()`, and `add()` methods are unchanged.
+
+The `Generator<T>` trait no longer requires `Self: Send + Sync`. Drawing a value
+is single-threaded, so the bound was never needed to produce values; it is now
+required only where a generator is actually shared across threads — by `boxed()`
+and by `deferred()`'s `set()`, which already carry it. This lets generators that
+borrow non-`Sync` data (such as the new `Pool` reference and value generators)
+implement the trait directly. Existing generators are unaffected.

--- a/examples/ledger.rs
+++ b/examples/ledger.rs
@@ -55,7 +55,7 @@ impl LedgerTest {
 
     #[rule]
     fn credit(&mut self, tc: TestCase) {
-        let account = tc.draw(self.accounts.references()).clone();
+        let account = tc.draw(self.accounts.values_reusable()).clone();
         let amount = tc.draw(gs::integers::<i64>().min_value(0).max_value(LIMIT));
         tc.note(&format!("credit '{}' with {}", account.clone(), amount));
         self.ledger.credit(account, amount);
@@ -63,8 +63,8 @@ impl LedgerTest {
 
     #[rule]
     fn transfer(&mut self, tc: TestCase) {
-        let from = tc.draw(self.accounts.references()).clone();
-        let to = tc.draw(self.accounts.references()).clone();
+        let from = tc.draw(self.accounts.values_reusable()).clone();
+        let to = tc.draw(self.accounts.values_reusable()).clone();
         let amount = tc.draw(gs::integers::<i64>().min_value(0).max_value(LIMIT));
         tc.note(&format!(
             "transfer '{}' from {} to {}",

--- a/examples/ledger.rs
+++ b/examples/ledger.rs
@@ -3,7 +3,7 @@
 
 use hegel::TestCase;
 use hegel::generators as gs;
-use hegel::stateful::{Variables, variables};
+use hegel::stateful::{Pool, pool};
 use std::collections::HashMap;
 
 const LIMIT: i64 = 1000000;
@@ -41,7 +41,7 @@ impl Ledger {
 
 struct LedgerTest {
     ledger: Ledger,
-    accounts: Variables<String>,
+    accounts: Pool<String>,
 }
 
 #[hegel::state_machine]
@@ -55,7 +55,7 @@ impl LedgerTest {
 
     #[rule]
     fn credit(&mut self, tc: TestCase) {
-        let account = self.accounts.draw().clone();
+        let account = tc.draw(self.accounts.references()).clone();
         let amount = tc.draw(gs::integers::<i64>().min_value(0).max_value(LIMIT));
         tc.note(&format!("credit '{}' with {}", account.clone(), amount));
         self.ledger.credit(account, amount);
@@ -63,8 +63,8 @@ impl LedgerTest {
 
     #[rule]
     fn transfer(&mut self, tc: TestCase) {
-        let from = self.accounts.draw().clone();
-        let to = self.accounts.draw().clone();
+        let from = tc.draw(self.accounts.references()).clone();
+        let to = tc.draw(self.accounts.references()).clone();
         let amount = tc.draw(gs::integers::<i64>().min_value(0).max_value(LIMIT));
         tc.note(&format!(
             "transfer '{}' from {} to {}",
@@ -87,7 +87,7 @@ impl LedgerTest {
 fn test_ledger(tc: TestCase) {
     let test = LedgerTest {
         ledger: Ledger::new(),
-        accounts: variables(&tc),
+        accounts: pool(&tc),
     };
     hegel::stateful::run(test, tc);
 }

--- a/hegel-c/include/hegel.h
+++ b/hegel-c/include/hegel.h
@@ -728,9 +728,9 @@ hegel_result_t hegel_collection_reject(hegel_context_t *ctx,
 
  A pool tracks a set of opaque variable ids that the engine can draw
  from and shrink over — the primitive behind hegel-rust's
- `stateful::Variables` and `#[hegel::state_machine]`. The caller keeps
+ `stateful::Pool` and `#[hegel::state_machine]`. The caller keeps
  its own mapping from variable id to the actual value it generated
- (mirroring how `Variables<T>` holds a `HashMap<i64, T>`).
+ (mirroring how `Pool<T>` holds a `HashMap<i64, T>`).
 
  On success writes the new pool's id into `*out_pool_id` and returns
  `HEGEL_OK`. The id is opaque; pass it to subsequent `hegel_pool_add`

--- a/hegel-c/src/lib.rs
+++ b/hegel-c/src/lib.rs
@@ -1458,9 +1458,9 @@ pub unsafe extern "C" fn hegel_collection_reject(
 ///
 /// A pool tracks a set of opaque variable ids that the engine can draw
 /// from and shrink over — the primitive behind hegel-rust's
-/// `stateful::Variables` and `#[hegel::state_machine]`. The caller keeps
+/// `stateful::Pool` and `#[hegel::state_machine]`. The caller keeps
 /// its own mapping from variable id to the actual value it generated
-/// (mirroring how `Variables<T>` holds a `HashMap<i64, T>`).
+/// (mirroring how `Pool<T>` holds a `HashMap<i64, T>`).
 ///
 /// On success writes the new pool's id into `*out_pool_id` and returns
 /// `HEGEL_OK`. The id is opaque; pass it to subsequent `hegel_pool_add`

--- a/src/generators/deferred.rs
+++ b/src/generators/deferred.rs
@@ -70,7 +70,7 @@ impl<T: Send + Sync + 'static> DeferredGeneratorDefinition<T> {
     /// # Panics
     ///
     /// Drawing from a handle before `set` is called will panic.
-    pub fn set(self, generator: impl Generator<T> + 'static) {
+    pub fn set(self, generator: impl Generator<T> + Send + Sync + 'static) {
         let _ = self.inner.set(generator.boxed());
     }
 }

--- a/src/generators/generators.rs
+++ b/src/generators/generators.rs
@@ -59,7 +59,7 @@ impl<'a, T: 'a> BasicGenerator<'a, T> {
 /// - Generators with a client-side fallback (filter, flat_map, lists with
 ///   non-basic elements, …) override `do_draw`. They may also override
 ///   `as_basic` to opt into schema generation when their inputs allow it.
-pub trait Generator<T>: Send + Sync {
+pub trait Generator<T> {
     /// Produce a value.
     ///
     /// The default delegates to [`as_basic`](Self::as_basic). Generators

--- a/src/stateful.rs
+++ b/src/stateful.rs
@@ -65,7 +65,7 @@ use crate::control::{AssumeFailed, StopTest, raise_control};
 use crate::generators::{Generator, integers};
 use crate::runner::Mode;
 use crate::test_case::raise_for_rc;
-use parking_lot::Mutex;
+use std::cell::RefCell;
 use std::cmp::min;
 use std::collections::HashMap;
 use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
@@ -157,7 +157,7 @@ impl<T> Pool<T> {
     pub fn values(&mut self) -> Values<'_, T> {
         Values {
             pool_id: self.pool_id,
-            values: Mutex::new(&mut self.values),
+            values: RefCell::new(&mut self.values),
         }
     }
 }
@@ -171,7 +171,7 @@ pub struct References<'a, T> {
     values: &'a HashMap<i64, T>,
 }
 
-impl<'a, T: Sync> Generator<&'a T> for References<'a, T> {
+impl<'a, T> Generator<&'a T> for References<'a, T> {
     fn do_draw(&self, tc: &TestCase) -> &'a T {
         tc.assume(!self.values.is_empty());
         let variable_id = pool_generate(tc, self.pool_id, false);
@@ -182,20 +182,19 @@ impl<'a, T: Sync> Generator<&'a T> for References<'a, T> {
 /// A generator that consumes values from a [`Pool`], removing each value it
 /// yields.
 ///
-/// Returned by [`Pool::values`]. Borrows the pool mutably; the inner [`Mutex`]
-/// is what lets it remove a value during a draw (which only has shared access
-/// to the generator) while keeping the generator `Send + Sync`.
+/// Returned by [`Pool::values`]. Borrows the pool mutably; the inner
+/// [`RefCell`] is what lets it remove a value during a draw, which only has
+/// shared access to the generator.
 pub struct Values<'a, T> {
     pool_id: i64,
-    values: Mutex<&'a mut HashMap<i64, T>>,
+    values: RefCell<&'a mut HashMap<i64, T>>,
 }
 
-impl<T: Send> Generator<T> for Values<'_, T> {
+impl<T> Generator<T> for Values<'_, T> {
     fn do_draw(&self, tc: &TestCase) -> T {
-        let mut values = self.values.lock();
-        tc.assume(!values.is_empty());
+        tc.assume(!self.values.borrow().is_empty());
         let variable_id = pool_generate(tc, self.pool_id, true);
-        values.remove(&variable_id).unwrap()
+        self.values.borrow_mut().remove(&variable_id).unwrap()
     }
 }
 

--- a/src/stateful.rs
+++ b/src/stateful.rs
@@ -62,9 +62,10 @@
 
 use crate::TestCase;
 use crate::control::{AssumeFailed, StopTest, raise_control};
-use crate::generators::integers;
+use crate::generators::{Generator, integers};
 use crate::runner::Mode;
 use crate::test_case::raise_for_rc;
+use parking_lot::Mutex;
 use std::cmp::min;
 use std::collections::HashMap;
 use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
@@ -86,29 +87,40 @@ impl<M> Rule<M> {
 }
 
 /// A pool of previously generated values.
-pub struct Variables<T> {
+///
+/// Create one with [`pool()`] and populate it with [`add`](Pool::add). To draw
+/// from the pool, use the generators it hands out rather than reading from it
+/// directly:
+///
+/// - [`references`](Pool::references) returns a generator over `&T` — drawing
+///   from it yields a reference to a value in the pool without removing it.
+/// - [`values`](Pool::values) returns a generator over `T` — drawing from it
+///   removes a value from the pool and yields it by value.
+///
+/// Both generators are used through [`tc.draw`](TestCase::draw), so the chosen
+/// value is recorded in the failing-test replay and the choice shrinks like any
+/// other draw.
+pub struct Pool<T> {
     pool_id: i64,
     tc: TestCase,
     values: HashMap<i64, T>,
 }
 
-impl<T> Variables<T> {
-    fn pool_generate(&self, consume: bool) -> i64 {
-        match self
-            .tc
-            .with_ctc(|ctc| ctc.pool_generate(self.pool_id, consume))
-        {
-            Ok(id) => id,
-            Err(_) => raise_control(StopTest),
-        }
+/// Ask the engine for a variable id from `pool_id`, consuming it if `consume`.
+fn pool_generate(tc: &TestCase, pool_id: i64, consume: bool) -> i64 {
+    match tc.with_ctc(|ctc| ctc.pool_generate(pool_id, consume)) {
+        Ok(id) => id,
+        Err(_) => raise_control(StopTest),
     }
+}
 
-    /// Returns true if no variables are in the pool.
+impl<T> Pool<T> {
+    /// Returns true if no values are in the pool.
     pub fn is_empty(&self) -> bool {
         self.values.is_empty()
     }
 
-    /// Number of variables currently in the pool.
+    /// Number of values currently in the pool.
     pub fn len(&self) -> usize {
         self.values.len()
     }
@@ -125,32 +137,75 @@ impl<T> Variables<T> {
         self.values.insert(variable_id, v);
     }
 
-    /// Draw a reference to a value from the pool (without removing it).
+    /// A generator over references to values in the pool.
     ///
-    /// Calls `assume(false)` if the pool is empty.
-    pub fn draw(&self) -> &T {
-        self.tc.assume(!self.is_empty());
-        let variable_id = self.pool_generate(false);
-        self.values.get(&variable_id).unwrap()
+    /// Drawing from it yields a `&T` borrowing a value in the pool, without
+    /// removing it. Drawing rejects the current test case (as if by
+    /// `assume(false)`) when the pool is empty.
+    pub fn references(&self) -> References<'_, T> {
+        References {
+            pool_id: self.pool_id,
+            values: &self.values,
+        }
     }
 
-    /// Remove and return a value from the pool.
+    /// A generator that consumes values from the pool.
     ///
-    /// Calls `assume(false)` if the pool is empty.
-    pub fn consume(&mut self) -> T {
-        self.tc.assume(!self.is_empty());
-        let variable_id = self.pool_generate(true);
-        self.values.remove(&variable_id).unwrap()
+    /// Drawing from it removes a value from the pool and yields it by value.
+    /// Once consumed, that value is never drawn again. Drawing rejects the
+    /// current test case (as if by `assume(false)`) when the pool is empty.
+    pub fn values(&mut self) -> Values<'_, T> {
+        Values {
+            pool_id: self.pool_id,
+            values: Mutex::new(&mut self.values),
+        }
     }
 }
 
-/// Create a new variable pool for stateful tests.
-pub fn variables<T>(tc: &TestCase) -> Variables<T> {
+/// A generator over references to the values in a [`Pool`].
+///
+/// Returned by [`Pool::references`]. Borrows the pool, so the references it
+/// produces stay valid for as long as the generator is alive.
+pub struct References<'a, T> {
+    pool_id: i64,
+    values: &'a HashMap<i64, T>,
+}
+
+impl<'a, T: Sync> Generator<&'a T> for References<'a, T> {
+    fn do_draw(&self, tc: &TestCase) -> &'a T {
+        tc.assume(!self.values.is_empty());
+        let variable_id = pool_generate(tc, self.pool_id, false);
+        self.values.get(&variable_id).unwrap()
+    }
+}
+
+/// A generator that consumes values from a [`Pool`], removing each value it
+/// yields.
+///
+/// Returned by [`Pool::values`]. Borrows the pool mutably; the inner [`Mutex`]
+/// is what lets it remove a value during a draw (which only has shared access
+/// to the generator) while keeping the generator `Send + Sync`.
+pub struct Values<'a, T> {
+    pool_id: i64,
+    values: Mutex<&'a mut HashMap<i64, T>>,
+}
+
+impl<T: Send> Generator<T> for Values<'_, T> {
+    fn do_draw(&self, tc: &TestCase) -> T {
+        let mut values = self.values.lock();
+        tc.assume(!values.is_empty());
+        let variable_id = pool_generate(tc, self.pool_id, true);
+        values.remove(&variable_id).unwrap()
+    }
+}
+
+/// Create a new value pool for stateful tests.
+pub fn pool<T>(tc: &TestCase) -> Pool<T> {
     let pool_id = match tc.with_ctc(|ctc| ctc.new_pool()) {
         Ok(id) => id,
         Err(_) => raise_control(StopTest), // nocov
     };
-    Variables {
+    Pool {
         pool_id,
         tc: tc.clone(),
         values: HashMap::new(),

--- a/src/stateful.rs
+++ b/src/stateful.rs
@@ -92,10 +92,11 @@ impl<M> Rule<M> {
 /// from the pool, use the generators it hands out rather than reading from it
 /// directly:
 ///
-/// - [`references`](Pool::references) returns a generator over `&T` — drawing
-///   from it yields a reference to a value in the pool without removing it.
-/// - [`values`](Pool::values) returns a generator over `T` — drawing from it
-///   removes a value from the pool and yields it by value.
+/// - [`values_reusable`](Pool::values_reusable) returns a generator over `&T` —
+///   drawing from it yields a reference to a value in the pool without removing
+///   it.
+/// - [`values_consumed`](Pool::values_consumed) returns a generator over `T` —
+///   drawing from it removes a value from the pool and yields it by value.
 ///
 /// Both generators are used through [`tc.draw`](TestCase::draw), so the chosen
 /// value is recorded in the failing-test replay and the choice shrinks like any
@@ -142,8 +143,8 @@ impl<T> Pool<T> {
     /// Drawing from it yields a `&T` borrowing a value in the pool, without
     /// removing it. Drawing rejects the current test case (as if by
     /// `assume(false)`) when the pool is empty.
-    pub fn references(&self) -> References<'_, T> {
-        References {
+    pub fn values_reusable(&self) -> ValuesReusable<'_, T> {
+        ValuesReusable {
             pool_id: self.pool_id,
             values: &self.values,
         }
@@ -154,8 +155,8 @@ impl<T> Pool<T> {
     /// Drawing from it removes a value from the pool and yields it by value.
     /// Once consumed, that value is never drawn again. Drawing rejects the
     /// current test case (as if by `assume(false)`) when the pool is empty.
-    pub fn values(&mut self) -> Values<'_, T> {
-        Values {
+    pub fn values_consumed(&mut self) -> ValuesConsumed<'_, T> {
+        ValuesConsumed {
             pool_id: self.pool_id,
             values: RefCell::new(&mut self.values),
         }
@@ -164,14 +165,14 @@ impl<T> Pool<T> {
 
 /// A generator over references to the values in a [`Pool`].
 ///
-/// Returned by [`Pool::references`]. Borrows the pool, so the references it
+/// Returned by [`Pool::values_reusable`]. Borrows the pool, so the references it
 /// produces stay valid for as long as the generator is alive.
-pub struct References<'a, T> {
+pub struct ValuesReusable<'a, T> {
     pool_id: i64,
     values: &'a HashMap<i64, T>,
 }
 
-impl<'a, T> Generator<&'a T> for References<'a, T> {
+impl<'a, T> Generator<&'a T> for ValuesReusable<'a, T> {
     fn do_draw(&self, tc: &TestCase) -> &'a T {
         tc.assume(!self.values.is_empty());
         let variable_id = pool_generate(tc, self.pool_id, false);
@@ -182,15 +183,15 @@ impl<'a, T> Generator<&'a T> for References<'a, T> {
 /// A generator that consumes values from a [`Pool`], removing each value it
 /// yields.
 ///
-/// Returned by [`Pool::values`]. Borrows the pool mutably; the inner
+/// Returned by [`Pool::values_consumed`]. Borrows the pool mutably; the inner
 /// [`RefCell`] is what lets it remove a value during a draw, which only has
 /// shared access to the generator.
-pub struct Values<'a, T> {
+pub struct ValuesConsumed<'a, T> {
     pool_id: i64,
     values: RefCell<&'a mut HashMap<i64, T>>,
 }
 
-impl<T> Generator<T> for Values<'_, T> {
+impl<T> Generator<T> for ValuesConsumed<'_, T> {
     fn do_draw(&self, tc: &TestCase) -> T {
         tc.assume(!self.values.borrow().is_empty());
         let variable_id = pool_generate(tc, self.pool_id, true);

--- a/tests/test_stateful.rs
+++ b/tests/test_stateful.rs
@@ -71,7 +71,7 @@ struct TestConsumeMachine {
 impl TestConsumeMachine {
     #[rule]
     fn draw(&mut self, tc: TestCase) {
-        let x = tc.draw(self.numbers.references());
+        let x = tc.draw(self.numbers.values_reusable());
         assert!(*x != self.consumed);
     }
 }
@@ -85,7 +85,7 @@ fn test_consume(tc: TestCase) {
     for element in elements.clone() {
         bundle.add(element);
     }
-    let consumed = tc.draw(bundle.values());
+    let consumed = tc.draw(bundle.values_consumed());
     let m = TestConsumeMachine {
         numbers: bundle,
         consumed,
@@ -147,7 +147,7 @@ struct TestDrawDomainMachine {
 impl TestDrawDomainMachine {
     #[rule]
     fn draw(&mut self, tc: TestCase) {
-        let x = tc.draw(self.pool.references());
+        let x = tc.draw(self.pool.values_reusable());
         assert!(self.domain.contains(x));
     }
 
@@ -290,7 +290,7 @@ mod stateful {
     impl DepthMachine {
         #[rule]
         fn charge(&mut self, tc: TestCase) {
-            let depth = tc.draw(self.charges.references()).depth;
+            let depth = tc.draw(self.charges.values_reusable()).depth;
             self.charges.add(DepthCharge { depth: depth + 1 });
         }
 
@@ -301,7 +301,7 @@ mod stateful {
 
         #[rule]
         fn is_not_too_deep(&mut self, tc: TestCase) {
-            let check = tc.draw(self.charges.references());
+            let check = tc.draw(self.charges.values_reusable());
             assert!(check.depth < 3, "depth {} is not less than 3", check.depth);
         }
     }

--- a/tests/test_stateful.rs
+++ b/tests/test_stateful.rs
@@ -3,7 +3,7 @@ mod common;
 use common::project::TempRustProject;
 use hegel::TestCase;
 use hegel::generators as gs;
-use hegel::stateful::{Variables, variables};
+use hegel::stateful::{Pool, pool};
 
 #[test]
 fn test_state_machine_failure() {
@@ -63,15 +63,15 @@ fn main() {}
 
 // Consuming an element from a set should mean subsequent draws never yield the element.
 struct TestConsumeMachine {
-    numbers: Variables<i32>,
+    numbers: Pool<i32>,
     consumed: i32,
 }
 
 #[hegel::state_machine]
 impl TestConsumeMachine {
     #[rule]
-    fn draw(&mut self, _tc: TestCase) {
-        let x = self.numbers.draw();
+    fn draw(&mut self, tc: TestCase) {
+        let x = tc.draw(self.numbers.references());
         assert!(*x != self.consumed);
     }
 }
@@ -81,11 +81,11 @@ fn test_consume(tc: TestCase) {
     let ints = gs::integers::<i32>;
     let elements = tc.draw(gs::vecs(ints()).unique(true));
     tc.assume(!elements.is_empty());
-    let mut bundle = variables(&tc);
+    let mut bundle = pool(&tc);
     for element in elements.clone() {
         bundle.add(element);
     }
-    let consumed = bundle.consume();
+    let consumed = tc.draw(bundle.values());
     let m = TestConsumeMachine {
         numbers: bundle,
         consumed,
@@ -140,20 +140,21 @@ fn test_state_machine_with_type_parameter(tc: TestCase) {
 // Drawing an element from a bundle should always yield an element that was previously added.
 struct TestDrawDomainMachine {
     domain: Vec<i32>,
-    variables: Variables<i32>,
+    pool: Pool<i32>,
 }
 
 #[hegel::state_machine]
 impl TestDrawDomainMachine {
     #[rule]
-    fn draw(&mut self, _tc: TestCase) {
-        let x = self.variables.draw();
+    fn draw(&mut self, tc: TestCase) {
+        let x = tc.draw(self.pool.references());
         assert!(self.domain.contains(x));
     }
 
     #[invariant]
     fn len_matches_domain(&mut self, _tc: TestCase) {
-        assert_eq!(self.variables.len(), self.domain.len());
+        assert!(!self.pool.is_empty());
+        assert_eq!(self.pool.len(), self.domain.len());
     }
 }
 
@@ -162,13 +163,13 @@ fn test_draw_domain(tc: TestCase) {
     let ints = gs::integers::<i32>;
     let elements = tc.draw(gs::vecs(ints()));
     tc.assume(!elements.is_empty());
-    let mut bundle = variables(&tc);
+    let mut bundle = pool(&tc);
     for element in elements.clone() {
         bundle.add(element);
     }
     let m = TestDrawDomainMachine {
         domain: elements,
-        variables: bundle,
+        pool: bundle,
     };
     hegel::stateful::run(m, tc);
 }
@@ -178,7 +179,7 @@ mod stateful {
     use super::common::utils::expect_panic;
     use hegel::TestCase;
     use hegel::generators as gs;
-    use hegel::stateful::{Rule, StateMachine, Variables, variables};
+    use hegel::stateful::{Pool, Rule, StateMachine, pool};
     use hegel::{Hegel, Settings, Verbosity};
     use std::panic::{AssertUnwindSafe, catch_unwind};
     use std::sync::{Arc, Mutex};
@@ -276,19 +277,20 @@ mod stateful {
         );
     }
 
+    #[derive(Debug)]
     struct DepthCharge {
         depth: i64,
     }
 
     struct DepthMachine {
-        charges: Variables<DepthCharge>,
+        charges: Pool<DepthCharge>,
     }
 
     #[hegel::state_machine]
     impl DepthMachine {
         #[rule]
-        fn charge(&mut self, _tc: TestCase) {
-            let depth = self.charges.draw().depth;
+        fn charge(&mut self, tc: TestCase) {
+            let depth = tc.draw(self.charges.references()).depth;
             self.charges.add(DepthCharge { depth: depth + 1 });
         }
 
@@ -298,8 +300,8 @@ mod stateful {
         }
 
         #[rule]
-        fn is_not_too_deep(&mut self, _tc: TestCase) {
-            let check = self.charges.draw();
+        fn is_not_too_deep(&mut self, tc: TestCase) {
+            let check = tc.draw(self.charges.references());
             assert!(check.depth < 3, "depth {} is not less than 3", check.depth);
         }
     }
@@ -468,7 +470,7 @@ mod stateful {
         expect_panic(
             || {
                 Hegel::new(|tc: TestCase| {
-                    let charges = variables(&tc);
+                    let charges = pool(&tc);
                     hegel::stateful::run(DepthMachine { charges }, tc);
                 })
                 .settings(Settings::new().database(None).test_cases(1000))


### PR DESCRIPTION
The first improvement is to rename Variables to Pool, because Variables sucks as a name (sorry).

The other improvement is to properly integrate it into the generators API rather than have its own draw methods. I always sortof intended those methods to be internal implementation details but then I just sortof... forgot to implement the public API corresponding to them.

You can now get two different generators off a Pool:

- `references()` yields `&T` without removing (the old `draw()`).
- `values()` yields `T`, removing it from the pool (the old `consume()`).

As well as being more unified with the rest of the ways we generate data and allowing you to use pool values in more places, this means that values drawn from pools in stateful tests will get printed properly (which is the actual thing that prompted me realising this needed doing).

This also removes the default Send + Sync bound from generators (because it was awkward for the pool generators) and applies it in the few places we need it. I think we need a better think through concurrency control on generators in general but I didn't want to make getting that right part of this PR.