### PR TITLE
Fix primitive_boolean not honoring small probabilities

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix `primitive_boolean` not honoring `p` (probability of drawing true) when it is very small.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-Fix `primitive_boolean` not honoring `p` (probability of drawing true) when it is very small.
+Fixes stateful testing terminating step generation prematurely.

--- a/hegel-c/src/native/core/choices.rs
+++ b/hegel-c/src/native/core/choices.rs
@@ -137,10 +137,8 @@ impl BooleanChoice {
         false
     }
 
-    /// Misalignment fallback for a replayed boolean (see [`ChoiceKind::unit`]).
-    /// `false`, matching Hypothesis's simplest choice for booleans
     pub fn unit(&self) -> bool {
-        false
+        true
     }
 
     pub fn max_index(&self) -> crate::native::bignum::BigUint {

--- a/hegel-c/src/native/core/choices.rs
+++ b/hegel-c/src/native/core/choices.rs
@@ -137,8 +137,10 @@ impl BooleanChoice {
         false
     }
 
+    /// Misalignment fallback for a replayed boolean (see [`ChoiceKind::unit`]).
+    /// `false`, matching Hypothesis's simplest choice for booleans
     pub fn unit(&self) -> bool {
-        true
+        false
     }
 
     pub fn max_index(&self) -> crate::native::bignum::BigUint {

--- a/hegel-c/src/native/core/state.rs
+++ b/hegel-c/src/native/core/state.rs
@@ -550,17 +550,15 @@ pub(crate) fn weighted_boolean_sample(p: f64, rng: &mut EngineRng) -> bool {
 /// floor (which would turn e.g. a stateful stop signal's `p = 2^-16` into
 /// `1/256`).
 ///
-/// Spends 8 bytes of entropy rather than one, so it is reserved for draws
-/// whose probability needs the precision (routed via
+/// Delegates to [`RngExt::random_bool`], which scales `p` to a 64-bit
+/// threshold and compares it against a fresh `u64` — spending 8 bytes of
+/// entropy rather than the one byte [`weighted_boolean_sample`] uses, so it is
+/// reserved for draws whose probability needs the precision (routed via
 /// [`NativeTestCase::weighted_precise`]); ordinary booleans keep the one-byte
-/// sampler. Callers must pass `0.0 < p < 1.0`; boundaries are forced without
-/// entropy by `weighted_precise`.
+/// sampler. Callers must pass `0.0 < p < 1.0` (`random_bool` panics outside
+/// `[0, 1]`).
 pub(crate) fn weighted_boolean_sample_precise(p: f64, rng: &mut EngineRng) -> bool {
-    let mut buf = [0u8; 8];
-    rng.fill_bytes(&mut buf);
-    // Top 53 bits -> uniform in [0, 1), the resolution of an f64 mantissa.
-    let uniform = (u64::from_le_bytes(buf) >> 11) as f64 * (1.0 / ((1u64 << 53) as f64));
-    uniform < p
+    rng.random_bool(p)
 }
 
 /// Interesting string constants: logic keywords, numeric edge cases,

--- a/hegel-c/src/native/core/state.rs
+++ b/hegel-c/src/native/core/state.rs
@@ -545,6 +545,24 @@ pub(crate) fn weighted_boolean_sample(p: f64, rng: &mut EngineRng) -> bool {
     u32::from(byte[0]) >= falsey
 }
 
+/// Full-precision weighted boolean: `true` with probability `p`, faithful to
+/// probabilities far below [`weighted_boolean_sample`]'s 1/256 quantization
+/// floor (which would turn e.g. a stateful stop signal's `p = 2^-16` into
+/// `1/256`).
+///
+/// Spends 8 bytes of entropy rather than one, so it is reserved for draws
+/// whose probability needs the precision (routed via
+/// [`NativeTestCase::weighted_precise`]); ordinary booleans keep the one-byte
+/// sampler. Callers must pass `0.0 < p < 1.0`; boundaries are forced without
+/// entropy by `weighted_precise`.
+pub(crate) fn weighted_boolean_sample_precise(p: f64, rng: &mut EngineRng) -> bool {
+    let mut buf = [0u8; 8];
+    rng.fill_bytes(&mut buf);
+    // Top 53 bits -> uniform in [0, 1), the resolution of an f64 mantissa.
+    let uniform = (u64::from_le_bytes(buf) >> 11) as f64 * (1.0 / ((1u64 << 53) as f64));
+    uniform < p
+}
+
 /// Interesting string constants: logic keywords, numeric edge cases,
 /// common Unicode stress strings. Stored as codepoint vectors so they can
 /// be validated against and inserted into the draw_string nasty pool.
@@ -1436,9 +1454,27 @@ impl NativeTestCase {
         Ok(s)
     }
 
-    /// Draw a boolean with probability `p` of being true.
-    /// If `forced` is Some, the result is forced to that value.
+    /// Draw a boolean with probability `p` of being true, sampled with the
+    /// one-byte [`weighted_boolean_sample`]. If `forced` is Some, the result is
+    /// forced to that value.
     pub fn weighted(&mut self, p: f64, forced: Option<bool>) -> Result<bool, EngineError> {
+        self.weighted_with(p, forced, weighted_boolean_sample)
+    }
+
+    /// Like [`Self::weighted`], but samples with the full-precision
+    /// [`weighted_boolean_sample_precise`], so probabilities below the one-byte
+    /// sampler's 1/256 floor (e.g. a stateful stop signal at `p = 2^-16`) are
+    /// honored. Routed here from `primitive_boolean`.
+    pub fn weighted_precise(&mut self, p: f64, forced: Option<bool>) -> Result<bool, EngineError> {
+        self.weighted_with(p, forced, weighted_boolean_sample_precise)
+    }
+
+    fn weighted_with(
+        &mut self,
+        p: f64,
+        forced: Option<bool>,
+        sample: impl Fn(f64, &mut EngineRng) -> bool,
+    ) -> Result<bool, EngineError> {
         let kind = BooleanChoice;
 
         let forced_value = forced.or(if p <= 0.0 {
@@ -1458,7 +1494,7 @@ impl NativeTestCase {
                 || ChoiceValue::Boolean(kind.simplest()),
                 || ChoiceValue::Boolean(kind.unit()),
                 |v| matches!(v, ChoiceValue::Boolean(_)),
-                |rng| ChoiceValue::Boolean(weighted_boolean_sample(p, rng)),
+                |rng| ChoiceValue::Boolean(sample(p, rng)),
             )?
         };
 

--- a/hegel-c/src/native/data_source.rs
+++ b/hegel-c/src/native/data_source.rs
@@ -278,7 +278,10 @@ impl DataSource for NativeDataSource {
                     "primitive_boolean: cannot force false when p = 1.0".to_string(),
                 ));
             }
-            ntc.weighted(p, forced)
+            // Full-precision sampler: callers (e.g. the stateful stop signal at
+            // p = 2^-16) rely on probabilities far below the one-byte sampler's
+            // 1/256 floor being honored.
+            ntc.weighted_precise(p, forced)
         })
     }
 


### PR DESCRIPTION
Used in hegel-ocaml stateful testing. Approximation of 2^-16 as 2^-8 caused tests to stop generating before reaching stateful_step_count about 15 percentage points more often than in Hypothesis (~24% vs ~9%).

