### PR TITLE
Don't copy doc comments to state machine rules

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This release prevents the `unused_doc_comments` lint from firing when using doc comments on stateful test `#[rule]`s or `#[invariant]`'s.

--- a/hegel-macros/src/stateful.rs
+++ b/hegel-macros/src/stateful.rs
@@ -42,7 +42,12 @@ pub fn expand_state_machine(mut block: ItemImpl) -> TokenStream {
 
             let info = || MethodInfo {
                 name: method.sig.ident.clone(),
-                attrs: method.attrs.clone(),
+                attrs: method
+                    .attrs
+                    .iter()
+                    .filter(|a| a.path().is_ident("cfg"))
+                    .cloned()
+                    .collect(),
             };
             if has_rule {
                 rules.push(info());

--- a/tests/test_stateful.rs
+++ b/tests/test_stateful.rs
@@ -167,6 +167,41 @@ fn test_draw_domain(tc: TestCase) {
     hegel::stateful::run(m, tc);
 }
 
+mod cfg_rules_ignored {
+    // These attributes needs applied on the module level, as `#[hegel::state_machine]` expands
+    // to two blocks. Otherwise they would only apply to the first block produced.
+    #![allow(unexpected_cfgs)]
+    #![forbid(unused_doc_comments)]
+
+    use hegel::TestCase;
+
+    struct TestCfgRulesIgnored {
+        count: u32,
+    }
+
+    #[hegel::state_machine]
+    impl TestCfgRulesIgnored {
+        /// Adds 1 to the internal value
+        #[rule]
+        fn increment(&mut self, _tc: TestCase) {
+            self.count += 1;
+        }
+
+        /// This rule should never be run as `nonexistent_config` does not exist
+        #[cfg(nonexistent_config)]
+        #[rule]
+        fn panic(&mut self, _tc: TestCase) {
+            compile_error!("should be compiled out");
+        }
+    }
+
+    #[hegel::test]
+    fn test_cfg_rules_ignored(tc: TestCase) {
+        let m = TestCfgRulesIgnored { count: 0 };
+        hegel::stateful::run(m, tc);
+    }
+}
+
 mod stateful {
     use super::common::project::TempRustProject;
     use super::common::utils::expect_panic;


### PR DESCRIPTION
Currently, all attributes applied to functions in a state machine are also applied to the list of rules.

Doc comments are desugared into attributes and thus are also copied to the list of rules. This leads to the `unused_doc_comments` lint firing,  as the doc comment should only be on the function, not in the list.

Only pass through `cfg` attributes, rather than all attributes. As the [other attributes listed in the Rust reference](https://doc.rust-lang.org/reference/attributes.html#built-in-attributes-index) all look like they should only be applied to the function rather than references to the function.
