### PR TITLE
Add hegel-typescript to release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -650,7 +650,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        repo: [hegel-go, hegel-ocaml]
+        repo: [hegel-go, hegel-ocaml, hegel-typescript]
     steps:
       - name: Generate app token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0


### PR DESCRIPTION
Adds `hegel-typescript` to the `bump-libhegel` dispatch matrix so it bumps its pinned `libhegel` version on each release, like the other bindings.

<details>
<summary>Details</summary>

hegel-typescript was [ported to drive `libhegel` directly via FFI](https://github.com/hegeldev/hegel-typescript) and now has a `bump-hegel-rust.yml` workflow listening for the `hegel-rust-release` `repository_dispatch` (reading `client_payload.version`), mirroring hegel-go/hegel-ocaml. The only missing piece was this repo fanning the dispatch out to it.

This adds one matrix entry to the `bump-libhegel` job; the dispatched `event_type` (`hegel-rust-release`) and `client_payload[version]` payload are unchanged.

Prerequisite (org setting, not this PR): the `HEGEL_RELEASE_APP_ID` GitHub App must be installed on `hegeldev/hegel-typescript` so the per-repo app token can be minted — already the case, since hegel-typescript's prior `bump-hegel-core` workflow used the same app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>
