### PR TITLE
Add Miri CI job for the engine and FFI boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,10 +333,37 @@ jobs:
       - name: lint
         run: just check-format-nix
 
+  # Run a fast core of the suite under Miri to catch undefined behaviour in the
+  # native engine and the in-process C-ABI boundary hegeltest drives it through.
+  # The expensive quality/compile suites and subprocess-driven tests are
+  # excluded (see `just check-miri`); the `test_miri` target drives every main
+  # feature through the FFI primitives at small example counts, which is what
+  # keeps the run tractable under Miri's interpreter.
+  miri:
+    name: miri
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust nightly + miri
+        run: rustup toolchain install nightly --profile minimal -c miri
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - uses: ./.github/actions/install-tools
+        with:
+          tools: just
+
+      - name: Run miri
+        run: just check-miri
+
   release:
     name: release
     if: github.event_name == 'push' && github.repository == 'hegeldev/hegel-rust'
-    needs: [lint, test, test-all-features, test-minimal-versions, docs, coverage, nix]
+    needs: [lint, test, test-all-features, test-minimal-versions, docs, coverage, nix, miri]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/justfile
+++ b/justfile
@@ -124,11 +124,29 @@ c-test-abort:
 c-header:
     HEGEL_C_HEADER_WRITE=1 cargo build -p hegeltest-c
 
+# Run a fast core of the suite under Miri to catch undefined behaviour in the
+# native engine and the in-process C-ABI boundary hegeltest drives it through.
+# The `test_miri` target exercises the main generator, combinator, derive,
+# targeting, assume, and shrinking features end-to-end: every draw flows through
+# the same `hegel_generate` / span / collection / target FFI primitives the
+# other language bindings use, so this covers the unsafe boundary while staying
+# tractable under Miri's interpreter (small example counts, no 100-example
+# property loops or budget-exhaustion draws).
+#
+# Requires the nightly toolchain with the miri component:
+# `rustup +nightly component add miri`.
+#
+# CI=1 disables the on-disk failure database (we don't want Miri writing files);
+# isolation is disabled because the engine seeds its PRNG from OS entropy.
+check-miri:
+    CI=1 MIRIFLAGS="-Zmiri-disable-isolation" cargo +nightly miri test --test test_miri
+
 # these aliases are provided as ux improvements for local developers. CI should use the longer
 # forms.
 test: check-tests
 coverage: check-coverage
 lint: check-lint
+miri: check-miri
 check: check-lint check-tests check-tests-all-features
 
 # Run cargo-insta, installing it first if it's missing. Pinned to the same

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,8 +1,10 @@
 pub mod project;
 pub mod utils;
 
+#[cfg(not(miri))]
 static TEST_CWD: std::sync::OnceLock<tempfile::TempDir> = std::sync::OnceLock::new();
 
+#[cfg(not(miri))]
 #[ctor::ctor]
 fn chdir_to_isolated_tempdir() {
     let tempdir = tempfile::Builder::new()

--- a/tests/test_miri.rs
+++ b/tests/test_miri.rs
@@ -1,0 +1,244 @@
+#![allow(dead_code)]
+
+mod common;
+
+use std::collections::{HashMap, HashSet};
+use std::fmt::Debug;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::{Arc, Mutex};
+
+use hegel::DefaultGenerator as DeriveGenerator;
+use hegel::generators::{self as gs, Generator};
+use hegel::{HealthCheck, Hegel, Settings, TestCase};
+
+const CASES: u64 = 8;
+
+fn check<T, G, P>(generator: G, property: P)
+where
+    G: Generator<T> + 'static,
+    P: Fn(&T) -> bool + 'static,
+    T: Debug,
+{
+    Hegel::new(move |tc: TestCase| {
+        let value = tc.draw(&generator);
+        assert!(property(&value), "property failed for {value:?}");
+    })
+    .settings(
+        Settings::new()
+            .test_cases(CASES)
+            .database(None)
+            .suppress_health_check(HealthCheck::all()),
+    )
+    .run();
+}
+
+fn minimal<T, G, P>(generator: G, condition: P) -> T
+where
+    G: Generator<T> + 'static,
+    P: Fn(&T) -> bool + 'static,
+    T: Send + Debug + 'static,
+{
+    let found: Arc<Mutex<Option<T>>> = Arc::new(Mutex::new(None));
+    let found_clone = Arc::clone(&found);
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        Hegel::new(move |tc: TestCase| {
+            let value = tc.draw(&generator);
+            if condition(&value) {
+                *found_clone.lock().unwrap() = Some(value);
+                panic!("HEGEL_MINIMAL_FOUND");
+            }
+        })
+        .settings(
+            Settings::new()
+                .test_cases(50)
+                .database(None)
+                .derandomize(true)
+                .suppress_health_check(HealthCheck::all()),
+        )
+        .run();
+    }));
+    if let Err(payload) = result {
+        let is_expected = payload
+            .downcast_ref::<&str>()
+            .copied()
+            .or_else(|| payload.downcast_ref::<String>().map(|s| s.as_str()))
+            .is_some_and(|s| s == "HEGEL_MINIMAL_FOUND");
+        if !is_expected {
+            std::panic::resume_unwind(payload);
+        }
+    }
+    found
+        .lock()
+        .unwrap()
+        .take()
+        .expect("no value satisfied the condition")
+}
+
+#[test]
+fn integers_respect_bounds() {
+    check(gs::integers::<i64>().min_value(-5).max_value(5), |x| {
+        (-5..=5).contains(x)
+    });
+}
+
+#[test]
+fn floats_are_finite_when_bounded() {
+    check(gs::floats::<f64>().min_value(0.0).max_value(1.0), |x| {
+        (0.0..=1.0).contains(x)
+    });
+}
+
+#[test]
+fn booleans_draw() {
+    check(gs::booleans(), |_| true);
+}
+
+#[test]
+fn text_respects_length() {
+    check(gs::text().min_size(1).max_size(4), |s: &String| {
+        (1..=4).contains(&s.chars().count())
+    });
+}
+
+#[test]
+fn binary_respects_length() {
+    check(gs::binary().min_size(2).max_size(6), |b: &Vec<u8>| {
+        (2..=6).contains(&b.len())
+    });
+}
+
+#[test]
+fn vecs_respect_length() {
+    check(
+        gs::vecs(gs::integers::<i32>()).min_size(1).max_size(5),
+        |v: &Vec<i32>| (1..=5).contains(&v.len()),
+    );
+}
+
+#[test]
+fn arrays_have_fixed_length() {
+    check(gs::arrays(gs::integers::<i32>()), |a: &[i32; 3]| {
+        a.len() == 3
+    });
+}
+
+#[test]
+fn hashmaps_and_hashsets_draw() {
+    check(
+        gs::hashmaps(gs::integers::<i32>(), gs::booleans()).max_size(4),
+        |m: &HashMap<i32, bool>| m.len() <= 4,
+    );
+    check(
+        gs::hashsets(gs::integers::<i32>()).max_size(4),
+        |s: &HashSet<i32>| s.len() <= 4,
+    );
+}
+
+#[test]
+fn tuples_draw() {
+    check(
+        gs::tuples!(gs::integers::<i32>(), gs::booleans(), gs::text()),
+        |_| true,
+    );
+}
+
+#[test]
+fn optional_and_one_of_and_sampled() {
+    check(gs::optional(gs::integers::<i32>()), |_: &Option<i32>| true);
+    check(
+        gs::one_of([
+            gs::just(1).boxed(),
+            gs::just(2).boxed(),
+            gs::just(3).boxed(),
+        ]),
+        |x: &i32| (1..=3).contains(x),
+    );
+    check(gs::sampled_from(vec!['a', 'b', 'c']), |c: &char| {
+        ['a', 'b', 'c'].contains(c)
+    });
+}
+
+#[test]
+fn map_filter_flatmap() {
+    check(gs::integers::<i32>().map(|x| x * 2), |x| x % 2 == 0);
+    check(
+        gs::integers::<i32>()
+            .min_value(0)
+            .max_value(20)
+            .filter(|x| x % 2 == 0),
+        |x| x % 2 == 0,
+    );
+    let g = gs::integers::<i32>()
+        .min_value(0)
+        .max_value(3)
+        .flat_map(|n| {
+            gs::vecs(gs::booleans())
+                .min_size(n as usize)
+                .max_size(n as usize)
+        });
+    check(g, |v: &Vec<bool>| v.len() <= 3);
+}
+
+#[derive(DeriveGenerator, Debug, Clone)]
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+#[derive(DeriveGenerator, Debug, Clone)]
+enum Shape {
+    Empty,
+    Circle(u32),
+    Rect { w: u32, h: u32 },
+}
+
+#[test]
+fn derive_struct_and_enum() {
+    check(gs::default::<Point>(), |_| true);
+    check(gs::default::<Shape>(), |_| true);
+}
+
+#[test]
+fn assume_filters_test_cases() {
+    Hegel::new(|tc: TestCase| {
+        let x: i32 = tc.draw(gs::integers().min_value(0).max_value(10));
+        tc.assume(x % 2 == 0);
+        assert!(x % 2 == 0);
+    })
+    .settings(
+        Settings::new()
+            .test_cases(CASES)
+            .database(None)
+            .suppress_health_check(HealthCheck::all()),
+    )
+    .run();
+}
+
+#[test]
+fn targeting_runs() {
+    Hegel::new(|tc: TestCase| {
+        let x: i32 = tc.draw(gs::integers().min_value(0).max_value(100));
+        tc.target(x as f64);
+    })
+    .settings(
+        Settings::new()
+            .test_cases(CASES)
+            .database(None)
+            .suppress_health_check(HealthCheck::all()),
+    )
+    .run();
+}
+
+#[test]
+fn deferred_delegates_to_inner() {
+    let d = gs::deferred::<i32>();
+    let g = d.generator();
+    d.set(gs::integers().min_value(0).max_value(10));
+    check(g, |x| (0..=10).contains(x));
+}
+
+#[test]
+fn shrinks_to_minimal_integer() {
+    let x = minimal(gs::integers::<i32>(), |x| *x > 1000);
+    assert_eq!(x, 1001);
+}


### PR DESCRIPTION
This adds a very basic set of tests that we run under miri (a lot of the test suite can't run under miri, and most of the rest is prohibitively slow) to catch problems like those fixed in #352 from cropping up in future.