### PR TITLE
Shrinker improvements

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch reduces redundant test executions by the shrinker.

--- a/hegel-c/src/native/shrinker/mod.rs
+++ b/hegel-c/src/native/shrinker/mod.rs
@@ -243,14 +243,8 @@ impl<'a> Shrinker<'a> {
         if sort_key(nodes) == sort_key(&self.current_nodes) {
             return Ok(true);
         }
-        // ported from Hypothesis's `cached_test_function` (shrinker.py):
-        // compare the candidate against the current target over
-        // the target's length window (truncating a candidate longer than the
-        // target — extra trailing nodes can't make it shortlex-smaller). If the
-        // truncated candidate is already shortlex >= the current target, no
-        // realised run from it can improve on the target, so reject it without
-        // running the test. Deletion candidates are shorter, hence
-        // shortlex-smaller, and are NOT rejected here — they still run.
+        // If the truncated candidate is already shortlex >= the current target, 
+        // no run from it can improve on the target, so reject it
         let cmp: &[ChoiceNode] = if nodes.len() > self.current_nodes.len() {
             &nodes[..self.current_nodes.len()]
         } else {
@@ -280,8 +274,10 @@ impl<'a> Shrinker<'a> {
             .iter()
             .enumerate()
             .take(nodes.len().min(self.current_nodes.len()))
-            .filter(|_| nodes.len() == self.current_nodes.len())
         {
+            if nodes.len() == self.current_nodes.len() {
+                continue
+            }
             if self.current_nodes[i].was_forced && candidate.value != self.current_nodes[i].value {
                 return Ok(false);
             }

--- a/hegel-c/src/native/shrinker/mod.rs
+++ b/hegel-c/src/native/shrinker/mod.rs
@@ -243,6 +243,22 @@ impl<'a> Shrinker<'a> {
         if sort_key(nodes) == sort_key(&self.current_nodes) {
             return Ok(true);
         }
+        // ported from Hypothesis's `cached_test_function` (shrinker.py): 
+        // compare the candidate against the current target over
+        // the target's length window (truncating a candidate longer than the
+        // target — extra trailing nodes can't make it shortlex-smaller). If the
+        // truncated candidate is already shortlex >= the current target, no
+        // realised run from it can improve on the target, so reject it without
+        // running the test. Deletion candidates are shorter, hence
+        // shortlex-smaller, and are NOT rejected here — they still run.
+        let cmp: &[ChoiceNode] = if nodes.len() > self.current_nodes.len() {
+            &nodes[..self.current_nodes.len()]
+        } else {
+            nodes
+        };
+        if sort_key(&self.current_nodes) < sort_key(cmp) {
+            return Ok(false);
+        }
         // Forced-node guard: a candidate may not differ from the
         // current shrink target at any index marked `was_forced`.
         // Forced choices stay put through shrinking. `replace` enforces

--- a/hegel-c/src/native/shrinker/mod.rs
+++ b/hegel-c/src/native/shrinker/mod.rs
@@ -243,7 +243,7 @@ impl<'a> Shrinker<'a> {
         if sort_key(nodes) == sort_key(&self.current_nodes) {
             return Ok(true);
         }
-        // If the truncated candidate is already shortlex >= the current target, 
+        // If the truncated candidate is already shortlex >= the current target,
         // no run from it can improve on the target, so reject it
         let cmp: &[ChoiceNode] = if nodes.len() > self.current_nodes.len() {
             &nodes[..self.current_nodes.len()]
@@ -275,8 +275,8 @@ impl<'a> Shrinker<'a> {
             .enumerate()
             .take(nodes.len().min(self.current_nodes.len()))
         {
-            if nodes.len() == self.current_nodes.len() {
-                continue
+            if nodes.len() != self.current_nodes.len() {
+                continue;
             }
             if self.current_nodes[i].was_forced && candidate.value != self.current_nodes[i].value {
                 return Ok(false);

--- a/hegel-c/src/native/shrinker/mod.rs
+++ b/hegel-c/src/native/shrinker/mod.rs
@@ -243,7 +243,7 @@ impl<'a> Shrinker<'a> {
         if sort_key(nodes) == sort_key(&self.current_nodes) {
             return Ok(true);
         }
-        // ported from Hypothesis's `cached_test_function` (shrinker.py): 
+        // ported from Hypothesis's `cached_test_function` (shrinker.py):
         // compare the candidate against the current target over
         // the target's length window (truncating a candidate longer than the
         // target — extra trailing nodes can't make it shortlex-smaller). If the

--- a/hegel-c/src/native/shrinker/mod.rs
+++ b/hegel-c/src/native/shrinker/mod.rs
@@ -249,10 +249,22 @@ impl<'a> Shrinker<'a> {
         // this on its own single-position path; consider covers callers
         // that build candidate sequences directly
         // (try_shortening_via_increment, delete_chunks, span passes, …).
+        //
+        // Only meaningful for SAME-LENGTH candidates: the comparison is
+        // positional, so once a candidate deletes nodes the indices past the
+        // deletion point are shifted and `candidate[i]` no longer corresponds
+        // to `current[i]`. Applying the guard there spuriously rejects every
+        // deletion that precedes a forced node (e.g. the swarm feature-flag
+        // draws re-recorded as forced throughout a stateful run), which is the
+        // single biggest blocker to deleting whole steps. For length-changing
+        // candidates the realised run re-derives forced-ness anyway, and
+        // `accept_improvement` only commits a strictly-smaller result, so
+        // skipping the guard here is safe.
         for (i, candidate) in nodes
             .iter()
             .enumerate()
             .take(nodes.len().min(self.current_nodes.len()))
+            .filter(|_| nodes.len() == self.current_nodes.len())
         {
             if self.current_nodes[i].was_forced && candidate.value != self.current_nodes[i].value {
                 return Ok(false);

--- a/hegel-c/tests/embedded/native/shrinker_cache_tests.rs
+++ b/hegel-c/tests/embedded/native/shrinker_cache_tests.rs
@@ -109,7 +109,11 @@ fn consider_cache_short_circuits_repeat_lookups() {
             }
             ShrinkRun::Probe { .. } => (false, Vec::new(), Spans::new()),
         }),
-        vec![int_node(0)],
+        // Start from a large target so the candidates below are shortlex-
+        // SMALLER and reach the run/cache path. (A shortlex-larger candidate
+        // is free-rejected by `consider` before the cache, so it would never
+        // exercise the cache.)
+        vec![int_node(201)],
         Spans::new(),
     );
     shrinker.max_stall = usize::MAX;

--- a/hegel-c/tests/embedded/native/shrinker_forced_node_tests.rs
+++ b/hegel-c/tests/embedded/native/shrinker_forced_node_tests.rs
@@ -214,3 +214,66 @@ fn normalize_unicode_chars_skips_forced_node() {
         _ => unreachable!(),
     }
 }
+
+// --- Regression tests for the `consider` changes ---------
+
+/// Forced-guard fix: the forced-value guard in `consider` must apply ONLY to
+/// same-length candidates. A deletion shifts every node after the cut, so
+/// comparing `candidate[i]` to `current[i]` at a forced index past the cut is
+/// meaningless and used to spuriously reject the deletion.
+///
+/// Here `current = [int(1), forced int(9), int(2)]`. Deleting index 0 yields
+/// the shorter `[forced int(9), int(2)]`: the forced node shifts from index 1
+/// to index 0, and the node now under the old forced index 1 (value 2) differs
+/// from 9. The pre-fix guard rejected this without running; the fix must run it
+/// and accept it (it is interesting and shortlex-smaller).
+#[test]
+fn consider_accepts_length_reducing_candidate_past_forced_node() {
+    let mut shrinker = accepting_shrinker(vec![
+        int_node(1, false),
+        int_node(9, true),
+        int_node(2, false),
+    ]);
+    let interesting = shrinker
+        .consider(&[int_node(9, true), int_node(2, false)])
+        .unwrap();
+    assert!(
+        interesting,
+        "length-reducing candidate must not be pre-rejected by the forced guard"
+    );
+    assert_eq!(
+        shrinker.current_nodes.len(),
+        2,
+        "the deletion should have been accepted as the new shrink target"
+    );
+}
+
+/// Free-reject (Hypothesis `cached_test_function` port): a candidate that is
+/// shortlex >= the current target can never improve it, so `consider` must
+/// reject it WITHOUT running the test closure.
+#[test]
+fn consider_free_rejects_shortlex_larger_candidate_without_running() {
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    let ran = Rc::new(Cell::new(false));
+    let inner = Rc::clone(&ran);
+    let mut shrinker = Shrinker::with_probe(
+        Box::new(move |run| match run {
+            ShrinkRun::Full(nodes) => {
+                inner.set(true);
+                (true, nodes.to_vec(), Spans::new())
+            }
+            ShrinkRun::Probe { .. } => (false, Vec::new(), Spans::new()),
+        }),
+        vec![int_node(5, false)],
+        Spans::new(),
+    );
+    // 7 > 5: shortlex-larger, so it cannot be an improvement.
+    let interesting = shrinker.consider(&[int_node(7, false)]).unwrap();
+    assert!(!interesting, "shortlex-larger candidate must be rejected");
+    assert!(
+        !ran.get(),
+        "shortlex-larger candidate must be free-rejected without running the test"
+    );
+}

--- a/hegel-c/tests/embedded/native/shrinker_scheduling_tests.rs
+++ b/hegel-c/tests/embedded/native/shrinker_scheduling_tests.rs
@@ -132,7 +132,12 @@ fn max_stall_grows_after_shrink() {
                     ChoiceValue::Integer(v) => i128::try_from(v).unwrap(),
                     _ => unreachable!(),
                 };
-                (v < 10, nodes.to_vec(), Spans::new())
+                // Interesting only at two sentinel values, both reachable by
+                // lowering. The burn candidates between them are uninteresting
+                // but still shortlex-SMALLER than the current target, so they
+                // reach the run path (a larger candidate would be free-rejected
+                // by `consider` before `calls` is incremented).
+                (v == 1 || v == 9, nodes.to_vec(), Spans::new())
             }
             ShrinkRun::Probe { .. } => (false, Vec::new(), Spans::new()),
         }),
@@ -146,13 +151,14 @@ fn max_stall_grows_after_shrink() {
     let accepted_first = shrinker.consider(&[int_node(9)]).unwrap();
     assert!(accepted_first);
     let stall_after_first = shrinker.max_stall;
-    // Burn 3 uninteresting calls (still within stall budget).
-    for v in 11..14 {
+    // Burn 3 uninteresting calls, smaller than the current target [9] so they
+    // run (still within stall budget).
+    for v in [8, 7, 6] {
         shrinker.consider(&[int_node(v)]).unwrap();
     }
-    // Another improvement.  span = calls - calls_at_last_shrink ≈ 3;
-    // grown = 6 > 5, so max_stall should grow.
-    shrinker.consider(&[int_node(5)]).unwrap();
+    // Another improvement (1 < 9).  span = calls - calls_at_last_shrink ≈ 3+;
+    // grown > 5, so max_stall should grow.
+    shrinker.consider(&[int_node(1)]).unwrap();
     assert!(
         shrinker.max_stall > stall_after_first,
         "max_stall failed to grow: {} -> {}",

--- a/hegel-c/tests/embedded/native/shrinker_spans_tests.rs
+++ b/hegel-c/tests/embedded/native/shrinker_spans_tests.rs
@@ -286,7 +286,9 @@ fn consider_cache_short_circuits_repeated_candidate() {
         initial,
         Spans::new(),
     );
-    let candidate = vec![int_node(7)];
+    // Shortlex-SMALLER than the initial target [5] so it reaches the run/cache
+    // path (a larger candidate would be free-rejected before the cache).
+    let candidate = vec![int_node(3)];
     shrinker.consider(&candidate).unwrap();
     shrinker.consider(&candidate).unwrap();
     shrinker.consider(&candidate).unwrap();


### PR DESCRIPTION
Reduced test body executions during shrinking by 6-9x in a stateful test mimicking one from the Aria team. Seems like an improvement in general?