### PR TITLE
Fix release: bump internal path-dependency pins

### DIFF
--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -72,12 +72,42 @@ def set_version(cargo_toml: Path, new_version: str) -> None:
     cargo_toml.write_text(new_text)
 
 
-def set_dep_version(cargo_toml: Path, dep_name: str, new_version: str) -> None:
-    text = cargo_toml.read_text()
-    pattern = rf'{re.escape(dep_name)} = \{{ version = "=[^"]+"'
-    replacement = f'{dep_name} = {{ version = "={new_version}"'
-    new_text = re.sub(pattern, replacement, text, count=2)
-    cargo_toml.write_text(new_text)
+def bump_internal_path_deps(cargo_toml: Path, new_version: str) -> None:
+    """Bump every internal (path) dependency pinned with `=` to new_version.
+
+    Internal crates are pinned exactly (`version = "=X.Y.Z"`) and declared
+    with a `path = ...`. Deriving the set to bump from "has a path dep and an
+    exact pin" (rather than a hardcoded crate list) means a change in
+    dependency direction can't silently leave a stale pin behind — which is
+    exactly how the inversion refactor broke the release: the root crate
+    gained a `hegeltest-c` path dependency that the old hardcoded list never
+    touched.
+    """
+    lines = cargo_toml.read_text().splitlines(keepends=True)
+    out = []
+    for line in lines:
+        if "path =" in line and re.search(r'version = "=[^"]+"', line):
+            line = re.sub(
+                r'version = "=[^"]+"', f'version = "={new_version}"', line
+            )
+        out.append(line)
+    cargo_toml.write_text("".join(out))
+
+
+def apply_version_bump(root: Path, new_version: str) -> None:
+    """Rewrite every workspace manifest to new_version (package + path deps).
+
+    Pure file rewriting, factored out of `release()` so it can be tested
+    without the publish/git/gh machinery around it.
+    """
+    manifests = [
+        root / "Cargo.toml",
+        root / "hegel-macros" / "Cargo.toml",
+        root / "hegel-c" / "Cargo.toml",
+    ]
+    for manifest in manifests:
+        set_version(manifest, new_version)
+        bump_internal_path_deps(manifest, new_version)
 
 
 def add_changelog(path: Path, *, version: str, content: str) -> None:
@@ -151,11 +181,7 @@ def release() -> None:
     )
     new_version = bump_version(m.group(1), release_type)
 
-    set_version(ROOT / "Cargo.toml", new_version)
-    set_version(ROOT / "hegel-macros" / "Cargo.toml", new_version)
-    set_version(ROOT / "hegel-c" / "Cargo.toml", new_version)
-    set_dep_version(ROOT / "Cargo.toml", "hegeltest-macros", new_version)
-    set_dep_version(ROOT / "hegel-c" / "Cargo.toml", "hegeltest", new_version)
+    apply_version_bump(ROOT, new_version)
 
     # regenerate the lockfile after version bump
     subprocess.run(["cargo", "update", "--workspace"], check=True, cwd=ROOT)

--- a/.github/scripts/test_release.py
+++ b/.github/scripts/test_release.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Tests for the version-rewriting half of release.py.
+
+The publish/git/gh half of `release()` can only run in CI with real
+credentials, but the file rewriting (`apply_version_bump`) is pure and is
+exactly where the inversion refactor broke the release: the root crate
+started depending on `hegeltest-c` via a `=`-pinned path dependency, and the
+old hardcoded bump list never touched it, so `cargo update --workspace` blew
+up with "failed to select a version for the requirement `hegeltest-c =
+0.19.1`" after the package version had already moved to 0.19.2.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import release
+
+ROOT_CARGO = """\
+[package]
+name = "hegeltest"
+version = "0.19.1"
+edition = "2024"
+
+[dependencies]
+hegeltest-macros = { version = "=0.19.1", path = "hegel-macros" }
+hegeltest-c = { version = "=0.19.1", path = "hegel-c", default-features = false }
+serde = { version = "1.0.103", features = ["derive"] }
+
+[features]
+__bench = ["hegeltest-c/__bench"]
+"""
+
+MACROS_CARGO = """\
+[package]
+name = "hegeltest-macros"
+version = "0.19.1"
+edition = "2024"
+
+[dependencies]
+syn = { version = "2.0", features = ["full"] }
+"""
+
+# Post-inversion: hegel-c no longer depends on hegeltest. It must keep
+# bumping cleanly (its package version moves; it has no internal deps to
+# touch) so that a future re-inversion is the only thing that re-adds one.
+C_CARGO = """\
+[package]
+name = "hegeltest-c"
+version = "0.19.1"
+edition = "2024"
+
+[dependencies]
+ciborium = "0.2.2"
+serde = { version = "1.0.103", features = ["derive"] }
+"""
+
+
+class ApplyVersionBumpTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        (self.root / "Cargo.toml").write_text(ROOT_CARGO)
+        (self.root / "hegel-macros").mkdir()
+        (self.root / "hegel-macros" / "Cargo.toml").write_text(MACROS_CARGO)
+        (self.root / "hegel-c").mkdir()
+        (self.root / "hegel-c" / "Cargo.toml").write_text(C_CARGO)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_bumps_every_package_version(self) -> None:
+        release.apply_version_bump(self.root, "0.19.2")
+        for rel in ["Cargo.toml", "hegel-macros/Cargo.toml", "hegel-c/Cargo.toml"]:
+            text = (self.root / rel).read_text()
+            self.assertIn('version = "0.19.2"', text, rel)
+            self.assertNotIn('version = "0.19.1"', text, rel)
+
+    def test_bumps_internal_path_dependency_pins(self) -> None:
+        # The regression: both internal path deps in the root manifest must
+        # follow the package version, or `cargo update --workspace` fails.
+        release.apply_version_bump(self.root, "0.19.2")
+        root_text = (self.root / "Cargo.toml").read_text()
+        self.assertIn(
+            'hegeltest-macros = { version = "=0.19.2", path = "hegel-macros" }',
+            root_text,
+        )
+        self.assertIn(
+            'hegeltest-c = { version = "=0.19.2", path = "hegel-c", '
+            "default-features = false }",
+            root_text,
+        )
+
+    def test_leaves_external_dependencies_untouched(self) -> None:
+        release.apply_version_bump(self.root, "0.19.2")
+        root_text = (self.root / "Cargo.toml").read_text()
+        # External deps carry no `path =`, so they must be left alone — and the
+        # `__bench` feature reference is not a version pin either.
+        self.assertIn('serde = { version = "1.0.103", features = ["derive"] }', root_text)
+        self.assertIn('__bench = ["hegeltest-c/__bench"]', root_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/justfile
+++ b/justfile
@@ -53,7 +53,10 @@ check-test-modules:
 check-internal-asserts:
     scripts/check-internal-asserts.py
 
-check-lint: check-format check-clippy check-nocov-style check-test-modules check-internal-asserts
+check-release-script:
+    .github/scripts/test_release.py
+
+check-lint: check-format check-clippy check-nocov-style check-test-modules check-internal-asserts check-release-script
 
 check-coverage:
     # requires cargo-llvm-cov and llvm-tools-preview


### PR DESCRIPTION
<!-- Human: please replace this line with the title and a short description. -->

<details>
<summary>Implementation details (AI-generated)</summary>

**Why the release job failed** ([run](https://github.com/hegeldev/hegel-rust/actions/runs/27619966191/job/81668588547)): the `inversion` refactor reversed the engine dependency direction — the root `hegeltest` crate now depends on `hegeltest-c` through a `=`-pinned path dependency. `release.py` still bumped a now-nonexistent `hegeltest` dependency *inside* `hegel-c/Cargo.toml` (the old direction) and never touched the new `hegeltest-c` pin in the root manifest. After the package version bumped to `0.19.2`, `cargo update --workspace` failed:

```
error: failed to select a version for the requirement `hegeltest-c = "=0.19.1"`
candidate versions found which didn't match: 0.19.2
required by package `hegeltest v0.19.2`
```

This failed at the first step of the `Release` job, before any tag/publish/push — so no partial release happened (no `v0.19.2` tag, nothing on crates.io, `RELEASE.md` still on `main`). The release re-triggers and completes once this lands.

**Fix:** derive the set of dependencies to bump from the manifests themselves ("a line with both a `path =` and an exact `version = "=..."` pin") instead of a hardcoded crate list, so a future change in dependency direction can't silently leave a stale pin behind. The pure file-rewriting is factored into `apply_version_bump()`.

**Test:** `.github/scripts/test_release.py` covers the regression (verified it fails against the old hardcoded-list logic) and is wired into `just check-lint` via a new `check-release-script` recipe. End-to-end, applying the bump to the real workspace now lets `cargo update --workspace` succeed.

</details>