### PR TITLE
Various robustness improvements to libhegel

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,10 @@
 RELEASE_TYPE: patch
 
-This patch removes the last thread-local state from libhegel. Error reporting
+This patch tightens libhegel's C ABI: it removes the last thread-local state,
+replaces the `#define`d integer constants with named enums, and documents
+pointer ownership.
+
+Error reporting
 no longer goes through a thread-local "last error" buffer; instead every
 fallible call records its diagnostic on an explicit `hegel_context_t` the
 caller passes in. A thread-local buffer is ill-defined under runtimes that
@@ -37,3 +41,22 @@ For libhegel C-ABI consumers (such as hegel-go) this is a **breaking change**:
   (`hegel_run_result_status`, the `hegel_failure_*` getters,
   `hegel_test_case_is_final_replay`, `hegel_version`, and the infallible
   `hegel_settings_*` setters) are unchanged.
+
+The `#define`d constants are now named enums, so they appear in debug info and
+type-check at the call site (also a **breaking change** for C-ABI consumers):
+
+- The `HEGEL_OK` / `HEGEL_E_*` codes are now the `hegel_result_t` enum, and
+  every fallible entry point returns `hegel_result_t` instead of `int`. The
+  values are unchanged (`HEGEL_OK` is 0, errors are negative), so the binary
+  ABI is the same — only the declared types change.
+- `HEGEL_PHASE_*`, `HEGEL_HC_*`, and `HEGEL_LABEL_*` are now the
+  `hegel_phase_t`, `hegel_health_check_t`, and `hegel_label_t` enums. The phase
+  and health-check parameters stay `uint32_t` (a bitwise OR of the flag
+  values), and the span label stays `uint64_t` (the label space is open — you
+  may pass your own stable keys beyond the named ones), so only the constants'
+  declaring type changes.
+
+Finally, the header now documents pointer ownership explicitly: every pointer
+you pass into a libhegel function stays owned by you (the library copies
+whatever it needs during the call), and pointers libhegel returns are borrows
+valid only until a documented point.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,62 +1,8 @@
-RELEASE_TYPE: patch
+RELEASE_TYPE: minor
 
 This patch tightens libhegel's C ABI: it removes the last thread-local state,
 replaces the `#define`d integer constants with named enums, and documents
 pointer ownership.
 
-Error reporting
-no longer goes through a thread-local "last error" buffer; instead every
-fallible call records its diagnostic on an explicit `hegel_context_t` the
-caller passes in. A thread-local buffer is ill-defined under runtimes that
-migrate work between OS threads mid-call (for example Go, whose goroutines can
-move between threads), where a message could be written on one thread and read
-on another. Threading an explicit context through the API removes that hazard.
-
-For Rust users this is an internal change — the public API is unchanged. The
-`hegeltest` crate keeps its error context in thread-local storage, which is
-sound because it only ever drives the engine from ordinary OS threads.
-
-For libhegel C-ABI consumers (such as hegel-go) this is a **breaking change**:
-
-- New `hegel_context_t` opaque handle with `hegel_context_new()`,
-  `hegel_context_free(ctx)`, and `hegel_context_last_error(ctx)`. Create one
-  per test (or per thread), pass it as the first argument to every fallible
-  call, and free it when done. A context is cheap; a single context must not be
-  shared across threads concurrently.
-
-- `hegel_last_error_message()` has been removed. Read diagnostics with
-  `hegel_context_last_error(ctx)` instead.
-
-- Every fallible entry point now takes a leading `hegel_context_t *ctx`
-  argument: `hegel_run_start`, `hegel_next_test_case`, `hegel_run_result`,
-  `hegel_generate`, `hegel_start_span`, `hegel_stop_span`,
-  `hegel_new_collection`, `hegel_collection_more`, `hegel_collection_reject`,
-  `hegel_new_pool`, `hegel_pool_add`, `hegel_pool_generate`,
-  `hegel_new_state_machine`, `hegel_state_machine_next_rule`,
-  `hegel_primitive_boolean`, `hegel_target`, `hegel_mark_complete`,
-  `hegel_test_case_from_blob`, `hegel_test_case_free`,
-  `hegel_settings_database`, and `hegel_settings_database_key`. Passing a NULL
-  context is allowed and simply opts out of error messages — the call still
-  returns its usual error code. Pure accessors that cannot fail
-  (`hegel_run_result_status`, the `hegel_failure_*` getters,
-  `hegel_test_case_is_final_replay`, `hegel_version`, and the infallible
-  `hegel_settings_*` setters) are unchanged.
-
-The `#define`d constants are now named enums, so they appear in debug info and
-type-check at the call site (also a **breaking change** for C-ABI consumers):
-
-- The `HEGEL_OK` / `HEGEL_E_*` codes are now the `hegel_result_t` enum, and
-  every fallible entry point returns `hegel_result_t` instead of `int`. The
-  values are unchanged (`HEGEL_OK` is 0, errors are negative), so the binary
-  ABI is the same — only the declared types change.
-- `HEGEL_PHASE_*`, `HEGEL_HC_*`, and `HEGEL_LABEL_*` are now the
-  `hegel_phase_t`, `hegel_health_check_t`, and `hegel_label_t` enums. The phase
-  and health-check parameters stay `uint32_t` (a bitwise OR of the flag
-  values), and the span label stays `uint64_t` (the label space is open — you
-  may pass your own stable keys beyond the named ones), so only the constants'
-  declaring type changes.
-
-Finally, the header now documents pointer ownership explicitly: every pointer
-you pass into a libhegel function stays owned by you (the library copies
-whatever it needs during the call), and pointers libhegel returns are borrows
-valid only until a documented point.
+For Rust users this is an internal-only change, but it is a significant breaking
+change for libhegel users.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,39 @@
+RELEASE_TYPE: patch
+
+This patch removes the last thread-local state from libhegel. Error reporting
+no longer goes through a thread-local "last error" buffer; instead every
+fallible call records its diagnostic on an explicit `hegel_context_t` the
+caller passes in. A thread-local buffer is ill-defined under runtimes that
+migrate work between OS threads mid-call (for example Go, whose goroutines can
+move between threads), where a message could be written on one thread and read
+on another. Threading an explicit context through the API removes that hazard.
+
+For Rust users this is an internal change — the public API is unchanged. The
+`hegeltest` crate keeps its error context in thread-local storage, which is
+sound because it only ever drives the engine from ordinary OS threads.
+
+For libhegel C-ABI consumers (such as hegel-go) this is a **breaking change**:
+
+- New `hegel_context_t` opaque handle with `hegel_context_new()`,
+  `hegel_context_free(ctx)`, and `hegel_context_last_error(ctx)`. Create one
+  per test (or per thread), pass it as the first argument to every fallible
+  call, and free it when done. A context is cheap; a single context must not be
+  shared across threads concurrently.
+
+- `hegel_last_error_message()` has been removed. Read diagnostics with
+  `hegel_context_last_error(ctx)` instead.
+
+- Every fallible entry point now takes a leading `hegel_context_t *ctx`
+  argument: `hegel_run_start`, `hegel_next_test_case`, `hegel_run_result`,
+  `hegel_generate`, `hegel_start_span`, `hegel_stop_span`,
+  `hegel_new_collection`, `hegel_collection_more`, `hegel_collection_reject`,
+  `hegel_new_pool`, `hegel_pool_add`, `hegel_pool_generate`,
+  `hegel_new_state_machine`, `hegel_state_machine_next_rule`,
+  `hegel_primitive_boolean`, `hegel_target`, `hegel_mark_complete`,
+  `hegel_test_case_from_blob`, `hegel_test_case_free`,
+  `hegel_settings_database`, and `hegel_settings_database_key`. Passing a NULL
+  context is allowed and simply opts out of error messages — the call still
+  returns its usual error code. Pure accessors that cannot fail
+  (`hegel_run_result_status`, the `hegel_failure_*` getters,
+  `hegel_test_case_is_final_replay`, `hegel_version`, and the infallible
+  `hegel_settings_*` setters) are unchanged.

--- a/hegel-c/cbindgen.toml
+++ b/hegel-c/cbindgen.toml
@@ -5,6 +5,21 @@ header = """
  *
  * This header is generated from hegel-c/src/lib.rs by cbindgen. Do not
  * edit it directly; re-run `just c-header` after changing the Rust source.
+ *
+ * Pointer ownership
+ * -----------------
+ * Every pointer you pass *into* a libhegel function stays owned by you: the
+ * library reads it during the call and copies out whatever it needs to keep,
+ * so you may free or reuse the memory as soon as the call returns. This
+ * applies to strings (char*), CBOR byte buffers, and arrays of strings alike.
+ *
+ * Pointers libhegel returns *to* you are borrows into a handle and are only
+ * valid until a stated point — each function documents its own lifetime (e.g.
+ * the bytes from hegel_generate are invalidated by the next call on that test
+ * case; result strings live until hegel_run_free). Copy them if you need them
+ * longer. Opaque handles (hegel_context_t*, hegel_settings_t*, hegel_run_t*,
+ * hegel_test_case_t* from hegel_test_case_from_blob) are owned by you and must
+ * be released with the matching hegel_*_free function.
  */"""
 include_guard = "HEGEL_H"
 pragma_once = false
@@ -16,6 +31,16 @@ documentation = true
 documentation_style = "c"
 style = "type"
 usize_is_size_t = true
+
+# These enums name constants that are passed as plain integers, not as the
+# enum type, so cbindgen sees no signature referencing them and would omit
+# them. Force them into the header so the named values are still emitted as
+# proper enums:
+#   - hegel_phase_t / hegel_health_check_t: bitwise-OR'd into a uint32_t mask.
+#   - hegel_label_t: a uint64_t span label (the label space is open, so the
+#     parameter can't be the closed enum type).
+[export]
+include = ["hegel_phase_t", "hegel_health_check_t", "hegel_label_t"]
 
 [export.rename]
 "HegelContext" = "hegel_context_t"

--- a/hegel-c/cbindgen.toml
+++ b/hegel-c/cbindgen.toml
@@ -18,6 +18,7 @@ style = "type"
 usize_is_size_t = true
 
 [export.rename]
+"HegelContext" = "hegel_context_t"
 "HegelRun" = "hegel_run_t"
 "HegelSettings" = "hegel_settings_t"
 "HegelTestCase" = "hegel_test_case_t"

--- a/hegel-c/cbindgen.toml
+++ b/hegel-c/cbindgen.toml
@@ -8,18 +8,32 @@ header = """
  *
  * Pointer ownership
  * -----------------
- * Every pointer you pass *into* a libhegel function stays owned by you: the
- * library reads it during the call and copies out whatever it needs to keep,
- * so you may free or reuse the memory as soon as the call returns. This
- * applies to strings (char*), CBOR byte buffers, and arrays of strings alike.
+ * Pointers you pass *into* a libhegel function are always yours. The library
+ * reads them during the call and copies whatever it needs to keep, so you may
+ * free or reuse the memory as soon as the call returns. This covers strings
+ * (char*), CBOR byte buffers, and arrays of strings alike.
  *
- * Pointers libhegel returns *to* you are borrows into a handle and are only
- * valid until a stated point — each function documents its own lifetime (e.g.
- * the bytes from hegel_generate are invalidated by the next call on that test
- * case; result strings live until hegel_run_free). Copy them if you need them
- * longer. Opaque handles (hegel_context_t*, hegel_settings_t*, hegel_run_t*,
- * hegel_test_case_t* from hegel_test_case_from_blob) are owned by you and must
- * be released with the matching hegel_*_free function.
+ * Of the pointers libhegel hands *back*, you own exactly the handles made by
+ * the four constructors, and must release each with its matching free:
+ *
+ *     hegel_context_new          ->  hegel_context_free
+ *     hegel_settings_new         ->  hegel_settings_free
+ *     hegel_run_start            ->  hegel_run_free
+ *     hegel_test_case_from_blob  ->  hegel_test_case_free
+ *
+ * Every *other* pointer libhegel returns is borrowed: libhegel still owns it,
+ * you must not free it, and it is valid only until a point that the returning
+ * function documents. Two cases are easy to trip over:
+ *
+ *   - The hegel_test_case_t* from hegel_next_test_case is borrowed from the
+ *     run and freed by hegel_run_free. Do NOT pass it to hegel_test_case_free
+ *     (that is only for a test case you made with hegel_test_case_from_blob).
+ *     Likewise the hegel_run_result_t* and hegel_failure_t* you read from a
+ *     run live until hegel_run_free.
+ *   - Returned strings and byte buffers (e.g. from hegel_generate,
+ *     hegel_context_last_error, hegel_run_result_error, the hegel_failure_*
+ *     getters) are transient — hegel_generate's bytes, for instance, are
+ *     invalidated by the next call on that test case. Copy them to keep them.
  */"""
 include_guard = "HEGEL_H"
 pragma_once = false

--- a/hegel-c/examples/echo.c
+++ b/hegel-c/examples/echo.c
@@ -67,32 +67,35 @@ static int64_t decode_small_integer(const uint8_t *bytes, size_t len) {
 }
 
 int main(void) {
+    hegel_context_t *ctx = hegel_context_new();
+
     hegel_settings_t *s = hegel_settings_new();
     hegel_settings_test_cases(s, 50);
-    hegel_settings_database(s, "");      /* disable database */
+    hegel_settings_database(ctx, s, "");      /* disable database */
     hegel_settings_derandomize(s, true); /* deterministic */
     hegel_settings_seed(s, 42, true);
 
-    hegel_run_t *run = hegel_run_start(s);
+    hegel_run_t *run = hegel_run_start(ctx, s);
     if (!run) {
-        fprintf(stderr, "hegel_run_start failed: %s\n", hegel_last_error_message());
+        fprintf(stderr, "hegel_run_start failed: %s\n", hegel_context_last_error(ctx));
         hegel_settings_free(s);
+        hegel_context_free(ctx);
         return 1;
     }
 
     size_t cases = 0;
     hegel_test_case_t *tc;
-    while ((tc = hegel_next_test_case(run)) != NULL) {
+    while ((tc = hegel_next_test_case(ctx, run)) != NULL) {
         const uint8_t *value;
         size_t value_len;
-        int rc = hegel_generate(tc, INTEGER_SCHEMA, sizeof(INTEGER_SCHEMA), &value, &value_len);
+        int rc = hegel_generate(ctx, tc, INTEGER_SCHEMA, sizeof(INTEGER_SCHEMA), &value, &value_len);
         if (rc == HEGEL_E_STOP_TEST) {
-            hegel_mark_complete(tc, HEGEL_STATUS_OVERRUN, NULL);
+            hegel_mark_complete(ctx, tc, HEGEL_STATUS_OVERRUN, NULL);
             continue;
         }
         if (rc != HEGEL_OK) {
-            fprintf(stderr, "hegel_generate failed: rc=%d %s\n", rc, hegel_last_error_message());
-            hegel_mark_complete(tc, HEGEL_STATUS_VALID, NULL);
+            fprintf(stderr, "hegel_generate failed: rc=%d %s\n", rc, hegel_context_last_error(ctx));
+            hegel_mark_complete(ctx, tc, HEGEL_STATUS_VALID, NULL);
             continue;
         }
 
@@ -100,19 +103,19 @@ int main(void) {
         if (n < 0 || n > 100) {
             char origin[64];
             snprintf(origin, sizeof origin, "out-of-range value %lld", (long long)n);
-            hegel_mark_complete(tc, HEGEL_STATUS_INTERESTING, origin);
+            hegel_mark_complete(ctx, tc, HEGEL_STATUS_INTERESTING, origin);
         } else {
             cases++;
-            hegel_mark_complete(tc, HEGEL_STATUS_VALID, NULL);
+            hegel_mark_complete(ctx, tc, HEGEL_STATUS_VALID, NULL);
         }
     }
 
-    const char *err = hegel_last_error_message();
+    const char *err = hegel_context_last_error(ctx);
     if (err[0] != '\0') {
         fprintf(stderr, "loop exited with error: %s\n", err);
     }
 
-    const hegel_run_result_t *result = hegel_run_result(run);
+    const hegel_run_result_t *result = hegel_run_result(ctx, run);
     hegel_run_status_t status = hegel_run_result_status(result);
     const char *status_str = status == HEGEL_RUN_STATUS_PASSED   ? "PASSED"
                              : status == HEGEL_RUN_STATUS_FAILED ? "FAILED"
@@ -129,5 +132,6 @@ int main(void) {
 
     hegel_run_free(run);
     hegel_settings_free(s);
+    hegel_context_free(ctx);
     return status == HEGEL_RUN_STATUS_PASSED ? 0 : 1;
 }

--- a/hegel-c/examples/echo.c
+++ b/hegel-c/examples/echo.c
@@ -88,7 +88,7 @@ int main(void) {
     while ((tc = hegel_next_test_case(ctx, run)) != NULL) {
         const uint8_t *value;
         size_t value_len;
-        int rc = hegel_generate(ctx, tc, INTEGER_SCHEMA, sizeof(INTEGER_SCHEMA), &value, &value_len);
+        hegel_result_t rc = hegel_generate(ctx, tc, INTEGER_SCHEMA, sizeof(INTEGER_SCHEMA), &value, &value_len);
         if (rc == HEGEL_E_STOP_TEST) {
             hegel_mark_complete(ctx, tc, HEGEL_STATUS_OVERRUN, NULL);
             continue;

--- a/hegel-c/examples/failing.c
+++ b/hegel-c/examples/failing.c
@@ -66,7 +66,7 @@ int main(void) {
     while ((tc = hegel_next_test_case(ctx, run)) != NULL) {
         const uint8_t *value;
         size_t value_len;
-        int rc = hegel_generate(ctx, tc, INTEGER_SCHEMA, sizeof(INTEGER_SCHEMA), &value, &value_len);
+        hegel_result_t rc = hegel_generate(ctx, tc, INTEGER_SCHEMA, sizeof(INTEGER_SCHEMA), &value, &value_len);
         if (rc == HEGEL_E_STOP_TEST) {
             hegel_mark_complete(ctx, tc, HEGEL_STATUS_OVERRUN, NULL);
             continue;

--- a/hegel-c/examples/failing.c
+++ b/hegel-c/examples/failing.c
@@ -46,54 +46,58 @@ static int decode_small_uint(const uint8_t *bytes, size_t len) {
 #define ORIGIN "n >= 5"
 
 int main(void) {
+    hegel_context_t *ctx = hegel_context_new();
+
     hegel_settings_t *s = hegel_settings_new();
     hegel_settings_test_cases(s, 200);
-    hegel_settings_database(s, "");
+    hegel_settings_database(ctx, s, "");
     hegel_settings_derandomize(s, true);
     hegel_settings_seed(s, 0xc0ffee, true);
 
-    hegel_run_t *run = hegel_run_start(s);
+    hegel_run_t *run = hegel_run_start(ctx, s);
     if (!run) {
-        fprintf(stderr, "hegel_run_start: %s\n", hegel_last_error_message());
+        fprintf(stderr, "hegel_run_start: %s\n", hegel_context_last_error(ctx));
         hegel_settings_free(s);
+        hegel_context_free(ctx);
         return 2;
     }
 
     hegel_test_case_t *tc;
-    while ((tc = hegel_next_test_case(run)) != NULL) {
+    while ((tc = hegel_next_test_case(ctx, run)) != NULL) {
         const uint8_t *value;
         size_t value_len;
-        int rc = hegel_generate(tc, INTEGER_SCHEMA, sizeof(INTEGER_SCHEMA), &value, &value_len);
+        int rc = hegel_generate(ctx, tc, INTEGER_SCHEMA, sizeof(INTEGER_SCHEMA), &value, &value_len);
         if (rc == HEGEL_E_STOP_TEST) {
-            hegel_mark_complete(tc, HEGEL_STATUS_OVERRUN, NULL);
+            hegel_mark_complete(ctx, tc, HEGEL_STATUS_OVERRUN, NULL);
             continue;
         }
         if (rc != HEGEL_OK) {
-            fprintf(stderr, "hegel_generate: rc=%d %s\n", rc, hegel_last_error_message());
-            hegel_mark_complete(tc, HEGEL_STATUS_VALID, NULL);
+            fprintf(stderr, "hegel_generate: rc=%d %s\n", rc, hegel_context_last_error(ctx));
+            hegel_mark_complete(ctx, tc, HEGEL_STATUS_VALID, NULL);
             continue;
         }
 
         int n = decode_small_uint(value, value_len);
         if (n < 0) {
             fprintf(stderr, "decode failed\n");
-            hegel_mark_complete(tc, HEGEL_STATUS_VALID, NULL);
+            hegel_mark_complete(ctx, tc, HEGEL_STATUS_VALID, NULL);
             continue;
         }
 
         if (n < 5) {
-            hegel_mark_complete(tc, HEGEL_STATUS_VALID, NULL);
+            hegel_mark_complete(ctx, tc, HEGEL_STATUS_VALID, NULL);
         } else {
-            hegel_mark_complete(tc, HEGEL_STATUS_INTERESTING, ORIGIN);
+            hegel_mark_complete(ctx, tc, HEGEL_STATUS_INTERESTING, ORIGIN);
         }
     }
 
-    const hegel_run_result_t *result = hegel_run_result(run);
+    const hegel_run_result_t *result = hegel_run_result(ctx, run);
     if (hegel_run_result_status(result) != HEGEL_RUN_STATUS_FAILED) {
         fprintf(stderr, "FAIL: expected a failing run, got status %d\n",
                 (int)hegel_run_result_status(result));
         hegel_run_free(run);
         hegel_settings_free(s);
+        hegel_context_free(ctx);
         return 1;
     }
 
@@ -102,6 +106,7 @@ int main(void) {
         fprintf(stderr, "FAIL: expected at least one failure, got %zu\n", nf);
         hegel_run_free(run);
         hegel_settings_free(s);
+        hegel_context_free(ctx);
         return 1;
     }
 
@@ -111,6 +116,7 @@ int main(void) {
         fprintf(stderr, "FAIL: expected origin to contain %s, got: %s\n", ORIGIN, origin);
         hegel_run_free(run);
         hegel_settings_free(s);
+        hegel_context_free(ctx);
         return 1;
     }
 
@@ -118,5 +124,6 @@ int main(void) {
 
     hegel_run_free(run);
     hegel_settings_free(s);
+    hegel_context_free(ctx);
     return 0;
 }

--- a/hegel-c/examples/invalid_schema.c
+++ b/hegel-c/examples/invalid_schema.c
@@ -39,30 +39,34 @@ static const uint8_t IPV4_TYPE_SCHEMA[] = {
 };
 
 int main(void) {
+    hegel_context_t *ctx = hegel_context_new();
+
     hegel_settings_t *s = hegel_settings_new();
     hegel_settings_test_cases(s, 1);
-    hegel_settings_database(s, "");
+    hegel_settings_database(ctx, s, "");
     hegel_settings_derandomize(s, true);
     hegel_settings_seed(s, 1, true);
 
-    hegel_run_t *run = hegel_run_start(s);
+    hegel_run_t *run = hegel_run_start(ctx, s);
     if (!run) {
-        fprintf(stderr, "hegel_run_start failed: %s\n", hegel_last_error_message());
+        fprintf(stderr, "hegel_run_start failed: %s\n", hegel_context_last_error(ctx));
         hegel_settings_free(s);
+        hegel_context_free(ctx);
         return 1;
     }
 
-    hegel_test_case_t *tc = hegel_next_test_case(run);
+    hegel_test_case_t *tc = hegel_next_test_case(ctx, run);
     if (!tc) {
         fprintf(stderr, "expected a test case\n");
         hegel_run_free(run);
         hegel_settings_free(s);
+        hegel_context_free(ctx);
         return 1;
     }
 
     const uint8_t *value;
     size_t value_len;
-    int rc = hegel_generate(tc, IPV4_TYPE_SCHEMA, sizeof(IPV4_TYPE_SCHEMA), &value, &value_len);
+    int rc = hegel_generate(ctx, tc, IPV4_TYPE_SCHEMA, sizeof(IPV4_TYPE_SCHEMA), &value, &value_len);
 
     int ok = 1;
     if (rc != HEGEL_E_INVALID_ARG) {
@@ -70,7 +74,7 @@ int main(void) {
                 HEGEL_E_INVALID_ARG, rc);
         ok = 0;
     }
-    const char *err = hegel_last_error_message();
+    const char *err = hegel_context_last_error(ctx);
     if (err[0] == '\0') {
         fprintf(stderr, "expected a diagnostic message for the invalid schema\n");
         ok = 0;
@@ -78,8 +82,9 @@ int main(void) {
         printf("invalid schema correctly rejected: rc=%d, message=\"%s\"\n", rc, err);
     }
 
-    hegel_mark_complete(tc, HEGEL_STATUS_INVALID, NULL);
+    hegel_mark_complete(ctx, tc, HEGEL_STATUS_INVALID, NULL);
     hegel_run_free(run);
     hegel_settings_free(s);
+    hegel_context_free(ctx);
     return ok ? 0 : 1;
 }

--- a/hegel-c/examples/invalid_schema.c
+++ b/hegel-c/examples/invalid_schema.c
@@ -66,7 +66,7 @@ int main(void) {
 
     const uint8_t *value;
     size_t value_len;
-    int rc = hegel_generate(ctx, tc, IPV4_TYPE_SCHEMA, sizeof(IPV4_TYPE_SCHEMA), &value, &value_len);
+    hegel_result_t rc = hegel_generate(ctx, tc, IPV4_TYPE_SCHEMA, sizeof(IPV4_TYPE_SCHEMA), &value, &value_len);
 
     int ok = 1;
     if (rc != HEGEL_E_INVALID_ARG) {

--- a/hegel-c/examples/pool.c
+++ b/hegel-c/examples/pool.c
@@ -85,13 +85,15 @@ static int64_t live_remove(struct live_set *s, int64_t id) {
 }
 
 int main(void) {
+    hegel_context_t *ctx = hegel_context_new();
+
     hegel_settings_t *s = hegel_settings_new();
     hegel_settings_test_cases(s, 100);
-    hegel_settings_database(s, "");
+    hegel_settings_database(ctx, s, "");
     hegel_settings_derandomize(s, true);
     hegel_settings_seed(s, 0x5ca1ab1e, true);
 
-    hegel_run_t *run = hegel_run_start(s);
+    hegel_run_t *run = hegel_run_start(ctx, s);
 
     const int STEPS = 12;
     size_t total = 0;
@@ -99,11 +101,11 @@ int main(void) {
     bool ok = true;
 
     hegel_test_case_t *tc;
-    while ((tc = hegel_next_test_case(run)) != NULL) {
+    while ((tc = hegel_next_test_case(ctx, run)) != NULL) {
         struct live_set live = { .count = 0 };
         int64_t pool;
-        if (hegel_new_pool(tc, &pool) != HEGEL_OK) {
-            hegel_mark_complete(tc, HEGEL_STATUS_OVERRUN, NULL);
+        if (hegel_new_pool(ctx, tc, &pool) != HEGEL_OK) {
+            hegel_mark_complete(ctx, tc, HEGEL_STATUS_OVERRUN, NULL);
             continue;
         }
 
@@ -114,25 +116,25 @@ int main(void) {
             size_t len;
 
             /* Decide push vs pop. */
-            int rc = hegel_generate(tc, BOOLEAN_SCHEMA, sizeof(BOOLEAN_SCHEMA), &bytes, &len);
+            int rc = hegel_generate(ctx, tc, BOOLEAN_SCHEMA, sizeof(BOOLEAN_SCHEMA), &bytes, &len);
             if (rc != HEGEL_OK) { overran = true; break; }
             bool push = decode_bool(bytes, len);
 
             if (push || live.count == 0) {
                 /* Push: generate a value and register it in the pool. */
-                rc = hegel_generate(tc, INTEGER_SCHEMA, sizeof(INTEGER_SCHEMA), &bytes, &len);
+                rc = hegel_generate(ctx, tc, INTEGER_SCHEMA, sizeof(INTEGER_SCHEMA), &bytes, &len);
                 if (rc != HEGEL_OK) { overran = true; break; }
                 /* The integer fits in one or two CBOR bytes for [0,1000];
                  * we only need a representative value, so use the length. */
                 int64_t value = (int64_t)len;
 
                 int64_t var_id;
-                if (hegel_pool_add(tc, pool, &var_id) != HEGEL_OK) { overran = true; break; }
+                if (hegel_pool_add(ctx, tc, pool, &var_id) != HEGEL_OK) { overran = true; break; }
                 live_add(&live, var_id, value);
             } else {
                 /* Pop: draw a live variable and consume it. */
                 int64_t var_id;
-                rc = hegel_pool_generate(tc, pool, true, &var_id);
+                rc = hegel_pool_generate(ctx, tc, pool, true, &var_id);
                 if (rc == HEGEL_E_STOP_TEST) { overran = true; break; }
                 if (rc != HEGEL_OK) { overran = true; break; }
 
@@ -146,19 +148,19 @@ int main(void) {
         }
 
         if (bad) {
-            hegel_mark_complete(tc, HEGEL_STATUS_INTERESTING, "drew a non-live variable");
+            hegel_mark_complete(ctx, tc, HEGEL_STATUS_INTERESTING, "drew a non-live variable");
             ok = false;
             continue;
         }
         if (overran) {
-            hegel_mark_complete(tc, HEGEL_STATUS_OVERRUN, NULL);
+            hegel_mark_complete(ctx, tc, HEGEL_STATUS_OVERRUN, NULL);
             continue;
         }
         total++;
-        hegel_mark_complete(tc, HEGEL_STATUS_VALID, NULL);
+        hegel_mark_complete(ctx, tc, HEGEL_STATUS_VALID, NULL);
     }
 
-    const hegel_run_result_t *result = hegel_run_result(run);
+    const hegel_run_result_t *result = hegel_run_result(ctx, run);
     bool passed = hegel_run_result_status(result) == HEGEL_RUN_STATUS_PASSED;
 
     printf("ran %zu valid cases (max live pool size seen: %zu), %s\n",
@@ -166,5 +168,6 @@ int main(void) {
 
     hegel_run_free(run);
     hegel_settings_free(s);
+    hegel_context_free(ctx);
     return (passed && ok) ? 0 : 1;
 }

--- a/hegel-c/examples/pool.c
+++ b/hegel-c/examples/pool.c
@@ -116,7 +116,7 @@ int main(void) {
             size_t len;
 
             /* Decide push vs pop. */
-            int rc = hegel_generate(ctx, tc, BOOLEAN_SCHEMA, sizeof(BOOLEAN_SCHEMA), &bytes, &len);
+            hegel_result_t rc = hegel_generate(ctx, tc, BOOLEAN_SCHEMA, sizeof(BOOLEAN_SCHEMA), &bytes, &len);
             if (rc != HEGEL_OK) { overran = true; break; }
             bool push = decode_bool(bytes, len);
 

--- a/hegel-c/examples/spans_collections.c
+++ b/hegel-c/examples/spans_collections.c
@@ -39,54 +39,56 @@ static bool decode_bool(const uint8_t *bytes, size_t len) {
 /* Draw a list of booleans, sized between min_size and max_size, using
  * a span (LIST) wrapping a collection (more/draw loop). Returns the
  * number of elements drawn, or -1 on engine error. */
-static int draw_bool_list(hegel_test_case_t *tc, uint64_t min_size, uint64_t max_size) {
-    if (hegel_start_span(tc, HEGEL_LABEL_LIST) != HEGEL_OK) return -1;
+static int draw_bool_list(hegel_context_t *ctx, hegel_test_case_t *tc, uint64_t min_size, uint64_t max_size) {
+    if (hegel_start_span(ctx, tc, HEGEL_LABEL_LIST) != HEGEL_OK) return -1;
 
     int64_t cid;
-    if (hegel_new_collection(tc, min_size, max_size, &cid) != HEGEL_OK) {
-        hegel_stop_span(tc, false);
+    if (hegel_new_collection(ctx, tc, min_size, max_size, &cid) != HEGEL_OK) {
+        hegel_stop_span(ctx, tc, false);
         return -1;
     }
 
     int n = 0;
     for (;;) {
         bool more;
-        int rc = hegel_collection_more(tc, cid, &more);
+        int rc = hegel_collection_more(ctx, tc, cid, &more);
         if (rc != HEGEL_OK) {
-            hegel_stop_span(tc, false);
+            hegel_stop_span(ctx, tc, false);
             return -1;
         }
         if (!more) break;
 
-        if (hegel_start_span(tc, HEGEL_LABEL_LIST_ELEMENT) != HEGEL_OK) {
-            hegel_stop_span(tc, false);
+        if (hegel_start_span(ctx, tc, HEGEL_LABEL_LIST_ELEMENT) != HEGEL_OK) {
+            hegel_stop_span(ctx, tc, false);
             return -1;
         }
         const uint8_t *value;
         size_t value_len;
-        rc = hegel_generate(tc, BOOLEAN_SCHEMA, sizeof(BOOLEAN_SCHEMA), &value, &value_len);
+        rc = hegel_generate(ctx, tc, BOOLEAN_SCHEMA, sizeof(BOOLEAN_SCHEMA), &value, &value_len);
         if (rc != HEGEL_OK) {
-            hegel_stop_span(tc, false);
-            hegel_stop_span(tc, false);
+            hegel_stop_span(ctx, tc, false);
+            hegel_stop_span(ctx, tc, false);
             return -1;
         }
         (void)decode_bool(value, value_len);   /* exercise the decode path */
-        hegel_stop_span(tc, false);
+        hegel_stop_span(ctx, tc, false);
         n++;
     }
 
-    hegel_stop_span(tc, false);
+    hegel_stop_span(ctx, tc, false);
     return n;
 }
 
 int main(void) {
+    hegel_context_t *ctx = hegel_context_new();
+
     hegel_settings_t *s = hegel_settings_new();
     hegel_settings_test_cases(s, 100);
-    hegel_settings_database(s, "");
+    hegel_settings_database(ctx, s, "");
     hegel_settings_derandomize(s, true);
     hegel_settings_seed(s, 0xfeedface, true);
 
-    hegel_run_t *run = hegel_run_start(s);
+    hegel_run_t *run = hegel_run_start(ctx, s);
 
     const uint64_t MIN_SIZE = 0;
     const uint64_t MAX_SIZE = 8;
@@ -94,24 +96,24 @@ int main(void) {
     size_t max_seen = 0;
 
     hegel_test_case_t *tc;
-    while ((tc = hegel_next_test_case(run)) != NULL) {
-        int n = draw_bool_list(tc, MIN_SIZE, MAX_SIZE);
+    while ((tc = hegel_next_test_case(ctx, run)) != NULL) {
+        int n = draw_bool_list(ctx, tc, MIN_SIZE, MAX_SIZE);
         if (n < 0) {
-            hegel_mark_complete(tc, HEGEL_STATUS_OVERRUN, NULL);
+            hegel_mark_complete(ctx, tc, HEGEL_STATUS_OVERRUN, NULL);
             continue;
         }
         if ((uint64_t)n < MIN_SIZE || (uint64_t)n > MAX_SIZE) {
             char origin[64];
             snprintf(origin, sizeof origin, "size %d out of range", n);
-            hegel_mark_complete(tc, HEGEL_STATUS_INTERESTING, origin);
+            hegel_mark_complete(ctx, tc, HEGEL_STATUS_INTERESTING, origin);
             continue;
         }
         total++;
         if ((size_t)n > max_seen) max_seen = (size_t)n;
-        hegel_mark_complete(tc, HEGEL_STATUS_VALID, NULL);
+        hegel_mark_complete(ctx, tc, HEGEL_STATUS_VALID, NULL);
     }
 
-    const hegel_run_result_t *result = hegel_run_result(run);
+    const hegel_run_result_t *result = hegel_run_result(ctx, run);
     bool passed = hegel_run_result_status(result) == HEGEL_RUN_STATUS_PASSED;
 
     printf("ran %zu valid cases (max list size seen: %zu), %s\n",
@@ -119,5 +121,6 @@ int main(void) {
 
     hegel_run_free(run);
     hegel_settings_free(s);
+    hegel_context_free(ctx);
     return passed ? 0 : 1;
 }

--- a/hegel-c/examples/spans_collections.c
+++ b/hegel-c/examples/spans_collections.c
@@ -51,7 +51,7 @@ static int draw_bool_list(hegel_context_t *ctx, hegel_test_case_t *tc, uint64_t 
     int n = 0;
     for (;;) {
         bool more;
-        int rc = hegel_collection_more(ctx, tc, cid, &more);
+        hegel_result_t rc = hegel_collection_more(ctx, tc, cid, &more);
         if (rc != HEGEL_OK) {
             hegel_stop_span(ctx, tc, false);
             return -1;

--- a/hegel-c/examples/state_machine.c
+++ b/hegel-c/examples/state_machine.c
@@ -31,13 +31,15 @@ static const char *INVARIANTS[] = { "non_negative" };
 #define NUM_INVARIANTS (sizeof(INVARIANTS) / sizeof(INVARIANTS[0]))
 
 int main(void) {
+    hegel_context_t *ctx = hegel_context_new();
+
     hegel_settings_t *s = hegel_settings_new();
     hegel_settings_test_cases(s, 100);
-    hegel_settings_database(s, "");
+    hegel_settings_database(ctx, s, "");
     hegel_settings_derandomize(s, true);
     hegel_settings_seed(s, 0x5ca1ab1e, true);
 
-    hegel_run_t *run = hegel_run_start(s);
+    hegel_run_t *run = hegel_run_start(ctx, s);
 
     const int STEPS = 20;
     size_t total = 0;
@@ -45,12 +47,12 @@ int main(void) {
     bool ok = true;
 
     hegel_test_case_t *tc;
-    while ((tc = hegel_next_test_case(run)) != NULL) {
+    while ((tc = hegel_next_test_case(ctx, run)) != NULL) {
         int64_t machine;
-        if (hegel_new_state_machine(tc, RULES, NUM_RULES,
+        if (hegel_new_state_machine(ctx, tc, RULES, NUM_RULES,
                                     INVARIANTS, NUM_INVARIANTS,
                                     &machine) != HEGEL_OK) {
-            hegel_mark_complete(tc, HEGEL_STATUS_OVERRUN, NULL);
+            hegel_mark_complete(ctx, tc, HEGEL_STATUS_OVERRUN, NULL);
             continue;
         }
 
@@ -59,7 +61,7 @@ int main(void) {
         bool bad = false;
         for (int step = 0; step < STEPS && !overran; step++) {
             int64_t rule;
-            int rc = hegel_state_machine_next_rule(tc, machine, &rule);
+            int rc = hegel_state_machine_next_rule(ctx, tc, machine, &rule);
             if (rc != HEGEL_OK) { overran = true; break; }
             if (rule >= NUM_RULES) { bad = true; break; }
             rule_counts[rule]++;
@@ -75,20 +77,20 @@ int main(void) {
         }
 
         if (bad) {
-            hegel_mark_complete(tc, HEGEL_STATUS_INTERESTING,
+            hegel_mark_complete(ctx, tc, HEGEL_STATUS_INTERESTING,
                                 "invariant violated");
             ok = false;
             continue;
         }
         if (overran) {
-            hegel_mark_complete(tc, HEGEL_STATUS_OVERRUN, NULL);
+            hegel_mark_complete(ctx, tc, HEGEL_STATUS_OVERRUN, NULL);
             continue;
         }
         total++;
-        hegel_mark_complete(tc, HEGEL_STATUS_VALID, NULL);
+        hegel_mark_complete(ctx, tc, HEGEL_STATUS_VALID, NULL);
     }
 
-    const hegel_run_result_t *result = hegel_run_result(run);
+    const hegel_run_result_t *result = hegel_run_result(ctx, run);
     bool passed = hegel_run_result_status(result) == HEGEL_RUN_STATUS_PASSED;
 
     /* Every rule should have been selected at least once across the run —
@@ -106,5 +108,6 @@ int main(void) {
 
     hegel_run_free(run);
     hegel_settings_free(s);
+    hegel_context_free(ctx);
     return (passed && ok) ? 0 : 1;
 }

--- a/hegel-c/examples/state_machine.c
+++ b/hegel-c/examples/state_machine.c
@@ -61,7 +61,7 @@ int main(void) {
         bool bad = false;
         for (int step = 0; step < STEPS && !overran; step++) {
             int64_t rule;
-            int rc = hegel_state_machine_next_rule(ctx, tc, machine, &rule);
+            hegel_result_t rc = hegel_state_machine_next_rule(ctx, tc, machine, &rule);
             if (rc != HEGEL_OK) { overran = true; break; }
             if (rule >= NUM_RULES) { bad = true; break; }
             rule_counts[rule]++;

--- a/hegel-c/include/hegel.h
+++ b/hegel-c/include/hegel.h
@@ -32,7 +32,7 @@
 
 /*
  The underlying engine reported an error. See
- `hegel_last_error_message()` for the diagnostic.
+ `hegel_context_last_error()` for the diagnostic.
  */
 #define HEGEL_E_BACKEND -3
 
@@ -45,7 +45,7 @@
 /*
  An argument other than a handle was invalid — NULL where a value was
  required, malformed CBOR, non-UTF-8 string, etc. See
- `hegel_last_error_message()` for specifics.
+ `hegel_context_last_error()` for specifics.
  */
 #define HEGEL_E_INVALID_ARG -5
 
@@ -64,7 +64,7 @@
 /*
  An internal invariant failed inside libhegel (e.g. CBOR
  re-serialisation). Should not happen in practice; please file a
- bug. See `hegel_last_error_message()` for the diagnostic.
+ bug. See `hegel_context_last_error()` for the diagnostic.
  */
 #define HEGEL_E_INTERNAL -8
 
@@ -306,6 +306,28 @@ typedef enum {
 } hegel_run_status_t;
 
 /*
+ Opaque error-reporting context.
+
+ libhegel records the diagnostic for a failed call on a context the caller
+ supplies, rather than in thread-local state. Thread-local error buffers
+ are ill-defined under runtimes (e.g. Go) that migrate a goroutine between
+ OS threads mid-call, so the message could be written on one thread and
+ read on another; an explicit context sidesteps that entirely.
+
+ Create one with `hegel_context_new`, pass it as the first argument to
+ every fallible `hegel_*` call, read the most recent message with
+ `hegel_context_last_error`, and free it with `hegel_context_free`. A
+ context is cheap; the expected usage is one per test (or per thread).
+
+ A single context must not be used concurrently from multiple threads —
+ each fallible call overwrites the stored message, so sharing one across
+ threads is a data race and unsupported. Passing `NULL` wherever a context
+ is accepted is allowed and simply opts out of error messages: the call
+ still returns its usual error code, there is just nothing to read back.
+ */
+typedef struct hegel_context_t hegel_context_t;
+
+/*
  One distinct failure surfaced by the run. The strings are owned by
  the parent `hegel_run_result_t`; reading them via
  `hegel_failure_panic_message` / `_origin` returns `const char*`
@@ -364,6 +386,29 @@ typedef struct hegel_test_case_t hegel_test_case_t;
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
+
+/*
+ Allocate a new error-reporting context initialised with an empty message.
+ Never returns NULL. Must be paired with a `hegel_context_free` call.
+ */
+hegel_context_t *hegel_context_new(void);
+
+/*
+ Free a context previously returned by `hegel_context_new`. Safe to call
+ with NULL (no-op).
+ */
+void hegel_context_free(hegel_context_t *ctx);
+
+/*
+ Most recent error message recorded on `ctx`, or the empty string if the
+ most recent call taking this context succeeded. Returns NULL only when
+ `ctx` itself is NULL.
+
+ The returned pointer borrows `ctx`'s internal buffer and is invalidated by
+ the next libhegel call that takes the same `ctx` — copy the bytes before
+ making another such call.
+ */
+const char *hegel_context_last_error(const hegel_context_t *ctx);
 
 /*
  Allocate a new settings handle initialised with libhegel's defaults
@@ -445,13 +490,13 @@ void hegel_settings_report_multiple_failures(hegel_settings_t *s, bool yes);
  - Otherwise → use the directory at `database` as the database root.
    The directory is created lazily.
  */
-void hegel_settings_database(hegel_settings_t *s, const char *database);
+void hegel_settings_database(hegel_context_t *ctx, hegel_settings_t *s, const char *database);
 
 /*
  Set the database key used to scope stored / replayed examples for this run.
  `key = NULL` clears it (the default).
  */
-void hegel_settings_database_key(hegel_settings_t *s, const char *key);
+void hegel_settings_database_key(hegel_context_t *ctx, hegel_settings_t *s, const char *key);
 
 /*
  Enable a specific set of phases via a `HEGEL_PHASE_*` bitmask.
@@ -479,10 +524,10 @@ void hegel_settings_suppress_health_check(hegel_settings_t *s, uint32_t checks);
  settings it needs.
 
  Returns NULL on failure with a diagnostic in
- `hegel_last_error_message`. The returned handle must be freed with
+ `hegel_context_last_error`. The returned handle must be freed with
  `hegel_run_free`.
  */
-hegel_run_t *hegel_run_start(const hegel_settings_t *settings);
+hegel_run_t *hegel_run_start(hegel_context_t *ctx, const hegel_settings_t *settings);
 
 /*
  Block until the engine produces the next test case, returning a
@@ -490,24 +535,24 @@ hegel_run_t *hegel_run_start(const hegel_settings_t *settings);
 
  The caller must complete the previous test case (via
  `hegel_mark_complete`) before requesting the next one — otherwise
- this returns NULL and sets `hegel_last_error_message`.
+ this returns NULL and sets `hegel_context_last_error`.
 
  Returns NULL when the run is finished; call `hegel_run_result` to
- read the outcome. A NULL with `hegel_last_error_message` set means
+ read the outcome. A NULL with `hegel_context_last_error` set means
  something went wrong (engine crash, caller misuse) rather than
  normal completion.
  */
-hegel_test_case_t *hegel_next_test_case(hegel_run_t *run);
+hegel_test_case_t *hegel_next_test_case(hegel_context_t *ctx, hegel_run_t *run);
 
 /*
  Return the aggregated result of a finished run, borrowed from the
  parent `hegel_run_t`. Returns NULL with
- `hegel_last_error_message` set if the run hasn't finished yet
+ `hegel_context_last_error` set if the run hasn't finished yet
  (`hegel_next_test_case` has not yet returned NULL on this run).
 
  The pointer is valid until `hegel_run_free`.
  */
-const hegel_run_result_t *hegel_run_result(hegel_run_t *run);
+const hegel_run_result_t *hegel_run_result(hegel_context_t *ctx, hegel_run_t *run);
 
 /*
  Free a run handle and its result. Safe to call with NULL.
@@ -535,13 +580,15 @@ void hegel_run_free(hegel_run_t *run);
  overruns. `hegel_test_case_is_final_replay` reports true: the replayed
  example *is* the counterexample.
 
- Returns NULL with a diagnostic in `hegel_last_error_message` if `s` or
+ Returns NULL with a diagnostic in `hegel_context_last_error` if `s` or
  `blob` is NULL, or if `blob` is not a valid failure blob (corrupt, or
  from an incompatible Hegel version). The returned handle is owned by
  the **caller** — unlike test cases from `hegel_next_test_case`, it must
  be released with `hegel_test_case_free`.
  */
-hegel_test_case_t *hegel_test_case_from_blob(const hegel_settings_t *s, const char *blob);
+hegel_test_case_t *hegel_test_case_from_blob(hegel_context_t *ctx,
+                                             const hegel_settings_t *s,
+                                             const char *blob);
 
 /*
  Free a standalone test case previously returned by
@@ -552,9 +599,9 @@ hegel_test_case_t *hegel_test_case_from_blob(const hegel_settings_t *s, const ch
  `hegel_next_test_case` — those are borrowed from the parent
  `hegel_run_t` and are released by `hegel_run_free`. Passing one here is
  detected (while the run is still alive) and refused, with a diagnostic
- in `hegel_last_error_message`.
+ in `hegel_context_last_error`.
  */
-void hegel_test_case_free(hegel_test_case_t *tc);
+void hegel_test_case_free(hegel_context_t *ctx, hegel_test_case_t *tc);
 
 /*
  Draw a value from the test case's data source, using the
@@ -572,9 +619,10 @@ void hegel_test_case_free(hegel_test_case_t *tc);
  call `hegel_mark_complete` with `HEGEL_STATUS_OVERRUN`).
  Returns `HEGEL_E_INVALID_ARG` on malformed schema, NULL outputs, or
  other argument errors; the diagnostic is in
- `hegel_last_error_message`.
+ `hegel_context_last_error`.
  */
-int hegel_generate(hegel_test_case_t *tc,
+int hegel_generate(hegel_context_t *ctx,
+                   hegel_test_case_t *tc,
                    const uint8_t *schema_cbor,
                    size_t schema_len,
                    const uint8_t **out_value_cbor,
@@ -586,14 +634,14 @@ int hegel_generate(hegel_test_case_t *tc,
  `hegel_stop_span(tc, false)` call when the structure is complete.
  `label` is one of the `HEGEL_LABEL_*` constants.
  */
-int hegel_start_span(hegel_test_case_t *tc, uint64_t label);
+int hegel_start_span(hegel_context_t *ctx, hegel_test_case_t *tc, uint64_t label);
 
 /*
  Close the most-recently opened span. Pass `discard = true` to mark
  the span as rejected (e.g. a `filter` predicate didn't hold and the
  engine should retry from before the span opened).
  */
-int hegel_stop_span(hegel_test_case_t *tc, bool discard);
+int hegel_stop_span(hegel_context_t *ctx, hegel_test_case_t *tc, bool discard);
 
 /*
  Start an engine-managed variable-length collection. The engine
@@ -605,7 +653,8 @@ int hegel_stop_span(hegel_test_case_t *tc, bool discard);
  and returns `HEGEL_OK`. The id is opaque; pass it to subsequent
  `hegel_collection_more` / `hegel_collection_reject` calls.
  */
-int hegel_new_collection(hegel_test_case_t *tc,
+int hegel_new_collection(hegel_context_t *ctx,
+                         hegel_test_case_t *tc,
                          uint64_t min_size,
                          uint64_t max_size,
                          int64_t *out_collection_id);
@@ -616,7 +665,10 @@ int hegel_new_collection(hegel_test_case_t *tc,
  `HEGEL_OK`. Call in a loop until `*out_more` is `false`, drawing
  the next element each time.
  */
-int hegel_collection_more(hegel_test_case_t *tc, int64_t collection_id, bool *out_more);
+int hegel_collection_more(hegel_context_t *ctx,
+                          hegel_test_case_t *tc,
+                          int64_t collection_id,
+                          bool *out_more);
 
 /*
  Tell the engine the last element it produced for this collection
@@ -624,7 +676,10 @@ int hegel_collection_more(hegel_test_case_t *tc, int64_t collection_id, bool *ou
  should try a different one. `why` is an optional human-readable
  rejection reason (NULL is allowed).
  */
-int hegel_collection_reject(hegel_test_case_t *tc, int64_t collection_id, const char *why);
+int hegel_collection_reject(hegel_context_t *ctx,
+                            hegel_test_case_t *tc,
+                            int64_t collection_id,
+                            const char *why);
 
 /*
  Create a new engine-managed *variable pool* for stateful testing.
@@ -639,7 +694,7 @@ int hegel_collection_reject(hegel_test_case_t *tc, int64_t collection_id, const 
  `HEGEL_OK`. The id is opaque; pass it to subsequent `hegel_pool_add`
  / `hegel_pool_generate` calls on the *same* test case.
  */
-int hegel_new_pool(hegel_test_case_t *tc, int64_t *out_pool_id);
+int hegel_new_pool(hegel_context_t *ctx, hegel_test_case_t *tc, int64_t *out_pool_id);
 
 /*
  Register a new variable in the pool. The engine assigns it a fresh
@@ -649,7 +704,10 @@ int hegel_new_pool(hegel_test_case_t *tc, int64_t *out_pool_id);
  returns `HEGEL_OK`. `pool_id` must be an id returned by
  `hegel_new_pool` on this test case.
  */
-int hegel_pool_add(hegel_test_case_t *tc, int64_t pool_id, int64_t *out_variable_id);
+int hegel_pool_add(hegel_context_t *ctx,
+                   hegel_test_case_t *tc,
+                   int64_t pool_id,
+                   int64_t *out_variable_id);
 
 /*
  Draw a variable id from the pool, letting the engine choose (and
@@ -664,7 +722,8 @@ int hegel_pool_add(hegel_test_case_t *tc, int64_t pool_id, int64_t *out_variable
  only draw when it knows it has added at least one variable) or treat
  it like any other budget-exhaustion outcome.
  */
-int hegel_pool_generate(hegel_test_case_t *tc,
+int hegel_pool_generate(hegel_context_t *ctx,
+                        hegel_test_case_t *tc,
                         int64_t pool_id,
                         bool consume,
                         int64_t *out_variable_id);
@@ -685,7 +744,8 @@ int hegel_pool_generate(hegel_test_case_t *tc,
  Returns `HEGEL_E_INVALID_ARG` if `num_rules` is zero, or on null /
  non-UTF-8 names.
  */
-int hegel_new_state_machine(hegel_test_case_t *tc,
+int hegel_new_state_machine(hegel_context_t *ctx,
+                            hegel_test_case_t *tc,
                             const char *const *rule_names,
                             size_t num_rules,
                             const char *const *invariant_names,
@@ -707,7 +767,8 @@ int hegel_new_state_machine(hegel_test_case_t *tc,
  (the caller should abort the body and call `hegel_mark_complete`
  with `HEGEL_STATUS_OVERRUN`).
  */
-int hegel_state_machine_next_rule(hegel_test_case_t *tc,
+int hegel_state_machine_next_rule(hegel_context_t *ctx,
+                                  hegel_test_case_t *tc,
                                   int64_t state_machine_id,
                                   int64_t *out_rule_index);
 
@@ -728,9 +789,10 @@ int hegel_state_machine_next_rule(hegel_test_case_t *tc,
  body and call `hegel_mark_complete` with `HEGEL_STATUS_OVERRUN`).
  Returns `HEGEL_E_INVALID_ARG` for a NULL `out_value`, a `p` outside
  `[0.0, 1.0]` (including NaN), or a contradictory forced value; the
- diagnostic is in `hegel_last_error_message`.
+ diagnostic is in `hegel_context_last_error`.
  */
-int hegel_primitive_boolean(hegel_test_case_t *tc,
+int hegel_primitive_boolean(hegel_context_t *ctx,
+                            hegel_test_case_t *tc,
                             double p,
                             bool forced,
                             bool has_forced,
@@ -745,11 +807,11 @@ int hegel_primitive_boolean(hegel_test_case_t *tc,
  and valid UTF-8.
 
  Returns `HEGEL_E_INVALID_ARG` (with a diagnostic in
- `hegel_last_error_message`) if `value` is not finite, or if `label`
+ `hegel_context_last_error`) if `value` is not finite, or if `label`
  has already been observed on this test case — each label may be
  recorded at most once per case.
  */
-int hegel_target(hegel_test_case_t *tc, double value, const char *label);
+int hegel_target(hegel_context_t *ctx, hegel_test_case_t *tc, double value, const char *label);
 
 /*
  Mark this test case complete with the given status.
@@ -773,7 +835,10 @@ int hegel_target(hegel_test_case_t *tc, double value, const char *label);
  assertion's message. hegel-rust's own panic-to-failure path does
  exactly this (see `src/run_lifecycle.rs`).
  */
-int hegel_mark_complete(hegel_test_case_t *tc, hegel_status_t status, const char *origin);
+int hegel_mark_complete(hegel_context_t *ctx,
+                        hegel_test_case_t *tc,
+                        hegel_status_t status,
+                        const char *origin);
 
 /*
  True iff this test case is the engine's *final replay* of a
@@ -839,16 +904,6 @@ const char *hegel_failure_origin(const hegel_failure_t *f);
  parent `hegel_run_result_t` and stays valid until `hegel_run_free`.
  */
 const char *hegel_failure_reproduction_blob(const hegel_failure_t *f);
-
-/*
- Most recent error message from libhegel on the calling thread, or
- the empty string if the most recent call succeeded.
-
- The returned pointer is a borrow into a thread-local buffer and is
- invalidated by the next libhegel call on this thread — copy the
- bytes before making another call.
- */
-const char *hegel_last_error_message(void);
 
 /*
  Libhegel's version, matching the parent `hegeltest` crate's

--- a/hegel-c/include/hegel.h
+++ b/hegel-c/include/hegel.h
@@ -3,6 +3,21 @@
  *
  * This header is generated from hegel-c/src/lib.rs by cbindgen. Do not
  * edit it directly; re-run `just c-header` after changing the Rust source.
+ *
+ * Pointer ownership
+ * -----------------
+ * Every pointer you pass *into* a libhegel function stays owned by you: the
+ * library reads it during the call and copies out whatever it needs to keep,
+ * so you may free or reuse the memory as soon as the call returns. This
+ * applies to strings (char*), CBOR byte buffers, and arrays of strings alike.
+ *
+ * Pointers libhegel returns *to* you are borrows into a handle and are only
+ * valid until a stated point — each function documents its own lifetime (e.g.
+ * the bytes from hegel_generate are invalidated by the next call on that test
+ * case; result strings live until hegel_run_free). Copy them if you need them
+ * longer. Opaque handles (hegel_context_t*, hegel_settings_t*, hegel_run_t*,
+ * hegel_test_case_t* from hegel_test_case_from_blob) are owned by you and must
+ * be released with the matching hegel_*_free function.
  */
 
 #ifndef HEGEL_H
@@ -11,204 +26,6 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
-
-/*
- Success.
- */
-#define HEGEL_OK 0
-
-/*
- The engine has exhausted its choice budget for this test case and
- wants the caller to abort the body and return. Treat the same as a
- validly-completed test case.
- */
-#define HEGEL_E_STOP_TEST -1
-
-/*
- An `assume` / `reject` precondition failed. The current test case is
- invalid and should be discarded.
- */
-#define HEGEL_E_ASSUME -2
-
-/*
- The underlying engine reported an error. See
- `hegel_context_last_error()` for the diagnostic.
- */
-#define HEGEL_E_BACKEND -3
-
-/*
- A handle pointer (`hegel_settings_t*`, `hegel_run_t*`,
- `hegel_test_case_t*`, …) was NULL where it must be non-NULL.
- */
-#define HEGEL_E_INVALID_HANDLE -4
-
-/*
- An argument other than a handle was invalid — NULL where a value was
- required, malformed CBOR, non-UTF-8 string, etc. See
- `hegel_context_last_error()` for specifics.
- */
-#define HEGEL_E_INVALID_ARG -5
-
-/*
- `hegel_mark_complete` (or a primitive on the same handle) was called
- for a test case that has already been completed.
- */
-#define HEGEL_E_ALREADY_COMPLETE -6
-
-/*
- `hegel_next_test_case` was called without first completing the
- previous test case with `hegel_mark_complete`.
- */
-#define HEGEL_E_NOT_COMPLETE -7
-
-/*
- An internal invariant failed inside libhegel (e.g. CBOR
- re-serialisation). Should not happen in practice; please file a
- bug. See `hegel_context_last_error()` for the diagnostic.
- */
-#define HEGEL_E_INTERNAL -8
-
-/*
- Run hard-coded explicit examples (none today, reserved for future use).
- */
-#define HEGEL_PHASE_EXPLICIT (1 << 0)
-
-/*
- Replay counterexamples persisted from previous runs (requires a
- database path + `hegel_settings_database_key`).
- */
-#define HEGEL_PHASE_REUSE (1 << 1)
-
-/*
- Randomly generate fresh test cases up to the `test_cases` budget.
- */
-#define HEGEL_PHASE_GENERATE (1 << 2)
-
-/*
- Apply hill-climbing toward observed `hegel_target` scores between
- generation rounds.
- */
-#define HEGEL_PHASE_TARGET (1 << 3)
-
-/*
- Shrink discovered failing examples toward minimal counterexamples.
- */
-#define HEGEL_PHASE_SHRINK (1 << 4)
-
-/*
- Convenience: all five phases enabled. This is the default.
- */
-#define HEGEL_PHASE_ALL 31
-
-/*
- Suppress: aborts the run if too many draws are rejected via
- `assume` / `Invalid` (default threshold: 200 in a row with no valid
- case).
- */
-#define HEGEL_HC_FILTER_TOO_MUCH (1 << 0)
-
-/*
- Suppress: aborts the run if individual test cases take so long that
- the overall run is impractical.
- */
-#define HEGEL_HC_TOO_SLOW (1 << 1)
-
-/*
- Suppress: aborts the run if generated values are so large that
- retaining them for shrinking is impractical.
- */
-#define HEGEL_HC_TEST_CASES_TOO_LARGE (1 << 2)
-
-/*
- Suppress: warns if the first generated test case is already
- disproportionately large.
- */
-#define HEGEL_HC_LARGE_INITIAL_TEST_CASE (1 << 3)
-
-/*
- Outer span around a list / sequence.
- */
-#define HEGEL_LABEL_LIST 1
-
-/*
- One element of a list.
- */
-#define HEGEL_LABEL_LIST_ELEMENT 2
-
-/*
- Outer span around a set (unordered, no duplicates).
- */
-#define HEGEL_LABEL_SET 3
-
-/*
- One element of a set.
- */
-#define HEGEL_LABEL_SET_ELEMENT 4
-
-/*
- Outer span around a map / dictionary.
- */
-#define HEGEL_LABEL_MAP 5
-
-/*
- One (key, value) entry of a map.
- */
-#define HEGEL_LABEL_MAP_ENTRY 6
-
-/*
- Outer span around a tuple / fixed-arity record.
- */
-#define HEGEL_LABEL_TUPLE 7
-
-/*
- Outer span around a `one_of` / disjunction; useful so the shrinker
- can swap which branch is taken.
- */
-#define HEGEL_LABEL_ONE_OF 8
-
-/*
- Outer span around an `optional` (None vs Some(value)).
- */
-#define HEGEL_LABEL_OPTIONAL 9
-
-/*
- Outer span around a fixed-shape record (named fields known
- statically).
- */
-#define HEGEL_LABEL_FIXED_DICT 10
-
-/*
- Outer span around a `flat_map` / monadic dependent draw.
- */
-#define HEGEL_LABEL_FLAT_MAP 11
-
-/*
- Outer span around a `filter` / rejection-sampling wrapper.
- */
-#define HEGEL_LABEL_FILTER 12
-
-/*
- Outer span around a `map` / pure transformation.
- */
-#define HEGEL_LABEL_MAPPED 13
-
-/*
- Outer span around a `sampled_from` / pick-from-collection draw.
- */
-#define HEGEL_LABEL_SAMPLED_FROM 14
-
-/*
- Outer span around the variant discriminator of a sum-type draw.
- */
-#define HEGEL_LABEL_ENUM_VARIANT 15
-
-/*
- Span around one swarm-testing feature-flag draw. Emitted internally
- by the engine's state-machine rule selection
- (`hegel_state_machine_next_rule`); callers normally never open this
- span themselves.
- */
-#define HEGEL_LABEL_FEATURE_FLAG 16
 
 /*
  How the engine should treat the run: a full property-test loop or a
@@ -265,6 +82,66 @@ typedef enum {
 } hegel_verbosity_t;
 
 /*
+ Result of a fallible libhegel call.
+
+ Every `int`-returning entry point (the per-test-case primitives, etc.)
+ returns one of these. `HEGEL_OK` is zero; every error is negative, so
+ `result != HEGEL_OK` (or `result < 0`) tests for failure. Handle-returning
+ entry points signal failure with NULL instead. For the error variants that
+ carry a diagnostic, the message is on the call's context — read it with
+ `hegel_context_last_error()`.
+ */
+typedef enum {
+    /*
+     Success.
+     */
+    HEGEL_OK = 0,
+    /*
+     The engine has exhausted its choice budget for this test case and
+     wants the caller to abort the body and return. Treat the same as a
+     validly-completed test case.
+     */
+    HEGEL_E_STOP_TEST = -1,
+    /*
+     An `assume` / `reject` precondition failed. The current test case is
+     invalid and should be discarded.
+     */
+    HEGEL_E_ASSUME = -2,
+    /*
+     The underlying engine reported an error. See
+     `hegel_context_last_error()` for the diagnostic.
+     */
+    HEGEL_E_BACKEND = -3,
+    /*
+     A handle pointer (`hegel_settings_t*`, `hegel_run_t*`,
+     `hegel_test_case_t*`, …) was NULL where it must be non-NULL.
+     */
+    HEGEL_E_INVALID_HANDLE = -4,
+    /*
+     An argument other than a handle was invalid — NULL where a value was
+     required, malformed CBOR, non-UTF-8 string, etc. See
+     `hegel_context_last_error()` for specifics.
+     */
+    HEGEL_E_INVALID_ARG = -5,
+    /*
+     `hegel_mark_complete` (or a primitive on the same handle) was called
+     for a test case that has already been completed.
+     */
+    HEGEL_E_ALREADY_COMPLETE = -6,
+    /*
+     `hegel_next_test_case` was called without first completing the
+     previous test case with `hegel_mark_complete`.
+     */
+    HEGEL_E_NOT_COMPLETE = -7,
+    /*
+     An internal invariant failed inside libhegel (e.g. CBOR
+     re-serialisation). Should not happen in practice; please file a
+     bug. See `hegel_context_last_error()` for the diagnostic.
+     */
+    HEGEL_E_INTERNAL = -8,
+} hegel_result_t;
+
+/*
  Outcome of a single test case. Passed to `hegel_mark_complete`.
 
  - `HEGEL_STATUS_VALID`: the test body ran to completion without
@@ -304,6 +181,154 @@ typedef enum {
     HEGEL_RUN_STATUS_FAILED = 1,
     HEGEL_RUN_STATUS_ERROR = 2,
 } hegel_run_status_t;
+
+/*
+ A phase of the property-test loop, used as a bit flag for
+ `hegel_settings_phases`.
+
+ `hegel_settings_phases` takes a bitwise OR of these values (e.g.
+ `HEGEL_PHASE_GENERATE | HEGEL_PHASE_SHRINK`); the phases not included are
+ disabled. The default is `HEGEL_PHASE_ALL`, which is almost always what you
+ want — turning a phase off is mainly useful for debugging or replay tooling.
+ */
+typedef enum {
+    /*
+     Run hard-coded explicit examples (none today, reserved for future use).
+     */
+    HEGEL_PHASE_EXPLICIT = (1 << 0),
+    /*
+     Replay counterexamples persisted from previous runs (requires a
+     database path + `hegel_settings_database_key`).
+     */
+    HEGEL_PHASE_REUSE = (1 << 1),
+    /*
+     Randomly generate fresh test cases up to the `test_cases` budget.
+     */
+    HEGEL_PHASE_GENERATE = (1 << 2),
+    /*
+     Apply hill-climbing toward observed `hegel_target` scores between
+     generation rounds.
+     */
+    HEGEL_PHASE_TARGET = (1 << 3),
+    /*
+     Shrink discovered failing examples toward minimal counterexamples.
+     */
+    HEGEL_PHASE_SHRINK = (1 << 4),
+    /*
+     Convenience: all five phases enabled. This is the default.
+     */
+    HEGEL_PHASE_ALL = 31,
+} hegel_phase_t;
+
+/*
+ A health check, used as a bit flag for
+ `hegel_settings_suppress_health_check`.
+
+ `hegel_settings_suppress_health_check` takes a bitwise OR of these values
+ naming the checks to *disable*. The default is "all enabled"; suppress a
+ check only when you understand why it is firing and accept the behavior.
+ */
+typedef enum {
+    /*
+     Aborts the run if too many draws are rejected via `assume` / `Invalid`
+     (default threshold: 200 in a row with no valid case).
+     */
+    HEGEL_HC_FILTER_TOO_MUCH = (1 << 0),
+    /*
+     Aborts the run if individual test cases take so long that the overall
+     run is impractical.
+     */
+    HEGEL_HC_TOO_SLOW = (1 << 1),
+    /*
+     Aborts the run if generated values are so large that retaining them for
+     shrinking is impractical.
+     */
+    HEGEL_HC_TEST_CASES_TOO_LARGE = (1 << 2),
+    /*
+     Warns if the first generated test case is already disproportionately
+     large.
+     */
+    HEGEL_HC_LARGE_INITIAL_TEST_CASE = (1 << 3),
+} hegel_health_check_t;
+
+/*
+ Identifies what kind of compound structure a span groups, passed to
+ `hegel_start_span` so the shrinker can choose appropriate shrink moves
+ (e.g. shortening lists vs. simplifying individual list elements). Pick
+ whichever label best describes the surrounding context. Mirrors
+ `hegeltest::test_case::labels`.
+ */
+typedef enum {
+    /*
+     Outer span around a list / sequence.
+     */
+    HEGEL_LABEL_LIST = 1,
+    /*
+     One element of a list.
+     */
+    HEGEL_LABEL_LIST_ELEMENT = 2,
+    /*
+     Outer span around a set (unordered, no duplicates).
+     */
+    HEGEL_LABEL_SET = 3,
+    /*
+     One element of a set.
+     */
+    HEGEL_LABEL_SET_ELEMENT = 4,
+    /*
+     Outer span around a map / dictionary.
+     */
+    HEGEL_LABEL_MAP = 5,
+    /*
+     One (key, value) entry of a map.
+     */
+    HEGEL_LABEL_MAP_ENTRY = 6,
+    /*
+     Outer span around a tuple / fixed-arity record.
+     */
+    HEGEL_LABEL_TUPLE = 7,
+    /*
+     Outer span around a `one_of` / disjunction; useful so the shrinker
+     can swap which branch is taken.
+     */
+    HEGEL_LABEL_ONE_OF = 8,
+    /*
+     Outer span around an `optional` (None vs Some(value)).
+     */
+    HEGEL_LABEL_OPTIONAL = 9,
+    /*
+     Outer span around a fixed-shape record (named fields known
+     statically).
+     */
+    HEGEL_LABEL_FIXED_DICT = 10,
+    /*
+     Outer span around a `flat_map` / monadic dependent draw.
+     */
+    HEGEL_LABEL_FLAT_MAP = 11,
+    /*
+     Outer span around a `filter` / rejection-sampling wrapper.
+     */
+    HEGEL_LABEL_FILTER = 12,
+    /*
+     Outer span around a `map` / pure transformation.
+     */
+    HEGEL_LABEL_MAPPED = 13,
+    /*
+     Outer span around a `sampled_from` / pick-from-collection draw.
+     */
+    HEGEL_LABEL_SAMPLED_FROM = 14,
+    /*
+     Outer span around the variant discriminator of a sum-type draw.
+     */
+    HEGEL_LABEL_ENUM_VARIANT = 15,
+    /*
+     Span around one swarm-testing feature-flag draw. Emitted internally
+     by the engine's state-machine rule selection
+     (`hegel_state_machine_next_rule`); callers normally never open this
+     span themselves.
+     */
+    HEGEL_LABEL_FEATURE_FLAG = 16,
+} hegel_label_t;
 
 /*
  Opaque error-reporting context.
@@ -499,18 +524,17 @@ void hegel_settings_database(hegel_context_t *ctx, hegel_settings_t *s, const ch
 void hegel_settings_database_key(hegel_context_t *ctx, hegel_settings_t *s, const char *key);
 
 /*
- Enable a specific set of phases via a `HEGEL_PHASE_*` bitmask.
- Phases not listed in the bitmask are disabled. The default is
- `HEGEL_PHASE_ALL`. Setting this to 0 produces a run that does
- nothing.
+ Enable a specific set of phases, given as a bitwise OR of `hegel_phase_t`
+ values. Phases not included are disabled. The default is `HEGEL_PHASE_ALL`.
+ Passing 0 produces a run that does nothing.
  */
 void hegel_settings_phases(hegel_settings_t *s, uint32_t phases);
 
 /*
- Suppress (disable) the health checks listed in the `HEGEL_HC_*`
- bitmask. The default is "no suppression"; use this when you know a
- check is going to fire and accept the underlying behavior (e.g. you
- intentionally have a high rejection rate).
+ Suppress (disable) a set of health checks, given as a bitwise OR of
+ `hegel_health_check_t` values. The default is "no suppression"; use this
+ when you know a check is going to fire and accept the underlying behavior
+ (e.g. you intentionally have a high rejection rate).
  */
 void hegel_settings_suppress_health_check(hegel_settings_t *s, uint32_t checks);
 
@@ -621,27 +645,31 @@ void hegel_test_case_free(hegel_context_t *ctx, hegel_test_case_t *tc);
  other argument errors; the diagnostic is in
  `hegel_context_last_error`.
  */
-int hegel_generate(hegel_context_t *ctx,
-                   hegel_test_case_t *tc,
-                   const uint8_t *schema_cbor,
-                   size_t schema_len,
-                   const uint8_t **out_value_cbor,
-                   size_t *out_value_len);
+hegel_result_t hegel_generate(hegel_context_t *ctx,
+                              hegel_test_case_t *tc,
+                              const uint8_t *schema_cbor,
+                              size_t schema_len,
+                              const uint8_t **out_value_cbor,
+                              size_t *out_value_len);
 
 /*
  Open a labeled span around a group of draws so the shrinker can
  reason about them as a unit. Pair with exactly one
  `hegel_stop_span(tc, false)` call when the structure is complete.
- `label` is one of the `HEGEL_LABEL_*` constants.
+
+ `label` is a `hegel_label_t` value for one of the well-known structure
+ kinds, but the type is `uint64_t` rather than the enum because the label
+ space is open: callers may pass any stable `u64` to tag their own span
+ kinds (the engine treats unrecognised labels as opaque grouping keys).
  */
-int hegel_start_span(hegel_context_t *ctx, hegel_test_case_t *tc, uint64_t label);
+hegel_result_t hegel_start_span(hegel_context_t *ctx, hegel_test_case_t *tc, uint64_t label);
 
 /*
  Close the most-recently opened span. Pass `discard = true` to mark
  the span as rejected (e.g. a `filter` predicate didn't hold and the
  engine should retry from before the span opened).
  */
-int hegel_stop_span(hegel_context_t *ctx, hegel_test_case_t *tc, bool discard);
+hegel_result_t hegel_stop_span(hegel_context_t *ctx, hegel_test_case_t *tc, bool discard);
 
 /*
  Start an engine-managed variable-length collection. The engine
@@ -653,11 +681,11 @@ int hegel_stop_span(hegel_context_t *ctx, hegel_test_case_t *tc, bool discard);
  and returns `HEGEL_OK`. The id is opaque; pass it to subsequent
  `hegel_collection_more` / `hegel_collection_reject` calls.
  */
-int hegel_new_collection(hegel_context_t *ctx,
-                         hegel_test_case_t *tc,
-                         uint64_t min_size,
-                         uint64_t max_size,
-                         int64_t *out_collection_id);
+hegel_result_t hegel_new_collection(hegel_context_t *ctx,
+                                    hegel_test_case_t *tc,
+                                    uint64_t min_size,
+                                    uint64_t max_size,
+                                    int64_t *out_collection_id);
 
 /*
  Ask whether the engine wants another element in this collection.
@@ -665,10 +693,10 @@ int hegel_new_collection(hegel_context_t *ctx,
  `HEGEL_OK`. Call in a loop until `*out_more` is `false`, drawing
  the next element each time.
  */
-int hegel_collection_more(hegel_context_t *ctx,
-                          hegel_test_case_t *tc,
-                          int64_t collection_id,
-                          bool *out_more);
+hegel_result_t hegel_collection_more(hegel_context_t *ctx,
+                                     hegel_test_case_t *tc,
+                                     int64_t collection_id,
+                                     bool *out_more);
 
 /*
  Tell the engine the last element it produced for this collection
@@ -676,10 +704,10 @@ int hegel_collection_more(hegel_context_t *ctx,
  should try a different one. `why` is an optional human-readable
  rejection reason (NULL is allowed).
  */
-int hegel_collection_reject(hegel_context_t *ctx,
-                            hegel_test_case_t *tc,
-                            int64_t collection_id,
-                            const char *why);
+hegel_result_t hegel_collection_reject(hegel_context_t *ctx,
+                                       hegel_test_case_t *tc,
+                                       int64_t collection_id,
+                                       const char *why);
 
 /*
  Create a new engine-managed *variable pool* for stateful testing.
@@ -694,7 +722,7 @@ int hegel_collection_reject(hegel_context_t *ctx,
  `HEGEL_OK`. The id is opaque; pass it to subsequent `hegel_pool_add`
  / `hegel_pool_generate` calls on the *same* test case.
  */
-int hegel_new_pool(hegel_context_t *ctx, hegel_test_case_t *tc, int64_t *out_pool_id);
+hegel_result_t hegel_new_pool(hegel_context_t *ctx, hegel_test_case_t *tc, int64_t *out_pool_id);
 
 /*
  Register a new variable in the pool. The engine assigns it a fresh
@@ -704,10 +732,10 @@ int hegel_new_pool(hegel_context_t *ctx, hegel_test_case_t *tc, int64_t *out_poo
  returns `HEGEL_OK`. `pool_id` must be an id returned by
  `hegel_new_pool` on this test case.
  */
-int hegel_pool_add(hegel_context_t *ctx,
-                   hegel_test_case_t *tc,
-                   int64_t pool_id,
-                   int64_t *out_variable_id);
+hegel_result_t hegel_pool_add(hegel_context_t *ctx,
+                              hegel_test_case_t *tc,
+                              int64_t pool_id,
+                              int64_t *out_variable_id);
 
 /*
  Draw a variable id from the pool, letting the engine choose (and
@@ -722,11 +750,11 @@ int hegel_pool_add(hegel_context_t *ctx,
  only draw when it knows it has added at least one variable) or treat
  it like any other budget-exhaustion outcome.
  */
-int hegel_pool_generate(hegel_context_t *ctx,
-                        hegel_test_case_t *tc,
-                        int64_t pool_id,
-                        bool consume,
-                        int64_t *out_variable_id);
+hegel_result_t hegel_pool_generate(hegel_context_t *ctx,
+                                   hegel_test_case_t *tc,
+                                   int64_t pool_id,
+                                   bool consume,
+                                   int64_t *out_variable_id);
 
 /*
  Register a *state machine* for engine-owned stateful (rule-based)
@@ -744,13 +772,13 @@ int hegel_pool_generate(hegel_context_t *ctx,
  Returns `HEGEL_E_INVALID_ARG` if `num_rules` is zero, or on null /
  non-UTF-8 names.
  */
-int hegel_new_state_machine(hegel_context_t *ctx,
-                            hegel_test_case_t *tc,
-                            const char *const *rule_names,
-                            size_t num_rules,
-                            const char *const *invariant_names,
-                            size_t num_invariants,
-                            int64_t *out_state_machine_id);
+hegel_result_t hegel_new_state_machine(hegel_context_t *ctx,
+                                       hegel_test_case_t *tc,
+                                       const char *const *rule_names,
+                                       size_t num_rules,
+                                       const char *const *invariant_names,
+                                       size_t num_invariants,
+                                       int64_t *out_state_machine_id);
 
 /*
  Draw the index of the next rule to run, in `[0, num_rules)`, letting
@@ -767,10 +795,10 @@ int hegel_new_state_machine(hegel_context_t *ctx,
  (the caller should abort the body and call `hegel_mark_complete`
  with `HEGEL_STATUS_OVERRUN`).
  */
-int hegel_state_machine_next_rule(hegel_context_t *ctx,
-                                  hegel_test_case_t *tc,
-                                  int64_t state_machine_id,
-                                  int64_t *out_rule_index);
+hegel_result_t hegel_state_machine_next_rule(hegel_context_t *ctx,
+                                             hegel_test_case_t *tc,
+                                             int64_t state_machine_id,
+                                             int64_t *out_rule_index);
 
 /*
  Draw a single boolean that is `true` with probability `p`. `p`
@@ -791,12 +819,12 @@ int hegel_state_machine_next_rule(hegel_context_t *ctx,
  `[0.0, 1.0]` (including NaN), or a contradictory forced value; the
  diagnostic is in `hegel_context_last_error`.
  */
-int hegel_primitive_boolean(hegel_context_t *ctx,
-                            hegel_test_case_t *tc,
-                            double p,
-                            bool forced,
-                            bool has_forced,
-                            bool *out_value);
+hegel_result_t hegel_primitive_boolean(hegel_context_t *ctx,
+                                       hegel_test_case_t *tc,
+                                       double p,
+                                       bool forced,
+                                       bool has_forced,
+                                       bool *out_value);
 
 /*
  Record a numeric observation under `label` for the engine's
@@ -811,7 +839,10 @@ int hegel_primitive_boolean(hegel_context_t *ctx,
  has already been observed on this test case — each label may be
  recorded at most once per case.
  */
-int hegel_target(hegel_context_t *ctx, hegel_test_case_t *tc, double value, const char *label);
+hegel_result_t hegel_target(hegel_context_t *ctx,
+                            hegel_test_case_t *tc,
+                            double value,
+                            const char *label);
 
 /*
  Mark this test case complete with the given status.
@@ -835,10 +866,10 @@ int hegel_target(hegel_context_t *ctx, hegel_test_case_t *tc, double value, cons
  assertion's message. hegel-rust's own panic-to-failure path does
  exactly this (see `src/run_lifecycle.rs`).
  */
-int hegel_mark_complete(hegel_context_t *ctx,
-                        hegel_test_case_t *tc,
-                        hegel_status_t status,
-                        const char *origin);
+hegel_result_t hegel_mark_complete(hegel_context_t *ctx,
+                                   hegel_test_case_t *tc,
+                                   hegel_status_t status,
+                                   const char *origin);
 
 /*
  True iff this test case is the engine's *final replay* of a

--- a/hegel-c/include/hegel.h
+++ b/hegel-c/include/hegel.h
@@ -6,18 +6,32 @@
  *
  * Pointer ownership
  * -----------------
- * Every pointer you pass *into* a libhegel function stays owned by you: the
- * library reads it during the call and copies out whatever it needs to keep,
- * so you may free or reuse the memory as soon as the call returns. This
- * applies to strings (char*), CBOR byte buffers, and arrays of strings alike.
+ * Pointers you pass *into* a libhegel function are always yours. The library
+ * reads them during the call and copies whatever it needs to keep, so you may
+ * free or reuse the memory as soon as the call returns. This covers strings
+ * (char*), CBOR byte buffers, and arrays of strings alike.
  *
- * Pointers libhegel returns *to* you are borrows into a handle and are only
- * valid until a stated point — each function documents its own lifetime (e.g.
- * the bytes from hegel_generate are invalidated by the next call on that test
- * case; result strings live until hegel_run_free). Copy them if you need them
- * longer. Opaque handles (hegel_context_t*, hegel_settings_t*, hegel_run_t*,
- * hegel_test_case_t* from hegel_test_case_from_blob) are owned by you and must
- * be released with the matching hegel_*_free function.
+ * Of the pointers libhegel hands *back*, you own exactly the handles made by
+ * the four constructors, and must release each with its matching free:
+ *
+ *     hegel_context_new          ->  hegel_context_free
+ *     hegel_settings_new         ->  hegel_settings_free
+ *     hegel_run_start            ->  hegel_run_free
+ *     hegel_test_case_from_blob  ->  hegel_test_case_free
+ *
+ * Every *other* pointer libhegel returns is borrowed: libhegel still owns it,
+ * you must not free it, and it is valid only until a point that the returning
+ * function documents. Two cases are easy to trip over:
+ *
+ *   - The hegel_test_case_t* from hegel_next_test_case is borrowed from the
+ *     run and freed by hegel_run_free. Do NOT pass it to hegel_test_case_free
+ *     (that is only for a test case you made with hegel_test_case_from_blob).
+ *     Likewise the hegel_run_result_t* and hegel_failure_t* you read from a
+ *     run live until hegel_run_free.
+ *   - Returned strings and byte buffers (e.g. from hegel_generate,
+ *     hegel_context_last_error, hegel_run_result_error, the hegel_failure_*
+ *     getters) are transient — hegel_generate's bytes, for instance, are
+ *     invalidated by the next call on that test case. Copy them to keep them.
  */
 
 #ifndef HEGEL_H

--- a/hegel-c/src/backend.rs
+++ b/hegel-c/src/backend.rs
@@ -18,7 +18,7 @@ pub enum DataSourceError {
     /// A caller-supplied argument (typically a schema) was semantically
     /// invalid. The main library converts this to a panic at the API surface;
     /// libhegel maps it to `HEGEL_E_INVALID_ARG` with the message exposed via
-    /// `hegel_last_error_message`. Carries a human-readable diagnostic.
+    /// `hegel_context_last_error`. Carries a human-readable diagnostic.
     InvalidArgument(String),
 }
 

--- a/hegel-c/src/lib.rs
+++ b/hegel-c/src/lib.rs
@@ -27,7 +27,7 @@
 
 #![allow(clippy::missing_safety_doc)]
 
-use std::ffi::{CStr, CString, c_char, c_int};
+use std::ffi::{CStr, CString, c_char};
 use std::ptr;
 use std::sync::Arc;
 use std::sync::Once;
@@ -94,49 +94,63 @@ use crate::backend::{DataSource, DataSourceError, Failure, TestCaseResult, TestR
 use crate::embed::{data_source_for_blob, run_native};
 use crate::settings::{Backend, HealthCheck, Mode, Phase, Settings, Verbosity};
 
-// ─── Error codes ────────────────────────────────────────────────────────────
-//
-// All `int`-returning entry points (the per-test-case primitives, etc.)
-// return one of these. Handle-returning entry points use NULL instead and
-// leave a description in `hegel_context_last_error()`.
+// ─── Result codes ───────────────────────────────────────────────────────────
 
-/// Success.
-pub const HEGEL_OK: c_int = 0;
+/// Result of a fallible libhegel call.
+///
+/// Every `int`-returning entry point (the per-test-case primitives, etc.)
+/// returns one of these. `HEGEL_OK` is zero; every error is negative, so
+/// `result != HEGEL_OK` (or `result < 0`) tests for failure. Handle-returning
+/// entry points signal failure with NULL instead. For the error variants that
+/// carry a diagnostic, the message is on the call's context — read it with
+/// `hegel_context_last_error()`.
+#[repr(C)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[allow(non_camel_case_types)]
+pub enum hegel_result_t {
+    /// Success.
+    HEGEL_OK = 0,
 
-/// The engine has exhausted its choice budget for this test case and
-/// wants the caller to abort the body and return. Treat the same as a
-/// validly-completed test case.
-pub const HEGEL_E_STOP_TEST: c_int = -1;
+    /// The engine has exhausted its choice budget for this test case and
+    /// wants the caller to abort the body and return. Treat the same as a
+    /// validly-completed test case.
+    HEGEL_E_STOP_TEST = -1,
 
-/// An `assume` / `reject` precondition failed. The current test case is
-/// invalid and should be discarded.
-pub const HEGEL_E_ASSUME: c_int = -2;
+    /// An `assume` / `reject` precondition failed. The current test case is
+    /// invalid and should be discarded.
+    HEGEL_E_ASSUME = -2,
 
-/// The underlying engine reported an error. See
-/// `hegel_context_last_error()` for the diagnostic.
-pub const HEGEL_E_BACKEND: c_int = -3;
+    /// The underlying engine reported an error. See
+    /// `hegel_context_last_error()` for the diagnostic.
+    HEGEL_E_BACKEND = -3,
 
-/// A handle pointer (`hegel_settings_t*`, `hegel_run_t*`,
-/// `hegel_test_case_t*`, …) was NULL where it must be non-NULL.
-pub const HEGEL_E_INVALID_HANDLE: c_int = -4;
+    /// A handle pointer (`hegel_settings_t*`, `hegel_run_t*`,
+    /// `hegel_test_case_t*`, …) was NULL where it must be non-NULL.
+    HEGEL_E_INVALID_HANDLE = -4,
 
-/// An argument other than a handle was invalid — NULL where a value was
-/// required, malformed CBOR, non-UTF-8 string, etc. See
-/// `hegel_context_last_error()` for specifics.
-pub const HEGEL_E_INVALID_ARG: c_int = -5;
+    /// An argument other than a handle was invalid — NULL where a value was
+    /// required, malformed CBOR, non-UTF-8 string, etc. See
+    /// `hegel_context_last_error()` for specifics.
+    HEGEL_E_INVALID_ARG = -5,
 
-/// `hegel_mark_complete` (or a primitive on the same handle) was called
-/// for a test case that has already been completed.
-pub const HEGEL_E_ALREADY_COMPLETE: c_int = -6;
+    /// `hegel_mark_complete` (or a primitive on the same handle) was called
+    /// for a test case that has already been completed.
+    HEGEL_E_ALREADY_COMPLETE = -6,
 
-/// `hegel_next_test_case` was called without first completing the
-/// previous test case with `hegel_mark_complete`.
-pub const HEGEL_E_NOT_COMPLETE: c_int = -7;
+    /// `hegel_next_test_case` was called without first completing the
+    /// previous test case with `hegel_mark_complete`.
+    HEGEL_E_NOT_COMPLETE = -7,
 
-/// An internal invariant failed inside libhegel (e.g. CBOR
-/// re-serialisation). Should not happen in practice; please file a
-/// bug. See `hegel_context_last_error()` for the diagnostic.
-pub const HEGEL_E_INTERNAL: c_int = -8;
+    /// An internal invariant failed inside libhegel (e.g. CBOR
+    /// re-serialisation). Should not happen in practice; please file a
+    /// bug. See `hegel_context_last_error()` for the diagnostic.
+    HEGEL_E_INTERNAL = -8,
+}
+
+// The result variants are used unqualified throughout this module (and match
+// the `int` codes the C ABI has always returned); glob-import them so the
+// bodies read as `HEGEL_OK` / `HEGEL_E_*` rather than the fully-qualified form.
+use hegel_result_t::*;
 
 // ─── Enums mirrored to C ────────────────────────────────────────────────────
 
@@ -253,116 +267,110 @@ pub enum hegel_verbosity_t {
     HEGEL_VERBOSITY_DEBUG = 3,
 }
 
-// ─── Phase bitmask ──────────────────────────────────────────────────────────
-//
-// Bitmask passed to `hegel_settings_phases` to enable / disable
-// individual phases of the property-test loop. The default
-// (`HEGEL_PHASE_ALL`) is almost always what you want; turning a phase
-// off is mainly useful for debugging or replay tooling.
+// ─── Phases ─────────────────────────────────────────────────────────────────
 
-/// Run hard-coded explicit examples (none today, reserved for future use).
-pub const HEGEL_PHASE_EXPLICIT: u32 = 1 << 0;
+/// A phase of the property-test loop, used as a bit flag for
+/// `hegel_settings_phases`.
+///
+/// `hegel_settings_phases` takes a bitwise OR of these values (e.g.
+/// `HEGEL_PHASE_GENERATE | HEGEL_PHASE_SHRINK`); the phases not included are
+/// disabled. The default is `HEGEL_PHASE_ALL`, which is almost always what you
+/// want — turning a phase off is mainly useful for debugging or replay tooling.
+#[repr(C)]
+#[derive(Copy, Clone)]
+#[allow(non_camel_case_types)]
+pub enum hegel_phase_t {
+    /// Run hard-coded explicit examples (none today, reserved for future use).
+    HEGEL_PHASE_EXPLICIT = 1 << 0,
+    /// Replay counterexamples persisted from previous runs (requires a
+    /// database path + `hegel_settings_database_key`).
+    HEGEL_PHASE_REUSE = 1 << 1,
+    /// Randomly generate fresh test cases up to the `test_cases` budget.
+    HEGEL_PHASE_GENERATE = 1 << 2,
+    /// Apply hill-climbing toward observed `hegel_target` scores between
+    /// generation rounds.
+    HEGEL_PHASE_TARGET = 1 << 3,
+    /// Shrink discovered failing examples toward minimal counterexamples.
+    HEGEL_PHASE_SHRINK = 1 << 4,
+    /// Convenience: all five phases enabled. This is the default.
+    HEGEL_PHASE_ALL = 0x1F,
+}
 
-/// Replay counterexamples persisted from previous runs (requires a
-/// database path + `hegel_settings_database_key`).
-pub const HEGEL_PHASE_REUSE: u32 = 1 << 1;
+// ─── Health checks ──────────────────────────────────────────────────────────
 
-/// Randomly generate fresh test cases up to the `test_cases` budget.
-pub const HEGEL_PHASE_GENERATE: u32 = 1 << 2;
-
-/// Apply hill-climbing toward observed `hegel_target` scores between
-/// generation rounds.
-pub const HEGEL_PHASE_TARGET: u32 = 1 << 3;
-
-/// Shrink discovered failing examples toward minimal counterexamples.
-pub const HEGEL_PHASE_SHRINK: u32 = 1 << 4;
-
-/// Convenience: all five phases enabled. This is the default.
-pub const HEGEL_PHASE_ALL: u32 = 0x1F;
-
-// ─── Health-check bitmask ───────────────────────────────────────────────────
-//
-// Bitmask passed to `hegel_settings_suppress_health_check` to *disable*
-// individual health checks. The default is "all enabled"; suppress only
-// when you understand why the check is firing and accept it.
-
-/// Suppress: aborts the run if too many draws are rejected via
-/// `assume` / `Invalid` (default threshold: 200 in a row with no valid
-/// case).
-pub const HEGEL_HC_FILTER_TOO_MUCH: u32 = 1 << 0;
-
-/// Suppress: aborts the run if individual test cases take so long that
-/// the overall run is impractical.
-pub const HEGEL_HC_TOO_SLOW: u32 = 1 << 1;
-
-/// Suppress: aborts the run if generated values are so large that
-/// retaining them for shrinking is impractical.
-pub const HEGEL_HC_TEST_CASES_TOO_LARGE: u32 = 1 << 2;
-
-/// Suppress: warns if the first generated test case is already
-/// disproportionately large.
-pub const HEGEL_HC_LARGE_INITIAL_TEST_CASE: u32 = 1 << 3;
+/// A health check, used as a bit flag for
+/// `hegel_settings_suppress_health_check`.
+///
+/// `hegel_settings_suppress_health_check` takes a bitwise OR of these values
+/// naming the checks to *disable*. The default is "all enabled"; suppress a
+/// check only when you understand why it is firing and accept the behavior.
+#[repr(C)]
+#[derive(Copy, Clone)]
+#[allow(non_camel_case_types)]
+pub enum hegel_health_check_t {
+    /// Aborts the run if too many draws are rejected via `assume` / `Invalid`
+    /// (default threshold: 200 in a row with no valid case).
+    HEGEL_HC_FILTER_TOO_MUCH = 1 << 0,
+    /// Aborts the run if individual test cases take so long that the overall
+    /// run is impractical.
+    HEGEL_HC_TOO_SLOW = 1 << 1,
+    /// Aborts the run if generated values are so large that retaining them for
+    /// shrinking is impractical.
+    HEGEL_HC_TEST_CASES_TOO_LARGE = 1 << 2,
+    /// Warns if the first generated test case is already disproportionately
+    /// large.
+    HEGEL_HC_LARGE_INITIAL_TEST_CASE = 1 << 3,
+}
 
 // ─── Span labels ────────────────────────────────────────────────────────────
-//
-// Identifiers passed to `hegel_start_span` so the shrinker knows what
-// kind of compound structure is being assembled. Pick whichever label
-// best describes the surrounding context; the engine uses these to
-// choose appropriate shrink moves (e.g. shortening lists vs. simplifying
-// individual list elements). Mirror `hegeltest::test_case::labels`.
 
-/// Outer span around a list / sequence.
-pub const HEGEL_LABEL_LIST: u64 = 1;
-
-/// One element of a list.
-pub const HEGEL_LABEL_LIST_ELEMENT: u64 = 2;
-
-/// Outer span around a set (unordered, no duplicates).
-pub const HEGEL_LABEL_SET: u64 = 3;
-
-/// One element of a set.
-pub const HEGEL_LABEL_SET_ELEMENT: u64 = 4;
-
-/// Outer span around a map / dictionary.
-pub const HEGEL_LABEL_MAP: u64 = 5;
-
-/// One (key, value) entry of a map.
-pub const HEGEL_LABEL_MAP_ENTRY: u64 = 6;
-
-/// Outer span around a tuple / fixed-arity record.
-pub const HEGEL_LABEL_TUPLE: u64 = 7;
-
-/// Outer span around a `one_of` / disjunction; useful so the shrinker
-/// can swap which branch is taken.
-pub const HEGEL_LABEL_ONE_OF: u64 = 8;
-
-/// Outer span around an `optional` (None vs Some(value)).
-pub const HEGEL_LABEL_OPTIONAL: u64 = 9;
-
-/// Outer span around a fixed-shape record (named fields known
-/// statically).
-pub const HEGEL_LABEL_FIXED_DICT: u64 = 10;
-
-/// Outer span around a `flat_map` / monadic dependent draw.
-pub const HEGEL_LABEL_FLAT_MAP: u64 = 11;
-
-/// Outer span around a `filter` / rejection-sampling wrapper.
-pub const HEGEL_LABEL_FILTER: u64 = 12;
-
-/// Outer span around a `map` / pure transformation.
-pub const HEGEL_LABEL_MAPPED: u64 = 13;
-
-/// Outer span around a `sampled_from` / pick-from-collection draw.
-pub const HEGEL_LABEL_SAMPLED_FROM: u64 = 14;
-
-/// Outer span around the variant discriminator of a sum-type draw.
-pub const HEGEL_LABEL_ENUM_VARIANT: u64 = 15;
-
-/// Span around one swarm-testing feature-flag draw. Emitted internally
-/// by the engine's state-machine rule selection
-/// (`hegel_state_machine_next_rule`); callers normally never open this
-/// span themselves.
-pub const HEGEL_LABEL_FEATURE_FLAG: u64 = 16;
+/// Identifies what kind of compound structure a span groups, passed to
+/// `hegel_start_span` so the shrinker can choose appropriate shrink moves
+/// (e.g. shortening lists vs. simplifying individual list elements). Pick
+/// whichever label best describes the surrounding context. Mirrors
+/// `hegeltest::test_case::labels`.
+#[repr(C)]
+#[derive(Copy, Clone)]
+#[allow(non_camel_case_types)]
+pub enum hegel_label_t {
+    /// Outer span around a list / sequence.
+    HEGEL_LABEL_LIST = 1,
+    /// One element of a list.
+    HEGEL_LABEL_LIST_ELEMENT = 2,
+    /// Outer span around a set (unordered, no duplicates).
+    HEGEL_LABEL_SET = 3,
+    /// One element of a set.
+    HEGEL_LABEL_SET_ELEMENT = 4,
+    /// Outer span around a map / dictionary.
+    HEGEL_LABEL_MAP = 5,
+    /// One (key, value) entry of a map.
+    HEGEL_LABEL_MAP_ENTRY = 6,
+    /// Outer span around a tuple / fixed-arity record.
+    HEGEL_LABEL_TUPLE = 7,
+    /// Outer span around a `one_of` / disjunction; useful so the shrinker
+    /// can swap which branch is taken.
+    HEGEL_LABEL_ONE_OF = 8,
+    /// Outer span around an `optional` (None vs Some(value)).
+    HEGEL_LABEL_OPTIONAL = 9,
+    /// Outer span around a fixed-shape record (named fields known
+    /// statically).
+    HEGEL_LABEL_FIXED_DICT = 10,
+    /// Outer span around a `flat_map` / monadic dependent draw.
+    HEGEL_LABEL_FLAT_MAP = 11,
+    /// Outer span around a `filter` / rejection-sampling wrapper.
+    HEGEL_LABEL_FILTER = 12,
+    /// Outer span around a `map` / pure transformation.
+    HEGEL_LABEL_MAPPED = 13,
+    /// Outer span around a `sampled_from` / pick-from-collection draw.
+    HEGEL_LABEL_SAMPLED_FROM = 14,
+    /// Outer span around the variant discriminator of a sum-type draw.
+    HEGEL_LABEL_ENUM_VARIANT = 15,
+    /// Span around one swarm-testing feature-flag draw. Emitted internally
+    /// by the engine's state-machine rule selection
+    /// (`hegel_state_machine_next_rule`); callers normally never open this
+    /// span themselves.
+    HEGEL_LABEL_FEATURE_FLAG = 16,
+}
 
 // ─── Error-reporting context ────────────────────────────────────────────────
 
@@ -766,54 +774,55 @@ pub unsafe extern "C" fn hegel_settings_database_key(
     }
 }
 
-/// Enable a specific set of phases via a `HEGEL_PHASE_*` bitmask.
-/// Phases not listed in the bitmask are disabled. The default is
-/// `HEGEL_PHASE_ALL`. Setting this to 0 produces a run that does
-/// nothing.
+/// Enable a specific set of phases, given as a bitwise OR of `hegel_phase_t`
+/// values. Phases not included are disabled. The default is `HEGEL_PHASE_ALL`.
+/// Passing 0 produces a run that does nothing.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hegel_settings_phases(s: *mut HegelSettings, phases: u32) {
+    use hegel_phase_t::*;
     let Some(inner) = (unsafe { settings_mut(s) }) else {
         return;
     };
     let mut v = Vec::new();
-    if phases & HEGEL_PHASE_EXPLICIT != 0 {
+    if phases & (HEGEL_PHASE_EXPLICIT as u32) != 0 {
         v.push(Phase::Explicit);
     }
-    if phases & HEGEL_PHASE_REUSE != 0 {
+    if phases & (HEGEL_PHASE_REUSE as u32) != 0 {
         v.push(Phase::Reuse);
     }
-    if phases & HEGEL_PHASE_GENERATE != 0 {
+    if phases & (HEGEL_PHASE_GENERATE as u32) != 0 {
         v.push(Phase::Generate);
     }
-    if phases & HEGEL_PHASE_TARGET != 0 {
+    if phases & (HEGEL_PHASE_TARGET as u32) != 0 {
         v.push(Phase::Target);
     }
-    if phases & HEGEL_PHASE_SHRINK != 0 {
+    if phases & (HEGEL_PHASE_SHRINK as u32) != 0 {
         v.push(Phase::Shrink);
     }
     *inner = inner.clone().phases(v);
 }
 
-/// Suppress (disable) the health checks listed in the `HEGEL_HC_*`
-/// bitmask. The default is "no suppression"; use this when you know a
-/// check is going to fire and accept the underlying behavior (e.g. you
-/// intentionally have a high rejection rate).
+/// Suppress (disable) a set of health checks, given as a bitwise OR of
+/// `hegel_health_check_t` values. The default is "no suppression"; use this
+/// when you know a check is going to fire and accept the underlying behavior
+/// (e.g. you intentionally have a high rejection rate).
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hegel_settings_suppress_health_check(s: *mut HegelSettings, checks: u32) {
+    use hegel_health_check_t::*;
     let Some(inner) = (unsafe { settings_mut(s) }) else {
         return;
     };
     let mut v = Vec::new();
-    if checks & HEGEL_HC_FILTER_TOO_MUCH != 0 {
+    if checks & (HEGEL_HC_FILTER_TOO_MUCH as u32) != 0 {
         v.push(HealthCheck::FilterTooMuch);
     }
-    if checks & HEGEL_HC_TOO_SLOW != 0 {
+    if checks & (HEGEL_HC_TOO_SLOW as u32) != 0 {
         v.push(HealthCheck::TooSlow);
     }
-    if checks & HEGEL_HC_TEST_CASES_TOO_LARGE != 0 {
+    if checks & (HEGEL_HC_TEST_CASES_TOO_LARGE as u32) != 0 {
         v.push(HealthCheck::TestCasesTooLarge);
     }
-    if checks & HEGEL_HC_LARGE_INITIAL_TEST_CASE != 0 {
+    if checks & (HEGEL_HC_LARGE_INITIAL_TEST_CASE as u32) != 0 {
         v.push(HealthCheck::LargeInitialTestCase);
     }
     *inner = inner.clone().suppress_health_check(v);
@@ -1198,7 +1207,7 @@ pub unsafe extern "C" fn hegel_test_case_free(ctx: *mut HegelContext, tc: *mut H
 
 // ─── Per-test-case primitives ───────────────────────────────────────────────
 
-unsafe fn tc_mut<'a>(tc: *mut HegelTestCase) -> Result<&'a mut HegelTestCase, c_int> {
+unsafe fn tc_mut<'a>(tc: *mut HegelTestCase) -> Result<&'a mut HegelTestCase, hegel_result_t> {
     let tc = unsafe { tc.as_mut() }.ok_or(HEGEL_E_INVALID_HANDLE)?;
     if tc.completed {
         return Err(HEGEL_E_ALREADY_COMPLETE);
@@ -1206,7 +1215,7 @@ unsafe fn tc_mut<'a>(tc: *mut HegelTestCase) -> Result<&'a mut HegelTestCase, c_
     Ok(tc)
 }
 
-fn translate_ds_error(ctx: *mut HegelContext, e: DataSourceError) -> c_int {
+fn translate_ds_error(ctx: *mut HegelContext, e: DataSourceError) -> hegel_result_t {
     match e {
         DataSourceError::StopTest => HEGEL_E_STOP_TEST,
         DataSourceError::Assume => HEGEL_E_ASSUME,
@@ -1247,7 +1256,7 @@ pub unsafe extern "C" fn hegel_generate(
     schema_len: usize,
     out_value_cbor: *mut *const u8,
     out_value_len: *mut usize,
-) -> c_int {
+) -> hegel_result_t {
     clear_last_error(ctx);
     let tc = match unsafe { tc_mut(tc) } {
         Ok(t) => t,
@@ -1302,13 +1311,17 @@ pub unsafe extern "C" fn hegel_generate(
 /// Open a labeled span around a group of draws so the shrinker can
 /// reason about them as a unit. Pair with exactly one
 /// `hegel_stop_span(tc, false)` call when the structure is complete.
-/// `label` is one of the `HEGEL_LABEL_*` constants.
+///
+/// `label` is a `hegel_label_t` value for one of the well-known structure
+/// kinds, but the type is `uint64_t` rather than the enum because the label
+/// space is open: callers may pass any stable `u64` to tag their own span
+/// kinds (the engine treats unrecognised labels as opaque grouping keys).
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hegel_start_span(
     ctx: *mut HegelContext,
     tc: *mut HegelTestCase,
     label: u64,
-) -> c_int {
+) -> hegel_result_t {
     clear_last_error(ctx);
     let tc = match unsafe { tc_mut(tc) } {
         Ok(t) => t,
@@ -1328,7 +1341,7 @@ pub unsafe extern "C" fn hegel_stop_span(
     ctx: *mut HegelContext,
     tc: *mut HegelTestCase,
     discard: bool,
-) -> c_int {
+) -> hegel_result_t {
     clear_last_error(ctx);
     let tc = match unsafe { tc_mut(tc) } {
         Ok(t) => t,
@@ -1355,7 +1368,7 @@ pub unsafe extern "C" fn hegel_new_collection(
     min_size: u64,
     max_size: u64,
     out_collection_id: *mut i64,
-) -> c_int {
+) -> hegel_result_t {
     clear_last_error(ctx);
     let tc = match unsafe { tc_mut(tc) } {
         Ok(t) => t,
@@ -1389,7 +1402,7 @@ pub unsafe extern "C" fn hegel_collection_more(
     tc: *mut HegelTestCase,
     collection_id: i64,
     out_more: *mut bool,
-) -> c_int {
+) -> hegel_result_t {
     clear_last_error(ctx);
     let tc = match unsafe { tc_mut(tc) } {
         Ok(t) => t,
@@ -1418,7 +1431,7 @@ pub unsafe extern "C" fn hegel_collection_reject(
     tc: *mut HegelTestCase,
     collection_id: i64,
     why: *const c_char,
-) -> c_int {
+) -> hegel_result_t {
     clear_last_error(ctx);
     let tc = match unsafe { tc_mut(tc) } {
         Ok(t) => t,
@@ -1457,7 +1470,7 @@ pub unsafe extern "C" fn hegel_new_pool(
     ctx: *mut HegelContext,
     tc: *mut HegelTestCase,
     out_pool_id: *mut i64,
-) -> c_int {
+) -> hegel_result_t {
     clear_last_error(ctx);
     let tc = match unsafe { tc_mut(tc) } {
         Ok(t) => t,
@@ -1488,7 +1501,7 @@ pub unsafe extern "C" fn hegel_pool_add(
     tc: *mut HegelTestCase,
     pool_id: i64,
     out_variable_id: *mut i64,
-) -> c_int {
+) -> hegel_result_t {
     clear_last_error(ctx);
     let tc = match unsafe { tc_mut(tc) } {
         Ok(t) => t,
@@ -1525,7 +1538,7 @@ pub unsafe extern "C" fn hegel_pool_generate(
     pool_id: i64,
     consume: bool,
     out_variable_id: *mut i64,
-) -> c_int {
+) -> hegel_result_t {
     clear_last_error(ctx);
     let tc = match unsafe { tc_mut(tc) } {
         Ok(t) => t,
@@ -1554,7 +1567,7 @@ unsafe fn names_from_c_array(
     what: &str,
     names: *const *const c_char,
     len: usize,
-) -> Result<Vec<String>, c_int> {
+) -> Result<Vec<String>, hegel_result_t> {
     if names.is_null() && len > 0 {
         set_last_error(ctx, &format!("{func}: {what} pointer is null"));
         return Err(HEGEL_E_INVALID_ARG);
@@ -1604,7 +1617,7 @@ pub unsafe extern "C" fn hegel_new_state_machine(
     invariant_names: *const *const c_char,
     num_invariants: usize,
     out_state_machine_id: *mut i64,
-) -> c_int {
+) -> hegel_result_t {
     clear_last_error(ctx);
     let tc = match unsafe { tc_mut(tc) } {
         Ok(t) => t,
@@ -1668,7 +1681,7 @@ pub unsafe extern "C" fn hegel_state_machine_next_rule(
     tc: *mut HegelTestCase,
     state_machine_id: i64,
     out_rule_index: *mut i64,
-) -> c_int {
+) -> hegel_result_t {
     clear_last_error(ctx);
     let tc = match unsafe { tc_mut(tc) } {
         Ok(t) => t,
@@ -1712,7 +1725,7 @@ pub unsafe extern "C" fn hegel_primitive_boolean(
     forced: bool,
     has_forced: bool,
     out_value: *mut bool,
-) -> c_int {
+) -> hegel_result_t {
     clear_last_error(ctx);
     let tc = match unsafe { tc_mut(tc) } {
         Ok(t) => t,
@@ -1748,7 +1761,7 @@ pub unsafe extern "C" fn hegel_target(
     tc: *mut HegelTestCase,
     value: f64,
     label: *const c_char,
-) -> c_int {
+) -> hegel_result_t {
     clear_last_error(ctx);
     let tc = match unsafe { tc_mut(tc) } {
         Ok(t) => t,
@@ -1797,7 +1810,7 @@ pub unsafe extern "C" fn hegel_mark_complete(
     tc: *mut HegelTestCase,
     status: hegel_status_t,
     origin: *const c_char,
-) -> c_int {
+) -> hegel_result_t {
     clear_last_error(ctx);
     let tc = match unsafe { tc.as_mut() } {
         Some(t) => t,

--- a/hegel-c/src/lib.rs
+++ b/hegel-c/src/lib.rs
@@ -18,13 +18,15 @@
 //   is `Send + Sync` so once handed across it works in place.
 //
 // - Errors are signalled via int return codes (`HEGEL_E_*`) on per-test-case
-//   primitives, or NULL returns with a thread-local last_error string for
-//   handle-level calls. There is no callback into C from Rust on the hot
-//   path; the loop is user-driven.
+//   primitives, or NULL returns for handle-level calls. The diagnostic for a
+//   failed call is recorded on an explicit `hegel_context_t` the caller
+//   passes in (rather than thread-local state, which is ill-defined under
+//   runtimes that migrate work between OS threads) and read back with
+//   `hegel_context_last_error`. There is no callback into C from Rust on the
+//   hot path; the loop is user-driven.
 
 #![allow(clippy::missing_safety_doc)]
 
-use std::cell::RefCell;
 use std::ffi::{CStr, CString, c_char, c_int};
 use std::ptr;
 use std::sync::Arc;
@@ -96,7 +98,7 @@ use crate::settings::{Backend, HealthCheck, Mode, Phase, Settings, Verbosity};
 //
 // All `int`-returning entry points (the per-test-case primitives, etc.)
 // return one of these. Handle-returning entry points use NULL instead and
-// leave a description in `hegel_last_error_message()`.
+// leave a description in `hegel_context_last_error()`.
 
 /// Success.
 pub const HEGEL_OK: c_int = 0;
@@ -111,7 +113,7 @@ pub const HEGEL_E_STOP_TEST: c_int = -1;
 pub const HEGEL_E_ASSUME: c_int = -2;
 
 /// The underlying engine reported an error. See
-/// `hegel_last_error_message()` for the diagnostic.
+/// `hegel_context_last_error()` for the diagnostic.
 pub const HEGEL_E_BACKEND: c_int = -3;
 
 /// A handle pointer (`hegel_settings_t*`, `hegel_run_t*`,
@@ -120,7 +122,7 @@ pub const HEGEL_E_INVALID_HANDLE: c_int = -4;
 
 /// An argument other than a handle was invalid — NULL where a value was
 /// required, malformed CBOR, non-UTF-8 string, etc. See
-/// `hegel_last_error_message()` for specifics.
+/// `hegel_context_last_error()` for specifics.
 pub const HEGEL_E_INVALID_ARG: c_int = -5;
 
 /// `hegel_mark_complete` (or a primitive on the same handle) was called
@@ -133,7 +135,7 @@ pub const HEGEL_E_NOT_COMPLETE: c_int = -7;
 
 /// An internal invariant failed inside libhegel (e.g. CBOR
 /// re-serialisation). Should not happen in practice; please file a
-/// bug. See `hegel_last_error_message()` for the diagnostic.
+/// bug. See `hegel_context_last_error()` for the diagnostic.
 pub const HEGEL_E_INTERNAL: c_int = -8;
 
 // ─── Enums mirrored to C ────────────────────────────────────────────────────
@@ -362,20 +364,78 @@ pub const HEGEL_LABEL_ENUM_VARIANT: u64 = 15;
 /// span themselves.
 pub const HEGEL_LABEL_FEATURE_FLAG: u64 = 16;
 
-// ─── Thread-local error message ─────────────────────────────────────────────
+// ─── Error-reporting context ────────────────────────────────────────────────
 
-thread_local! {
-    static LAST_ERROR: RefCell<CString> = RefCell::new(CString::new("").unwrap());
+/// Opaque error-reporting context.
+///
+/// libhegel records the diagnostic for a failed call on a context the caller
+/// supplies, rather than in thread-local state. Thread-local error buffers
+/// are ill-defined under runtimes (e.g. Go) that migrate a goroutine between
+/// OS threads mid-call, so the message could be written on one thread and
+/// read on another; an explicit context sidesteps that entirely.
+///
+/// Create one with `hegel_context_new`, pass it as the first argument to
+/// every fallible `hegel_*` call, read the most recent message with
+/// `hegel_context_last_error`, and free it with `hegel_context_free`. A
+/// context is cheap; the expected usage is one per test (or per thread).
+///
+/// A single context must not be used concurrently from multiple threads —
+/// each fallible call overwrites the stored message, so sharing one across
+/// threads is a data race and unsupported. Passing `NULL` wherever a context
+/// is accepted is allowed and simply opts out of error messages: the call
+/// still returns its usual error code, there is just nothing to read back.
+pub struct HegelContext {
+    last_error: CString,
 }
 
-fn set_last_error(msg: &str) {
-    let c =
-        CString::new(msg).unwrap_or_else(|_| CString::new("error message contained NUL").unwrap());
-    LAST_ERROR.with(|cell| *cell.borrow_mut() = c);
+/// Allocate a new error-reporting context initialised with an empty message.
+/// Never returns NULL. Must be paired with a `hegel_context_free` call.
+#[unsafe(no_mangle)]
+pub extern "C" fn hegel_context_new() -> *mut HegelContext {
+    Box::into_raw(Box::new(HegelContext {
+        last_error: CString::default(),
+    }))
 }
 
-fn clear_last_error() {
-    LAST_ERROR.with(|cell| *cell.borrow_mut() = CString::new("").unwrap());
+/// Free a context previously returned by `hegel_context_new`. Safe to call
+/// with NULL (no-op).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn hegel_context_free(ctx: *mut HegelContext) {
+    if !ctx.is_null() {
+        drop(unsafe { Box::from_raw(ctx) });
+    }
+}
+
+/// Most recent error message recorded on `ctx`, or the empty string if the
+/// most recent call taking this context succeeded. Returns NULL only when
+/// `ctx` itself is NULL.
+///
+/// The returned pointer borrows `ctx`'s internal buffer and is invalidated by
+/// the next libhegel call that takes the same `ctx` — copy the bytes before
+/// making another such call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn hegel_context_last_error(ctx: *const HegelContext) -> *const c_char {
+    match unsafe { ctx.as_ref() } {
+        Some(c) => c.last_error.as_ptr(),
+        None => ptr::null(),
+    }
+}
+
+/// Record `msg` as `ctx`'s most recent error. A NULL `ctx` discards the
+/// message (the caller opted out of error reporting).
+fn set_last_error(ctx: *mut HegelContext, msg: &str) {
+    if let Some(c) = unsafe { ctx.as_mut() } {
+        c.last_error = CString::new(msg)
+            .unwrap_or_else(|_| CString::new("error message contained NUL").unwrap());
+    }
+}
+
+/// Reset `ctx`'s error message to empty at the start of a fallible call. A
+/// NULL `ctx` is a no-op.
+fn clear_last_error(ctx: *mut HegelContext) {
+    if let Some(c) = unsafe { ctx.as_mut() } {
+        c.last_error = CString::default();
+    }
 }
 
 // ─── HegelSettings ──────────────────────────────────────────────────────────
@@ -665,7 +725,11 @@ pub unsafe extern "C" fn hegel_settings_report_multiple_failures(s: *mut HegelSe
 /// - Otherwise → use the directory at `database` as the database root.
 ///   The directory is created lazily.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn hegel_settings_database(s: *mut HegelSettings, database: *const c_char) {
+pub unsafe extern "C" fn hegel_settings_database(
+    ctx: *mut HegelContext,
+    s: *mut HegelSettings,
+    database: *const c_char,
+) {
     let Some(inner) = (unsafe { settings_mut(s) }) else {
         return;
     };
@@ -677,14 +741,18 @@ pub unsafe extern "C" fn hegel_settings_database(s: *mut HegelSettings, database
     match cstr.to_str() {
         Ok("") => *inner = inner.clone().database(None),
         Ok(path) => *inner = inner.clone().database(Some(path.to_string())),
-        Err(_) => set_last_error("hegel_settings_database: path is not valid UTF-8"),
+        Err(_) => set_last_error(ctx, "hegel_settings_database: path is not valid UTF-8"),
     }
 }
 
 /// Set the database key used to scope stored / replayed examples for this run.
 /// `key = NULL` clears it (the default).
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn hegel_settings_database_key(s: *mut HegelSettings, key: *const c_char) {
+pub unsafe extern "C" fn hegel_settings_database_key(
+    ctx: *mut HegelContext,
+    s: *mut HegelSettings,
+    key: *const c_char,
+) {
     let Some(hs) = (unsafe { s.as_mut() }) else {
         return;
     };
@@ -694,7 +762,7 @@ pub unsafe extern "C" fn hegel_settings_database_key(s: *mut HegelSettings, key:
     }
     match unsafe { CStr::from_ptr(key) }.to_str() {
         Ok(k) => hs.database_key = Some(k.to_string()),
-        Err(_) => set_last_error("hegel_settings_database_key: key is not valid UTF-8"),
+        Err(_) => set_last_error(ctx, "hegel_settings_database_key: key is not valid UTF-8"),
     }
 }
 
@@ -798,14 +866,17 @@ fn install_worker_panic_hook() {
 /// settings it needs.
 ///
 /// Returns NULL on failure with a diagnostic in
-/// `hegel_last_error_message`. The returned handle must be freed with
+/// `hegel_context_last_error`. The returned handle must be freed with
 /// `hegel_run_free`.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn hegel_run_start(settings: *const HegelSettings) -> *mut HegelRun {
-    clear_last_error();
+pub unsafe extern "C" fn hegel_run_start(
+    ctx: *mut HegelContext,
+    settings: *const HegelSettings,
+) -> *mut HegelRun {
+    clear_last_error(ctx);
     install_worker_panic_hook();
     let Some(handle) = (unsafe { settings.as_ref() }) else {
-        set_last_error("hegel_run_start: settings pointer is null");
+        set_last_error(ctx, "hegel_run_start: settings pointer is null");
         return ptr::null_mut();
     };
     let settings = handle.inner.clone();
@@ -876,7 +947,7 @@ pub unsafe extern "C" fn hegel_run_start(settings: *const HegelSettings) -> *mut
         // provoked in-process without destabilising the test runner.
         // nocov start
         Err(e) => {
-            set_last_error(&format!("hegel_run_start: failed to spawn worker: {}", e));
+            set_last_error(ctx, &format!("hegel_run_start: spawn failed: {}", e));
             return ptr::null_mut();
         } // nocov end
     };
@@ -896,17 +967,20 @@ pub unsafe extern "C" fn hegel_run_start(settings: *const HegelSettings) -> *mut
 ///
 /// The caller must complete the previous test case (via
 /// `hegel_mark_complete`) before requesting the next one — otherwise
-/// this returns NULL and sets `hegel_last_error_message`.
+/// this returns NULL and sets `hegel_context_last_error`.
 ///
 /// Returns NULL when the run is finished; call `hegel_run_result` to
-/// read the outcome. A NULL with `hegel_last_error_message` set means
+/// read the outcome. A NULL with `hegel_context_last_error` set means
 /// something went wrong (engine crash, caller misuse) rather than
 /// normal completion.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn hegel_next_test_case(run: *mut HegelRun) -> *mut HegelTestCase {
-    clear_last_error();
+pub unsafe extern "C" fn hegel_next_test_case(
+    ctx: *mut HegelContext,
+    run: *mut HegelRun,
+) -> *mut HegelTestCase {
+    clear_last_error(ctx);
     let Some(run) = (unsafe { run.as_mut() }) else {
-        set_last_error("hegel_next_test_case: run pointer is null");
+        set_last_error(ctx, "hegel_next_test_case: run pointer is null");
         return ptr::null_mut();
     };
 
@@ -914,6 +988,7 @@ pub unsafe extern "C" fn hegel_next_test_case(run: *mut HegelRun) -> *mut HegelT
     if let Some(tc) = run.current_tc.as_ref() {
         if !tc.completed {
             set_last_error(
+                ctx,
                 "hegel_next_test_case: previous test case was not marked complete \
                  (call hegel_mark_complete before requesting the next case)",
             );
@@ -957,7 +1032,7 @@ pub unsafe extern "C" fn hegel_next_test_case(run: *mut HegelRun) -> *mut HegelT
             // Rust, and this extern "C" entry point must return null, not panic.
             // nocov start
             run.drained = true;
-            set_last_error("hegel_next_test_case: worker terminated without reporting a result");
+            set_last_error(ctx, "hegel_next_test_case: worker exited without a result");
             ptr::null_mut()
             // nocov end
         }
@@ -966,21 +1041,24 @@ pub unsafe extern "C" fn hegel_next_test_case(run: *mut HegelRun) -> *mut HegelT
 
 /// Return the aggregated result of a finished run, borrowed from the
 /// parent `hegel_run_t`. Returns NULL with
-/// `hegel_last_error_message` set if the run hasn't finished yet
+/// `hegel_context_last_error` set if the run hasn't finished yet
 /// (`hegel_next_test_case` has not yet returned NULL on this run).
 ///
 /// The pointer is valid until `hegel_run_free`.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn hegel_run_result(run: *mut HegelRun) -> *const HegelRunResult {
-    clear_last_error();
+pub unsafe extern "C" fn hegel_run_result(
+    ctx: *mut HegelContext,
+    run: *mut HegelRun,
+) -> *const HegelRunResult {
+    clear_last_error(ctx);
     let Some(run) = (unsafe { run.as_ref() }) else {
-        set_last_error("hegel_run_result: run pointer is null");
+        set_last_error(ctx, "hegel_run_result: run pointer is null");
         return ptr::null();
     };
     match &run.result {
         Some(r) => r as *const HegelRunResult,
         None => {
-            set_last_error("hegel_run_result: run has not finished yet");
+            set_last_error(ctx, "hegel_run_result: run has not finished yet");
             ptr::null()
         }
     }
@@ -1051,31 +1129,33 @@ pub unsafe extern "C" fn hegel_run_free(run: *mut HegelRun) {
 /// overruns. `hegel_test_case_is_final_replay` reports true: the replayed
 /// example *is* the counterexample.
 ///
-/// Returns NULL with a diagnostic in `hegel_last_error_message` if `s` or
+/// Returns NULL with a diagnostic in `hegel_context_last_error` if `s` or
 /// `blob` is NULL, or if `blob` is not a valid failure blob (corrupt, or
 /// from an incompatible Hegel version). The returned handle is owned by
 /// the **caller** — unlike test cases from `hegel_next_test_case`, it must
 /// be released with `hegel_test_case_free`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hegel_test_case_from_blob(
+    ctx: *mut HegelContext,
     s: *const HegelSettings,
     blob: *const c_char,
 ) -> *mut HegelTestCase {
-    clear_last_error();
+    clear_last_error(ctx);
     let Some(handle) = (unsafe { s.as_ref() }) else {
-        set_last_error("hegel_test_case_from_blob: settings pointer is null");
+        set_last_error(ctx, "hegel_test_case_from_blob: settings pointer is null");
         return ptr::null_mut();
     };
     if blob.is_null() {
-        set_last_error("hegel_test_case_from_blob: blob pointer is null");
+        set_last_error(ctx, "hegel_test_case_from_blob: blob pointer is null");
         return ptr::null_mut();
     }
     let Ok(blob) = (unsafe { CStr::from_ptr(blob) }).to_str() else {
-        set_last_error("hegel_test_case_from_blob: blob is not valid UTF-8");
+        set_last_error(ctx, "hegel_test_case_from_blob: blob is not valid UTF-8");
         return ptr::null_mut();
     };
     let Some(ds) = data_source_for_blob(&handle.inner, blob) else {
         set_last_error(
+            ctx,
             "hegel_test_case_from_blob: the supplied failure blob could not be decoded. \
              It may be corrupt or from an incompatible Hegel version.",
         );
@@ -1098,15 +1178,16 @@ pub unsafe extern "C" fn hegel_test_case_from_blob(
 /// `hegel_next_test_case` — those are borrowed from the parent
 /// `hegel_run_t` and are released by `hegel_run_free`. Passing one here is
 /// detected (while the run is still alive) and refused, with a diagnostic
-/// in `hegel_last_error_message`.
+/// in `hegel_context_last_error`.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn hegel_test_case_free(tc: *mut HegelTestCase) {
-    clear_last_error();
+pub unsafe extern "C" fn hegel_test_case_free(ctx: *mut HegelContext, tc: *mut HegelTestCase) {
+    clear_last_error(ctx);
     if tc.is_null() {
         return;
     }
     if unsafe { (*tc).ack.is_some() } {
         set_last_error(
+            ctx,
             "hegel_test_case_free: this test case is owned by its hegel_run_t \
              (it came from hegel_next_test_case); it is freed by hegel_run_free",
         );
@@ -1125,15 +1206,15 @@ unsafe fn tc_mut<'a>(tc: *mut HegelTestCase) -> Result<&'a mut HegelTestCase, c_
     Ok(tc)
 }
 
-fn translate_ds_error(e: DataSourceError) -> c_int {
+fn translate_ds_error(ctx: *mut HegelContext, e: DataSourceError) -> c_int {
     match e {
         DataSourceError::StopTest => HEGEL_E_STOP_TEST,
         DataSourceError::Assume => HEGEL_E_ASSUME,
         // A caller-supplied schema was semantically invalid (e.g. an unknown
         // type string). Surface it as HEGEL_E_INVALID_ARG with the diagnostic
-        // in hegel_last_error_message — never a panic across the FFI boundary.
+        // in hegel_context_last_error — never a panic across the FFI boundary.
         DataSourceError::InvalidArgument(msg) => {
-            set_last_error(&msg);
+            set_last_error(ctx, &msg);
             HEGEL_E_INVALID_ARG
         } // `DataSourceError` is `#[non_exhaustive]`, but it now lives in this
           // crate, so an in-crate match is exhaustive without a wildcard. Adding
@@ -1157,26 +1238,27 @@ fn translate_ds_error(e: DataSourceError) -> c_int {
 /// call `hegel_mark_complete` with `HEGEL_STATUS_OVERRUN`).
 /// Returns `HEGEL_E_INVALID_ARG` on malformed schema, NULL outputs, or
 /// other argument errors; the diagnostic is in
-/// `hegel_last_error_message`.
+/// `hegel_context_last_error`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hegel_generate(
+    ctx: *mut HegelContext,
     tc: *mut HegelTestCase,
     schema_cbor: *const u8,
     schema_len: usize,
     out_value_cbor: *mut *const u8,
     out_value_len: *mut usize,
 ) -> c_int {
-    clear_last_error();
+    clear_last_error(ctx);
     let tc = match unsafe { tc_mut(tc) } {
         Ok(t) => t,
         Err(rc) => return rc,
     };
     if schema_cbor.is_null() && schema_len > 0 {
-        set_last_error("hegel_generate: schema pointer is null");
+        set_last_error(ctx, "hegel_generate: schema pointer is null");
         return HEGEL_E_INVALID_ARG;
     }
     if out_value_cbor.is_null() || out_value_len.is_null() {
-        set_last_error("hegel_generate: out parameter is null");
+        set_last_error(ctx, "hegel_generate: out parameter is null");
         return HEGEL_E_INVALID_ARG;
     }
 
@@ -1184,14 +1266,17 @@ pub unsafe extern "C" fn hegel_generate(
     let schema: Value = match ciborium::de::from_reader(schema_bytes) {
         Ok(v) => v,
         Err(e) => {
-            set_last_error(&format!("hegel_generate: malformed CBOR schema: {}", e));
+            set_last_error(
+                ctx,
+                &format!("hegel_generate: malformed CBOR schema: {}", e),
+            );
             return HEGEL_E_INVALID_ARG;
         }
     };
 
     let value = match tc.ds.generate(&schema) {
         Ok(v) => v,
-        Err(e) => return translate_ds_error(e),
+        Err(e) => return translate_ds_error(ctx, e),
     };
 
     tc.last_value.clear();
@@ -1201,10 +1286,10 @@ pub unsafe extern "C" fn hegel_generate(
     // than panic across the C ABI.
     if let Err(e) = ciborium::ser::into_writer(&value, &mut tc.last_value) {
         // nocov start
-        set_last_error(&format!(
-            "hegel_generate: failed to re-serialize value: {}",
-            e
-        )); // nocov end
+        set_last_error(
+            ctx,
+            &format!("hegel_generate: failed to re-serialize value: {}", e),
+        ); // nocov end
         return HEGEL_E_INTERNAL; // nocov
     }
     unsafe {
@@ -1219,15 +1304,19 @@ pub unsafe extern "C" fn hegel_generate(
 /// `hegel_stop_span(tc, false)` call when the structure is complete.
 /// `label` is one of the `HEGEL_LABEL_*` constants.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn hegel_start_span(tc: *mut HegelTestCase, label: u64) -> c_int {
-    clear_last_error();
+pub unsafe extern "C" fn hegel_start_span(
+    ctx: *mut HegelContext,
+    tc: *mut HegelTestCase,
+    label: u64,
+) -> c_int {
+    clear_last_error(ctx);
     let tc = match unsafe { tc_mut(tc) } {
         Ok(t) => t,
         Err(rc) => return rc,
     };
     match tc.ds.start_span(label) {
         Ok(()) => HEGEL_OK,
-        Err(e) => translate_ds_error(e),
+        Err(e) => translate_ds_error(ctx, e),
     }
 }
 
@@ -1235,15 +1324,19 @@ pub unsafe extern "C" fn hegel_start_span(tc: *mut HegelTestCase, label: u64) ->
 /// the span as rejected (e.g. a `filter` predicate didn't hold and the
 /// engine should retry from before the span opened).
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn hegel_stop_span(tc: *mut HegelTestCase, discard: bool) -> c_int {
-    clear_last_error();
+pub unsafe extern "C" fn hegel_stop_span(
+    ctx: *mut HegelContext,
+    tc: *mut HegelTestCase,
+    discard: bool,
+) -> c_int {
+    clear_last_error(ctx);
     let tc = match unsafe { tc_mut(tc) } {
         Ok(t) => t,
         Err(rc) => return rc,
     };
     match tc.ds.stop_span(discard) {
         Ok(()) => HEGEL_OK,
-        Err(e) => translate_ds_error(e),
+        Err(e) => translate_ds_error(ctx, e),
     }
 }
 
@@ -1257,18 +1350,19 @@ pub unsafe extern "C" fn hegel_stop_span(tc: *mut HegelTestCase, discard: bool) 
 /// `hegel_collection_more` / `hegel_collection_reject` calls.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hegel_new_collection(
+    ctx: *mut HegelContext,
     tc: *mut HegelTestCase,
     min_size: u64,
     max_size: u64,
     out_collection_id: *mut i64,
 ) -> c_int {
-    clear_last_error();
+    clear_last_error(ctx);
     let tc = match unsafe { tc_mut(tc) } {
         Ok(t) => t,
         Err(rc) => return rc,
     };
     if out_collection_id.is_null() {
-        set_last_error("hegel_new_collection: out parameter is null");
+        set_last_error(ctx, "hegel_new_collection: out parameter is null");
         return HEGEL_E_INVALID_ARG;
     }
     let max = if max_size == u64::MAX {
@@ -1281,7 +1375,7 @@ pub unsafe extern "C" fn hegel_new_collection(
             unsafe { *out_collection_id = id };
             HEGEL_OK
         }
-        Err(e) => translate_ds_error(e),
+        Err(e) => translate_ds_error(ctx, e),
     }
 }
 
@@ -1291,17 +1385,18 @@ pub unsafe extern "C" fn hegel_new_collection(
 /// the next element each time.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hegel_collection_more(
+    ctx: *mut HegelContext,
     tc: *mut HegelTestCase,
     collection_id: i64,
     out_more: *mut bool,
 ) -> c_int {
-    clear_last_error();
+    clear_last_error(ctx);
     let tc = match unsafe { tc_mut(tc) } {
         Ok(t) => t,
         Err(rc) => return rc,
     };
     if out_more.is_null() {
-        set_last_error("hegel_collection_more: out parameter is null");
+        set_last_error(ctx, "hegel_collection_more: out parameter is null");
         return HEGEL_E_INVALID_ARG;
     }
     match tc.ds.collection_more(collection_id) {
@@ -1309,7 +1404,7 @@ pub unsafe extern "C" fn hegel_collection_more(
             unsafe { *out_more = m };
             HEGEL_OK
         }
-        Err(e) => translate_ds_error(e),
+        Err(e) => translate_ds_error(ctx, e),
     }
 }
 
@@ -1319,11 +1414,12 @@ pub unsafe extern "C" fn hegel_collection_more(
 /// rejection reason (NULL is allowed).
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hegel_collection_reject(
+    ctx: *mut HegelContext,
     tc: *mut HegelTestCase,
     collection_id: i64,
     why: *const c_char,
 ) -> c_int {
-    clear_last_error();
+    clear_last_error(ctx);
     let tc = match unsafe { tc_mut(tc) } {
         Ok(t) => t,
         Err(rc) => return rc,
@@ -1334,14 +1430,14 @@ pub unsafe extern "C" fn hegel_collection_reject(
         match unsafe { CStr::from_ptr(why) }.to_str() {
             Ok(s) => Some(s),
             Err(_) => {
-                set_last_error("hegel_collection_reject: why is not valid UTF-8");
+                set_last_error(ctx, "hegel_collection_reject: why is not valid UTF-8");
                 return HEGEL_E_INVALID_ARG;
             }
         }
     };
     match tc.ds.collection_reject(collection_id, why_str) {
         Ok(()) => HEGEL_OK,
-        Err(e) => translate_ds_error(e),
+        Err(e) => translate_ds_error(ctx, e),
     }
 }
 
@@ -1357,14 +1453,18 @@ pub unsafe extern "C" fn hegel_collection_reject(
 /// `HEGEL_OK`. The id is opaque; pass it to subsequent `hegel_pool_add`
 /// / `hegel_pool_generate` calls on the *same* test case.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn hegel_new_pool(tc: *mut HegelTestCase, out_pool_id: *mut i64) -> c_int {
-    clear_last_error();
+pub unsafe extern "C" fn hegel_new_pool(
+    ctx: *mut HegelContext,
+    tc: *mut HegelTestCase,
+    out_pool_id: *mut i64,
+) -> c_int {
+    clear_last_error(ctx);
     let tc = match unsafe { tc_mut(tc) } {
         Ok(t) => t,
         Err(rc) => return rc,
     };
     if out_pool_id.is_null() {
-        set_last_error("hegel_new_pool: out parameter is null");
+        set_last_error(ctx, "hegel_new_pool: out parameter is null");
         return HEGEL_E_INVALID_ARG;
     }
     match tc.ds.new_pool() {
@@ -1372,7 +1472,7 @@ pub unsafe extern "C" fn hegel_new_pool(tc: *mut HegelTestCase, out_pool_id: *mu
             unsafe { *out_pool_id = id };
             HEGEL_OK
         }
-        Err(e) => translate_ds_error(e),
+        Err(e) => translate_ds_error(ctx, e),
     }
 }
 
@@ -1384,17 +1484,18 @@ pub unsafe extern "C" fn hegel_new_pool(tc: *mut HegelTestCase, out_pool_id: *mu
 /// `hegel_new_pool` on this test case.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hegel_pool_add(
+    ctx: *mut HegelContext,
     tc: *mut HegelTestCase,
     pool_id: i64,
     out_variable_id: *mut i64,
 ) -> c_int {
-    clear_last_error();
+    clear_last_error(ctx);
     let tc = match unsafe { tc_mut(tc) } {
         Ok(t) => t,
         Err(rc) => return rc,
     };
     if out_variable_id.is_null() {
-        set_last_error("hegel_pool_add: out parameter is null");
+        set_last_error(ctx, "hegel_pool_add: out parameter is null");
         return HEGEL_E_INVALID_ARG;
     }
     match tc.ds.pool_add(pool_id) {
@@ -1402,7 +1503,7 @@ pub unsafe extern "C" fn hegel_pool_add(
             unsafe { *out_variable_id = id };
             HEGEL_OK
         }
-        Err(e) => translate_ds_error(e),
+        Err(e) => translate_ds_error(ctx, e),
     }
 }
 
@@ -1419,18 +1520,19 @@ pub unsafe extern "C" fn hegel_pool_add(
 /// it like any other budget-exhaustion outcome.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hegel_pool_generate(
+    ctx: *mut HegelContext,
     tc: *mut HegelTestCase,
     pool_id: i64,
     consume: bool,
     out_variable_id: *mut i64,
 ) -> c_int {
-    clear_last_error();
+    clear_last_error(ctx);
     let tc = match unsafe { tc_mut(tc) } {
         Ok(t) => t,
         Err(rc) => return rc,
     };
     if out_variable_id.is_null() {
-        set_last_error("hegel_pool_generate: out parameter is null");
+        set_last_error(ctx, "hegel_pool_generate: out parameter is null");
         return HEGEL_E_INVALID_ARG;
     }
     match tc.ds.pool_generate(pool_id, consume) {
@@ -1438,22 +1540,23 @@ pub unsafe extern "C" fn hegel_pool_generate(
             unsafe { *out_variable_id = id };
             HEGEL_OK
         }
-        Err(e) => translate_ds_error(e),
+        Err(e) => translate_ds_error(ctx, e),
     }
 }
 
 /// Convert a C array of `len` NUL-terminated strings into owned Rust
-/// strings, setting `hegel_last_error_message` and returning the error
+/// strings, setting `hegel_context_last_error` and returning the error
 /// code on a null array (with `len > 0`), a null entry, or a non-UTF-8
 /// entry.
 unsafe fn names_from_c_array(
+    ctx: *mut HegelContext,
     func: &str,
     what: &str,
     names: *const *const c_char,
     len: usize,
 ) -> Result<Vec<String>, c_int> {
     if names.is_null() && len > 0 {
-        set_last_error(&format!("{func}: {what} pointer is null"));
+        set_last_error(ctx, &format!("{func}: {what} pointer is null"));
         return Err(HEGEL_E_INVALID_ARG);
     }
     let ptrs: &[*const c_char] = if len == 0 {
@@ -1464,13 +1567,13 @@ unsafe fn names_from_c_array(
     let mut out = Vec::with_capacity(len);
     for (i, &p) in ptrs.iter().enumerate() {
         if p.is_null() {
-            set_last_error(&format!("{func}: {what}[{i}] is null"));
+            set_last_error(ctx, &format!("{func}: {what}[{i}] is null"));
             return Err(HEGEL_E_INVALID_ARG);
         }
         match unsafe { CStr::from_ptr(p) }.to_str() {
             Ok(s) => out.push(s.to_string()),
             Err(_) => {
-                set_last_error(&format!("{func}: {what}[{i}] is not valid UTF-8"));
+                set_last_error(ctx, &format!("{func}: {what}[{i}] is not valid UTF-8"));
                 return Err(HEGEL_E_INVALID_ARG);
             }
         }
@@ -1494,6 +1597,7 @@ unsafe fn names_from_c_array(
 /// non-UTF-8 names.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hegel_new_state_machine(
+    ctx: *mut HegelContext,
     tc: *mut HegelTestCase,
     rule_names: *const *const c_char,
     num_rules: usize,
@@ -1501,17 +1605,18 @@ pub unsafe extern "C" fn hegel_new_state_machine(
     num_invariants: usize,
     out_state_machine_id: *mut i64,
 ) -> c_int {
-    clear_last_error();
+    clear_last_error(ctx);
     let tc = match unsafe { tc_mut(tc) } {
         Ok(t) => t,
         Err(rc) => return rc,
     };
     if out_state_machine_id.is_null() {
-        set_last_error("hegel_new_state_machine: out parameter is null");
+        set_last_error(ctx, "hegel_new_state_machine: out parameter is null");
         return HEGEL_E_INVALID_ARG;
     }
     let rules = match unsafe {
         names_from_c_array(
+            ctx,
             "hegel_new_state_machine",
             "rule_names",
             rule_names,
@@ -1523,6 +1628,7 @@ pub unsafe extern "C" fn hegel_new_state_machine(
     };
     let invariants = match unsafe {
         names_from_c_array(
+            ctx,
             "hegel_new_state_machine",
             "invariant_names",
             invariant_names,
@@ -1539,7 +1645,7 @@ pub unsafe extern "C" fn hegel_new_state_machine(
             unsafe { *out_state_machine_id = id };
             HEGEL_OK
         }
-        Err(e) => translate_ds_error(e),
+        Err(e) => translate_ds_error(ctx, e),
     }
 }
 
@@ -1558,17 +1664,18 @@ pub unsafe extern "C" fn hegel_new_state_machine(
 /// with `HEGEL_STATUS_OVERRUN`).
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hegel_state_machine_next_rule(
+    ctx: *mut HegelContext,
     tc: *mut HegelTestCase,
     state_machine_id: i64,
     out_rule_index: *mut i64,
 ) -> c_int {
-    clear_last_error();
+    clear_last_error(ctx);
     let tc = match unsafe { tc_mut(tc) } {
         Ok(t) => t,
         Err(rc) => return rc,
     };
     if out_rule_index.is_null() {
-        set_last_error("hegel_state_machine_next_rule: out parameter is null");
+        set_last_error(ctx, "hegel_state_machine_next_rule: out parameter is null");
         return HEGEL_E_INVALID_ARG;
     }
     match tc.ds.state_machine_next_rule(state_machine_id) {
@@ -1576,7 +1683,7 @@ pub unsafe extern "C" fn hegel_state_machine_next_rule(
             unsafe { *out_rule_index = index };
             HEGEL_OK
         }
-        Err(e) => translate_ds_error(e),
+        Err(e) => translate_ds_error(ctx, e),
     }
 }
 
@@ -1596,22 +1703,23 @@ pub unsafe extern "C" fn hegel_state_machine_next_rule(
 /// body and call `hegel_mark_complete` with `HEGEL_STATUS_OVERRUN`).
 /// Returns `HEGEL_E_INVALID_ARG` for a NULL `out_value`, a `p` outside
 /// `[0.0, 1.0]` (including NaN), or a contradictory forced value; the
-/// diagnostic is in `hegel_last_error_message`.
+/// diagnostic is in `hegel_context_last_error`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hegel_primitive_boolean(
+    ctx: *mut HegelContext,
     tc: *mut HegelTestCase,
     p: f64,
     forced: bool,
     has_forced: bool,
     out_value: *mut bool,
 ) -> c_int {
-    clear_last_error();
+    clear_last_error(ctx);
     let tc = match unsafe { tc_mut(tc) } {
         Ok(t) => t,
         Err(rc) => return rc,
     };
     if out_value.is_null() {
-        set_last_error("hegel_primitive_boolean: out parameter is null");
+        set_last_error(ctx, "hegel_primitive_boolean: out parameter is null");
         return HEGEL_E_INVALID_ARG;
     }
     match tc.ds.primitive_boolean(p, has_forced.then_some(forced)) {
@@ -1619,7 +1727,7 @@ pub unsafe extern "C" fn hegel_primitive_boolean(
             unsafe { *out_value = v };
             HEGEL_OK
         }
-        Err(e) => translate_ds_error(e),
+        Err(e) => translate_ds_error(ctx, e),
     }
 }
 
@@ -1631,34 +1739,35 @@ pub unsafe extern "C" fn hegel_primitive_boolean(
 /// and valid UTF-8.
 ///
 /// Returns `HEGEL_E_INVALID_ARG` (with a diagnostic in
-/// `hegel_last_error_message`) if `value` is not finite, or if `label`
+/// `hegel_context_last_error`) if `value` is not finite, or if `label`
 /// has already been observed on this test case — each label may be
 /// recorded at most once per case.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hegel_target(
+    ctx: *mut HegelContext,
     tc: *mut HegelTestCase,
     value: f64,
     label: *const c_char,
 ) -> c_int {
-    clear_last_error();
+    clear_last_error(ctx);
     let tc = match unsafe { tc_mut(tc) } {
         Ok(t) => t,
         Err(rc) => return rc,
     };
     if label.is_null() {
-        set_last_error("hegel_target: label is null");
+        set_last_error(ctx, "hegel_target: label is null");
         return HEGEL_E_INVALID_ARG;
     }
     let label = match unsafe { CStr::from_ptr(label) }.to_str() {
         Ok(s) => s,
         Err(_) => {
-            set_last_error("hegel_target: label is not valid UTF-8");
+            set_last_error(ctx, "hegel_target: label is not valid UTF-8");
             return HEGEL_E_INVALID_ARG;
         }
     };
     match tc.ds.target_observation(value, label) {
         Ok(()) => HEGEL_OK,
-        Err(e) => translate_ds_error(e),
+        Err(e) => translate_ds_error(ctx, e),
     }
 }
 
@@ -1684,11 +1793,12 @@ pub unsafe extern "C" fn hegel_target(
 /// exactly this (see `src/run_lifecycle.rs`).
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hegel_mark_complete(
+    ctx: *mut HegelContext,
     tc: *mut HegelTestCase,
     status: hegel_status_t,
     origin: *const c_char,
 ) -> c_int {
-    clear_last_error();
+    clear_last_error(ctx);
     let tc = match unsafe { tc.as_mut() } {
         Some(t) => t,
         None => return HEGEL_E_INVALID_HANDLE,
@@ -1708,7 +1818,7 @@ pub unsafe extern "C" fn hegel_mark_complete(
                 match unsafe { CStr::from_ptr(origin) }.to_str() {
                     Ok(s) => s.to_string(),
                     Err(_) => {
-                        set_last_error("hegel_mark_complete: origin is not valid UTF-8");
+                        set_last_error(ctx, "hegel_mark_complete: origin is not valid UTF-8");
                         return HEGEL_E_INVALID_ARG;
                     }
                 }
@@ -1839,23 +1949,6 @@ pub unsafe extern "C" fn hegel_failure_reproduction_blob(f: *const HegelFailure)
 }
 
 // ─── Diagnostics ────────────────────────────────────────────────────────────
-
-/// Most recent error message from libhegel on the calling thread, or
-/// the empty string if the most recent call succeeded.
-///
-/// The returned pointer is a borrow into a thread-local buffer and is
-/// invalidated by the next libhegel call on this thread — copy the
-/// bytes before making another call.
-#[unsafe(no_mangle)]
-pub extern "C" fn hegel_last_error_message() -> *const c_char {
-    LAST_ERROR.with(|cell| {
-        // Returning a borrowed pointer into a thread-local RefCell is sound
-        // as long as no other libhegel call on this thread fires before the
-        // caller is done with the pointer. The C header documents that.
-        let r = cell.borrow();
-        r.as_ptr()
-    })
-}
 
 /// Libhegel's version, matching the parent `hegeltest` crate's
 /// `CARGO_PKG_VERSION` (e.g. `"0.14.12"`). The returned pointer is

--- a/hegel-c/src/native/core/state_machine.rs
+++ b/hegel-c/src/native/core/state_machine.rs
@@ -10,8 +10,8 @@ use std::collections::HashSet;
 
 use super::choices::EngineError;
 use super::state::NativeTestCase;
-use crate::HEGEL_LABEL_FEATURE_FLAG;
 use crate::control::hegel_internal_assert;
+use crate::hegel_label_t::HEGEL_LABEL_FEATURE_FLAG;
 use crate::native::bignum::{BigInt, ToPrimitive};
 
 /// Draw a uniform index in `[0, n)`.
@@ -54,7 +54,7 @@ impl FeatureFlags {
     }
 
     fn is_enabled(&mut self, ntc: &mut NativeTestCase, i: usize) -> Result<bool, EngineError> {
-        ntc.start_span(HEGEL_LABEL_FEATURE_FLAG);
+        ntc.start_span(HEGEL_LABEL_FEATURE_FLAG as u64);
         let forced = if self.at_least_one_of.len() == 1 && self.at_least_one_of.contains(&i) {
             Some(false)
         } else {

--- a/hegel-c/tests/c_abi_inprocess.rs
+++ b/hegel-c/tests/c_abi_inprocess.rs
@@ -9,10 +9,11 @@
 //! engine over this same ABI.
 
 use hegel_c::{
-    HEGEL_E_ALREADY_COMPLETE, HEGEL_E_INVALID_ARG, HEGEL_E_INVALID_HANDLE, HEGEL_OK, HegelRun,
-    HegelTestCase, hegel_backend_t, hegel_collection_more, hegel_collection_reject,
-    hegel_failure_origin, hegel_failure_panic_message, hegel_failure_reproduction_blob,
-    hegel_generate, hegel_mark_complete, hegel_mode_t, hegel_new_collection, hegel_new_pool,
+    HEGEL_E_ALREADY_COMPLETE, HEGEL_E_INVALID_ARG, HEGEL_E_INVALID_HANDLE, HEGEL_OK, HegelContext,
+    HegelRun, HegelTestCase, hegel_backend_t, hegel_collection_more, hegel_collection_reject,
+    hegel_context_free, hegel_context_last_error, hegel_context_new, hegel_failure_origin,
+    hegel_failure_panic_message, hegel_failure_reproduction_blob, hegel_generate,
+    hegel_mark_complete, hegel_mode_t, hegel_new_collection, hegel_new_pool,
     hegel_new_state_machine, hegel_next_test_case, hegel_pool_add, hegel_pool_generate,
     hegel_primitive_boolean, hegel_run_free, hegel_run_result, hegel_run_result_error,
     hegel_run_result_failure, hegel_run_result_failure_count, hegel_run_result_status,
@@ -27,8 +28,8 @@ use std::ffi::CString;
 use std::os::raw::c_char;
 use std::ptr;
 
-fn last_error() -> String {
-    let p = hegel_c::hegel_last_error_message();
+fn last_error(ctx: *const HegelContext) -> String {
+    let p = unsafe { hegel_context_last_error(ctx) };
     if p.is_null() {
         String::new()
     } else {
@@ -40,22 +41,23 @@ fn last_error() -> String {
 
 #[test]
 fn null_handles_are_rejected_without_crashing() {
+    let ctx = hegel_context_new();
     unsafe {
         // Settings setters tolerate a null handle (documented no-op).
         hegel_settings_mode(ptr::null_mut(), hegel_mode_t::HEGEL_MODE_TEST_RUN);
         hegel_settings_backend(ptr::null_mut(), hegel_backend_t::HEGEL_BACKEND_AUTO);
-        hegel_settings_database(ptr::null_mut(), c"x".as_ptr());
-        hegel_settings_database_key(ptr::null_mut(), c"x".as_ptr());
+        hegel_settings_database(ctx, ptr::null_mut(), c"x".as_ptr());
+        hegel_settings_database_key(ctx, ptr::null_mut(), c"x".as_ptr());
         hegel_settings_phases(ptr::null_mut(), 0);
         hegel_settings_suppress_health_check(ptr::null_mut(), 0);
         hegel_settings_report_multiple_failures(ptr::null_mut(), true);
 
-        // Handle-returning entry points return null + set the thread-local error.
-        assert!(hegel_run_start(ptr::null()).is_null());
-        assert!(!last_error().is_empty());
-        assert!(hegel_next_test_case(ptr::null_mut()).is_null());
-        assert!(hegel_run_result(ptr::null_mut()).is_null());
-        assert!(hegel_test_case_from_blob(ptr::null(), c"AAEC".as_ptr()).is_null());
+        // Handle-returning entry points return null + record the error on ctx.
+        assert!(hegel_run_start(ctx, ptr::null()).is_null());
+        assert!(!last_error(ctx).is_empty());
+        assert!(hegel_next_test_case(ctx, ptr::null_mut()).is_null());
+        assert!(hegel_run_result(ctx, ptr::null_mut()).is_null());
+        assert!(hegel_test_case_from_blob(ctx, ptr::null(), c"AAEC".as_ptr()).is_null());
 
         // Result inspection on a null result / null failure reports the
         // "nothing here" value rather than dereferencing.
@@ -70,7 +72,7 @@ fn null_handles_are_rejected_without_crashing() {
         // Free is null-safe.
         hegel_settings_free(ptr::null_mut());
         hegel_run_free(ptr::null_mut());
-        hegel_test_case_free(ptr::null_mut());
+        hegel_test_case_free(ctx, ptr::null_mut());
 
         // Per-test-case primitives on a null handle report an invalid handle.
         let tc: *mut HegelTestCase = ptr::null_mut();
@@ -79,6 +81,7 @@ fn null_handles_are_rejected_without_crashing() {
         let schema = [0u8];
         assert_eq!(
             hegel_generate(
+                ctx,
                 tc,
                 schema.as_ptr(),
                 schema.len(),
@@ -87,69 +90,86 @@ fn null_handles_are_rejected_without_crashing() {
             ),
             HEGEL_E_INVALID_HANDLE
         );
-        assert_eq!(hegel_start_span(tc, 1), HEGEL_E_INVALID_HANDLE);
-        assert_eq!(hegel_stop_span(tc, false), HEGEL_E_INVALID_HANDLE);
+        assert_eq!(hegel_start_span(ctx, tc, 1), HEGEL_E_INVALID_HANDLE);
+        assert_eq!(hegel_stop_span(ctx, tc, false), HEGEL_E_INVALID_HANDLE);
         let mut id = 0i64;
         assert_eq!(
-            hegel_new_collection(tc, 0, u64::MAX, &mut id),
+            hegel_new_collection(ctx, tc, 0, u64::MAX, &mut id),
             HEGEL_E_INVALID_HANDLE
         );
         let mut more = false;
         assert_eq!(
-            hegel_collection_more(tc, 0, &mut more),
+            hegel_collection_more(ctx, tc, 0, &mut more),
             HEGEL_E_INVALID_HANDLE
         );
         assert_eq!(
-            hegel_collection_reject(tc, 0, ptr::null()),
+            hegel_collection_reject(ctx, tc, 0, ptr::null()),
             HEGEL_E_INVALID_HANDLE
         );
-        assert_eq!(hegel_new_pool(tc, &mut id), HEGEL_E_INVALID_HANDLE);
-        assert_eq!(hegel_pool_add(tc, 0, &mut id), HEGEL_E_INVALID_HANDLE);
+        assert_eq!(hegel_new_pool(ctx, tc, &mut id), HEGEL_E_INVALID_HANDLE);
+        assert_eq!(hegel_pool_add(ctx, tc, 0, &mut id), HEGEL_E_INVALID_HANDLE);
         assert_eq!(
-            hegel_pool_generate(tc, 0, false, &mut id),
+            hegel_pool_generate(ctx, tc, 0, false, &mut id),
             HEGEL_E_INVALID_HANDLE
         );
-        assert_eq!(hegel_target(tc, 0.0, c"x".as_ptr()), HEGEL_E_INVALID_HANDLE);
+        assert_eq!(
+            hegel_target(ctx, tc, 0.0, c"x".as_ptr()),
+            HEGEL_E_INVALID_HANDLE
+        );
         assert_ne!(
-            hegel_mark_complete(tc, hegel_status_t::HEGEL_STATUS_VALID, ptr::null()),
+            hegel_mark_complete(ctx, tc, hegel_status_t::HEGEL_STATUS_VALID, ptr::null()),
             HEGEL_OK
         );
         assert!(!hegel_test_case_is_final_replay(tc));
+
+        // A null context is tolerated wherever a context is accepted: the call
+        // still returns its error code, the diagnostic is just discarded (there is
+        // nowhere to record it). This drives the null-context arms of libhegel's
+        // internal set/clear-error helpers and of hegel_context_last_error.
+        assert!(hegel_run_start(ptr::null_mut(), ptr::null()).is_null());
+        assert!(hegel_context_last_error(ptr::null()).is_null());
+    }
+    unsafe {
+        hegel_context_free(ctx);
     }
 }
 
 #[test]
 fn settings_string_setters_handle_bad_input() {
+    let ctx = hegel_context_new();
     unsafe {
         let s = hegel_settings_new();
         // database(null) leaves the default in place; key(null) clears it.
-        hegel_settings_database(s, ptr::null());
-        hegel_settings_database_key(s, ptr::null());
+        hegel_settings_database(ctx, s, ptr::null());
+        hegel_settings_database_key(ctx, s, ptr::null());
 
         // Non-UTF-8 bytes are rejected (recorded as an error), not honoured.
         let bad: [c_char; 2] = [0xFFu8 as c_char, 0];
-        hegel_settings_database(s, bad.as_ptr());
-        assert!(last_error().contains("not valid UTF-8"));
-        hegel_settings_database_key(s, bad.as_ptr());
-        assert!(last_error().contains("not valid UTF-8"));
+        hegel_settings_database(ctx, s, bad.as_ptr());
+        assert!(last_error(ctx).contains("not valid UTF-8"));
+        hegel_settings_database_key(ctx, s, bad.as_ptr());
+        assert!(last_error(ctx).contains("not valid UTF-8"));
 
         hegel_settings_free(s);
+        hegel_context_free(ctx);
     }
 }
 
 #[test]
 fn from_blob_rejects_bad_input() {
+    let ctx = hegel_context_new();
     unsafe {
         let s = hegel_settings_new();
-        assert!(hegel_test_case_from_blob(s, ptr::null()).is_null());
-        assert!(last_error().contains("null"));
+        assert!(hegel_test_case_from_blob(ctx, s, ptr::null()).is_null());
+        assert!(last_error(ctx).contains("null"));
         let bad: [c_char; 2] = [0xFFu8 as c_char, 0];
-        assert!(hegel_test_case_from_blob(s, bad.as_ptr()).is_null());
-        assert!(last_error().contains("UTF-8"));
+        assert!(hegel_test_case_from_blob(ctx, s, bad.as_ptr()).is_null());
+        assert!(last_error(ctx).contains("UTF-8"));
         let garbage = CString::new("!!! not a blob !!!").unwrap();
-        assert!(hegel_test_case_from_blob(s, garbage.as_ptr()).is_null());
-        assert!(last_error().contains("could not be decoded"));
+        assert!(hegel_test_case_from_blob(ctx, s, garbage.as_ptr()).is_null());
+        assert!(last_error(ctx).contains("could not be decoded"));
         hegel_settings_free(s);
+        hegel_context_free(ctx);
     }
 }
 
@@ -159,32 +179,34 @@ fn from_blob_rejects_bad_input() {
 /// the next case before completing the current one.
 #[test]
 fn explicit_backend_run_and_lifecycle_misuse() {
+    let ctx = hegel_context_new();
     unsafe {
         let s = hegel_settings_new();
         hegel_settings_backend(s, hegel_backend_t::HEGEL_BACKEND_DEFAULT);
         let empty = CString::new("").unwrap();
-        hegel_settings_database(s, empty.as_ptr());
+        hegel_settings_database(ctx, s, empty.as_ptr());
         hegel_c::hegel_settings_test_cases(s, 5);
         hegel_c::hegel_settings_seed(s, 1, true);
 
-        let run: *mut HegelRun = hegel_run_start(s);
+        let run: *mut HegelRun = hegel_run_start(ctx, s);
         assert!(!run.is_null());
 
         // Reading the result before the run is drained is an error.
-        assert!(hegel_run_result(run).is_null());
+        assert!(hegel_run_result(ctx, run).is_null());
 
         let schema = integer_schema();
-        let tc = hegel_next_test_case(run);
+        let tc = hegel_next_test_case(ctx, run);
         assert!(!tc.is_null());
 
         // Requesting the next case before completing this one is rejected.
-        assert!(hegel_next_test_case(run).is_null());
-        assert!(last_error().contains("not marked complete"));
+        assert!(hegel_next_test_case(ctx, run).is_null());
+        assert!(last_error(ctx).contains("not marked complete"));
 
         let mut out_ptr: *const u8 = ptr::null();
         let mut out_len = 0usize;
         assert_eq!(
             hegel_generate(
+                ctx,
                 tc,
                 schema.as_ptr(),
                 schema.len(),
@@ -194,29 +216,30 @@ fn explicit_backend_run_and_lifecycle_misuse() {
             HEGEL_OK
         );
         assert_eq!(
-            hegel_mark_complete(tc, hegel_status_t::HEGEL_STATUS_VALID, ptr::null()),
+            hegel_mark_complete(ctx, tc, hegel_status_t::HEGEL_STATUS_VALID, ptr::null()),
             HEGEL_OK
         );
 
         // Drain the rest normally.
         loop {
-            let tc = hegel_next_test_case(run);
+            let tc = hegel_next_test_case(ctx, run);
             if tc.is_null() {
                 break;
             }
             let mut p: *const u8 = ptr::null();
             let mut n = 0usize;
             assert_eq!(
-                hegel_generate(tc, schema.as_ptr(), schema.len(), &mut p, &mut n),
+                hegel_generate(ctx, tc, schema.as_ptr(), schema.len(), &mut p, &mut n),
                 HEGEL_OK
             );
-            hegel_mark_complete(tc, hegel_status_t::HEGEL_STATUS_VALID, ptr::null());
+            hegel_mark_complete(ctx, tc, hegel_status_t::HEGEL_STATUS_VALID, ptr::null());
         }
 
-        let result = hegel_run_result(run);
+        let result = hegel_run_result(ctx, run);
         assert!(!result.is_null());
         hegel_run_free(run);
         hegel_settings_free(s);
+        hegel_context_free(ctx);
     }
 }
 
@@ -224,17 +247,19 @@ fn explicit_backend_run_and_lifecycle_misuse() {
 /// early) must abort and join the worker without deadlocking.
 #[test]
 fn run_free_with_undrained_case_does_not_deadlock() {
+    let ctx = hegel_context_new();
     unsafe {
         let s = hegel_settings_new();
         let empty = CString::new("").unwrap();
-        hegel_settings_database(s, empty.as_ptr());
-        let run = hegel_run_start(s);
+        hegel_settings_database(ctx, s, empty.as_ptr());
+        let run = hegel_run_start(ctx, s);
         assert!(!run.is_null());
-        let tc = hegel_next_test_case(run);
+        let tc = hegel_next_test_case(ctx, run);
         assert!(!tc.is_null());
         // Drop everything without marking the case complete.
         hegel_run_free(run);
         hegel_settings_free(s);
+        hegel_context_free(ctx);
     }
 }
 
@@ -256,28 +281,30 @@ fn version_is_reported() {
 /// or faulting.
 #[test]
 fn next_after_drain_returns_null() {
+    let ctx = hegel_context_new();
     unsafe {
         let s = hegel_settings_new();
         let empty = CString::new("").unwrap();
-        hegel_settings_database(s, empty.as_ptr());
+        hegel_settings_database(ctx, s, empty.as_ptr());
         hegel_c::hegel_settings_test_cases(s, 3);
-        let run = hegel_run_start(s);
+        let run = hegel_run_start(ctx, s);
         let schema = integer_schema();
         loop {
-            let tc = hegel_next_test_case(run);
+            let tc = hegel_next_test_case(ctx, run);
             if tc.is_null() {
                 break;
             }
             let mut p: *const u8 = ptr::null();
             let mut n = 0usize;
-            hegel_generate(tc, schema.as_ptr(), schema.len(), &mut p, &mut n);
-            hegel_mark_complete(tc, hegel_status_t::HEGEL_STATUS_VALID, ptr::null());
+            hegel_generate(ctx, tc, schema.as_ptr(), schema.len(), &mut p, &mut n);
+            hegel_mark_complete(ctx, tc, hegel_status_t::HEGEL_STATUS_VALID, ptr::null());
         }
         // Already drained: a further call is a no-op NULL with no error set.
-        assert!(hegel_next_test_case(run).is_null());
-        assert!(last_error().is_empty());
+        assert!(hegel_next_test_case(ctx, run).is_null());
+        assert!(last_error(ctx).is_empty());
         hegel_run_free(run);
         hegel_settings_free(s);
+        hegel_context_free(ctx);
     }
 }
 
@@ -291,14 +318,15 @@ fn next_after_drain_returns_null() {
 #[test]
 fn live_test_case_argument_validation() {
     let bad_utf8: [c_char; 2] = [0xFFu8 as c_char, 0];
+    let ctx = hegel_context_new();
     unsafe {
         let s = hegel_settings_new();
         let empty = CString::new("").unwrap();
-        hegel_settings_database(s, empty.as_ptr());
+        hegel_settings_database(ctx, s, empty.as_ptr());
         hegel_c::hegel_settings_test_cases(s, 5);
         hegel_c::hegel_settings_seed(s, 1, true);
-        let run = hegel_run_start(s);
-        let tc = hegel_next_test_case(run);
+        let run = hegel_run_start(ctx, s);
+        let tc = hegel_next_test_case(ctx, run);
         assert!(!tc.is_null());
 
         let schema = integer_schema();
@@ -307,13 +335,14 @@ fn live_test_case_argument_validation() {
 
         // generate: null schema pointer with a non-zero length.
         assert_eq!(
-            hegel_generate(tc, ptr::null(), 4, &mut out_ptr, &mut out_len),
+            hegel_generate(ctx, tc, ptr::null(), 4, &mut out_ptr, &mut out_len),
             HEGEL_E_INVALID_ARG
         );
-        assert!(last_error().contains("schema pointer is null"));
+        assert!(last_error(ctx).contains("schema pointer is null"));
         // generate: null out-parameter.
         assert_eq!(
             hegel_generate(
+                ctx,
                 tc,
                 schema.as_ptr(),
                 schema.len(),
@@ -322,11 +351,12 @@ fn live_test_case_argument_validation() {
             ),
             HEGEL_E_INVALID_ARG
         );
-        assert!(last_error().contains("out parameter is null"));
+        assert!(last_error(ctx).contains("out parameter is null"));
         // generate: well-formed pointer but truncated/garbage CBOR.
         let garbage = [0x82u8, 0x01]; // array(2) with only one element → decode error
         assert_eq!(
             hegel_generate(
+                ctx,
                 tc,
                 garbage.as_ptr(),
                 garbage.len(),
@@ -335,32 +365,36 @@ fn live_test_case_argument_validation() {
             ),
             HEGEL_E_INVALID_ARG
         );
-        assert!(last_error().contains("malformed CBOR"));
+        assert!(last_error(ctx).contains("malformed CBOR"));
 
         // Null out-parameters on the collection / pool constructors.
         let mut id = 0i64;
         assert_eq!(
-            hegel_new_collection(tc, 0, u64::MAX, ptr::null_mut()),
+            hegel_new_collection(ctx, tc, 0, u64::MAX, ptr::null_mut()),
             HEGEL_E_INVALID_ARG
         );
-        assert_eq!(hegel_new_pool(tc, ptr::null_mut()), HEGEL_E_INVALID_ARG);
+        assert_eq!(
+            hegel_new_pool(ctx, tc, ptr::null_mut()),
+            HEGEL_E_INVALID_ARG
+        );
 
         // A real collection, to reach collection_more's null out-param check,
         // the NULL-`why` reject branch, and the non-UTF-8 `why` rejection.
-        assert_eq!(hegel_new_collection(tc, 0, 3, &mut id), HEGEL_OK);
+        assert_eq!(hegel_new_collection(ctx, tc, 0, 3, &mut id), HEGEL_OK);
         assert_eq!(
-            hegel_collection_more(tc, id, ptr::null_mut()),
+            hegel_collection_more(ctx, tc, id, ptr::null_mut()),
             HEGEL_E_INVALID_ARG
         );
         // The `why` string is decoded before the collection is consulted, so a
         // non-UTF-8 reason is rejected regardless of collection state.
         assert_eq!(
-            hegel_collection_reject(tc, id, bad_utf8.as_ptr()),
+            hegel_collection_reject(ctx, tc, id, bad_utf8.as_ptr()),
             HEGEL_E_INVALID_ARG
         );
         let mut more = false;
-        if hegel_collection_more(tc, id, &mut more) == HEGEL_OK && more {
+        if hegel_collection_more(ctx, tc, id, &mut more) == HEGEL_OK && more {
             hegel_generate(
+                ctx,
                 tc,
                 schema.as_ptr(),
                 schema.len(),
@@ -368,26 +402,26 @@ fn live_test_case_argument_validation() {
                 &mut out_len,
             );
             // NULL why is the accepted "no reason given" branch.
-            assert_eq!(hegel_collection_reject(tc, id, ptr::null()), HEGEL_OK);
+            assert_eq!(hegel_collection_reject(ctx, tc, id, ptr::null()), HEGEL_OK);
         }
 
         // A real pool, to reach pool_add / pool_generate null out-param checks.
         let mut pool = 0i64;
-        assert_eq!(hegel_new_pool(tc, &mut pool), HEGEL_OK);
+        assert_eq!(hegel_new_pool(ctx, tc, &mut pool), HEGEL_OK);
         assert_eq!(
-            hegel_pool_add(tc, pool, ptr::null_mut()),
+            hegel_pool_add(ctx, tc, pool, ptr::null_mut()),
             HEGEL_E_INVALID_ARG
         );
         assert_eq!(
-            hegel_pool_generate(tc, pool, false, ptr::null_mut()),
+            hegel_pool_generate(ctx, tc, pool, false, ptr::null_mut()),
             HEGEL_E_INVALID_ARG
         );
 
         // target: null label, then non-UTF-8 label.
-        assert_eq!(hegel_target(tc, 0.0, ptr::null()), HEGEL_E_INVALID_ARG);
-        assert!(last_error().contains("label is null"));
+        assert_eq!(hegel_target(ctx, tc, 0.0, ptr::null()), HEGEL_E_INVALID_ARG);
+        assert!(last_error(ctx).contains("label is null"));
         assert_eq!(
-            hegel_target(tc, 0.0, bad_utf8.as_ptr()),
+            hegel_target(ctx, tc, 0.0, bad_utf8.as_ptr()),
             HEGEL_E_INVALID_ARG
         );
 
@@ -395,19 +429,23 @@ fn live_test_case_argument_validation() {
         // errors — HEGEL_E_INVALID_ARG with a diagnostic, never a panic across
         // the C ABI (libhegel must stay correct under panic=abort).
         assert_eq!(
-            hegel_target(tc, f64::NAN, c"x".as_ptr()),
+            hegel_target(ctx, tc, f64::NAN, c"x".as_ptr()),
             HEGEL_E_INVALID_ARG
         );
-        assert!(last_error().contains("finite score"));
-        assert_eq!(hegel_target(tc, 1.0, c"dup".as_ptr()), HEGEL_OK);
-        assert_eq!(hegel_target(tc, 2.0, c"dup".as_ptr()), HEGEL_E_INVALID_ARG);
-        assert!(last_error().contains("would overwrite previous"));
+        assert!(last_error(ctx).contains("finite score"));
+        assert_eq!(hegel_target(ctx, tc, 1.0, c"dup".as_ptr()), HEGEL_OK);
+        assert_eq!(
+            hegel_target(ctx, tc, 2.0, c"dup".as_ptr()),
+            HEGEL_E_INVALID_ARG
+        );
+        assert!(last_error(ctx).contains("would overwrite previous"));
 
         // mark_complete with a non-UTF-8 origin (only consulted for
         // INTERESTING). This is rejected *before* the case is marked complete,
         // so the handle is still live afterwards.
         assert_eq!(
             hegel_mark_complete(
+                ctx,
                 tc,
                 hegel_status_t::HEGEL_STATUS_INTERESTING,
                 bad_utf8.as_ptr()
@@ -417,13 +455,14 @@ fn live_test_case_argument_validation() {
 
         // Now actually complete it.
         assert_eq!(
-            hegel_mark_complete(tc, hegel_status_t::HEGEL_STATUS_VALID, ptr::null()),
+            hegel_mark_complete(ctx, tc, hegel_status_t::HEGEL_STATUS_VALID, ptr::null()),
             HEGEL_OK
         );
 
         // A completed case rejects further draws and a second completion.
         assert_eq!(
             hegel_generate(
+                ctx,
                 tc,
                 schema.as_ptr(),
                 schema.len(),
@@ -433,29 +472,30 @@ fn live_test_case_argument_validation() {
             HEGEL_E_ALREADY_COMPLETE
         );
         assert_eq!(
-            hegel_mark_complete(tc, hegel_status_t::HEGEL_STATUS_VALID, ptr::null()),
+            hegel_mark_complete(ctx, tc, hegel_status_t::HEGEL_STATUS_VALID, ptr::null()),
             HEGEL_E_ALREADY_COMPLETE
         );
         // It is owned by the run, so freeing it directly is refused.
-        hegel_test_case_free(tc);
-        assert!(last_error().contains("owned by its hegel_run_t"));
+        hegel_test_case_free(ctx, tc);
+        assert!(last_error(ctx).contains("owned by its hegel_run_t"));
 
         // Drain the remainder as VALID.
         loop {
-            let tc = hegel_next_test_case(run);
+            let tc = hegel_next_test_case(ctx, run);
             if tc.is_null() {
                 break;
             }
             let mut p: *const u8 = ptr::null();
             let mut n = 0usize;
-            hegel_generate(tc, schema.as_ptr(), schema.len(), &mut p, &mut n);
-            hegel_mark_complete(tc, hegel_status_t::HEGEL_STATUS_VALID, ptr::null());
+            hegel_generate(ctx, tc, schema.as_ptr(), schema.len(), &mut p, &mut n);
+            hegel_mark_complete(ctx, tc, hegel_status_t::HEGEL_STATUS_VALID, ptr::null());
         }
 
-        let result = hegel_run_result(run);
+        let result = hegel_run_result(ctx, run);
         assert!(!result.is_null());
         hegel_run_free(run);
         hegel_settings_free(s);
+        hegel_context_free(ctx);
     }
 }
 
@@ -466,33 +506,39 @@ fn live_test_case_argument_validation() {
 /// index branch.
 #[test]
 fn interesting_with_null_origin_synthesizes_placeholder() {
+    let ctx = hegel_context_new();
     unsafe {
         let s = hegel_settings_new();
         let empty = CString::new("").unwrap();
-        hegel_settings_database(s, empty.as_ptr());
+        hegel_settings_database(ctx, s, empty.as_ptr());
         hegel_c::hegel_settings_test_cases(s, 5);
         hegel_c::hegel_settings_seed(s, 1, true);
-        let run = hegel_run_start(s);
+        let run = hegel_run_start(ctx, s);
         let schema = integer_schema();
         loop {
-            let tc = hegel_next_test_case(run);
+            let tc = hegel_next_test_case(ctx, run);
             if tc.is_null() {
                 break;
             }
             let mut p: *const u8 = ptr::null();
             let mut n = 0usize;
             // Every case fails, so the failure reproduces and is recorded.
-            match hegel_generate(tc, schema.as_ptr(), schema.len(), &mut p, &mut n) {
+            match hegel_generate(ctx, tc, schema.as_ptr(), schema.len(), &mut p, &mut n) {
                 HEGEL_OK => {
-                    hegel_mark_complete(tc, hegel_status_t::HEGEL_STATUS_INTERESTING, ptr::null());
+                    hegel_mark_complete(
+                        ctx,
+                        tc,
+                        hegel_status_t::HEGEL_STATUS_INTERESTING,
+                        ptr::null(),
+                    );
                 }
                 _ => {
-                    hegel_mark_complete(tc, hegel_status_t::HEGEL_STATUS_OVERRUN, ptr::null());
+                    hegel_mark_complete(ctx, tc, hegel_status_t::HEGEL_STATUS_OVERRUN, ptr::null());
                 }
             }
         }
 
-        let result = hegel_run_result(run);
+        let result = hegel_run_result(ctx, run);
         assert!(!result.is_null());
         assert!(hegel_run_result_status(result) == hegel_run_status_t::HEGEL_RUN_STATUS_FAILED);
         assert!(hegel_run_result_error(result).is_null());
@@ -517,6 +563,7 @@ fn interesting_with_null_origin_synthesizes_placeholder() {
 
         hegel_run_free(run);
         hegel_settings_free(s);
+        hegel_context_free(ctx);
     }
 }
 
@@ -528,15 +575,16 @@ fn interesting_with_null_origin_synthesizes_placeholder() {
 /// unreachable on a live (non-overrun) case.
 #[test]
 fn primitives_after_overrun_all_report_stop_test() {
+    let ctx = hegel_context_new();
     unsafe {
         let s = hegel_settings_new();
         let empty = CString::new("").unwrap();
-        hegel_settings_database(s, empty.as_ptr());
+        hegel_settings_database(ctx, s, empty.as_ptr());
         hegel_c::hegel_settings_test_cases(s, 5);
-        let run = hegel_run_start(s);
+        let run = hegel_run_start(ctx, s);
         let schema = integer_schema();
 
-        let tc = hegel_next_test_case(run);
+        let tc = hegel_next_test_case(ctx, run);
         assert!(!tc.is_null());
 
         // Exhaust the choice budget by drawing until generate reports overrun.
@@ -545,6 +593,7 @@ fn primitives_after_overrun_all_report_stop_test() {
         let mut overran = false;
         for _ in 0..1_000_000 {
             if hegel_generate(
+                ctx,
                 tc,
                 schema.as_ptr(),
                 schema.len(),
@@ -560,38 +609,42 @@ fn primitives_after_overrun_all_report_stop_test() {
 
         // With the case aborted, each primitive now reports STOP_TEST.
         assert_eq!(
-            hegel_start_span(tc, hegel_c::HEGEL_LABEL_LIST),
+            hegel_start_span(ctx, tc, hegel_c::HEGEL_LABEL_LIST),
             hegel_c::HEGEL_E_STOP_TEST
         );
-        assert_eq!(hegel_stop_span(tc, false), hegel_c::HEGEL_E_STOP_TEST);
+        assert_eq!(hegel_stop_span(ctx, tc, false), hegel_c::HEGEL_E_STOP_TEST);
         let mut id = 0i64;
         assert_eq!(
-            hegel_new_collection(tc, 0, 3, &mut id),
+            hegel_new_collection(ctx, tc, 0, 3, &mut id),
             hegel_c::HEGEL_E_STOP_TEST
         );
         // collection_reject short-circuits on the aborted flag before it would
         // look up the (here nonexistent) collection id, so id 0 is safe.
         assert_eq!(
-            hegel_collection_reject(tc, 0, ptr::null()),
+            hegel_collection_reject(ctx, tc, 0, ptr::null()),
             hegel_c::HEGEL_E_STOP_TEST
         );
-        assert_eq!(hegel_new_pool(tc, &mut id), hegel_c::HEGEL_E_STOP_TEST);
-        assert_eq!(hegel_pool_add(tc, 0, &mut id), hegel_c::HEGEL_E_STOP_TEST);
+        assert_eq!(hegel_new_pool(ctx, tc, &mut id), hegel_c::HEGEL_E_STOP_TEST);
+        assert_eq!(
+            hegel_pool_add(ctx, tc, 0, &mut id),
+            hegel_c::HEGEL_E_STOP_TEST
+        );
 
-        hegel_mark_complete(tc, hegel_status_t::HEGEL_STATUS_OVERRUN, ptr::null());
+        hegel_mark_complete(ctx, tc, hegel_status_t::HEGEL_STATUS_OVERRUN, ptr::null());
         // Drain the rest.
         loop {
-            let tc = hegel_next_test_case(run);
+            let tc = hegel_next_test_case(ctx, run);
             if tc.is_null() {
                 break;
             }
             let mut p: *const u8 = ptr::null();
             let mut n = 0usize;
-            hegel_generate(tc, schema.as_ptr(), schema.len(), &mut p, &mut n);
-            hegel_mark_complete(tc, hegel_status_t::HEGEL_STATUS_VALID, ptr::null());
+            hegel_generate(ctx, tc, schema.as_ptr(), schema.len(), &mut p, &mut n);
+            hegel_mark_complete(ctx, tc, hegel_status_t::HEGEL_STATUS_VALID, ptr::null());
         }
         hegel_run_free(run);
         hegel_settings_free(s);
+        hegel_context_free(ctx);
     }
 }
 
@@ -605,6 +658,7 @@ fn primitives_after_overrun_all_report_stop_test() {
 #[test]
 fn state_machine_and_primitive_boolean_paths() {
     let bad_utf8: [c_char; 2] = [0xFFu8 as c_char, 0];
+    let ctx = hegel_context_new();
     unsafe {
         // Invalid (null) handle on all three entry points.
         let null_tc: *mut HegelTestCase = ptr::null_mut();
@@ -612,102 +666,103 @@ fn state_machine_and_primitive_boolean_paths() {
         let rules: [*const c_char; 1] = [rule_a.as_ptr()];
         let mut out_id = 0i64;
         assert_eq!(
-            hegel_new_state_machine(null_tc, rules.as_ptr(), 1, ptr::null(), 0, &mut out_id),
+            hegel_new_state_machine(ctx, null_tc, rules.as_ptr(), 1, ptr::null(), 0, &mut out_id),
             HEGEL_E_INVALID_HANDLE
         );
         assert_eq!(
-            hegel_state_machine_next_rule(null_tc, 0, &mut out_id),
+            hegel_state_machine_next_rule(ctx, null_tc, 0, &mut out_id),
             HEGEL_E_INVALID_HANDLE
         );
         let mut bv = false;
         assert_eq!(
-            hegel_primitive_boolean(null_tc, 0.5, false, false, &mut bv),
+            hegel_primitive_boolean(ctx, null_tc, 0.5, false, false, &mut bv),
             HEGEL_E_INVALID_HANDLE
         );
 
         // A live test case for the argument-validation and happy paths.
         let s = hegel_settings_new();
         let empty = CString::new("").unwrap();
-        hegel_settings_database(s, empty.as_ptr());
+        hegel_settings_database(ctx, s, empty.as_ptr());
         hegel_c::hegel_settings_test_cases(s, 5);
-        let run = hegel_run_start(s);
-        let tc = hegel_next_test_case(run);
+        let run = hegel_run_start(ctx, s);
+        let tc = hegel_next_test_case(ctx, run);
         assert!(!tc.is_null());
 
         // new_state_machine: null out parameter.
         assert_eq!(
-            hegel_new_state_machine(tc, rules.as_ptr(), 1, ptr::null(), 0, ptr::null_mut()),
+            hegel_new_state_machine(ctx, tc, rules.as_ptr(), 1, ptr::null(), 0, ptr::null_mut()),
             HEGEL_E_INVALID_ARG
         );
         // null rule-name array with a non-zero count.
         assert_eq!(
-            hegel_new_state_machine(tc, ptr::null(), 1, ptr::null(), 0, &mut out_id),
+            hegel_new_state_machine(ctx, tc, ptr::null(), 1, ptr::null(), 0, &mut out_id),
             HEGEL_E_INVALID_ARG
         );
-        assert!(last_error().contains("rule_names pointer is null"));
+        assert!(last_error(ctx).contains("rule_names pointer is null"));
         // a null entry in the rule-name array.
         let null_entry: [*const c_char; 1] = [ptr::null()];
         assert_eq!(
-            hegel_new_state_machine(tc, null_entry.as_ptr(), 1, ptr::null(), 0, &mut out_id),
+            hegel_new_state_machine(ctx, tc, null_entry.as_ptr(), 1, ptr::null(), 0, &mut out_id),
             HEGEL_E_INVALID_ARG
         );
-        assert!(last_error().contains("rule_names[0] is null"));
+        assert!(last_error(ctx).contains("rule_names[0] is null"));
         // a non-UTF-8 entry in the rule-name array.
         let bad_entry: [*const c_char; 1] = [bad_utf8.as_ptr()];
         assert_eq!(
-            hegel_new_state_machine(tc, bad_entry.as_ptr(), 1, ptr::null(), 0, &mut out_id),
+            hegel_new_state_machine(ctx, tc, bad_entry.as_ptr(), 1, ptr::null(), 0, &mut out_id),
             HEGEL_E_INVALID_ARG
         );
-        assert!(last_error().contains("not valid UTF-8"));
+        assert!(last_error(ctx).contains("not valid UTF-8"));
         // valid rules but a bad invariant array (drives the second name decode).
         let bad_inv: [*const c_char; 1] = [ptr::null()];
         assert_eq!(
-            hegel_new_state_machine(tc, rules.as_ptr(), 1, bad_inv.as_ptr(), 1, &mut out_id),
+            hegel_new_state_machine(ctx, tc, rules.as_ptr(), 1, bad_inv.as_ptr(), 1, &mut out_id),
             HEGEL_E_INVALID_ARG
         );
-        assert!(last_error().contains("invariant_names[0] is null"));
+        assert!(last_error(ctx).contains("invariant_names[0] is null"));
 
         // A valid single-rule machine: registration, next_rule's null-out
         // guard, then a real rule draw (always rule 0).
         assert_eq!(
-            hegel_new_state_machine(tc, rules.as_ptr(), 1, ptr::null(), 0, &mut out_id),
+            hegel_new_state_machine(ctx, tc, rules.as_ptr(), 1, ptr::null(), 0, &mut out_id),
             HEGEL_OK
         );
         assert_eq!(
-            hegel_state_machine_next_rule(tc, out_id, ptr::null_mut()),
+            hegel_state_machine_next_rule(ctx, tc, out_id, ptr::null_mut()),
             HEGEL_E_INVALID_ARG
         );
         let mut rule_idx = -1i64;
         assert_eq!(
-            hegel_state_machine_next_rule(tc, out_id, &mut rule_idx),
+            hegel_state_machine_next_rule(ctx, tc, out_id, &mut rule_idx),
             HEGEL_OK
         );
         assert_eq!(rule_idx, 0, "a single-rule machine always selects rule 0");
 
         // primitive_boolean: happy path, null out, and an out-of-range p.
         assert_eq!(
-            hegel_primitive_boolean(tc, 0.5, false, false, &mut bv),
+            hegel_primitive_boolean(ctx, tc, 0.5, false, false, &mut bv),
             HEGEL_OK
         );
         assert_eq!(
-            hegel_primitive_boolean(tc, 0.5, false, false, ptr::null_mut()),
+            hegel_primitive_boolean(ctx, tc, 0.5, false, false, ptr::null_mut()),
             HEGEL_E_INVALID_ARG
         );
         assert_eq!(
-            hegel_primitive_boolean(tc, 2.0, false, false, &mut bv),
+            hegel_primitive_boolean(ctx, tc, 2.0, false, false, &mut bv),
             HEGEL_E_INVALID_ARG
         );
 
-        hegel_mark_complete(tc, hegel_status_t::HEGEL_STATUS_VALID, ptr::null());
+        hegel_mark_complete(ctx, tc, hegel_status_t::HEGEL_STATUS_VALID, ptr::null());
         loop {
-            let tc = hegel_next_test_case(run);
+            let tc = hegel_next_test_case(ctx, run);
             if tc.is_null() {
                 break;
             }
-            hegel_mark_complete(tc, hegel_status_t::HEGEL_STATUS_VALID, ptr::null());
+            hegel_mark_complete(ctx, tc, hegel_status_t::HEGEL_STATUS_VALID, ptr::null());
         }
         hegel_run_free(run);
         hegel_settings_free(s);
+        hegel_context_free(ctx);
     }
 }
 

--- a/hegel-c/tests/c_abi_inprocess.rs
+++ b/hegel-c/tests/c_abi_inprocess.rs
@@ -8,18 +8,18 @@
 //! they hit are measured. The happy path is covered by hegeltest driving the
 //! engine over this same ABI.
 
+use hegel_c::hegel_result_t::*;
 use hegel_c::{
-    HEGEL_E_ALREADY_COMPLETE, HEGEL_E_INVALID_ARG, HEGEL_E_INVALID_HANDLE, HEGEL_OK, HegelContext,
-    HegelRun, HegelTestCase, hegel_backend_t, hegel_collection_more, hegel_collection_reject,
-    hegel_context_free, hegel_context_last_error, hegel_context_new, hegel_failure_origin,
-    hegel_failure_panic_message, hegel_failure_reproduction_blob, hegel_generate,
-    hegel_mark_complete, hegel_mode_t, hegel_new_collection, hegel_new_pool,
-    hegel_new_state_machine, hegel_next_test_case, hegel_pool_add, hegel_pool_generate,
-    hegel_primitive_boolean, hegel_run_free, hegel_run_result, hegel_run_result_error,
-    hegel_run_result_failure, hegel_run_result_failure_count, hegel_run_result_status,
-    hegel_run_start, hegel_run_status_t, hegel_settings_backend, hegel_settings_database,
-    hegel_settings_database_key, hegel_settings_free, hegel_settings_mode, hegel_settings_new,
-    hegel_settings_phases, hegel_settings_report_multiple_failures,
+    HegelContext, HegelRun, HegelTestCase, hegel_backend_t, hegel_collection_more,
+    hegel_collection_reject, hegel_context_free, hegel_context_last_error, hegel_context_new,
+    hegel_failure_origin, hegel_failure_panic_message, hegel_failure_reproduction_blob,
+    hegel_generate, hegel_label_t, hegel_mark_complete, hegel_mode_t, hegel_new_collection,
+    hegel_new_pool, hegel_new_state_machine, hegel_next_test_case, hegel_pool_add,
+    hegel_pool_generate, hegel_primitive_boolean, hegel_run_free, hegel_run_result,
+    hegel_run_result_error, hegel_run_result_failure, hegel_run_result_failure_count,
+    hegel_run_result_status, hegel_run_start, hegel_run_status_t, hegel_settings_backend,
+    hegel_settings_database, hegel_settings_database_key, hegel_settings_free, hegel_settings_mode,
+    hegel_settings_new, hegel_settings_phases, hegel_settings_report_multiple_failures,
     hegel_settings_suppress_health_check, hegel_start_span, hegel_state_machine_next_rule,
     hegel_status_t, hegel_stop_span, hegel_target, hegel_test_case_free, hegel_test_case_from_blob,
     hegel_test_case_is_final_replay, hegel_version,
@@ -599,7 +599,7 @@ fn primitives_after_overrun_all_report_stop_test() {
                 schema.len(),
                 &mut out_ptr,
                 &mut out_len,
-            ) == hegel_c::HEGEL_E_STOP_TEST
+            ) == HEGEL_E_STOP_TEST
             {
                 overran = true;
                 break;
@@ -609,26 +609,23 @@ fn primitives_after_overrun_all_report_stop_test() {
 
         // With the case aborted, each primitive now reports STOP_TEST.
         assert_eq!(
-            hegel_start_span(ctx, tc, hegel_c::HEGEL_LABEL_LIST),
-            hegel_c::HEGEL_E_STOP_TEST
+            hegel_start_span(ctx, tc, hegel_label_t::HEGEL_LABEL_LIST as u64),
+            HEGEL_E_STOP_TEST
         );
-        assert_eq!(hegel_stop_span(ctx, tc, false), hegel_c::HEGEL_E_STOP_TEST);
+        assert_eq!(hegel_stop_span(ctx, tc, false), HEGEL_E_STOP_TEST);
         let mut id = 0i64;
         assert_eq!(
             hegel_new_collection(ctx, tc, 0, 3, &mut id),
-            hegel_c::HEGEL_E_STOP_TEST
+            HEGEL_E_STOP_TEST
         );
         // collection_reject short-circuits on the aborted flag before it would
         // look up the (here nonexistent) collection id, so id 0 is safe.
         assert_eq!(
             hegel_collection_reject(ctx, tc, 0, ptr::null()),
-            hegel_c::HEGEL_E_STOP_TEST
+            HEGEL_E_STOP_TEST
         );
-        assert_eq!(hegel_new_pool(ctx, tc, &mut id), hegel_c::HEGEL_E_STOP_TEST);
-        assert_eq!(
-            hegel_pool_add(ctx, tc, 0, &mut id),
-            hegel_c::HEGEL_E_STOP_TEST
-        );
+        assert_eq!(hegel_new_pool(ctx, tc, &mut id), HEGEL_E_STOP_TEST);
+        assert_eq!(hegel_pool_add(ctx, tc, 0, &mut id), HEGEL_E_STOP_TEST);
 
         hegel_mark_complete(ctx, tc, hegel_status_t::HEGEL_STATUS_OVERRUN, ptr::null());
         // Drain the rest.

--- a/hegel-c/tests/embedded/native/state_machine_tests.rs
+++ b/hegel-c/tests/embedded/native/state_machine_tests.rs
@@ -52,7 +52,7 @@ fn zero_p_disabled_enables_every_rule() {
     assert_eq!(ntc.spans.len(), 1);
     assert_eq!(
         ntc.spans[0usize].label,
-        crate::HEGEL_LABEL_FEATURE_FLAG.to_string()
+        (crate::hegel_label_t::HEGEL_LABEL_FEATURE_FLAG as u64).to_string()
     );
     assert!(!ntc.spans[0usize].discarded);
 }
@@ -261,7 +261,7 @@ fn overrun_inside_is_enabled_leaves_the_span_open_until_freeze() {
     assert_eq!(ntc.spans.len(), 1);
     assert_eq!(
         ntc.spans[0usize].label,
-        crate::HEGEL_LABEL_FEATURE_FLAG.to_string()
+        (crate::hegel_label_t::HEGEL_LABEL_FEATURE_FLAG as u64).to_string()
     );
     assert_eq!(ntc.spans[0usize].start, 2);
     assert_eq!(ntc.spans[0usize].end, 2);

--- a/hegel-c/tests/smoke.rs
+++ b/hegel-c/tests/smoke.rs
@@ -119,25 +119,29 @@ enum CBackend {
     Urandom = 2,
 }
 
+type FnContextNew = unsafe extern "C" fn() -> *mut u8;
+type FnContextFree = unsafe extern "C" fn(*mut u8);
+type FnContextLastError = unsafe extern "C" fn(*const u8) -> *const c_char;
 type FnSettingsNew = unsafe extern "C" fn() -> *mut u8;
 type FnSettingsFree = unsafe extern "C" fn(*mut u8);
 type FnSettingsTestCases = unsafe extern "C" fn(*mut u8, u64);
-type FnSettingsDatabase = unsafe extern "C" fn(*mut u8, *const c_char);
-type FnSettingsDatabaseKey = unsafe extern "C" fn(*mut u8, *const c_char);
+type FnSettingsDatabase = unsafe extern "C" fn(*mut u8, *mut u8, *const c_char);
+type FnSettingsDatabaseKey = unsafe extern "C" fn(*mut u8, *mut u8, *const c_char);
 type FnSettingsSeed = unsafe extern "C" fn(*mut u8, u64, bool);
 type FnSettingsDerandomize = unsafe extern "C" fn(*mut u8, bool);
 type FnSettingsBackend = unsafe extern "C" fn(*mut u8, CBackend);
-type FnRunStart = unsafe extern "C" fn(*const u8) -> *mut u8;
-type FnNextTestCase = unsafe extern "C" fn(*mut u8) -> *mut u8;
-type FnRunResult = unsafe extern "C" fn(*mut u8) -> *const u8;
+type FnRunStart = unsafe extern "C" fn(*mut u8, *const u8) -> *mut u8;
+type FnNextTestCase = unsafe extern "C" fn(*mut u8, *mut u8) -> *mut u8;
+type FnRunResult = unsafe extern "C" fn(*mut u8, *mut u8) -> *const u8;
 type FnRunFree = unsafe extern "C" fn(*mut u8);
 type FnGenerate =
-    unsafe extern "C" fn(*mut u8, *const u8, usize, *mut *const u8, *mut usize) -> c_int;
-type FnMarkComplete = unsafe extern "C" fn(*mut u8, CStatus, *const c_char) -> c_int;
-type FnNewPool = unsafe extern "C" fn(*mut u8, *mut i64) -> c_int;
-type FnPoolAdd = unsafe extern "C" fn(*mut u8, i64, *mut i64) -> c_int;
-type FnPoolGenerate = unsafe extern "C" fn(*mut u8, i64, bool, *mut i64) -> c_int;
+    unsafe extern "C" fn(*mut u8, *mut u8, *const u8, usize, *mut *const u8, *mut usize) -> c_int;
+type FnMarkComplete = unsafe extern "C" fn(*mut u8, *mut u8, CStatus, *const c_char) -> c_int;
+type FnNewPool = unsafe extern "C" fn(*mut u8, *mut u8, *mut i64) -> c_int;
+type FnPoolAdd = unsafe extern "C" fn(*mut u8, *mut u8, i64, *mut i64) -> c_int;
+type FnPoolGenerate = unsafe extern "C" fn(*mut u8, *mut u8, i64, bool, *mut i64) -> c_int;
 type FnNewStateMachine = unsafe extern "C" fn(
+    *mut u8,
     *mut u8,
     *const *const c_char,
     usize,
@@ -145,10 +149,11 @@ type FnNewStateMachine = unsafe extern "C" fn(
     usize,
     *mut i64,
 ) -> c_int;
-type FnStateMachineNextRule = unsafe extern "C" fn(*mut u8, i64, *mut u64) -> c_int;
-type FnPrimitiveBoolean = unsafe extern "C" fn(*mut u8, f64, bool, bool, *mut bool) -> c_int;
-type FnTarget = unsafe extern "C" fn(*mut u8, f64, *const c_char) -> c_int;
-type FnCollectionMore = unsafe extern "C" fn(*mut u8, i64, *mut bool) -> c_int;
+type FnStateMachineNextRule = unsafe extern "C" fn(*mut u8, *mut u8, i64, *mut u64) -> c_int;
+type FnPrimitiveBoolean =
+    unsafe extern "C" fn(*mut u8, *mut u8, f64, bool, bool, *mut bool) -> c_int;
+type FnTarget = unsafe extern "C" fn(*mut u8, *mut u8, f64, *const c_char) -> c_int;
+type FnCollectionMore = unsafe extern "C" fn(*mut u8, *mut u8, i64, *mut bool) -> c_int;
 type FnRunResultStatus = unsafe extern "C" fn(*const u8) -> CRunStatus;
 type FnRunResultError = unsafe extern "C" fn(*const u8) -> *const c_char;
 type FnRunResultFailureCount = unsafe extern "C" fn(*const u8) -> usize;
@@ -156,13 +161,15 @@ type FnRunResultFailure = unsafe extern "C" fn(*const u8, usize) -> *const u8;
 type FnFailureOrigin = unsafe extern "C" fn(*const u8) -> *const c_char;
 type FnFailurePanicMessage = unsafe extern "C" fn(*const u8) -> *const c_char;
 type FnFailureReproduceBlob = unsafe extern "C" fn(*const u8) -> *const c_char;
-type FnTestCaseFromBlob = unsafe extern "C" fn(*const u8, *const c_char) -> *mut u8;
-type FnTestCaseFree = unsafe extern "C" fn(*mut u8);
+type FnTestCaseFromBlob = unsafe extern "C" fn(*mut u8, *const u8, *const c_char) -> *mut u8;
+type FnTestCaseFree = unsafe extern "C" fn(*mut u8, *mut u8);
 type FnTestCaseIsFinalReplay = unsafe extern "C" fn(*const u8) -> bool;
-type FnLastErrorMessage = unsafe extern "C" fn() -> *const c_char;
 
 // Bundle of the symbols we use, so the test bodies stay readable.
 struct Api<'a> {
+    context_new: Symbol<'a, FnContextNew>,
+    context_free: Symbol<'a, FnContextFree>,
+    context_last_error: Symbol<'a, FnContextLastError>,
     settings_new: Symbol<'a, FnSettingsNew>,
     settings_free: Symbol<'a, FnSettingsFree>,
     settings_test_cases: Symbol<'a, FnSettingsTestCases>,
@@ -195,12 +202,14 @@ struct Api<'a> {
     test_case_from_blob: Symbol<'a, FnTestCaseFromBlob>,
     test_case_free: Symbol<'a, FnTestCaseFree>,
     test_case_is_final_replay: Symbol<'a, FnTestCaseIsFinalReplay>,
-    last_error_message: Symbol<'a, FnLastErrorMessage>,
 }
 
 unsafe fn bind(lib: &Library) -> Api<'_> {
     unsafe {
         Api {
+            context_new: lib.get(b"hegel_context_new\0").unwrap(),
+            context_free: lib.get(b"hegel_context_free\0").unwrap(),
+            context_last_error: lib.get(b"hegel_context_last_error\0").unwrap(),
             settings_new: lib.get(b"hegel_settings_new\0").unwrap(),
             settings_free: lib.get(b"hegel_settings_free\0").unwrap(),
             settings_test_cases: lib.get(b"hegel_settings_test_cases\0").unwrap(),
@@ -233,7 +242,6 @@ unsafe fn bind(lib: &Library) -> Api<'_> {
             test_case_from_blob: lib.get(b"hegel_test_case_from_blob\0").unwrap(),
             test_case_free: lib.get(b"hegel_test_case_free\0").unwrap(),
             test_case_is_final_replay: lib.get(b"hegel_test_case_is_final_replay\0").unwrap(),
-            last_error_message: lib.get(b"hegel_last_error_message\0").unwrap(),
         }
     }
 }
@@ -283,23 +291,24 @@ fn libhegel_runs_passing_property() {
     let a = unsafe { bind(&lib) };
 
     unsafe {
+        let ctx = (a.context_new)();
         let s = (a.settings_new)();
         assert!(!s.is_null());
         (a.settings_test_cases)(s, 25);
         let empty = CString::new("").unwrap();
-        (a.settings_database)(s, empty.as_ptr());
+        (a.settings_database)(ctx, s, empty.as_ptr());
         (a.settings_derandomize)(s, true);
         (a.settings_seed)(s, 1, true);
 
-        let run = (a.run_start)(s);
+        let run = (a.run_start)(ctx, s);
         assert!(!run.is_null());
 
         let schema = integer_schema(0, 100);
         let mut cases = 0usize;
         loop {
-            let tc = (a.next_test_case)(run);
+            let tc = (a.next_test_case)(ctx, run);
             if tc.is_null() {
-                let err = CStr::from_ptr((a.last_error_message)()).to_string_lossy();
+                let err = CStr::from_ptr((a.context_last_error)(ctx)).to_string_lossy();
                 assert_eq!(err, "", "next_test_case returned NULL with error: {}", err);
                 break;
             }
@@ -308,6 +317,7 @@ fn libhegel_runs_passing_property() {
             let mut val_ptr: *const u8 = ptr::null();
             let mut val_len: usize = 0;
             let rc = (a.generate)(
+                ctx,
                 tc,
                 schema.as_ptr(),
                 schema.len(),
@@ -326,12 +336,12 @@ fn libhegel_runs_passing_property() {
                 panic!("expected integer, got {:?}", v);
             }
 
-            let mc = (a.mark_complete)(tc, CStatus::Valid, ptr::null());
+            let mc = (a.mark_complete)(ctx, tc, CStatus::Valid, ptr::null());
             assert_eq!(mc, HEGEL_OK);
         }
         assert!(cases >= 1, "expected at least one test case to run");
 
-        let result = (a.run_result)(run);
+        let result = (a.run_result)(ctx, run);
         assert!(!result.is_null(), "run_result null after drained loop");
         assert_eq!(
             (a.run_result_status)(result),
@@ -346,6 +356,7 @@ fn libhegel_runs_passing_property() {
 
         (a.run_free)(run);
         (a.settings_free)(s);
+        (a.context_free)(ctx);
     }
 }
 
@@ -359,22 +370,23 @@ fn libhegel_runs_with_urandom_backend() {
     let a = unsafe { bind(&lib) };
 
     unsafe {
+        let ctx = (a.context_new)();
         let s = (a.settings_new)();
         assert!(!s.is_null());
         (a.settings_test_cases)(s, 10);
         let empty = CString::new("").unwrap();
-        (a.settings_database)(s, empty.as_ptr());
+        (a.settings_database)(ctx, s, empty.as_ptr());
         (a.settings_backend)(s, CBackend::Urandom);
 
-        let run = (a.run_start)(s);
+        let run = (a.run_start)(ctx, s);
         assert!(!run.is_null());
 
         let schema = integer_schema(0, 100);
         let mut cases = 0usize;
         loop {
-            let tc = (a.next_test_case)(run);
+            let tc = (a.next_test_case)(ctx, run);
             if tc.is_null() {
-                let err = CStr::from_ptr((a.last_error_message)()).to_string_lossy();
+                let err = CStr::from_ptr((a.context_last_error)(ctx)).to_string_lossy();
                 assert_eq!(err, "", "next_test_case returned NULL with error: {}", err);
                 break;
             }
@@ -383,6 +395,7 @@ fn libhegel_runs_with_urandom_backend() {
             let mut val_ptr: *const u8 = ptr::null();
             let mut val_len: usize = 0;
             let rc = (a.generate)(
+                ctx,
                 tc,
                 schema.as_ptr(),
                 schema.len(),
@@ -398,17 +411,18 @@ fn libhegel_runs_with_urandom_backend() {
             let n: i128 = i.into();
             assert!((0..=100).contains(&n), "got out-of-range value {}", n);
 
-            assert_eq!((a.mark_complete)(tc, CStatus::Valid, ptr::null()), 0);
+            assert_eq!((a.mark_complete)(ctx, tc, CStatus::Valid, ptr::null()), 0);
         }
         assert!(cases >= 1, "expected at least one test case to run");
 
-        let result = (a.run_result)(run);
+        let result = (a.run_result)(ctx, run);
         assert!(!result.is_null());
         assert_eq!((a.run_result_status)(result), CRunStatus::Passed);
         assert_eq!((a.run_result_failure_count)(result), 0);
 
         (a.run_free)(run);
         (a.settings_free)(s);
+        (a.context_free)(ctx);
     }
 }
 
@@ -418,24 +432,25 @@ fn invalid_schema_returns_error_not_abort() {
     // (`{"type":"ipv4"}`) used to `panic!("Unknown schema type")` inside the
     // engine, which — crossing the `extern "C"` boundary — aborted the host
     // process (SIGABRT). It must now return HEGEL_E_INVALID_ARG with a
-    // diagnostic in hegel_last_error_message and leave the process running.
+    // diagnostic in hegel_context_last_error and leave the process running.
     // Under the `panic = "abort"` build (`just c-test-abort`) this test only
     // passes if no panic is reachable on the schema-interpretation path.
     let lib = unsafe { load() };
     let a = unsafe { bind(&lib) };
 
     unsafe {
+        let ctx = (a.context_new)();
         let s = (a.settings_new)();
         (a.settings_test_cases)(s, 1);
         let empty = CString::new("").unwrap();
-        (a.settings_database)(s, empty.as_ptr());
+        (a.settings_database)(ctx, s, empty.as_ptr());
         (a.settings_derandomize)(s, true);
         (a.settings_seed)(s, 1, true);
 
-        let run = (a.run_start)(s);
+        let run = (a.run_start)(ctx, s);
         assert!(!run.is_null());
 
-        let tc = (a.next_test_case)(run);
+        let tc = (a.next_test_case)(ctx, run);
         assert!(!tc.is_null(), "expected a test case");
 
         // Several distinct malformed schemas, each of which previously
@@ -451,21 +466,22 @@ fn invalid_schema_returns_error_not_abort() {
         for bad in [unknown_type, bad_codec] {
             let mut val_ptr: *const u8 = ptr::null();
             let mut val_len: usize = 0;
-            let rc = (a.generate)(tc, bad.as_ptr(), bad.len(), &mut val_ptr, &mut val_len);
+            let rc = (a.generate)(ctx, tc, bad.as_ptr(), bad.len(), &mut val_ptr, &mut val_len);
             assert_eq!(
                 rc, HEGEL_E_INVALID_ARG,
                 "invalid schema should return HEGEL_E_INVALID_ARG, got rc={rc}"
             );
-            let err = CStr::from_ptr((a.last_error_message)()).to_string_lossy();
+            let err = CStr::from_ptr((a.context_last_error)(ctx)).to_string_lossy();
             assert!(
                 !err.is_empty(),
                 "expected a diagnostic message for the invalid schema"
             );
         }
 
-        (a.mark_complete)(tc, CStatus::Invalid, ptr::null());
+        (a.mark_complete)(ctx, tc, CStatus::Invalid, ptr::null());
         (a.run_free)(run);
         (a.settings_free)(s);
+        (a.context_free)(ctx);
     }
 }
 
@@ -481,16 +497,17 @@ fn caller_usage_errors_return_error_not_abort() {
     let a = unsafe { bind(&lib) };
 
     unsafe {
+        let ctx = (a.context_new)();
         let s = (a.settings_new)();
         (a.settings_test_cases)(s, 1);
         let empty = CString::new("").unwrap();
-        (a.settings_database)(s, empty.as_ptr());
+        (a.settings_database)(ctx, s, empty.as_ptr());
         (a.settings_derandomize)(s, true);
         (a.settings_seed)(s, 1, true);
 
-        let run = (a.run_start)(s);
+        let run = (a.run_start)(ctx, s);
         assert!(!run.is_null());
-        let tc = (a.next_test_case)(run);
+        let tc = (a.next_test_case)(ctx, run);
         assert!(!tc.is_null(), "expected a test case");
 
         let label = CString::new("x").unwrap();
@@ -498,35 +515,39 @@ fn caller_usage_errors_return_error_not_abort() {
 
         // Non-finite score, and a label observed twice, are usage errors.
         assert_eq!(
-            (a.target)(tc, f64::NAN, label.as_ptr()),
+            (a.target)(ctx, tc, f64::NAN, label.as_ptr()),
             HEGEL_E_INVALID_ARG
         );
         assert!(
-            !CStr::from_ptr((a.last_error_message)())
+            !CStr::from_ptr((a.context_last_error)(ctx))
                 .to_bytes()
                 .is_empty()
         );
-        assert_eq!((a.target)(tc, 1.0, dup.as_ptr()), HEGEL_OK);
-        assert_eq!((a.target)(tc, 2.0, dup.as_ptr()), HEGEL_E_INVALID_ARG);
+        assert_eq!((a.target)(ctx, tc, 1.0, dup.as_ptr()), HEGEL_OK);
+        assert_eq!((a.target)(ctx, tc, 2.0, dup.as_ptr()), HEGEL_E_INVALID_ARG);
 
         // Opaque handle ids that were never issued: unknown collection (map
         // lookup), unknown pool / state machine (Vec bounds check).
         let mut more = false;
         assert_eq!(
-            (a.collection_more)(tc, 9999, &mut more),
+            (a.collection_more)(ctx, tc, 9999, &mut more),
             HEGEL_E_INVALID_ARG
         );
         let mut var_id = 0i64;
-        assert_eq!((a.pool_add)(tc, 9999, &mut var_id), HEGEL_E_INVALID_ARG);
+        assert_eq!(
+            (a.pool_add)(ctx, tc, 9999, &mut var_id),
+            HEGEL_E_INVALID_ARG
+        );
         let mut rule_idx = 0u64;
         assert_eq!(
-            (a.state_machine_next_rule)(tc, 9999, &mut rule_idx),
+            (a.state_machine_next_rule)(ctx, tc, 9999, &mut rule_idx),
             HEGEL_E_INVALID_ARG
         );
 
-        (a.mark_complete)(tc, CStatus::Valid, ptr::null());
+        (a.mark_complete)(ctx, tc, CStatus::Valid, ptr::null());
         (a.run_free)(run);
         (a.settings_free)(s);
+        (a.context_free)(ctx);
     }
 }
 
@@ -536,21 +557,22 @@ fn libhegel_reports_shrunk_failure() {
     let a = unsafe { bind(&lib) };
 
     unsafe {
+        let ctx = (a.context_new)();
         let s = (a.settings_new)();
         (a.settings_test_cases)(s, 200);
         let empty = CString::new("").unwrap();
-        (a.settings_database)(s, empty.as_ptr());
+        (a.settings_database)(ctx, s, empty.as_ptr());
         (a.settings_derandomize)(s, true);
         (a.settings_seed)(s, 0xc0ffee, true);
 
-        let run = (a.run_start)(s);
+        let run = (a.run_start)(ctx, s);
         let schema = integer_schema(0, 100);
         let origin = CString::new("n >= 5 failed").unwrap();
 
         loop {
-            let tc = (a.next_test_case)(run);
+            let tc = (a.next_test_case)(ctx, run);
             if tc.is_null() {
-                let err = CStr::from_ptr((a.last_error_message)()).to_string_lossy();
+                let err = CStr::from_ptr((a.context_last_error)(ctx)).to_string_lossy();
                 assert_eq!(err, "", "got error mid-loop: {}", err);
                 break;
             }
@@ -558,6 +580,7 @@ fn libhegel_reports_shrunk_failure() {
             let mut val_ptr: *const u8 = ptr::null();
             let mut val_len: usize = 0;
             let rc = (a.generate)(
+                ctx,
                 tc,
                 schema.as_ptr(),
                 schema.len(),
@@ -566,7 +589,7 @@ fn libhegel_reports_shrunk_failure() {
             );
             if rc == HEGEL_E_STOP_TEST {
                 // HEGEL_E_STOP_TEST — engine exhausted during a shrink probe.
-                (a.mark_complete)(tc, CStatus::Overrun, ptr::null());
+                (a.mark_complete)(ctx, tc, CStatus::Overrun, ptr::null());
                 continue;
             }
             assert_eq!(rc, HEGEL_OK, "unexpected generate rc={}", rc);
@@ -587,10 +610,10 @@ fn libhegel_reports_shrunk_failure() {
             } else {
                 ptr::null()
             };
-            (a.mark_complete)(tc, status, origin_ptr);
+            (a.mark_complete)(ctx, tc, status, origin_ptr);
         }
 
-        let result = (a.run_result)(run);
+        let result = (a.run_result)(ctx, run);
         assert!(!result.is_null());
         assert_eq!(
             (a.run_result_status)(result),
@@ -619,16 +642,17 @@ fn libhegel_reports_shrunk_failure() {
 
         (a.run_free)(run);
         (a.settings_free)(s);
+        (a.context_free)(ctx);
     }
 }
 
 /// Drive the `n < 5` failing property to completion. Shared by the
 /// blob tests below, which read the reproduce blob off the run result.
-unsafe fn drive_failing_property(a: &Api, run: *mut u8) {
+unsafe fn drive_failing_property(a: &Api, ctx: *mut u8, run: *mut u8) {
     let schema = integer_schema(0, 100);
     let origin = CString::new("n >= 5 failed").unwrap();
     loop {
-        let tc = unsafe { (a.next_test_case)(run) };
+        let tc = unsafe { (a.next_test_case)(ctx, run) };
         if tc.is_null() {
             break;
         }
@@ -636,6 +660,7 @@ unsafe fn drive_failing_property(a: &Api, run: *mut u8) {
         let mut val_len: usize = 0;
         let rc = unsafe {
             (a.generate)(
+                ctx,
                 tc,
                 schema.as_ptr(),
                 schema.len(),
@@ -644,7 +669,7 @@ unsafe fn drive_failing_property(a: &Api, run: *mut u8) {
             )
         };
         if rc == HEGEL_E_STOP_TEST {
-            unsafe { (a.mark_complete)(tc, CStatus::Overrun, ptr::null()) };
+            unsafe { (a.mark_complete)(ctx, tc, CStatus::Overrun, ptr::null()) };
             continue;
         }
         assert_eq!(rc, HEGEL_OK, "unexpected generate rc={}", rc);
@@ -654,28 +679,28 @@ unsafe fn drive_failing_property(a: &Api, run: *mut u8) {
         };
         let n: i128 = i.into();
         if n < 5 {
-            unsafe { (a.mark_complete)(tc, CStatus::Valid, ptr::null()) };
+            unsafe { (a.mark_complete)(ctx, tc, CStatus::Valid, ptr::null()) };
         } else {
-            unsafe { (a.mark_complete)(tc, CStatus::Interesting, origin.as_ptr()) };
+            unsafe { (a.mark_complete)(ctx, tc, CStatus::Interesting, origin.as_ptr()) };
         }
     }
 }
 
 /// Run the `n < 5` failing property once and return the reproduce blob of
 /// its first failure. Shared by the blob-replay tests below.
-unsafe fn discover_failure_blob(a: &Api) -> CString {
+unsafe fn discover_failure_blob(a: &Api, ctx: *mut u8) -> CString {
     unsafe {
         let s = (a.settings_new)();
         (a.settings_test_cases)(s, 200);
         let empty = CString::new("").unwrap();
-        (a.settings_database)(s, empty.as_ptr());
+        (a.settings_database)(ctx, s, empty.as_ptr());
         (a.settings_derandomize)(s, true);
         (a.settings_seed)(s, 0xc0ffee, true);
 
-        let run = (a.run_start)(s);
-        drive_failing_property(a, run);
+        let run = (a.run_start)(ctx, s);
+        drive_failing_property(a, ctx, run);
 
-        let result = (a.run_result)(run);
+        let result = (a.run_result)(ctx, run);
         assert_eq!(
             (a.run_result_status)(result),
             CRunStatus::Failed,
@@ -699,13 +724,13 @@ unsafe fn discover_failure_blob(a: &Api) -> CString {
 /// Replay `blob` as one standalone test case and return the single drawn
 /// integer of the `n < 5` property, marking the case Interesting/Valid as
 /// the property dictates and freeing the handle.
-unsafe fn replay_blob_once(a: &Api, s: *const u8, blob: &CStr) -> i128 {
+unsafe fn replay_blob_once(a: &Api, ctx: *mut u8, s: *const u8, blob: &CStr) -> i128 {
     unsafe {
-        let tc = (a.test_case_from_blob)(s, blob.as_ptr());
+        let tc = (a.test_case_from_blob)(ctx, s, blob.as_ptr());
         assert!(
             !tc.is_null(),
             "hegel_test_case_from_blob failed: {}",
-            CStr::from_ptr((a.last_error_message)()).to_string_lossy()
+            CStr::from_ptr((a.context_last_error)(ctx)).to_string_lossy()
         );
         assert!(
             (a.test_case_is_final_replay)(tc),
@@ -716,6 +741,7 @@ unsafe fn replay_blob_once(a: &Api, s: *const u8, blob: &CStr) -> i128 {
         let mut val_ptr: *const u8 = ptr::null();
         let mut val_len: usize = 0;
         let rc = (a.generate)(
+            ctx,
             tc,
             schema.as_ptr(),
             schema.len(),
@@ -730,12 +756,12 @@ unsafe fn replay_blob_once(a: &Api, s: *const u8, blob: &CStr) -> i128 {
         // The caller plays the property's role: it alone decides whether
         // the replayed example still fails.
         if n < 5 {
-            (a.mark_complete)(tc, CStatus::Valid, ptr::null());
+            (a.mark_complete)(ctx, tc, CStatus::Valid, ptr::null());
         } else {
             let origin = CString::new("n >= 5 failed").unwrap();
-            (a.mark_complete)(tc, CStatus::Interesting, origin.as_ptr());
+            (a.mark_complete)(ctx, tc, CStatus::Interesting, origin.as_ptr());
         }
-        (a.test_case_free)(tc);
+        (a.test_case_free)(ctx, tc);
         n
     }
 }
@@ -746,20 +772,22 @@ fn libhegel_blob_test_case_replays_the_counterexample() {
     let a = unsafe { bind(&lib) };
 
     unsafe {
-        let blob = discover_failure_blob(&a);
+        let ctx = (a.context_new)();
+        let blob = discover_failure_blob(&a, ctx);
 
         // Replay the blob as standalone test cases — no run handle, no
         // worker. Replaying twice exercises the multiple-reproduce_failures
         // usage: one call per blob, each its own test case.
         let s = (a.settings_new)();
-        let first = replay_blob_once(&a, s, &blob);
+        let first = replay_blob_once(&a, ctx, s, &blob);
         assert!(
             first >= 5,
             "replayed value {first} should still violate the n < 5 property"
         );
-        let second = replay_blob_once(&a, s, &blob);
+        let second = replay_blob_once(&a, ctx, s, &blob);
         assert_eq!(first, second, "blob replay must be deterministic");
         (a.settings_free)(s);
+        (a.context_free)(ctx);
     }
 }
 
@@ -769,28 +797,30 @@ fn libhegel_test_case_from_blob_rejects_bad_input() {
     let a = unsafe { bind(&lib) };
 
     unsafe {
+        let ctx = (a.context_new)();
         let s = (a.settings_new)();
 
         // An undecodable blob: NULL with a diagnostic.
         let garbage = CString::new("!!! not a blob !!!").unwrap();
-        let tc = (a.test_case_from_blob)(s, garbage.as_ptr());
+        let tc = (a.test_case_from_blob)(ctx, s, garbage.as_ptr());
         assert!(tc.is_null());
-        let err = CStr::from_ptr((a.last_error_message)()).to_string_lossy();
+        let err = CStr::from_ptr((a.context_last_error)(ctx)).to_string_lossy();
         assert!(
             err.contains("could not be decoded"),
             "unexpected error: {err}"
         );
 
         // NULL blob and NULL settings: NULL with a diagnostic.
-        let tc = (a.test_case_from_blob)(s, ptr::null());
+        let tc = (a.test_case_from_blob)(ctx, s, ptr::null());
         assert!(tc.is_null());
-        assert!(!CStr::from_ptr((a.last_error_message)()).is_empty());
+        assert!(!CStr::from_ptr((a.context_last_error)(ctx)).is_empty());
         let blob = CString::new("AAEC").unwrap();
-        let tc = (a.test_case_from_blob)(ptr::null(), blob.as_ptr());
+        let tc = (a.test_case_from_blob)(ctx, ptr::null(), blob.as_ptr());
         assert!(tc.is_null());
-        assert!(!CStr::from_ptr((a.last_error_message)()).is_empty());
+        assert!(!CStr::from_ptr((a.context_last_error)(ctx)).is_empty());
 
         (a.settings_free)(s);
+        (a.context_free)(ctx);
     }
 }
 
@@ -800,30 +830,32 @@ fn libhegel_test_case_free_refuses_run_owned_test_cases() {
     let a = unsafe { bind(&lib) };
 
     unsafe {
+        let ctx = (a.context_new)();
         // Freeing NULL is a no-op.
-        (a.test_case_free)(ptr::null_mut());
+        (a.test_case_free)(ctx, ptr::null_mut());
 
         let s = (a.settings_new)();
         (a.settings_test_cases)(s, 1);
         let empty = CString::new("").unwrap();
-        (a.settings_database)(s, empty.as_ptr());
-        let run = (a.run_start)(s);
+        (a.settings_database)(ctx, s, empty.as_ptr());
+        let run = (a.run_start)(ctx, s);
 
         // A test case pumped from a run is owned by the run: freeing it
         // must be refused, leaving the handle usable.
-        let tc = (a.next_test_case)(run);
+        let tc = (a.next_test_case)(ctx, run);
         assert!(!tc.is_null());
-        (a.test_case_free)(tc);
-        let err = CStr::from_ptr((a.last_error_message)()).to_string_lossy();
+        (a.test_case_free)(ctx, tc);
+        let err = CStr::from_ptr((a.context_last_error)(ctx)).to_string_lossy();
         assert!(
             err.contains("owned by its hegel_run_t"),
             "unexpected error: {err}"
         );
         // Still usable after the refused free.
-        assert_eq!((a.mark_complete)(tc, CStatus::Valid, ptr::null()), 0);
+        assert_eq!((a.mark_complete)(ctx, tc, CStatus::Valid, ptr::null()), 0);
 
         (a.run_free)(run);
         (a.settings_free)(s);
+        (a.context_free)(ctx);
     }
 }
 
@@ -833,35 +865,36 @@ fn libhegel_pool_primitives_draw_added_variables() {
     let a = unsafe { bind(&lib) };
 
     unsafe {
+        let ctx = (a.context_new)();
         let s = (a.settings_new)();
         (a.settings_test_cases)(s, 25);
         let empty = CString::new("").unwrap();
-        (a.settings_database)(s, empty.as_ptr());
+        (a.settings_database)(ctx, s, empty.as_ptr());
         (a.settings_derandomize)(s, true);
         (a.settings_seed)(s, 3, true);
 
-        let run = (a.run_start)(s);
+        let run = (a.run_start)(ctx, s);
         assert!(!run.is_null());
 
         let mut saw_pool_draw = false;
         let mut saw_empty_reject = false;
         loop {
-            let tc = (a.next_test_case)(run);
+            let tc = (a.next_test_case)(ctx, run);
             if tc.is_null() {
-                let err = CStr::from_ptr((a.last_error_message)()).to_string_lossy();
+                let err = CStr::from_ptr((a.context_last_error)(ctx)).to_string_lossy();
                 assert_eq!(err, "", "next_test_case returned NULL with error: {}", err);
                 break;
             }
 
             // Build a pool and register three variables.
             let mut pool_id: i64 = -1;
-            let rc = (a.new_pool)(tc, &mut pool_id);
+            let rc = (a.new_pool)(ctx, tc, &mut pool_id);
             assert_eq!(rc, HEGEL_OK, "new_pool failed: rc={}", rc);
 
             let mut added = Vec::new();
             for _ in 0..3 {
                 let mut var_id: i64 = -1;
-                let rc = (a.pool_add)(tc, pool_id, &mut var_id);
+                let rc = (a.pool_add)(ctx, tc, pool_id, &mut var_id);
                 assert_eq!(rc, HEGEL_OK, "pool_add failed: rc={}", rc);
                 added.push(var_id);
             }
@@ -873,9 +906,9 @@ fn libhegel_pool_primitives_draw_added_variables() {
             // the engine's choice budget is exhausted mid-shrink, so treat
             // that the same way the other primitives do.
             let mut drawn: i64 = -1;
-            let rc = (a.pool_generate)(tc, pool_id, false, &mut drawn);
+            let rc = (a.pool_generate)(ctx, tc, pool_id, false, &mut drawn);
             if rc == HEGEL_E_STOP_TEST {
-                (a.mark_complete)(tc, CStatus::Overrun, ptr::null());
+                (a.mark_complete)(ctx, tc, CStatus::Overrun, ptr::null());
                 continue;
             }
             assert_eq!(rc, HEGEL_OK, "pool_generate failed: rc={}", rc);
@@ -890,7 +923,7 @@ fn libhegel_pool_primitives_draw_added_variables() {
             let mut consumed = 0;
             for _ in 0..3 {
                 let mut v: i64 = -1;
-                let rc = (a.pool_generate)(tc, pool_id, true, &mut v);
+                let rc = (a.pool_generate)(ctx, tc, pool_id, true, &mut v);
                 if rc == HEGEL_E_STOP_TEST {
                     break;
                 }
@@ -900,7 +933,7 @@ fn libhegel_pool_primitives_draw_added_variables() {
             }
             if consumed == 3 {
                 let mut v: i64 = -1;
-                let rc = (a.pool_generate)(tc, pool_id, true, &mut v);
+                let rc = (a.pool_generate)(ctx, tc, pool_id, true, &mut v);
                 assert_eq!(
                     rc, HEGEL_E_ASSUME,
                     "expected HEGEL_E_ASSUME on empty pool, got rc={}",
@@ -909,7 +942,7 @@ fn libhegel_pool_primitives_draw_added_variables() {
                 saw_empty_reject = true;
             }
 
-            (a.mark_complete)(tc, CStatus::Valid, ptr::null());
+            (a.mark_complete)(ctx, tc, CStatus::Valid, ptr::null());
         }
 
         assert!(saw_pool_draw, "expected at least one successful pool draw");
@@ -918,7 +951,7 @@ fn libhegel_pool_primitives_draw_added_variables() {
             "expected to drain a pool to empty at least once"
         );
 
-        let result = (a.run_result)(run);
+        let result = (a.run_result)(ctx, run);
         assert!(!result.is_null());
         assert_eq!(
             (a.run_result_status)(result),
@@ -928,6 +961,7 @@ fn libhegel_pool_primitives_draw_added_variables() {
 
         (a.run_free)(run);
         (a.settings_free)(s);
+        (a.context_free)(ctx);
     }
 }
 
@@ -937,14 +971,15 @@ fn libhegel_state_machine_selects_registered_rules_with_swarm() {
     let a = unsafe { bind(&lib) };
 
     unsafe {
+        let ctx = (a.context_new)();
         let s = (a.settings_new)();
         (a.settings_test_cases)(s, 50);
         let empty = CString::new("").unwrap();
-        (a.settings_database)(s, empty.as_ptr());
+        (a.settings_database)(ctx, s, empty.as_ptr());
         (a.settings_derandomize)(s, true);
         (a.settings_seed)(s, 3, true);
 
-        let run = (a.run_start)(s);
+        let run = (a.run_start)(ctx, s);
         assert!(!run.is_null());
 
         let rule_names: Vec<CString> = ["push", "pop", "clear"]
@@ -958,9 +993,9 @@ fn libhegel_state_machine_selects_registered_rules_with_swarm() {
         let mut saw_rule_draw = false;
         let mut longest_single_rule_run = 0usize;
         loop {
-            let tc = (a.next_test_case)(run);
+            let tc = (a.next_test_case)(ctx, run);
             if tc.is_null() {
-                let err = CStr::from_ptr((a.last_error_message)()).to_string_lossy();
+                let err = CStr::from_ptr((a.context_last_error)(ctx)).to_string_lossy();
                 assert_eq!(err, "", "next_test_case returned NULL with error: {}", err);
                 break;
             }
@@ -969,6 +1004,7 @@ fn libhegel_state_machine_selects_registered_rules_with_swarm() {
             // and must leave the test case usable.
             let mut machine_id: i64 = -1;
             let rc = (a.new_state_machine)(
+                ctx,
                 tc,
                 ptr::null(),
                 0,
@@ -983,6 +1019,7 @@ fn libhegel_state_machine_selects_registered_rules_with_swarm() {
             );
 
             let rc = (a.new_state_machine)(
+                ctx,
                 tc,
                 rule_ptrs.as_ptr(),
                 rule_ptrs.len(),
@@ -1001,7 +1038,7 @@ fn libhegel_state_machine_selects_registered_rules_with_swarm() {
             let mut previous: Option<u64> = None;
             for _ in 0..25 {
                 let mut index: u64 = u64::MAX;
-                let rc = (a.state_machine_next_rule)(tc, machine_id, &mut index);
+                let rc = (a.state_machine_next_rule)(ctx, tc, machine_id, &mut index);
                 if rc == HEGEL_E_STOP_TEST {
                     // HEGEL_E_STOP_TEST — engine exhausted during a shrink
                     // probe.
@@ -1021,9 +1058,9 @@ fn libhegel_state_machine_selects_registered_rules_with_swarm() {
             }
 
             if overran {
-                (a.mark_complete)(tc, CStatus::Overrun, ptr::null());
+                (a.mark_complete)(ctx, tc, CStatus::Overrun, ptr::null());
             } else {
-                (a.mark_complete)(tc, CStatus::Valid, ptr::null());
+                (a.mark_complete)(ctx, tc, CStatus::Valid, ptr::null());
             }
         }
 
@@ -1039,7 +1076,7 @@ fn libhegel_state_machine_selects_registered_rules_with_swarm() {
             longest_single_rule_run
         );
 
-        let result = (a.run_result)(run);
+        let result = (a.run_result)(ctx, run);
         assert!(!result.is_null());
         assert_eq!(
             (a.run_result_status)(result),
@@ -1049,6 +1086,7 @@ fn libhegel_state_machine_selects_registered_rules_with_swarm() {
 
         (a.run_free)(run);
         (a.settings_free)(s);
+        (a.context_free)(ctx);
     }
 }
 
@@ -1058,40 +1096,41 @@ fn libhegel_primitive_boolean_draws_and_forces() {
     let a = unsafe { bind(&lib) };
 
     unsafe {
+        let ctx = (a.context_new)();
         let s = (a.settings_new)();
         (a.settings_test_cases)(s, 50);
         let empty = CString::new("").unwrap();
-        (a.settings_database)(s, empty.as_ptr());
+        (a.settings_database)(ctx, s, empty.as_ptr());
         (a.settings_derandomize)(s, true);
         (a.settings_seed)(s, 11, true);
 
-        let run = (a.run_start)(s);
+        let run = (a.run_start)(ctx, s);
         assert!(!run.is_null());
 
         let mut saw_true = false;
         let mut saw_false = false;
         loop {
-            let tc = (a.next_test_case)(run);
+            let tc = (a.next_test_case)(ctx, run);
             if tc.is_null() {
-                let err = CStr::from_ptr((a.last_error_message)()).to_string_lossy();
+                let err = CStr::from_ptr((a.context_last_error)(ctx)).to_string_lossy();
                 assert_eq!(err, "", "next_test_case returned NULL with error: {}", err);
                 break;
             }
 
             // Forced draws are deterministic regardless of p.
             let mut v = false;
-            let rc = (a.primitive_boolean)(tc, 0.5, true, true, &mut v);
+            let rc = (a.primitive_boolean)(ctx, tc, 0.5, true, true, &mut v);
             assert_eq!(rc, HEGEL_OK, "forced-true draw failed: rc={}", rc);
             assert!(v);
-            let rc = (a.primitive_boolean)(tc, 0.5, false, true, &mut v);
+            let rc = (a.primitive_boolean)(ctx, tc, 0.5, false, true, &mut v);
             assert_eq!(rc, HEGEL_OK, "forced-false draw failed: rc={}", rc);
             assert!(!v);
 
             // Boundary probabilities auto-force without consuming entropy.
-            let rc = (a.primitive_boolean)(tc, 0.0, false, false, &mut v);
+            let rc = (a.primitive_boolean)(ctx, tc, 0.0, false, false, &mut v);
             assert_eq!(rc, HEGEL_OK, "p=0 draw failed: rc={}", rc);
             assert!(!v);
-            let rc = (a.primitive_boolean)(tc, 1.0, false, false, &mut v);
+            let rc = (a.primitive_boolean)(ctx, tc, 1.0, false, false, &mut v);
             assert_eq!(rc, HEGEL_OK, "p=1 draw failed: rc={}", rc);
             assert!(v);
 
@@ -1099,9 +1138,9 @@ fn libhegel_primitive_boolean_draws_and_forces() {
             // run. The draw can report STOP_TEST if the engine's choice
             // budget is exhausted mid-shrink, so treat that the same way the
             // other primitives do.
-            let rc = (a.primitive_boolean)(tc, 0.5, false, false, &mut v);
+            let rc = (a.primitive_boolean)(ctx, tc, 0.5, false, false, &mut v);
             if rc == HEGEL_E_STOP_TEST {
-                (a.mark_complete)(tc, CStatus::Overrun, ptr::null());
+                (a.mark_complete)(ctx, tc, CStatus::Overrun, ptr::null());
                 continue;
             }
             assert_eq!(rc, HEGEL_OK, "unforced draw failed: rc={}", rc);
@@ -1111,13 +1150,13 @@ fn libhegel_primitive_boolean_draws_and_forces() {
                 saw_false = true;
             }
 
-            (a.mark_complete)(tc, CStatus::Valid, ptr::null());
+            (a.mark_complete)(ctx, tc, CStatus::Valid, ptr::null());
         }
 
         assert!(saw_true, "expected an unforced draw to come up true");
         assert!(saw_false, "expected an unforced draw to come up false");
 
-        let result = (a.run_result)(run);
+        let result = (a.run_result)(ctx, run);
         assert!(!result.is_null());
         assert_eq!(
             (a.run_result_status)(result),
@@ -1127,6 +1166,7 @@ fn libhegel_primitive_boolean_draws_and_forces() {
 
         (a.run_free)(run);
         (a.settings_free)(s);
+        (a.context_free)(ctx);
     }
 }
 
@@ -1136,17 +1176,18 @@ fn libhegel_primitive_boolean_rejects_invalid_arguments() {
     let a = unsafe { bind(&lib) };
 
     unsafe {
+        let ctx = (a.context_new)();
         let s = (a.settings_new)();
         (a.settings_test_cases)(s, 1);
         let empty = CString::new("").unwrap();
-        (a.settings_database)(s, empty.as_ptr());
+        (a.settings_database)(ctx, s, empty.as_ptr());
 
-        let run = (a.run_start)(s);
+        let run = (a.run_start)(ctx, s);
         assert!(!run.is_null());
 
         let mut saw_test_case = false;
         loop {
-            let tc = (a.next_test_case)(run);
+            let tc = (a.next_test_case)(ctx, run);
             if tc.is_null() {
                 break;
             }
@@ -1154,7 +1195,7 @@ fn libhegel_primitive_boolean_rejects_invalid_arguments() {
 
             // NULL test-case handle is reported as HEGEL_E_INVALID_HANDLE.
             let mut v = false;
-            let rc = (a.primitive_boolean)(ptr::null_mut(), 0.5, false, false, &mut v);
+            let rc = (a.primitive_boolean)(ctx, ptr::null_mut(), 0.5, false, false, &mut v);
             assert_eq!(
                 rc, HEGEL_E_INVALID_HANDLE,
                 "expected HEGEL_E_INVALID_HANDLE, got rc={}",
@@ -1162,7 +1203,7 @@ fn libhegel_primitive_boolean_rejects_invalid_arguments() {
             );
 
             // Each rejected argument returns HEGEL_E_INVALID_ARG with a
-            // diagnostic in last_error_message.
+            // diagnostic in context_last_error.
             let invalid: [(f64, bool, bool); 5] = [
                 (f64::NAN, false, false), // p must not be NaN
                 (-0.5, false, false),     // p below range
@@ -1171,18 +1212,18 @@ fn libhegel_primitive_boolean_rejects_invalid_arguments() {
                 (1.0, false, true),       // cannot force false when p = 1
             ];
             for (p, forced, has_forced) in invalid {
-                let rc = (a.primitive_boolean)(tc, p, forced, has_forced, &mut v);
+                let rc = (a.primitive_boolean)(ctx, tc, p, forced, has_forced, &mut v);
                 assert_eq!(
                     rc, HEGEL_E_INVALID_ARG,
                     "expected HEGEL_E_INVALID_ARG for p={}, forced={}, has_forced={}",
                     p, forced, has_forced
                 );
-                let err = CStr::from_ptr((a.last_error_message)()).to_string_lossy();
+                let err = CStr::from_ptr((a.context_last_error)(ctx)).to_string_lossy();
                 assert!(!err.is_empty(), "expected a diagnostic message");
             }
 
             // NULL out pointer.
-            let rc = (a.primitive_boolean)(tc, 0.5, false, false, ptr::null_mut());
+            let rc = (a.primitive_boolean)(ctx, tc, 0.5, false, false, ptr::null_mut());
             assert_eq!(
                 rc, HEGEL_E_INVALID_ARG,
                 "expected HEGEL_E_INVALID_ARG for null out"
@@ -1190,18 +1231,18 @@ fn libhegel_primitive_boolean_rejects_invalid_arguments() {
 
             // Argument errors do not poison the test case: a valid draw
             // afterwards still succeeds.
-            let rc = (a.primitive_boolean)(tc, 0.5, false, false, &mut v);
+            let rc = (a.primitive_boolean)(ctx, tc, 0.5, false, false, &mut v);
             assert_eq!(
                 rc, HEGEL_OK,
                 "valid draw after rejections failed: rc={}",
                 rc
             );
 
-            (a.mark_complete)(tc, CStatus::Valid, ptr::null());
+            (a.mark_complete)(ctx, tc, CStatus::Valid, ptr::null());
         }
         assert!(saw_test_case, "expected the run to produce a test case");
 
-        let result = (a.run_result)(run);
+        let result = (a.run_result)(ctx, run);
         assert!(!result.is_null());
         assert_eq!(
             (a.run_result_status)(result),
@@ -1211,6 +1252,7 @@ fn libhegel_primitive_boolean_rejects_invalid_arguments() {
 
         (a.run_free)(run);
         (a.settings_free)(s);
+        (a.context_free)(ctx);
     }
 }
 
@@ -1220,36 +1262,38 @@ fn next_test_case_without_mark_complete_errors() {
     let a = unsafe { bind(&lib) };
 
     unsafe {
+        let ctx = (a.context_new)();
         let s = (a.settings_new)();
         (a.settings_test_cases)(s, 5);
         let empty = CString::new("").unwrap();
-        (a.settings_database)(s, empty.as_ptr());
+        (a.settings_database)(ctx, s, empty.as_ptr());
         (a.settings_derandomize)(s, true);
         (a.settings_seed)(s, 7, true);
 
-        let run = (a.run_start)(s);
-        let tc1 = (a.next_test_case)(run);
+        let run = (a.run_start)(ctx, s);
+        let tc1 = (a.next_test_case)(ctx, run);
         assert!(!tc1.is_null());
         // Deliberately skip mark_complete.
-        let tc2 = (a.next_test_case)(run);
+        let tc2 = (a.next_test_case)(ctx, run);
         assert!(tc2.is_null(), "expected NULL on second next_test_case");
-        let err = CStr::from_ptr((a.last_error_message)())
+        let err = CStr::from_ptr((a.context_last_error)(ctx))
             .to_string_lossy()
             .into_owned();
         assert!(err.contains("not marked complete"), "got: {}", err);
 
         // Now mark first complete and let the loop drain so run_free is clean.
-        (a.mark_complete)(tc1, CStatus::Valid, ptr::null());
+        (a.mark_complete)(ctx, tc1, CStatus::Valid, ptr::null());
         loop {
-            let tc = (a.next_test_case)(run);
+            let tc = (a.next_test_case)(ctx, run);
             if tc.is_null() {
                 break;
             }
-            (a.mark_complete)(tc, CStatus::Valid, ptr::null());
+            (a.mark_complete)(ctx, tc, CStatus::Valid, ptr::null());
         }
 
         (a.run_free)(run);
         (a.settings_free)(s);
+        (a.context_free)(ctx);
     }
 }
 
@@ -1259,18 +1303,20 @@ fn run_free_after_early_exit_does_not_hang() {
     let a = unsafe { bind(&lib) };
 
     unsafe {
+        let ctx = (a.context_new)();
         let s = (a.settings_new)();
         (a.settings_test_cases)(s, 100);
         let empty = CString::new("").unwrap();
-        (a.settings_database)(s, empty.as_ptr());
+        (a.settings_database)(ctx, s, empty.as_ptr());
         (a.settings_derandomize)(s, true);
         (a.settings_seed)(s, 99, true);
 
-        let run = (a.run_start)(s);
+        let run = (a.run_start)(ctx, s);
         // Grab one test case, don't complete it, jump straight to free.
-        let _ = (a.next_test_case)(run);
+        let _ = (a.next_test_case)(ctx, run);
         (a.run_free)(run);
         (a.settings_free)(s);
+        (a.context_free)(ctx);
         // Reaching here without deadlocking is the assertion.
     }
 }
@@ -1296,22 +1342,24 @@ fn libhegel_replays_persisted_failure_with_same_database_key() {
     // ---- run 1 ----
     let mut last_failure: Option<i128> = None;
     unsafe {
+        let ctx = (a.context_new)();
         let s = (a.settings_new)();
         (a.settings_test_cases)(s, 200);
-        (a.settings_database)(s, db_path.as_ptr());
-        (a.settings_database_key)(s, key.as_ptr());
+        (a.settings_database)(ctx, s, db_path.as_ptr());
+        (a.settings_database_key)(ctx, s, key.as_ptr());
         (a.settings_derandomize)(s, true);
         (a.settings_seed)(s, 1, true);
 
-        let run = (a.run_start)(s);
+        let run = (a.run_start)(ctx, s);
         loop {
-            let tc = (a.next_test_case)(run);
+            let tc = (a.next_test_case)(ctx, run);
             if tc.is_null() {
                 break;
             }
             let mut val_ptr: *const u8 = ptr::null();
             let mut val_len: usize = 0;
             let rc = (a.generate)(
+                ctx,
                 tc,
                 schema.as_ptr(),
                 schema.len(),
@@ -1319,7 +1367,7 @@ fn libhegel_replays_persisted_failure_with_same_database_key() {
                 &mut val_len,
             );
             if rc == HEGEL_E_STOP_TEST {
-                (a.mark_complete)(tc, CStatus::Overrun, ptr::null());
+                (a.mark_complete)(ctx, tc, CStatus::Overrun, ptr::null());
                 continue;
             }
             assert_eq!(rc, HEGEL_OK);
@@ -1331,35 +1379,38 @@ fn libhegel_replays_persisted_failure_with_same_database_key() {
             if predicate(n) {
                 last_failure = Some(n);
                 let origin = CString::new("n >= 1_000_000").unwrap();
-                (a.mark_complete)(tc, CStatus::Interesting, origin.as_ptr());
+                (a.mark_complete)(ctx, tc, CStatus::Interesting, origin.as_ptr());
             } else {
-                (a.mark_complete)(tc, CStatus::Valid, ptr::null());
+                (a.mark_complete)(ctx, tc, CStatus::Valid, ptr::null());
             }
         }
         (a.run_free)(run);
         (a.settings_free)(s);
+        (a.context_free)(ctx);
     }
     assert!(last_failure.is_some(), "run 1 never observed the failure");
 
     // ---- run 2: same key + same db, expect replay first ----
     let mut first_seen: Option<i128> = None;
     unsafe {
+        let ctx = (a.context_new)();
         let s = (a.settings_new)();
         (a.settings_test_cases)(s, 200);
-        (a.settings_database)(s, db_path.as_ptr());
-        (a.settings_database_key)(s, key.as_ptr());
+        (a.settings_database)(ctx, s, db_path.as_ptr());
+        (a.settings_database_key)(ctx, s, key.as_ptr());
         (a.settings_derandomize)(s, true);
         (a.settings_seed)(s, 1, true);
 
-        let run = (a.run_start)(s);
+        let run = (a.run_start)(ctx, s);
         loop {
-            let tc = (a.next_test_case)(run);
+            let tc = (a.next_test_case)(ctx, run);
             if tc.is_null() {
                 break;
             }
             let mut val_ptr: *const u8 = ptr::null();
             let mut val_len: usize = 0;
             let rc = (a.generate)(
+                ctx,
                 tc,
                 schema.as_ptr(),
                 schema.len(),
@@ -1367,7 +1418,7 @@ fn libhegel_replays_persisted_failure_with_same_database_key() {
                 &mut val_len,
             );
             if rc == HEGEL_E_STOP_TEST {
-                (a.mark_complete)(tc, CStatus::Overrun, ptr::null());
+                (a.mark_complete)(ctx, tc, CStatus::Overrun, ptr::null());
                 continue;
             }
             assert_eq!(rc, HEGEL_OK);
@@ -1381,13 +1432,14 @@ fn libhegel_replays_persisted_failure_with_same_database_key() {
             }
             if predicate(n) {
                 let origin = CString::new("n >= 1_000_000").unwrap();
-                (a.mark_complete)(tc, CStatus::Interesting, origin.as_ptr());
+                (a.mark_complete)(ctx, tc, CStatus::Interesting, origin.as_ptr());
             } else {
-                (a.mark_complete)(tc, CStatus::Valid, ptr::null());
+                (a.mark_complete)(ctx, tc, CStatus::Valid, ptr::null());
             }
         }
         (a.run_free)(run);
         (a.settings_free)(s);
+        (a.context_free)(ctx);
     }
 
     let first = first_seen.expect("run 2 never received a test case");
@@ -1410,26 +1462,28 @@ fn health_check_surfaces_as_run_error() {
     let a = unsafe { bind(&lib) };
 
     unsafe {
+        let ctx = (a.context_new)();
         let s = (a.settings_new)();
         (a.settings_test_cases)(s, 200);
         let empty = CString::new("").unwrap();
-        (a.settings_database)(s, empty.as_ptr());
+        (a.settings_database)(ctx, s, empty.as_ptr());
         (a.settings_derandomize)(s, true);
         (a.settings_seed)(s, 1, true);
 
-        let run = (a.run_start)(s);
+        let run = (a.run_start)(ctx, s);
         let schema = integer_schema(0, 1_000_000);
 
         // Reject everything we draw. The engine eventually trips
         // FilterTooMuch and errors the run.
         loop {
-            let tc = (a.next_test_case)(run);
+            let tc = (a.next_test_case)(ctx, run);
             if tc.is_null() {
                 break;
             }
             let mut val_ptr: *const u8 = ptr::null();
             let mut val_len: usize = 0;
             let rc = (a.generate)(
+                ctx,
                 tc,
                 schema.as_ptr(),
                 schema.len(),
@@ -1438,13 +1492,13 @@ fn health_check_surfaces_as_run_error() {
             );
             let _ = (val_ptr, val_len);
             if rc == HEGEL_E_STOP_TEST {
-                (a.mark_complete)(tc, CStatus::Overrun, ptr::null());
+                (a.mark_complete)(ctx, tc, CStatus::Overrun, ptr::null());
             } else {
-                (a.mark_complete)(tc, CStatus::Invalid, ptr::null());
+                (a.mark_complete)(ctx, tc, CStatus::Invalid, ptr::null());
             }
         }
 
-        let last_err = CStr::from_ptr((a.last_error_message)())
+        let last_err = CStr::from_ptr((a.context_last_error)(ctx))
             .to_string_lossy()
             .into_owned();
         assert_eq!(
@@ -1453,12 +1507,12 @@ fn health_check_surfaces_as_run_error() {
             last_err
         );
 
-        let result = (a.run_result)(run);
+        let result = (a.run_result)(ctx, run);
         assert!(
             !result.is_null(),
             "hegel_run_result returned NULL after the health check fired; \
              last_error = {}",
-            CStr::from_ptr((a.last_error_message)()).to_string_lossy()
+            CStr::from_ptr((a.context_last_error)(ctx)).to_string_lossy()
         );
 
         // The run errored, lists no failures, and carries the
@@ -1487,6 +1541,7 @@ fn health_check_surfaces_as_run_error() {
 
         (a.run_free)(run);
         (a.settings_free)(s);
+        (a.context_free)(ctx);
     }
 }
 
@@ -1591,21 +1646,23 @@ fn run_shrinker_sweep(
     for seed in seeds {
         let mut last_failing: Option<i128> = None;
         unsafe {
+            let ctx = (a.context_new)();
             let s = (a.settings_new)();
             (a.settings_test_cases)(s, 100);
-            (a.settings_database)(s, empty.as_ptr());
+            (a.settings_database)(ctx, s, empty.as_ptr());
             (a.settings_derandomize)(s, true);
             (a.settings_seed)(s, seed, true);
 
-            let run = (a.run_start)(s);
+            let run = (a.run_start)(ctx, s);
             loop {
-                let tc = (a.next_test_case)(run);
+                let tc = (a.next_test_case)(ctx, run);
                 if tc.is_null() {
                     break;
                 }
                 let mut val_ptr: *const u8 = ptr::null();
                 let mut val_len: usize = 0;
                 let rc = (a.generate)(
+                    ctx,
                     tc,
                     schema.as_ptr(),
                     schema.len(),
@@ -1613,7 +1670,7 @@ fn run_shrinker_sweep(
                     &mut val_len,
                 );
                 if rc == HEGEL_E_STOP_TEST {
-                    (a.mark_complete)(tc, CStatus::Overrun, ptr::null());
+                    (a.mark_complete)(ctx, tc, CStatus::Overrun, ptr::null());
                     continue;
                 }
                 assert_eq!(rc, HEGEL_OK);
@@ -1632,13 +1689,14 @@ fn run_shrinker_sweep(
                             origin_cs.as_ptr()
                         }
                     };
-                    (a.mark_complete)(tc, CStatus::Interesting, origin_ptr);
+                    (a.mark_complete)(ctx, tc, CStatus::Interesting, origin_ptr);
                 } else {
-                    (a.mark_complete)(tc, CStatus::Valid, ptr::null());
+                    (a.mark_complete)(ctx, tc, CStatus::Valid, ptr::null());
                 }
             }
             (a.run_free)(run);
             (a.settings_free)(s);
+            (a.context_free)(ctx);
         }
         let final_value = last_failing.unwrap_or(i128::MIN);
         observed.push(final_value);

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -3,20 +3,21 @@
 //! hegeltest drives the engine the same way every other language binding
 //! does: through the `hegel_*` C functions exported by the `hegel-c` crate
 //! (lib name `hegel_c`), passing CBOR bytes and opaque handles and reading
-//! back `c_int` error codes. This module is the single place that touches
+//! back `hegel_result_t` codes. This module is the single place that touches
 //! those raw functions; the rest of the frontend works against the safe
 //! wrappers here.
 //!
 //! The wrappers deliberately do *not* know about hegeltest's control-flow
-//! unwinds: the per-test-case methods return `Result<_, c_int>` and leave it
-//! to [`crate::test_case`] to translate a non-`HEGEL_OK` code into the right
-//! [`crate::control`] payload (a `StopTest` / `AssumeFailed` / invalid-argument
-//! unwind). Keeping that split means the unsafe boundary stays small and the
-//! control-flow policy stays with the test lifecycle.
+//! unwinds: the per-test-case methods return `Result<_, hegel_result_t>` and
+//! leave it to [`crate::test_case`] to translate a non-`HEGEL_OK` code into the
+//! right [`crate::control`] payload (a `StopTest` / `AssumeFailed` /
+//! invalid-argument unwind). Keeping that split means the unsafe boundary stays
+//! small and the control-flow policy stays with the test lifecycle.
 
 use crate::runner::{Backend, Database, HealthCheck, Mode, Phase, Settings, Verbosity};
+use hegel_c::hegel_result_t;
 use std::ffi::{CStr, CString};
-use std::os::raw::{c_char, c_int};
+use std::os::raw::c_char;
 use std::ptr;
 
 /// Owns a `*mut HegelContext` — libhegel's explicit per-call error channel —
@@ -263,7 +264,7 @@ impl CTestCase {
     /// Generate a CBOR value for `schema_cbor`, returning a fresh copy of the
     /// bytes (libhegel's buffer is invalidated by the next call on this
     /// handle, so we copy immediately).
-    pub(crate) fn generate(&self, schema_cbor: &[u8]) -> Result<Vec<u8>, c_int> {
+    pub(crate) fn generate(&self, schema_cbor: &[u8]) -> Result<Vec<u8>, hegel_result_t> {
         let mut out_ptr: *const u8 = ptr::null();
         let mut out_len: usize = 0;
         // SAFETY: schema bytes + out params are valid; on HEGEL_OK libhegel
@@ -278,7 +279,7 @@ impl CTestCase {
                 &mut out_len,
             )
         });
-        if rc != hegel_c::HEGEL_OK {
+        if rc != hegel_result_t::HEGEL_OK {
             return Err(rc);
         }
         // SAFETY: on success out_ptr/out_len describe a valid borrowed buffer.
@@ -286,13 +287,13 @@ impl CTestCase {
         Ok(bytes.to_vec())
     }
 
-    pub(crate) fn start_span(&self, label: u64) -> Result<(), c_int> {
+    pub(crate) fn start_span(&self, label: u64) -> Result<(), hegel_result_t> {
         rc_to_unit(with_context(|ctx| unsafe {
             hegel_c::hegel_start_span(ctx, self.raw, label)
         }))
     }
 
-    pub(crate) fn stop_span(&self, discard: bool) -> Result<(), c_int> {
+    pub(crate) fn stop_span(&self, discard: bool) -> Result<(), hegel_result_t> {
         rc_to_unit(with_context(|ctx| unsafe {
             hegel_c::hegel_stop_span(ctx, self.raw, discard)
         }))
@@ -302,7 +303,7 @@ impl CTestCase {
         &self,
         min_size: u64,
         max_size: Option<u64>,
-    ) -> Result<i64, c_int> {
+    ) -> Result<i64, hegel_result_t> {
         let mut id: i64 = 0;
         let rc = with_context(|ctx| unsafe {
             hegel_c::hegel_new_collection(
@@ -316,7 +317,7 @@ impl CTestCase {
         rc_to_value(rc, id)
     }
 
-    pub(crate) fn collection_more(&self, collection_id: i64) -> Result<bool, c_int> {
+    pub(crate) fn collection_more(&self, collection_id: i64) -> Result<bool, hegel_result_t> {
         let mut more = false;
         let rc = with_context(|ctx| unsafe {
             hegel_c::hegel_collection_more(ctx, self.raw, collection_id, &mut more)
@@ -328,7 +329,7 @@ impl CTestCase {
         &self,
         collection_id: i64,
         why: Option<&str>,
-    ) -> Result<(), c_int> {
+    ) -> Result<(), hegel_result_t> {
         let c_why = why.map(cstring_lossy);
         let why_ptr = c_why.as_ref().map_or(ptr::null(), |c| c.as_ptr());
         rc_to_unit(with_context(|ctx| unsafe {
@@ -336,20 +337,20 @@ impl CTestCase {
         }))
     }
 
-    pub(crate) fn new_pool(&self) -> Result<i64, c_int> {
+    pub(crate) fn new_pool(&self) -> Result<i64, hegel_result_t> {
         let mut id: i64 = 0;
         let rc = with_context(|ctx| unsafe { hegel_c::hegel_new_pool(ctx, self.raw, &mut id) });
         rc_to_value(rc, id)
     }
 
-    pub(crate) fn pool_add(&self, pool_id: i64) -> Result<i64, c_int> {
+    pub(crate) fn pool_add(&self, pool_id: i64) -> Result<i64, hegel_result_t> {
         let mut id: i64 = 0;
         let rc =
             with_context(|ctx| unsafe { hegel_c::hegel_pool_add(ctx, self.raw, pool_id, &mut id) });
         rc_to_value(rc, id)
     }
 
-    pub(crate) fn pool_generate(&self, pool_id: i64, consume: bool) -> Result<i64, c_int> {
+    pub(crate) fn pool_generate(&self, pool_id: i64, consume: bool) -> Result<i64, hegel_result_t> {
         let mut id: i64 = 0;
         let rc = with_context(|ctx| unsafe {
             hegel_c::hegel_pool_generate(ctx, self.raw, pool_id, consume, &mut id)
@@ -361,7 +362,7 @@ impl CTestCase {
         &self,
         rule_names: &[&str],
         invariant_names: &[&str],
-    ) -> Result<i64, c_int> {
+    ) -> Result<i64, hegel_result_t> {
         // Keep the CStrings alive until the call returns; the pointer arrays
         // borrow into them.
         let rule_cstrings: Vec<CString> = rule_names.iter().map(|s| cstring_lossy(s)).collect();
@@ -385,7 +386,10 @@ impl CTestCase {
         rc_to_value(rc, id)
     }
 
-    pub(crate) fn state_machine_next_rule(&self, state_machine_id: i64) -> Result<i64, c_int> {
+    pub(crate) fn state_machine_next_rule(
+        &self,
+        state_machine_id: i64,
+    ) -> Result<i64, hegel_result_t> {
         let mut out: i64 = 0;
         let rc = with_context(|ctx| unsafe {
             hegel_c::hegel_state_machine_next_rule(ctx, self.raw, state_machine_id, &mut out)
@@ -393,7 +397,7 @@ impl CTestCase {
         rc_to_value(rc, out)
     }
 
-    pub(crate) fn target(&self, score: f64, label: &str) -> Result<(), c_int> {
+    pub(crate) fn target(&self, score: f64, label: &str) -> Result<(), hegel_result_t> {
         let c_label = cstring_lossy(label);
         rc_to_unit(with_context(|ctx| unsafe {
             hegel_c::hegel_target(ctx, self.raw, score, c_label.as_ptr())
@@ -406,7 +410,7 @@ impl CTestCase {
         &self,
         status: hegel_c::hegel_status_t,
         origin: Option<&str>,
-    ) -> Result<(), c_int> {
+    ) -> Result<(), hegel_result_t> {
         let c_origin = origin.map(cstring_lossy);
         let origin_ptr = c_origin.as_ref().map_or(ptr::null(), |c| c.as_ptr());
         rc_to_unit(with_context(|ctx| unsafe {
@@ -479,16 +483,16 @@ pub(crate) struct Failure {
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-fn rc_to_unit(rc: c_int) -> Result<(), c_int> {
-    if rc == hegel_c::HEGEL_OK {
+fn rc_to_unit(rc: hegel_result_t) -> Result<(), hegel_result_t> {
+    if rc == hegel_result_t::HEGEL_OK {
         Ok(())
     } else {
         Err(rc)
     }
 }
 
-fn rc_to_value<T>(rc: c_int, value: T) -> Result<T, c_int> {
-    if rc == hegel_c::HEGEL_OK {
+fn rc_to_value<T>(rc: hegel_result_t, value: T) -> Result<T, hegel_result_t> {
+    if rc == hegel_result_t::HEGEL_OK {
         Ok(value)
     } else {
         Err(rc)
@@ -533,11 +537,11 @@ fn phases_bitmask(phases: &[Phase]) -> u32 {
     let mut mask = 0;
     for phase in phases {
         mask |= match phase {
-            Phase::Explicit => hegel_c::HEGEL_PHASE_EXPLICIT,
-            Phase::Reuse => hegel_c::HEGEL_PHASE_REUSE,
-            Phase::Generate => hegel_c::HEGEL_PHASE_GENERATE,
-            Phase::Target => hegel_c::HEGEL_PHASE_TARGET,
-            Phase::Shrink => hegel_c::HEGEL_PHASE_SHRINK,
+            Phase::Explicit => hegel_c::hegel_phase_t::HEGEL_PHASE_EXPLICIT as u32,
+            Phase::Reuse => hegel_c::hegel_phase_t::HEGEL_PHASE_REUSE as u32,
+            Phase::Generate => hegel_c::hegel_phase_t::HEGEL_PHASE_GENERATE as u32,
+            Phase::Target => hegel_c::hegel_phase_t::HEGEL_PHASE_TARGET as u32,
+            Phase::Shrink => hegel_c::hegel_phase_t::HEGEL_PHASE_SHRINK as u32,
         };
     }
     mask
@@ -547,10 +551,16 @@ fn health_check_bitmask(checks: &[HealthCheck]) -> u32 {
     let mut mask = 0;
     for check in checks {
         mask |= match check {
-            HealthCheck::FilterTooMuch => hegel_c::HEGEL_HC_FILTER_TOO_MUCH,
-            HealthCheck::TooSlow => hegel_c::HEGEL_HC_TOO_SLOW,
-            HealthCheck::TestCasesTooLarge => hegel_c::HEGEL_HC_TEST_CASES_TOO_LARGE,
-            HealthCheck::LargeInitialTestCase => hegel_c::HEGEL_HC_LARGE_INITIAL_TEST_CASE,
+            HealthCheck::FilterTooMuch => {
+                hegel_c::hegel_health_check_t::HEGEL_HC_FILTER_TOO_MUCH as u32
+            }
+            HealthCheck::TooSlow => hegel_c::hegel_health_check_t::HEGEL_HC_TOO_SLOW as u32,
+            HealthCheck::TestCasesTooLarge => {
+                hegel_c::hegel_health_check_t::HEGEL_HC_TEST_CASES_TOO_LARGE as u32
+            }
+            HealthCheck::LargeInitialTestCase => {
+                hegel_c::hegel_health_check_t::HEGEL_HC_LARGE_INITIAL_TEST_CASE as u32
+            }
         };
     }
     mask

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -19,22 +19,74 @@ use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_int};
 use std::ptr;
 
-/// The most recent error message libhegel recorded on this thread, or an
-/// empty string if the last call succeeded. libhegel's buffer is borrowed
-/// and invalidated by the next call on this thread, so we copy it out
-/// immediately.
-pub(crate) fn last_error_string() -> String {
-    // SAFETY: returns a borrowed pointer into a thread-local buffer valid
-    // until the next libhegel call on this thread; we copy before returning.
-    let p = hegel_c::hegel_last_error_message();
-    if p.is_null() {
-        // libhegel's thread-local error buffer is a CString whose pointer is
-        // never null; this guard exists for FFI soundness (CStr::from_ptr is UB
-        // on null), so the branch is unreachable in practice but must stay a
-        // guard rather than become a panic.
-        return String::new(); // nocov
+/// Owns a `*mut HegelContext` — libhegel's explicit per-call error channel —
+/// and frees it on drop.
+struct Context {
+    raw: *mut hegel_c::HegelContext,
+}
+
+impl Context {
+    fn new() -> Self {
+        // SAFETY: hegel_context_new never returns null.
+        Context {
+            raw: hegel_c::hegel_context_new(),
+        }
     }
-    unsafe { CStr::from_ptr(p) }.to_string_lossy().into_owned()
+
+    fn as_ptr(&self) -> *mut hegel_c::HegelContext {
+        self.raw
+    }
+
+    /// Copy out the most recent error message recorded on this context.
+    /// libhegel's buffer is borrowed and invalidated by the next call taking
+    /// this context, so we copy immediately.
+    fn last_error(&self) -> String {
+        // SAFETY: self.raw is a live, non-null context handle.
+        let p = unsafe { hegel_c::hegel_context_last_error(self.raw) };
+        if p.is_null() {
+            // hegel_context_last_error only returns null for a null context,
+            // and self.raw is never null; this guard keeps CStr::from_ptr
+            // sound rather than becoming a panic.
+            return String::new(); // nocov
+        }
+        unsafe { CStr::from_ptr(p) }.to_string_lossy().into_owned()
+    }
+}
+
+impl Drop for Context {
+    fn drop(&mut self) {
+        // SAFETY: `raw` came from hegel_context_new and is freed exactly once.
+        unsafe { hegel_c::hegel_context_free(self.raw) };
+    }
+}
+
+thread_local! {
+    /// This thread's libhegel error context.
+    ///
+    /// libhegel reports a failed call's diagnostic on an explicit context
+    /// handle rather than its own thread-local state — deliberately, so that
+    /// callers running on green threads / fibers that migrate between OS
+    /// threads mid-call (e.g. Go's goroutines) are not pinned to thread-local
+    /// error storage. The hegel-rust frontend has no such constraint: it
+    /// drives the engine from ordinary OS threads, and a failed call and the
+    /// [`last_error_string`] that reads its message always run on the same
+    /// thread. So it is sound — and simplest — to keep one context per thread
+    /// here and pass it to every fallible call. Each thread gets its own, so
+    /// no two threads ever share one (and it is freed when the thread exits).
+    static CONTEXT: Context = Context::new();
+}
+
+/// Run `f` with this thread's libhegel error-context pointer.
+fn with_context<R>(f: impl FnOnce(*mut hegel_c::HegelContext) -> R) -> R {
+    CONTEXT.with(|c| f(c.as_ptr()))
+}
+
+/// The most recent error message libhegel recorded on this thread's context,
+/// or an empty string if the last call on it succeeded. Read synchronously on
+/// the same thread that made the failing call, before any later call can
+/// overwrite it.
+pub(crate) fn last_error_string() -> String {
+    CONTEXT.with(|c| c.last_error())
 }
 
 /// Build a NUL-terminated C string, replacing any interior NUL (which a
@@ -75,22 +127,25 @@ impl SettingsHandle {
                 raw,
                 settings.report_multiple_failures,
             );
+            // The database setters take an error context (their only failure
+            // is a non-UTF-8 path/key); thread this thread's context through
+            // even though we always build the C strings from valid Rust `&str`.
             match &settings.database {
                 // Empty string disables the database; a path selects it; Unset
                 // leaves libhegel's default in place (don't call the setter).
                 Database::Disabled => {
                     let empty = CString::new("").unwrap();
-                    hegel_c::hegel_settings_database(raw, empty.as_ptr());
+                    with_context(|ctx| hegel_c::hegel_settings_database(ctx, raw, empty.as_ptr()));
                 }
                 Database::Path(path) => {
                     let c = cstring_lossy(path);
-                    hegel_c::hegel_settings_database(raw, c.as_ptr());
+                    with_context(|ctx| hegel_c::hegel_settings_database(ctx, raw, c.as_ptr()));
                 }
                 Database::Unset => {}
             }
             if let Some(key) = database_key {
                 let c = cstring_lossy(key);
-                hegel_c::hegel_settings_database_key(raw, c.as_ptr());
+                with_context(|ctx| hegel_c::hegel_settings_database_key(ctx, raw, c.as_ptr()));
             }
             hegel_c::hegel_settings_phases(raw, phases_bitmask(&settings.phases));
             hegel_c::hegel_settings_suppress_health_check(
@@ -127,7 +182,7 @@ impl RunHandle {
     /// could not be started.
     pub(crate) fn start(settings: &SettingsHandle) -> Result<Self, String> {
         // SAFETY: settings.as_ptr() is a live, non-null handle.
-        let raw = unsafe { hegel_c::hegel_run_start(settings.as_ptr()) };
+        let raw = with_context(|ctx| unsafe { hegel_c::hegel_run_start(ctx, settings.as_ptr()) });
         if raw.is_null() {
             // settings is always a live handle, so hegel_run_start returns null
             // only on OS worker-thread spawn failure: a real but unprovokable
@@ -143,7 +198,7 @@ impl RunHandle {
     pub(crate) fn next_test_case(&self) -> Option<CTestCase> {
         // SAFETY: self.raw is a live run handle; libhegel blocks until the next
         // case or returns null at completion.
-        let raw = unsafe { hegel_c::hegel_next_test_case(self.raw) };
+        let raw = with_context(|ctx| unsafe { hegel_c::hegel_next_test_case(ctx, self.raw) });
         if raw.is_null() {
             None
         } else {
@@ -156,7 +211,7 @@ impl RunHandle {
     pub(crate) fn result(&self) -> RunResult<'_> {
         // SAFETY: called after the pull loop drained; libhegel returns a
         // borrowed pointer valid for the run's lifetime.
-        let raw = unsafe { hegel_c::hegel_run_result(self.raw) };
+        let raw = with_context(|ctx| unsafe { hegel_c::hegel_run_result(ctx, self.raw) });
         RunResult {
             raw,
             _run: std::marker::PhantomData,
@@ -196,7 +251,9 @@ impl CTestCase {
     pub(crate) fn from_blob(settings: &SettingsHandle, blob: &str) -> Result<Self, String> {
         let c_blob = cstring_lossy(blob);
         // SAFETY: settings is live; c_blob is a valid NUL-terminated string.
-        let raw = unsafe { hegel_c::hegel_test_case_from_blob(settings.as_ptr(), c_blob.as_ptr()) };
+        let raw = with_context(|ctx| unsafe {
+            hegel_c::hegel_test_case_from_blob(ctx, settings.as_ptr(), c_blob.as_ptr())
+        });
         if raw.is_null() {
             return Err(last_error_string());
         }
@@ -211,15 +268,16 @@ impl CTestCase {
         let mut out_len: usize = 0;
         // SAFETY: schema bytes + out params are valid; on HEGEL_OK libhegel
         // writes a borrowed (ptr, len) we copy before any further call.
-        let rc = unsafe {
+        let rc = with_context(|ctx| unsafe {
             hegel_c::hegel_generate(
+                ctx,
                 self.raw,
                 schema_cbor.as_ptr(),
                 schema_cbor.len(),
                 &mut out_ptr,
                 &mut out_len,
             )
-        };
+        });
         if rc != hegel_c::HEGEL_OK {
             return Err(rc);
         }
@@ -229,11 +287,15 @@ impl CTestCase {
     }
 
     pub(crate) fn start_span(&self, label: u64) -> Result<(), c_int> {
-        rc_to_unit(unsafe { hegel_c::hegel_start_span(self.raw, label) })
+        rc_to_unit(with_context(|ctx| unsafe {
+            hegel_c::hegel_start_span(ctx, self.raw, label)
+        }))
     }
 
     pub(crate) fn stop_span(&self, discard: bool) -> Result<(), c_int> {
-        rc_to_unit(unsafe { hegel_c::hegel_stop_span(self.raw, discard) })
+        rc_to_unit(with_context(|ctx| unsafe {
+            hegel_c::hegel_stop_span(ctx, self.raw, discard)
+        }))
     }
 
     pub(crate) fn new_collection(
@@ -242,15 +304,23 @@ impl CTestCase {
         max_size: Option<u64>,
     ) -> Result<i64, c_int> {
         let mut id: i64 = 0;
-        let rc = unsafe {
-            hegel_c::hegel_new_collection(self.raw, min_size, max_size.unwrap_or(u64::MAX), &mut id)
-        };
+        let rc = with_context(|ctx| unsafe {
+            hegel_c::hegel_new_collection(
+                ctx,
+                self.raw,
+                min_size,
+                max_size.unwrap_or(u64::MAX),
+                &mut id,
+            )
+        });
         rc_to_value(rc, id)
     }
 
     pub(crate) fn collection_more(&self, collection_id: i64) -> Result<bool, c_int> {
         let mut more = false;
-        let rc = unsafe { hegel_c::hegel_collection_more(self.raw, collection_id, &mut more) };
+        let rc = with_context(|ctx| unsafe {
+            hegel_c::hegel_collection_more(ctx, self.raw, collection_id, &mut more)
+        });
         rc_to_value(rc, more)
     }
 
@@ -261,24 +331,29 @@ impl CTestCase {
     ) -> Result<(), c_int> {
         let c_why = why.map(cstring_lossy);
         let why_ptr = c_why.as_ref().map_or(ptr::null(), |c| c.as_ptr());
-        rc_to_unit(unsafe { hegel_c::hegel_collection_reject(self.raw, collection_id, why_ptr) })
+        rc_to_unit(with_context(|ctx| unsafe {
+            hegel_c::hegel_collection_reject(ctx, self.raw, collection_id, why_ptr)
+        }))
     }
 
     pub(crate) fn new_pool(&self) -> Result<i64, c_int> {
         let mut id: i64 = 0;
-        let rc = unsafe { hegel_c::hegel_new_pool(self.raw, &mut id) };
+        let rc = with_context(|ctx| unsafe { hegel_c::hegel_new_pool(ctx, self.raw, &mut id) });
         rc_to_value(rc, id)
     }
 
     pub(crate) fn pool_add(&self, pool_id: i64) -> Result<i64, c_int> {
         let mut id: i64 = 0;
-        let rc = unsafe { hegel_c::hegel_pool_add(self.raw, pool_id, &mut id) };
+        let rc =
+            with_context(|ctx| unsafe { hegel_c::hegel_pool_add(ctx, self.raw, pool_id, &mut id) });
         rc_to_value(rc, id)
     }
 
     pub(crate) fn pool_generate(&self, pool_id: i64, consume: bool) -> Result<i64, c_int> {
         let mut id: i64 = 0;
-        let rc = unsafe { hegel_c::hegel_pool_generate(self.raw, pool_id, consume, &mut id) };
+        let rc = with_context(|ctx| unsafe {
+            hegel_c::hegel_pool_generate(ctx, self.raw, pool_id, consume, &mut id)
+        });
         rc_to_value(rc, id)
     }
 
@@ -296,8 +371,9 @@ impl CTestCase {
         let invariant_ptrs: Vec<*const c_char> =
             invariant_cstrings.iter().map(|c| c.as_ptr()).collect();
         let mut id: i64 = 0;
-        let rc = unsafe {
+        let rc = with_context(|ctx| unsafe {
             hegel_c::hegel_new_state_machine(
+                ctx,
                 self.raw,
                 rule_ptrs.as_ptr(),
                 rule_ptrs.len(),
@@ -305,20 +381,23 @@ impl CTestCase {
                 invariant_ptrs.len(),
                 &mut id,
             )
-        };
+        });
         rc_to_value(rc, id)
     }
 
     pub(crate) fn state_machine_next_rule(&self, state_machine_id: i64) -> Result<i64, c_int> {
         let mut out: i64 = 0;
-        let rc =
-            unsafe { hegel_c::hegel_state_machine_next_rule(self.raw, state_machine_id, &mut out) };
+        let rc = with_context(|ctx| unsafe {
+            hegel_c::hegel_state_machine_next_rule(ctx, self.raw, state_machine_id, &mut out)
+        });
         rc_to_value(rc, out)
     }
 
     pub(crate) fn target(&self, score: f64, label: &str) -> Result<(), c_int> {
         let c_label = cstring_lossy(label);
-        rc_to_unit(unsafe { hegel_c::hegel_target(self.raw, score, c_label.as_ptr()) })
+        rc_to_unit(with_context(|ctx| unsafe {
+            hegel_c::hegel_target(ctx, self.raw, score, c_label.as_ptr())
+        }))
     }
 
     /// Report the test case's outcome. `origin` is supplied only for an
@@ -330,7 +409,9 @@ impl CTestCase {
     ) -> Result<(), c_int> {
         let c_origin = origin.map(cstring_lossy);
         let origin_ptr = c_origin.as_ref().map_or(ptr::null(), |c| c.as_ptr());
-        rc_to_unit(unsafe { hegel_c::hegel_mark_complete(self.raw, status, origin_ptr) })
+        rc_to_unit(with_context(|ctx| unsafe {
+            hegel_c::hegel_mark_complete(ctx, self.raw, status, origin_ptr)
+        }))
     }
 
     /// Whether this is the engine's final replay of a minimal counterexample
@@ -346,7 +427,7 @@ impl Drop for CTestCase {
             // SAFETY: a `owned` handle came from from_blob and is ours to free
             // exactly once. Run-owned handles (owned = false) are freed by the
             // run and must not be touched here.
-            unsafe { hegel_c::hegel_test_case_free(self.raw) };
+            with_context(|ctx| unsafe { hegel_c::hegel_test_case_free(ctx, self.raw) });
         }
     }
 }

--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -9,7 +9,6 @@ use ciborium::Value;
 use parking_lot::Mutex;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
-use std::os::raw::c_int;
 use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
 use std::sync::Arc;
 
@@ -68,9 +67,9 @@ macro_rules! invalid_argument {
 }
 pub(crate) use invalid_argument;
 
-/// Translate a non-`HEGEL_OK` libhegel return code into the matching
+/// Translate a non-`HEGEL_OK` libhegel result code into the matching
 /// control-flow unwind. Mirrors the previous `DataSourceError` mapping, but
-/// over the C ABI's `c_int` codes:
+/// over the C ABI's `hegel_result_t` codes:
 ///
 /// - `HEGEL_E_STOP_TEST` — the engine ran out of data for this case.
 /// - `HEGEL_E_ASSUME` — the engine rejected the draw (an assumption failed).
@@ -80,14 +79,15 @@ pub(crate) use invalid_argument;
 /// - anything else — an engine/framework invariant we don't expect on the hot
 ///   path; treat it as an internal error rather than a shrinkable failure.
 #[track_caller]
-pub(crate) fn raise_for_rc(rc: c_int) -> ! {
+pub(crate) fn raise_for_rc(rc: hegel_c::hegel_result_t) -> ! {
+    use hegel_c::hegel_result_t::*;
     match rc {
-        hegel_c::HEGEL_E_STOP_TEST => raise_control(StopTest),
-        hegel_c::HEGEL_E_ASSUME => raise_control(AssumeFailed), // nocov
-        hegel_c::HEGEL_E_INVALID_ARG => invalid_argument!("{}", crate::ffi::last_error_string()),
+        HEGEL_E_STOP_TEST => raise_control(StopTest),
+        HEGEL_E_ASSUME => raise_control(AssumeFailed), // nocov
+        HEGEL_E_INVALID_ARG => invalid_argument!("{}", crate::ffi::last_error_string()),
         other => hegel_internal_error!(
             "libhegel returned unexpected code {}: {}",
-            other,
+            other as i32,
             crate::ffi::last_error_string()
         ),
     }
@@ -717,7 +717,7 @@ impl TestCase {
             // nocov start
             hegel_internal_error!(
                 "hegel_mark_complete failed: rc={} {}",
-                rc,
+                rc as i32,
                 crate::ffi::last_error_string()
             );
             // nocov end

--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -75,8 +75,8 @@ pub(crate) use invalid_argument;
 /// - `HEGEL_E_STOP_TEST` — the engine ran out of data for this case.
 /// - `HEGEL_E_ASSUME` — the engine rejected the draw (an assumption failed).
 /// - `HEGEL_E_INVALID_ARG` — a caller-supplied argument (typically a
-///   generator's schema) was semantically invalid; the diagnostic is in the
-///   thread-local last-error, read synchronously here.
+///   generator's schema) was semantically invalid; the diagnostic is read
+///   synchronously from this thread's libhegel error context.
 /// - anything else — an engine/framework invariant we don't expect on the hot
 ///   path; treat it as an internal error rather than a shrinkable failure.
 #[track_caller]

--- a/tests/embedded/ffi_tests.rs
+++ b/tests/embedded/ffi_tests.rs
@@ -65,18 +65,19 @@ fn ffi_drives_a_passing_run_exercising_every_primitive() {
 
         // A span wrapping a small engine-managed collection of ints, rejecting
         // any zero element so collection_reject is exercised.
-        tc.start_span(hegel_c::HEGEL_LABEL_LIST).unwrap();
+        tc.start_span(hegel_c::hegel_label_t::HEGEL_LABEL_LIST as u64)
+            .unwrap();
         let cid = tc.new_collection(0, Some(3)).unwrap();
         let mut drew_overrun = false;
         loop {
             match tc.collection_more(cid) {
                 Ok(true) => {}
                 Ok(false) => break,
-                Err(hegel_c::HEGEL_E_STOP_TEST) => {
+                Err(hegel_c::hegel_result_t::HEGEL_E_STOP_TEST) => {
                     drew_overrun = true;
                     break;
                 }
-                Err(rc) => panic!("collection_more rc={rc}"),
+                Err(rc) => panic!("collection_more rc={rc:?}"),
             }
             match tc.generate(&schema) {
                 Ok(bytes) => {
@@ -84,11 +85,11 @@ fn ffi_drives_a_passing_run_exercising_every_primitive() {
                         tc.collection_reject(cid, Some("zero")).unwrap();
                     }
                 }
-                Err(hegel_c::HEGEL_E_STOP_TEST) => {
+                Err(hegel_c::hegel_result_t::HEGEL_E_STOP_TEST) => {
                     drew_overrun = true;
                     break;
                 }
-                Err(rc) => panic!("generate rc={rc}"),
+                Err(rc) => panic!("generate rc={rc:?}"),
             }
         }
         tc.stop_span(false).unwrap();
@@ -102,11 +103,11 @@ fn ffi_drives_a_passing_run_exercising_every_primitive() {
         let added = tc.pool_add(pool).unwrap();
         match tc.pool_generate(pool, false) {
             Ok(drawn) => assert_eq!(drawn, added, "non-consuming draw returns the added id"),
-            Err(hegel_c::HEGEL_E_STOP_TEST) => {
+            Err(hegel_c::hegel_result_t::HEGEL_E_STOP_TEST) => {
                 tc.mark_complete(OVERRUN, None).unwrap();
                 continue;
             }
-            Err(rc) => panic!("pool_generate rc={rc}"),
+            Err(rc) => panic!("pool_generate rc={rc:?}"),
         }
 
         // A targeting observation, then the actual draw the "property" sees.
@@ -117,8 +118,10 @@ fn ffi_drives_a_passing_run_exercising_every_primitive() {
                 assert!((0..=100).contains(&n));
                 tc.mark_complete(VALID, None).unwrap();
             }
-            Err(hegel_c::HEGEL_E_STOP_TEST) => tc.mark_complete(OVERRUN, None).unwrap(),
-            Err(rc) => panic!("generate rc={rc}"),
+            Err(hegel_c::hegel_result_t::HEGEL_E_STOP_TEST) => {
+                tc.mark_complete(OVERRUN, None).unwrap()
+            }
+            Err(rc) => panic!("generate rc={rc:?}"),
         }
     }
     assert!(cases >= 1);
@@ -148,8 +151,10 @@ fn ffi_reports_failure_with_blob_then_replays_it() {
                     tc.mark_complete(VALID, None).unwrap();
                 }
             }
-            Err(hegel_c::HEGEL_E_STOP_TEST) => tc.mark_complete(OVERRUN, None).unwrap(),
-            Err(rc) => panic!("generate rc={rc}"),
+            Err(hegel_c::hegel_result_t::HEGEL_E_STOP_TEST) => {
+                tc.mark_complete(OVERRUN, None).unwrap()
+            }
+            Err(rc) => panic!("generate rc={rc:?}"),
         }
     }
 

--- a/tests/embedded/test_case_tests.rs
+++ b/tests/embedded/test_case_tests.rs
@@ -76,7 +76,7 @@ fn invalid_argument_error_is_raised_as_a_usage_error() {
 
 // ── error-code translation ───────────────────────────────────────────────
 //
-// `raise_for_rc` maps libhegel's `c_int` return codes to control-flow
+// `raise_for_rc` maps libhegel's `hegel_result_t` codes to control-flow
 // unwinds. The per-primitive `TestCase` methods (start_span, stop_span,
 // generate, the pool/collection calls) are thin wrappers that call it on any
 // non-OK code, so a span call after the engine runs out of data concludes the
@@ -85,7 +85,8 @@ fn invalid_argument_error_is_raised_as_a_usage_error() {
 #[test]
 fn stop_test_code_unwinds_as_stop_test() {
     let payload =
-        std::panic::catch_unwind(|| raise_for_rc(hegel_c::HEGEL_E_STOP_TEST)).unwrap_err();
+        std::panic::catch_unwind(|| raise_for_rc(hegel_c::hegel_result_t::HEGEL_E_STOP_TEST))
+            .unwrap_err();
     assert!(
         payload.downcast_ref::<crate::control::StopTest>().is_some(),
         "expected a StopTest control unwind"
@@ -94,7 +95,9 @@ fn stop_test_code_unwinds_as_stop_test() {
 
 #[test]
 fn assume_code_unwinds_as_assume_failed() {
-    let payload = std::panic::catch_unwind(|| raise_for_rc(hegel_c::HEGEL_E_ASSUME)).unwrap_err();
+    let payload =
+        std::panic::catch_unwind(|| raise_for_rc(hegel_c::hegel_result_t::HEGEL_E_ASSUME))
+            .unwrap_err();
     assert!(
         payload
             .downcast_ref::<crate::control::AssumeFailed>()
@@ -151,11 +154,15 @@ fn span_calls_after_overrun_unwind_as_stop_test() {
 
 #[test]
 fn unexpected_code_unwinds_as_an_internal_error() {
-    // Any libhegel return code the frontend doesn't model is a framework
-    // invariant violation, surfaced as an internal error (not a shrinkable
-    // failure). 4242 is a code the engine never returns.
-    let payload = std::panic::catch_unwind(|| raise_for_rc(4242)).unwrap_err();
+    // Any libhegel result code the frontend doesn't model as control flow is a
+    // framework invariant violation, surfaced as an internal error (not a
+    // shrinkable failure). `HEGEL_E_BACKEND` (-3) is such a code: the
+    // per-test-case path only ever expects OK / STOP_TEST / ASSUME /
+    // INVALID_ARG, so a backend error reaching `raise_for_rc` is unexpected.
+    let payload =
+        std::panic::catch_unwind(|| raise_for_rc(hegel_c::hegel_result_t::HEGEL_E_BACKEND))
+            .unwrap_err();
     let msg = panic_payload_message(payload);
-    assert!(msg.contains("unexpected code 4242"), "{msg}");
+    assert!(msg.contains("unexpected code -3"), "{msg}");
     assert!(msg.contains("Internal error in hegel"), "{msg}");
 }


### PR DESCRIPTION
This:

1. Clarifies semantics of pointer ownership
2. Adds a context type for holding error messages rather than using thread locals. The expected pattern (and what is done in hegel-rust) is that the context type is held in the client's equivalent of a thread local, but it's also fine to e.g. create a fresh context per test.
3. Replaces defines with enums.

All of which were requested for making it easier to use from hegel-go.