### PR TITLE
Fix forced node guard in candidate consideration

### DIFF
--- a/hegel-c/src/native/shrinker/mod.rs
+++ b/hegel-c/src/native/shrinker/mod.rs
@@ -249,10 +249,22 @@ impl<'a> Shrinker<'a> {
         // this on its own single-position path; consider covers callers
         // that build candidate sequences directly
         // (try_shortening_via_increment, delete_chunks, span passes, …).
+        //
+        // Only meaningful for SAME-LENGTH candidates: the comparison is
+        // positional, so once a candidate deletes nodes the indices past the
+        // deletion point are shifted and `candidate[i]` no longer corresponds
+        // to `current[i]`. Applying the guard there spuriously rejects every
+        // deletion that precedes a forced node (e.g. the swarm feature-flag
+        // draws re-recorded as forced throughout a stateful run), which is the
+        // single biggest blocker to deleting whole steps. For length-changing
+        // candidates the realised run re-derives forced-ness anyway, and
+        // `accept_improvement` only commits a strictly-smaller result, so
+        // skipping the guard here is safe.
         for (i, candidate) in nodes
             .iter()
             .enumerate()
             .take(nodes.len().min(self.current_nodes.len()))
+            .filter(|_| nodes.len() == self.current_nodes.len())
         {
             if self.current_nodes[i].was_forced && candidate.value != self.current_nodes[i].value {
                 return Ok(false);


### PR DESCRIPTION
Reduced unnecessary test body execs by ~6x when shrinking a pathological stateful test that Jane Street seemed to hit.