### PR TITLE
Allow parallel streams of choices for concurrent data generation

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,16 @@
+RELEASE_TYPE: patch
+
+This patch makes cloned `TestCase`s generate from independent choice
+streams. Cloning a test case and moving the clone to another thread was
+already supported, but concurrent draws across clones interleaved into one
+shared sequence: values changed run to run, failures involving concurrent
+generation shrank poorly or not at all, and the docs warned the feature was
+borderline-internal. Each clone now draws from its own stream, so threads
+generating concurrently no longer interfere with each other: the same seed
+reproduces the same values on every stream, failures shrink normally
+(including the values drawn inside clones), and the shrunk counterexample
+replays exactly.
+
+Variable pools and engine-managed collections remain shared across clones;
+using one of those from two threads at the same time still makes the
+affected draws depend on scheduling order.

--- a/hegel-c/RELEASE.md
+++ b/hegel-c/RELEASE.md
@@ -1,0 +1,24 @@
+RELEASE_TYPE: minor
+
+This release changes `hegel_test_case_clone` to hand out an *independent
+stream* of the test case rather than a view onto the same choice sequence.
+A clone still shares the test case's outcome — `hegel_mark_complete` on any
+handle completes the whole family, and the choice budget is shared — but it
+generates from its own choice sequence, so clones can be driven
+concurrently from different threads without perturbing each other, and the
+values every stream produces are deterministic under replay and shrink
+correctly. Previously concurrent clone draws interleaved into one shared
+sequence, which was explicitly non-deterministic.
+
+Each cloned stream is recorded as a single choice in the stream it was
+cloned from, so cloning now consumes one choice position on the source
+handle, takes the source handle's lock like a draw (it can return
+`HEGEL_E_CONCURRENT_USE` on contention), and fails with
+`HEGEL_E_ALREADY_COMPLETE` once the test case has completed, where it
+previously succeeded and returned a dead handle. Reproduce blobs now encode
+the cloned streams' choices alongside their parent's, so blobs from tests
+that clone are not readable by older libhegel versions.
+
+Collections, variable pools, and state machines remain shared across the
+family — ids from one handle work on any other — but concurrent use of one
+such object from two streams makes the affected values scheduling-dependent.

--- a/hegel-c/include/hegel.h
+++ b/hegel-c/include/hegel.h
@@ -137,8 +137,9 @@ typedef enum {
      A single test-case handle was used from two threads at once. Each
      handle may be driven by at most one thread at a time; to generate from
      several threads, `hegel_test_case_clone` the handle and give each
-     thread its own clone. (Clones share the underlying test case but have
-     independent per-handle locks, so they may be driven concurrently.)
+     thread its own clone. (Clones share the underlying test case's
+     outcome and budgets but generate from independent streams, so they
+     may be driven concurrently and deterministically.)
      Returned by the draw primitives; `hegel_mark_complete` instead waits
      for the in-flight operation, because completion always succeeds under
      first-caller-wins.
@@ -764,21 +765,26 @@ hegel_result_t hegel_test_case_from_blob(hegel_context_t *ctx,
 hegel_result_t hegel_test_case_free(hegel_context_t *ctx, hegel_test_case_t *tc);
 
 /*
- Clone a test-case handle, writing a new handle that shares the same
- underlying test case into `*out_test_case`.
+ Clone a test-case handle, writing a new handle onto an *independent
+ stream* of the same test case into `*out_test_case`.
 
- The clone is a *view onto the same test case*, not an independent one: it
- draws from the same data source, and `hegel_mark_complete` on any handle in
- the family marks them all complete. Clones exist so a test case can be
- driven from several threads — each handle has its own lock, so two clones
- may draw concurrently, whereas using a *single* handle from two threads
- returns `HEGEL_E_CONCURRENT_USE`. (Concurrent draws across clones are
- currently non-deterministic; making them robust is future work.)
+ The clone shares the test case's outcome — `hegel_mark_complete` on any
+ handle in the family marks them all complete, and budgets are shared —
+ but generates from its own independent choice sequence. The clone and
+ the handle it came from can therefore be driven concurrently from
+ different threads without perturbing each other, and the values each
+ produces are deterministic under replay and shrink correctly. (Whereas
+ using a *single* handle from two threads returns
+ `HEGEL_E_CONCURRENT_USE`.) Collections, variable pools, and state
+ machines remain shared across the family — ids from one handle work on
+ any other — but *concurrent* use of one such object from two streams
+ makes the affected values scheduling-dependent.
 
- Cloning is allowed on a clone (the result shares the same family) and
- after the family has completed (the clone simply reports
- `HEGEL_E_ALREADY_COMPLETE` on use). It does not take the source handle's
- lock, so a handle may be cloned while another thread is mid-draw on it.
+ Cloning is a stream operation: it occupies one choice position on the
+ source handle's stream, takes the source handle's lock like a draw
+ (`HEGEL_E_CONCURRENT_USE` if another thread is mid-operation on it), and
+ fails with `HEGEL_E_ALREADY_COMPLETE` once the family has completed.
+ Cloning a clone creates a further independent stream.
 
  The new handle holds its own reference to the shared test case and must be
  released with `hegel_test_case_free`, like any other handle. The underlying

--- a/hegel-c/src/backend.rs
+++ b/hegel-c/src/backend.rs
@@ -53,6 +53,17 @@ pub trait DataSource: Send + Sync {
     /// End the current span. If `discard` is true, the span's choices are discarded.
     fn stop_span(&self, discard: bool) -> Result<(), DataSourceError>;
 
+    /// Create an independent cloned stream of this test case and return a
+    /// data source for it.
+    ///
+    /// The clone occupies one choice position in this stream and then
+    /// generates from its own independent choice sequence, so the clone and
+    /// every other stream of the family can be driven concurrently from
+    /// different threads without perturbing each other, deterministically
+    /// under replay. Completion ([`Self::mark_complete`]) remains
+    /// family-wide.
+    fn clone_stream(&self) -> Result<Box<dyn DataSource + Send + Sync>, DataSourceError>;
+
     /// Create a new collection. Returns an opaque handle.
     fn new_collection(&self, min_size: u64, max_size: Option<u64>) -> Result<i64, DataSourceError>;
 

--- a/hegel-c/src/lib.rs
+++ b/hegel-c/src/lib.rs
@@ -117,8 +117,9 @@ pub enum hegel_result_t {
     /// A single test-case handle was used from two threads at once. Each
     /// handle may be driven by at most one thread at a time; to generate from
     /// several threads, `hegel_test_case_clone` the handle and give each
-    /// thread its own clone. (Clones share the underlying test case but have
-    /// independent per-handle locks, so they may be driven concurrently.)
+    /// thread its own clone. (Clones share the underlying test case's
+    /// outcome and budgets but generate from independent streams, so they
+    /// may be driven concurrently and deterministically.)
     /// Returned by the draw primitives; `hegel_mark_complete` instead waits
     /// for the in-flight operation, because completion always succeeds under
     /// first-caller-wins.
@@ -432,21 +433,22 @@ enum WorkerMessage {
 /// `hegel_next_test_case` / `hegel_test_case_from_blob` and every
 /// `hegel_test_case_clone` descended from it.
 ///
-/// The data source, completion status, and run ack are family-wide: marking
-/// any handle complete marks the whole family, and the underlying
-/// `DataSource` is the single connection all handles draw from. Concurrent
-/// draws from two clones are memory-safe (the `NativeDataSource` serialises
-/// internally) but currently non-deterministic — making concurrent clone use
-/// robust is future work.
+/// The completion status and run ack are family-wide: marking any handle
+/// complete marks the whole family. Each handle draws from its own *stream*
+/// data source (see [`HegelTestCase::stream`]) — the root handle from the
+/// family's root stream, each clone from the independent stream
+/// `hegel_test_case_clone` created for it — so concurrent draws on
+/// different handles generate independently and deterministically.
 ///
 /// Every handle owns one `Arc<FamilyShared>` reference; the run keeps its own
 /// reference too. The `Arc` strong count is the family's reference count, so
-/// the data source is dropped only once every handle has been freed and the
+/// the engine state is dropped only once every handle has been freed and the
 /// run has released its reference.
 struct FamilyShared {
-    /// The single underlying data source, shared by every handle through the
-    /// family's own `Arc`.
-    ds: Box<dyn DataSource + Send + Sync>,
+    /// The family's root-stream data source. Every handle keeps the family
+    /// alive; the root handle also draws from this source, and completion
+    /// (which is family-wide in the engine) is reported through it.
+    ds: Arc<dyn DataSource + Send + Sync>,
     /// Family-wide completion status. Set once via `compare_exchange` in
     /// [`Self::complete`] so `ds.mark_complete` runs and the ack is sent
     /// exactly once, no matter which handle reports it.
@@ -511,6 +513,10 @@ struct LocalState {
 /// `hegel_test_case_free`
 pub struct HegelTestCase {
     family: Arc<FamilyShared>,
+    /// The independent stream this handle draws from: the family's root
+    /// stream for the root handle, a cloned stream for a
+    /// `hegel_test_case_clone` handle.
+    stream: Arc<dyn DataSource + Send + Sync>,
     local: Mutex<LocalState>,
 }
 
@@ -1385,21 +1391,26 @@ pub unsafe extern "C" fn hegel_test_case_free(
     HEGEL_OK
 }
 
-/// Clone a test-case handle, writing a new handle that shares the same
-/// underlying test case into `*out_test_case`.
+/// Clone a test-case handle, writing a new handle onto an *independent
+/// stream* of the same test case into `*out_test_case`.
 ///
-/// The clone is a *view onto the same test case*, not an independent one: it
-/// draws from the same data source, and `hegel_mark_complete` on any handle in
-/// the family marks them all complete. Clones exist so a test case can be
-/// driven from several threads — each handle has its own lock, so two clones
-/// may draw concurrently, whereas using a *single* handle from two threads
-/// returns `HEGEL_E_CONCURRENT_USE`. (Concurrent draws across clones are
-/// currently non-deterministic; making them robust is future work.)
+/// The clone shares the test case's outcome — `hegel_mark_complete` on any
+/// handle in the family marks them all complete, and budgets are shared —
+/// but generates from its own independent choice sequence. The clone and
+/// the handle it came from can therefore be driven concurrently from
+/// different threads without perturbing each other, and the values each
+/// produces are deterministic under replay and shrink correctly. (Whereas
+/// using a *single* handle from two threads returns
+/// `HEGEL_E_CONCURRENT_USE`.) Collections, variable pools, and state
+/// machines remain shared across the family — ids from one handle work on
+/// any other — but *concurrent* use of one such object from two streams
+/// makes the affected values scheduling-dependent.
 ///
-/// Cloning is allowed on a clone (the result shares the same family) and
-/// after the family has completed (the clone simply reports
-/// `HEGEL_E_ALREADY_COMPLETE` on use). It does not take the source handle's
-/// lock, so a handle may be cloned while another thread is mid-draw on it.
+/// Cloning is a stream operation: it occupies one choice position on the
+/// source handle's stream, takes the source handle's lock like a draw
+/// (`HEGEL_E_CONCURRENT_USE` if another thread is mid-operation on it), and
+/// fails with `HEGEL_E_ALREADY_COMPLETE` once the family has completed.
+/// Cloning a clone creates a further independent stream.
 ///
 /// The new handle holds its own reference to the shared test case and must be
 /// released with `hegel_test_case_free`, like any other handle. The underlying
@@ -1420,11 +1431,15 @@ pub unsafe extern "C" fn hegel_test_case_clone(
         return HEGEL_E_INVALID_ARG;
     }
     unsafe { *out_test_case = ptr::null_mut() };
-    let Some(src) = (unsafe { tc.as_ref() }) else {
-        set_last_error(ctx, "hegel_test_case_clone: test case pointer is null");
-        return HEGEL_E_INVALID_HANDLE;
+    let (src, _guard) = match unsafe { tc_guard(tc) } {
+        Ok(pair) => pair,
+        Err(rc) => return rc,
     };
-    let clone = handle_from_family(Arc::clone(&src.family));
+    let stream = match src.stream.clone_stream() {
+        Ok(stream) => stream,
+        Err(e) => return translate_ds_error(ctx, e),
+    };
+    let clone = handle_from_stream(Arc::clone(&src.family), Arc::from(stream));
     unsafe { *out_test_case = clone };
     HEGEL_OK
 }
@@ -1437,18 +1452,29 @@ fn new_family(
     ack: Option<mpsc::Sender<()>>,
 ) -> Arc<FamilyShared> {
     Arc::new(FamilyShared {
-        ds,
+        ds: Arc::from(ds),
         completed: AtomicBool::new(false),
         ack,
     })
 }
 
-/// Allocate a handle holding one reference to `family`, and return its raw
-/// pointer. Each handle has its own `local` buffer so concurrent clones do not
-/// stomp each other's borrowed values.
+/// Allocate the root handle for `family` — drawing from the family's root
+/// stream — and return its raw pointer.
 fn handle_from_family(family: Arc<FamilyShared>) -> *mut HegelTestCase {
+    let stream = Arc::clone(&family.ds);
+    handle_from_stream(family, stream)
+}
+
+/// Allocate a handle holding one reference to `family` that draws from
+/// `stream`, and return its raw pointer. Each handle has its own `local`
+/// buffer so concurrent handles do not stomp each other's borrowed values.
+fn handle_from_stream(
+    family: Arc<FamilyShared>,
+    stream: Arc<dyn DataSource + Send + Sync>,
+) -> *mut HegelTestCase {
     into_raw_send_sync(HegelTestCase {
         family,
+        stream,
         local: Mutex::new(LocalState {
             last_value: Vec::new(),
             completed: false,
@@ -1555,7 +1581,7 @@ pub unsafe extern "C" fn hegel_generate(
         }
     };
 
-    let value = match tc.family.ds.generate(&schema) {
+    let value = match tc.stream.generate(&schema) {
         Ok(v) => v,
         Err(e) => return translate_ds_error(ctx, e),
     };
@@ -1595,7 +1621,7 @@ pub unsafe extern "C" fn hegel_start_span(
         Ok(t) => t,
         Err(rc) => return rc,
     };
-    match tc.family.ds.start_span(label) {
+    match tc.stream.start_span(label) {
         Ok(()) => HEGEL_OK,
         Err(e) => translate_ds_error(ctx, e),
     }
@@ -1615,7 +1641,7 @@ pub unsafe extern "C" fn hegel_stop_span(
         Ok(t) => t,
         Err(rc) => return rc,
     };
-    match tc.family.ds.stop_span(discard) {
+    match tc.stream.stop_span(discard) {
         Ok(()) => HEGEL_OK,
         Err(e) => translate_ds_error(ctx, e),
     }
@@ -1651,7 +1677,7 @@ pub unsafe extern "C" fn hegel_new_collection(
     } else {
         Some(max_size)
     };
-    match tc.family.ds.new_collection(min_size, max) {
+    match tc.stream.new_collection(min_size, max) {
         Ok(id) => {
             unsafe { *out_collection_id = id };
             HEGEL_OK
@@ -1680,7 +1706,7 @@ pub unsafe extern "C" fn hegel_collection_more(
         set_last_error(ctx, "hegel_collection_more: out parameter is null");
         return HEGEL_E_INVALID_ARG;
     }
-    match tc.family.ds.collection_more(collection_id) {
+    match tc.stream.collection_more(collection_id) {
         Ok(m) => {
             unsafe { *out_more = m };
             HEGEL_OK
@@ -1716,7 +1742,7 @@ pub unsafe extern "C" fn hegel_collection_reject(
             }
         }
     };
-    match tc.family.ds.collection_reject(collection_id, why_str) {
+    match tc.stream.collection_reject(collection_id, why_str) {
         Ok(()) => HEGEL_OK,
         Err(e) => translate_ds_error(ctx, e),
     }
@@ -1748,7 +1774,7 @@ pub unsafe extern "C" fn hegel_new_pool(
         set_last_error(ctx, "hegel_new_pool: out parameter is null");
         return HEGEL_E_INVALID_ARG;
     }
-    match tc.family.ds.new_pool() {
+    match tc.stream.new_pool() {
         Ok(id) => {
             unsafe { *out_pool_id = id };
             HEGEL_OK
@@ -1779,7 +1805,7 @@ pub unsafe extern "C" fn hegel_pool_add(
         set_last_error(ctx, "hegel_pool_add: out parameter is null");
         return HEGEL_E_INVALID_ARG;
     }
-    match tc.family.ds.pool_add(pool_id) {
+    match tc.stream.pool_add(pool_id) {
         Ok(id) => {
             unsafe { *out_variable_id = id };
             HEGEL_OK
@@ -1816,7 +1842,7 @@ pub unsafe extern "C" fn hegel_pool_generate(
         set_last_error(ctx, "hegel_pool_generate: out parameter is null");
         return HEGEL_E_INVALID_ARG;
     }
-    match tc.family.ds.pool_generate(pool_id, consume) {
+    match tc.stream.pool_generate(pool_id, consume) {
         Ok(id) => {
             unsafe { *out_variable_id = id };
             HEGEL_OK
@@ -1921,7 +1947,7 @@ pub unsafe extern "C" fn hegel_new_state_machine(
     };
     let rule_refs: Vec<&str> = rules.iter().map(|s| s.as_str()).collect();
     let invariant_refs: Vec<&str> = invariants.iter().map(|s| s.as_str()).collect();
-    match tc.family.ds.new_state_machine(&rule_refs, &invariant_refs) {
+    match tc.stream.new_state_machine(&rule_refs, &invariant_refs) {
         Ok(id) => {
             unsafe { *out_state_machine_id = id };
             HEGEL_OK
@@ -1959,7 +1985,7 @@ pub unsafe extern "C" fn hegel_state_machine_next_rule(
         set_last_error(ctx, "hegel_state_machine_next_rule: out parameter is null");
         return HEGEL_E_INVALID_ARG;
     }
-    match tc.family.ds.state_machine_next_rule(state_machine_id) {
+    match tc.stream.state_machine_next_rule(state_machine_id) {
         Ok(index) => {
             unsafe { *out_rule_index = index };
             HEGEL_OK
@@ -2050,7 +2076,7 @@ pub unsafe extern "C" fn hegel_target(
             return HEGEL_E_INVALID_ARG;
         }
     };
-    match tc.family.ds.target_observation(value, label) {
+    match tc.stream.target_observation(value, label) {
         Ok(()) => HEGEL_OK,
         Err(e) => translate_ds_error(ctx, e),
     }

--- a/hegel-c/src/native/core/choices.rs
+++ b/hegel-c/src/native/core/choices.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use super::state::{Span, SpanEvent};
 use crate::control::hegel_internal_assert;
 use crate::native::bignum::{BigInt, BigUint, Zero};
 use crate::native::floats::sign_aware_lte;
@@ -646,6 +647,11 @@ pub enum ChoiceKind {
     Float(FloatChoice),
     Bytes(BytesChoice),
     String(StringChoice),
+    /// A clone of the test case was created at this position. The choice's
+    /// value is the cloned stream's own choice sequence (a [`CloneRecord`]);
+    /// the clone's identity (its counter within the parent stream) is
+    /// deterministic, so the kind itself carries no configuration.
+    Clone,
 }
 
 /// The value produced by a choice.
@@ -660,6 +666,174 @@ pub enum ChoiceValue {
     /// conversion to `String` (with the surrogate filter) happens at the
     /// user-facing boundary.
     String(Vec<u32>),
+    /// The choice sequence of a cloned stream, recursively. Shared via `Arc`
+    /// so shrink candidates that only differ outside this clone reuse the
+    /// child sequence instead of deep-copying it.
+    Clone(Arc<CloneRecord>),
+}
+
+/// The children of a [`CloneRecord`]: either bare choice values (a record
+/// deserialized from storage, where kinds and spans were never persisted) or
+/// the realized nodes of an executed stream together with its span structure.
+#[derive(Clone, Debug)]
+enum CloneChildren {
+    Values(Vec<ChoiceValue>),
+    Realized {
+        nodes: Vec<ChoiceNode>,
+        spans: Vec<Span>,
+        span_events: Vec<(usize, SpanEvent)>,
+    },
+}
+
+/// The choice sequence of one cloned stream, carried as the value of a
+/// [`ChoiceKind::Clone`] node in its parent stream.
+///
+/// A record's *identity* — equality, hashing, and its contribution to sort
+/// keys — is the sequence of child choice values, recursively. The realized
+/// info (child kinds, forced flags, spans, span events) is carried when the
+/// record was produced by executing the stream, and is what the shrinker and
+/// data tree interrogate; it is never serialized and never part of equality,
+/// so a record round-tripped through storage compares equal to the realized
+/// record it came from.
+#[derive(Clone, Debug)]
+pub struct CloneRecord {
+    children: CloneChildren,
+    /// Cached [`flattened_len`] of the children, so sort-key comparison of
+    /// deep trees costs one integer read per record instead of a walk.
+    flat_len: usize,
+}
+
+impl CloneRecord {
+    /// A record from bare child values (deserialized storage, or a
+    /// hand-built replay prefix). Carries no realized info.
+    pub fn from_values(values: Vec<ChoiceValue>) -> Self {
+        let flat_len = flattened_len_of_values(values.iter());
+        CloneRecord {
+            children: CloneChildren::Values(values),
+            flat_len,
+        }
+    }
+
+    /// A record from an executed stream: its realized nodes plus the span
+    /// structure recorded alongside them.
+    pub fn from_run(
+        nodes: Vec<ChoiceNode>,
+        spans: Vec<Span>,
+        span_events: Vec<(usize, SpanEvent)>,
+    ) -> Self {
+        let flat_len = flattened_len(&nodes);
+        CloneRecord {
+            children: CloneChildren::Realized {
+                nodes,
+                spans,
+                span_events,
+            },
+            flat_len,
+        }
+    }
+
+    /// The empty record: a clone that drew nothing.
+    pub fn empty() -> Self {
+        Self::from_values(Vec::new())
+    }
+
+    /// Number of direct children (top-level choices in the cloned stream).
+    pub fn len(&self) -> usize {
+        match &self.children {
+            CloneChildren::Values(v) => v.len(),
+            CloneChildren::Realized { nodes, .. } => nodes.len(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// The `i`-th child choice value.
+    pub fn value_at(&self, i: usize) -> &ChoiceValue {
+        match &self.children {
+            CloneChildren::Values(v) => &v[i],
+            CloneChildren::Realized { nodes, .. } => &nodes[i].value,
+        }
+    }
+
+    /// The child choice values, in order.
+    pub fn values(&self) -> impl Iterator<Item = &ChoiceValue> + '_ {
+        let (values, nodes) = match &self.children {
+            CloneChildren::Values(v) => (Some(v.iter()), None),
+            CloneChildren::Realized { nodes, .. } => (None, Some(nodes.iter())),
+        };
+        values
+            .into_iter()
+            .flatten()
+            .chain(nodes.into_iter().flatten().map(|n| &n.value))
+    }
+
+    /// The realized child nodes, when this record came from an execution.
+    pub fn realized_nodes(&self) -> Option<&[ChoiceNode]> {
+        match &self.children {
+            CloneChildren::Values(_) => None,
+            CloneChildren::Realized { nodes, .. } => Some(nodes),
+        }
+    }
+
+    /// The cloned stream's recorded spans (empty for a values-only record).
+    pub fn spans(&self) -> &[Span] {
+        match &self.children {
+            CloneChildren::Values(_) => &[],
+            CloneChildren::Realized { spans, .. } => spans,
+        }
+    }
+
+    /// The cloned stream's span open/close events, tagged with the child
+    /// draw position at which each fired (empty for a values-only record).
+    pub fn span_events(&self) -> &[(usize, SpanEvent)] {
+        match &self.children {
+            CloneChildren::Values(_) => &[],
+            CloneChildren::Realized { span_events, .. } => span_events,
+        }
+    }
+
+    /// Total number of choices in the cloned stream, counting nested clones'
+    /// children recursively. Cached at construction.
+    pub fn flat_len(&self) -> usize {
+        self.flat_len
+    }
+}
+
+impl PartialEq for CloneRecord {
+    fn eq(&self, other: &Self) -> bool {
+        self.flat_len == other.flat_len
+            && self.len() == other.len()
+            && self.values().zip(other.values()).all(|(a, b)| a == b)
+    }
+}
+
+impl Eq for CloneRecord {}
+
+impl std::hash::Hash for CloneRecord {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.len().hash(state);
+        for v in self.values() {
+            v.hash(state);
+        }
+    }
+}
+
+/// Total number of choices in `nodes`, counting each clone node as one
+/// choice plus its children, recursively. Equal to `nodes.len()` for a
+/// sequence with no clone nodes.
+pub fn flattened_len(nodes: &[ChoiceNode]) -> usize {
+    flattened_len_of_values(nodes.iter().map(|n| &n.value))
+}
+
+fn flattened_len_of_values<'a>(values: impl Iterator<Item = &'a ChoiceValue>) -> usize {
+    values
+        .map(|v| match v {
+            ChoiceValue::Clone(record) => 1 + record.flat_len(),
+            _ => 1,
+        })
+        .sum()
 }
 
 /// Bit-exact equality for floats keeps `-0.0` distinct from `0.0` and
@@ -672,6 +846,7 @@ impl PartialEq for ChoiceValue {
             (ChoiceValue::Float(a), ChoiceValue::Float(b)) => a.to_bits() == b.to_bits(),
             (ChoiceValue::Bytes(a), ChoiceValue::Bytes(b)) => a == b,
             (ChoiceValue::String(a), ChoiceValue::String(b)) => a == b,
+            (ChoiceValue::Clone(a), ChoiceValue::Clone(b)) => Arc::ptr_eq(a, b) || a == b,
             _ => false,
         }
     }
@@ -688,6 +863,7 @@ impl std::hash::Hash for ChoiceValue {
             ChoiceValue::Float(f) => f.to_bits().hash(state),
             ChoiceValue::Bytes(v) => v.hash(state),
             ChoiceValue::String(v) => v.hash(state),
+            ChoiceValue::Clone(r) => r.hash(state),
         }
     }
 }
@@ -730,6 +906,7 @@ impl ChoiceKind {
             ChoiceKind::Float(fc) => ChoiceValue::Float(fc.simplest()),
             ChoiceKind::Bytes(bc) => ChoiceValue::Bytes(bc.simplest()),
             ChoiceKind::String(sc) => ChoiceValue::String(sc.simplest()),
+            ChoiceKind::Clone => ChoiceValue::Clone(Arc::new(CloneRecord::empty())),
         }
     }
 
@@ -745,6 +922,7 @@ impl ChoiceKind {
             ChoiceKind::Float(fc) => ChoiceValue::Float(fc.unit()),
             ChoiceKind::Bytes(bc) => ChoiceValue::Bytes(bc.unit()),
             ChoiceKind::String(sc) => ChoiceValue::String(sc.unit()),
+            ChoiceKind::Clone => ChoiceValue::Clone(Arc::new(CloneRecord::empty())),
         }
     }
 
@@ -756,6 +934,7 @@ impl ChoiceKind {
             ChoiceKind::Float(fc) => fc.max_index(),
             ChoiceKind::Bytes(bc) => bc.max_index(),
             ChoiceKind::String(sc) => sc.max_index(),
+            ChoiceKind::Clone => unreachable!("clone choices have no dense index"),
         }
     }
 
@@ -767,6 +946,7 @@ impl ChoiceKind {
             (ChoiceKind::Float(fc), ChoiceValue::Float(v)) => fc.to_index(*v),
             (ChoiceKind::Bytes(bc), ChoiceValue::Bytes(v)) => bc.to_index(v),
             (ChoiceKind::String(sc), ChoiceValue::String(v)) => sc.to_index(v),
+            (ChoiceKind::Clone, _) => unreachable!("clone choices have no dense index"),
             _ => panic!("ChoiceKind::to_index: kind/value mismatch"),
         }
     }
@@ -780,6 +960,7 @@ impl ChoiceKind {
             ChoiceKind::Float(fc) => fc.from_index(index).map(ChoiceValue::Float),
             ChoiceKind::Bytes(bc) => bc.from_index(index).map(ChoiceValue::Bytes),
             ChoiceKind::String(sc) => sc.from_index(index).map(ChoiceValue::String),
+            ChoiceKind::Clone => unreachable!("clone choices have no dense index"),
         }
     }
 
@@ -791,6 +972,7 @@ impl ChoiceKind {
             (ChoiceKind::Float(fc), ChoiceValue::Float(v)) => fc.validate(*v),
             (ChoiceKind::Bytes(bc), ChoiceValue::Bytes(v)) => bc.validate(v),
             (ChoiceKind::String(sc), ChoiceValue::String(v)) => sc.validate(v),
+            (ChoiceKind::Clone, ChoiceValue::Clone(_)) => true,
             _ => false,
         }
     }
@@ -804,6 +986,7 @@ impl ChoiceKind {
             ChoiceKind::Float(fc) => fc.max_index() + BigUint::from(1u32),
             ChoiceKind::Bytes(bc) => bc.max_index() + BigUint::from(1u32),
             ChoiceKind::String(sc) => sc.max_index() + BigUint::from(1u32),
+            ChoiceKind::Clone => unreachable!("clone choices have no dense index"),
         }
     }
 
@@ -828,6 +1011,7 @@ impl ChoiceKind {
         };
         match self {
             ChoiceKind::Boolean(_) => 2u128.min(cap),
+            ChoiceKind::Clone => cap,
             ChoiceKind::Integer(ic) => scalar(ic.max_index()),
             ChoiceKind::Float(fc) => scalar(fc.max_index()),
             ChoiceKind::Bytes(bc) => {
@@ -860,6 +1044,7 @@ impl ChoiceKind {
             ChoiceKind::String(sc) => {
                 ChoiceValue::String(crate::native::core::state::biased_string_sample(sc, rng))
             }
+            ChoiceKind::Clone => unreachable!("clone values are never randomly sampled"),
         }
     }
 
@@ -901,6 +1086,9 @@ impl ChoiceKind {
                 } else {
                     None
                 }
+            }
+            ChoiceKind::Clone => {
+                unreachable!("Clone max_children always exceeds the enumeration cap")
             }
         }
     }
@@ -977,15 +1165,17 @@ impl ChoiceNode {
 /// Borrowed view of a [`ChoiceNode`]'s sort key, used to order nodes during
 /// shrinking (via [`NodesSortKey`]).
 ///
-/// Cross-variant order is `Scalar < Sequence`; scalars compare by
+/// Cross-variant order is `Scalar < Sequence < Clone`; scalars compare by
 /// `(magnitude, sign)`, sequence variants shortlex on length then per-element
-/// keys. The per-element keys for `Bytes` and `String` are resolved lazily
+/// keys, and clones recursively by their child sequences' [`NodesSortKey`].
+/// The per-element keys for `Bytes` and `String` are resolved lazily
 /// during comparison — `String` defers `codepoint_key` to the moment of
 /// compare — so no `Vec<u32>` ever gets allocated.
 pub enum NodeSortKeyRef<'a> {
     Scalar(crate::native::bignum::BigUint, bool),
     Bytes(&'a [u8]),
     String(&'a StringChoice, &'a [u32]),
+    Clone(&'a CloneRecord),
 }
 
 impl<'a> NodeSortKeyRef<'a> {
@@ -993,6 +1183,7 @@ impl<'a> NodeSortKeyRef<'a> {
         match self {
             NodeSortKeyRef::Scalar(..) => 0,
             NodeSortKeyRef::Bytes(..) | NodeSortKeyRef::String(..) => 1,
+            NodeSortKeyRef::Clone(..) => 2,
         }
     }
 
@@ -1003,18 +1194,22 @@ impl<'a> NodeSortKeyRef<'a> {
         match self {
             NodeSortKeyRef::Bytes(b) => b.len(),
             NodeSortKeyRef::String(_, cps) => cps.len(),
-            NodeSortKeyRef::Scalar(..) => unreachable!("seq_len on scalar"),
+            NodeSortKeyRef::Scalar(..) | NodeSortKeyRef::Clone(..) => {
+                unreachable!("seq_len on non-sequence")
+            }
         }
     }
 
     /// `i`-th per-element key in the sort-order alphabet. `i` must be in
-    /// `0..self.seq_len()`. Calling on `Scalar` is unreachable in the
-    /// only call sites (sequence-element comparison).
+    /// `0..self.seq_len()`. Calling on `Scalar` or `Clone` is unreachable in
+    /// the only call sites (sequence-element comparison).
     fn seq_key_at(&self, i: usize) -> u32 {
         match self {
             NodeSortKeyRef::Bytes(b) => b[i] as u32,
             NodeSortKeyRef::String(sc, cps) => sc.codepoint_key(cps[i]),
-            NodeSortKeyRef::Scalar(..) => unreachable!("seq_key_at on scalar"),
+            NodeSortKeyRef::Scalar(..) | NodeSortKeyRef::Clone(..) => {
+                unreachable!("seq_key_at on non-sequence")
+            }
         }
     }
 }
@@ -1040,9 +1235,8 @@ impl<'a> Ord for NodeSortKeyRef<'a> {
             (NodeSortKeyRef::Scalar(am, an), NodeSortKeyRef::Scalar(bm, bn)) => {
                 (am, an).cmp(&(bm, bn))
             }
-            (NodeSortKeyRef::Scalar(..), _) | (_, NodeSortKeyRef::Scalar(..)) => {
-                self.category().cmp(&other.category())
-            }
+            (NodeSortKeyRef::Clone(a), NodeSortKeyRef::Clone(b)) => clone_records_cmp(a, b),
+            _ if self.category() != other.category() => self.category().cmp(&other.category()),
             _ => {
                 let la = self.seq_len();
                 let lb = other.seq_len();
@@ -1060,6 +1254,41 @@ impl<'a> Ord for NodeSortKeyRef<'a> {
             }
         }
     }
+}
+
+/// Ordering between two clone records: flattened choice count first, then
+/// child count, then per-child node keys. The elementwise step needs the
+/// children's kinds and so requires realized records; sort keys are only ever
+/// computed over realized choice sequences (a values-only record exists only
+/// inside replay prefixes, which are never sort-key-compared).
+fn clone_records_cmp(a: &CloneRecord, b: &CloneRecord) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    match a.flat_len().cmp(&b.flat_len()) {
+        Ordering::Equal => {}
+        ord => return ord,
+    }
+    match a.len().cmp(&b.len()) {
+        Ordering::Equal => {}
+        ord => return ord,
+    }
+    let a_nodes = a
+        .realized_nodes()
+        .unwrap_or_else(|| unreachable!("sort keys are only computed over realized sequences"));
+    let b_nodes = b
+        .realized_nodes()
+        .unwrap_or_else(|| unreachable!("sort keys are only computed over realized sequences"));
+    elementwise_nodes_cmp(a_nodes, b_nodes)
+}
+
+/// Per-node key comparison of two equal-length node slices.
+fn elementwise_nodes_cmp(a: &[ChoiceNode], b: &[ChoiceNode]) -> std::cmp::Ordering {
+    for (na, nb) in a.iter().zip(b.iter()) {
+        match na.sort_key_ref().cmp(&nb.sort_key_ref()) {
+            std::cmp::Ordering::Equal => continue,
+            ord => return ord,
+        }
+    }
+    std::cmp::Ordering::Equal
 }
 
 impl ChoiceNode {
@@ -1081,15 +1310,22 @@ impl ChoiceNode {
             }
             (ChoiceKind::Bytes(_), ChoiceValue::Bytes(v)) => NodeSortKeyRef::Bytes(v),
             (ChoiceKind::String(sc), ChoiceValue::String(v)) => NodeSortKeyRef::String(sc, v),
+            (ChoiceKind::Clone, ChoiceValue::Clone(r)) => NodeSortKeyRef::Clone(r),
             _ => unreachable!("mismatched choice kind and value"),
         }
     }
 }
 
-/// Shortlex sort key for a sequence of choice nodes, as a borrowed view.
-/// Shorter sequences are simpler; among equal lengths, smaller per-element
-/// keys win. Comparison is allocation-free: per-element keys are resolved
-/// lazily and the first inequality short-circuits.
+/// Sort key for a sequence of choice nodes, as a borrowed view.
+///
+/// Sequences with fewer *total* choices — counting the children of clone
+/// nodes recursively, see [`flattened_len`] — are simpler, so deleting a
+/// draw inside a clone is progress just like deleting a top-level draw.
+/// Among equal flattened counts, fewer top-level nodes win (plain shortlex;
+/// for clone-free sequences the flattened count *is* the length, so this
+/// matches the historical shortlex order exactly), and among equal lengths,
+/// smaller per-element keys win. Comparison is allocation-free: per-element
+/// keys are resolved lazily and the first inequality short-circuits.
 #[derive(Clone, Copy)]
 pub struct NodesSortKey<'a>(pub &'a [ChoiceNode]);
 
@@ -1110,17 +1346,15 @@ impl<'a> PartialOrd for NodesSortKey<'a> {
 impl<'a> Ord for NodesSortKey<'a> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         use std::cmp::Ordering;
+        match flattened_len(self.0).cmp(&flattened_len(other.0)) {
+            Ordering::Equal => {}
+            ord => return ord,
+        }
         match self.0.len().cmp(&other.0.len()) {
             Ordering::Equal => {}
             ord => return ord,
         }
-        for (a, b) in self.0.iter().zip(other.0.iter()) {
-            match a.sort_key_ref().cmp(&b.sort_key_ref()) {
-                Ordering::Equal => continue,
-                ord => return ord,
-            }
-        }
-        Ordering::Equal
+        elementwise_nodes_cmp(self.0, other.0)
     }
 }
 

--- a/hegel-c/src/native/core/choices.rs
+++ b/hegel-c/src/native/core/choices.rs
@@ -732,9 +732,14 @@ impl CloneRecord {
         }
     }
 
-    /// The empty record: a clone that drew nothing.
+    /// The empty record: a clone that drew nothing. Realized (with no
+    /// nodes or spans), not values-only: the engine substitutes this record
+    /// wherever a clone value is punned or placeholdered
+    /// ([`ChoiceKind::simplest`], [`ChoiceKind::unit`], the pre-reassembly
+    /// clone node), and those positions can end up in shrink candidates that
+    /// get sort-key-compared — which requires realized info.
     pub fn empty() -> Self {
-        Self::from_values(Vec::new())
+        Self::from_run(Vec::new(), Vec::new(), Vec::new())
     }
 
     /// Number of direct children (top-level choices in the cloned stream).

--- a/hegel-c/src/native/core/choices.rs
+++ b/hegel-c/src/native/core/choices.rs
@@ -732,12 +732,7 @@ impl CloneRecord {
         }
     }
 
-    /// The empty record: a clone that drew nothing. Realized (with no
-    /// nodes or spans), not values-only: the engine substitutes this record
-    /// wherever a clone value is punned or placeholdered
-    /// ([`ChoiceKind::simplest`], [`ChoiceKind::unit`], the pre-reassembly
-    /// clone node), and those positions can end up in shrink candidates that
-    /// get sort-key-compared — which requires realized info.
+    /// The empty record: a clone that drew nothing.
     pub fn empty() -> Self {
         Self::from_run(Vec::new(), Vec::new(), Vec::new())
     }

--- a/hegel-c/src/native/core/choices.rs
+++ b/hegel-c/src/native/core/choices.rs
@@ -827,6 +827,11 @@ pub fn flattened_len(nodes: &[ChoiceNode]) -> usize {
     flattened_len_of_values(nodes.iter().map(|n| &n.value))
 }
 
+/// [`flattened_len`] over bare choice values (e.g. a replay prefix).
+pub fn flattened_values_len(values: &[ChoiceValue]) -> usize {
+    flattened_len_of_values(values.iter())
+}
+
 fn flattened_len_of_values<'a>(values: impl Iterator<Item = &'a ChoiceValue>) -> usize {
     values
         .map(|v| match v {

--- a/hegel-c/src/native/core/mod.rs
+++ b/hegel-c/src/native/core/mod.rs
@@ -4,10 +4,13 @@ pub(crate) mod state;
 pub(crate) mod state_machine;
 pub use choices::{
     BytesChoice, ChoiceKind, ChoiceNode, ChoiceValue, CloneRecord, EngineError, FloatChoice,
-    InterestingOrigin, NodesSortKey, Status, StringChoice, sort_key,
+    InterestingOrigin, NodesSortKey, Status, StringChoice, flattened_len, flattened_values_len,
+    sort_key,
 };
 pub use float_index::{float_to_index, index_to_float};
-pub use state::{ManyState, NativeTestCase, NativeVariables, Span, SpanEvent, Spans};
+pub use state::{
+    ManyState, NativeTestCase, NativeTestCaseHandle, NativeVariables, Span, SpanEvent, Spans,
+};
 pub use state_machine::NativeStateMachine;
 
 /// Maximum number of choices a single test case can make.

--- a/hegel-c/src/native/core/mod.rs
+++ b/hegel-c/src/native/core/mod.rs
@@ -3,8 +3,8 @@ pub(crate) mod float_index;
 pub(crate) mod state;
 pub(crate) mod state_machine;
 pub use choices::{
-    BytesChoice, ChoiceKind, ChoiceNode, ChoiceValue, EngineError, FloatChoice, InterestingOrigin,
-    NodesSortKey, Status, StringChoice, sort_key,
+    BytesChoice, ChoiceKind, ChoiceNode, ChoiceValue, CloneRecord, EngineError, FloatChoice,
+    InterestingOrigin, NodesSortKey, Status, StringChoice, sort_key,
 };
 pub use float_index::{float_to_index, index_to_float};
 pub use state::{ManyState, NativeTestCase, NativeVariables, Span, SpanEvent, Spans};
@@ -12,6 +12,12 @@ pub use state_machine::NativeStateMachine;
 
 /// Maximum number of choices a single test case can make.
 pub const BUFFER_SIZE: usize = 8 * 1024;
+
+/// Maximum nesting depth of cloned streams (a clone made from a clone made
+/// from …). The engine rejects deeper clones the same way it rejects
+/// over-deep spans, and the choice deserializer refuses deeper nesting so
+/// corrupt storage can't drive unbounded recursion.
+pub const MAX_CLONE_DEPTH: usize = 100;
 
 /// Probability of drawing a boundary/special value per special candidate.
 pub const BOUNDARY_PROBABILITY: f64 = 0.01;

--- a/hegel-c/src/native/core/state.rs
+++ b/hegel-c/src/native/core/state.rs
@@ -1,14 +1,17 @@
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
-use std::sync::{LazyLock, Mutex};
+use std::sync::atomic::{AtomicI64, AtomicU8, AtomicUsize, Ordering};
+use std::sync::{Arc, LazyLock, Mutex};
 
 use rand::{Rng, RngExt};
 
 use crate::native::rng::EngineRng;
 
+use super::MAX_CLONE_DEPTH;
 use super::choices::{
     BooleanChoice, BytesChoice, ChoiceKind, ChoiceNode, ChoiceTemplate, ChoiceTemplateKind,
-    ChoiceValue, EngineError, FloatChoice, IntegerChoice, InterestingOrigin, Status, StringChoice,
+    ChoiceValue, CloneRecord, EngineError, FloatChoice, IntegerChoice, InterestingOrigin, Status,
+    StringChoice,
 };
 use super::float_index::index_to_float;
 use super::state_machine::NativeStateMachine;
@@ -913,26 +916,147 @@ pub trait DataObserver: Send {
     fn conclude_test(&mut self, _status: Status, _origin: Option<InterestingOrigin>) {}
 }
 
+/// Shared handle to one stream of a test case family. The root stream is
+/// owned directly by whoever constructed it; cloned streams are only ever
+/// reachable through this handle.
+pub type NativeTestCaseHandle = Arc<Mutex<NativeTestCase>>;
+
+/// The [`Status`] mirror value meaning "not concluded yet" in
+/// [`FamilyCore::concluded_status`].
+const STATUS_UNSET: u8 = u8::MAX;
+
+/// State shared by every stream of one test-case *family*: the root
+/// [`NativeTestCase`] plus every stream cloned from it, directly or
+/// transitively, via [`NativeTestCase::clone_stream`].
+///
+/// A family concludes exactly once: the first stream to conclude wins, and
+/// every other stream's subsequent draws fail fast with the family's
+/// verdict. The draw budget and `tc.target()` observations are likewise
+/// family-wide. Collections, variable pools, and state machines are shared
+/// across streams so ids remain valid on any clone; they are shared mutable
+/// state, so when several clones use one concurrently the interleaving (and
+/// therefore replay of the affected values) is scheduling-dependent.
+pub struct FamilyCore {
+    /// The family's write-once conclusion, with the interesting origin for
+    /// an `Interesting` verdict.
+    conclusion: Mutex<Option<(Status, Option<InterestingOrigin>)>>,
+    /// Lock-free mirror of the conclusion's status for the draw hot path:
+    /// [`STATUS_UNSET`] until concluded, then the status discriminant.
+    concluded_status: AtomicU8,
+    /// Draws made across every stream of the family.
+    total_draws: AtomicUsize,
+    /// Cap on [`Self::total_draws`]. `usize::MAX` for bare replays, whose
+    /// per-stream prefix caps already bound every stream; the requested
+    /// `max_size` whenever an RNG or trailing template can extend draws.
+    budget: AtomicUsize,
+    /// `tc.target()` observations, keyed by label. Family-wide so the
+    /// once-per-test-case label uniqueness holds across clones.
+    pub(crate) target_observations: Mutex<HashMap<String, f64>>,
+    /// Variable-length collection state, keyed by collection id.
+    pub(crate) collections: Mutex<HashMap<i64, ManyState>>,
+    next_collection_id: AtomicI64,
+    /// Variable pools for stateful testing, indexed by pool id.
+    pub(crate) variable_pools: Mutex<Vec<NativeVariables>>,
+    /// State machines, indexed by machine id. Each machine sits behind its
+    /// own lock so two clones drawing rules concurrently serialize on the
+    /// machine while drawing from their own streams.
+    pub(crate) state_machines: Mutex<Vec<Arc<Mutex<NativeStateMachine>>>>,
+}
+
+impl FamilyCore {
+    fn new(budget: usize) -> Self {
+        FamilyCore {
+            conclusion: Mutex::new(None),
+            concluded_status: AtomicU8::new(STATUS_UNSET),
+            total_draws: AtomicUsize::new(0),
+            budget: AtomicUsize::new(budget),
+            target_observations: Mutex::new(HashMap::new()),
+            collections: Mutex::new(HashMap::new()),
+            next_collection_id: AtomicI64::new(0),
+            variable_pools: Mutex::new(Vec::new()),
+            state_machines: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// The family's concluded status, or `None` while still running.
+    pub fn status(&self) -> Option<Status> {
+        match self.concluded_status.load(Ordering::Acquire) {
+            STATUS_UNSET => None,
+            raw => Some(match raw {
+                0 => Status::EarlyStop,
+                1 => Status::Invalid,
+                2 => Status::Valid,
+                3 => Status::Interesting,
+                _ => unreachable!("concluded_status only stores Status discriminants"),
+            }),
+        }
+    }
+
+    /// Claim the family-wide conclusion. First caller wins; later calls are
+    /// no-ops.
+    pub fn conclude(&self, status: Status, origin: Option<InterestingOrigin>) {
+        let mut guard = self.conclusion.lock().unwrap_or_else(|e| e.into_inner());
+        if guard.is_none() {
+            *guard = Some((status, origin));
+            self.concluded_status.store(status as u8, Ordering::Release);
+        }
+    }
+
+    /// The full conclusion (status plus origin), or `None` while running.
+    pub fn conclusion(&self) -> Option<(Status, Option<InterestingOrigin>)> {
+        self.conclusion
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
+
+    /// Reserve one draw against the family budget. Returns `false` when the
+    /// budget is exhausted.
+    fn try_take_draw(&self) -> bool {
+        self.total_draws.fetch_add(1, Ordering::Relaxed) < self.budget.load(Ordering::Relaxed)
+    }
+
+    fn set_budget(&self, budget: usize) {
+        self.budget.store(budget, Ordering::Relaxed);
+    }
+
+    /// Allocate the next collection id.
+    pub(crate) fn next_collection_id(&self) -> i64 {
+        self.next_collection_id.fetch_add(1, Ordering::Relaxed)
+    }
+}
+
 /// A test case backed by a sequence of typed choices.
 ///
 /// During random generation, choices are drawn from the RNG.
 /// During replay/shrinking, choices are drawn from a prefix.
+///
+/// One `NativeTestCase` is one *stream* of a test-case family: the root
+/// stream, or a cloned stream created by [`Self::clone_stream`]. Each stream
+/// has its own prefix, RNG, nodes, and span structure, so streams driven
+/// from different threads generate independently; the conclusion, draw
+/// budget, and stateful bookkeeping are shared through [`FamilyCore`].
 pub struct NativeTestCase {
     prefix: Vec<ChoiceValue>,
     prefix_nodes: Option<Vec<ChoiceNode>>,
     rng: Option<EngineRng>,
     max_size: usize,
     pub nodes: Vec<ChoiceNode>,
-    pub status: Option<Status>,
     /// Set to `true` by [`Self::freeze`] on the first call; subsequent calls
-    /// are no-ops. A dedicated boolean (rather than checking `status`) lets
-    /// `conclude_test` set `self.status` before calling `freeze()` without
-    /// triggering the idempotency early-return.
+    /// are no-ops. A dedicated boolean (rather than checking the family's
+    /// status) lets `conclude_test` conclude before calling `freeze()`
+    /// without triggering the idempotency early-return.
     frozen: bool,
-    pub collections: HashMap<i64, ManyState>,
-    next_collection_id: i64,
-    pub variable_pools: Vec<NativeVariables>,
-    pub state_machines: Vec<NativeStateMachine>,
+    /// State shared with every other stream of this test case's family.
+    pub(crate) family: Arc<FamilyCore>,
+    /// This stream's position in the clone tree: empty for the root, the
+    /// parent's id plus the parent's clone counter for a cloned stream.
+    clone_id: Vec<usize>,
+    /// Number of clones made from this stream so far.
+    clone_counter: usize,
+    /// Streams cloned from this one, each with the index of its clone node
+    /// in [`Self::nodes`]. Drained by [`Self::reassemble`].
+    clone_children: Vec<(usize, NativeTestCaseHandle)>,
     pub spans: Spans,
     /// Indices into `spans` for currently-open spans, in nesting order.
     /// Each entry was pushed by `start_span` and is awaiting a matching
@@ -964,10 +1088,6 @@ pub struct NativeTestCase {
     /// Set by [`Self::for_choices`] and called by each draw method and
     /// by [`Self::freeze`].
     observer: Option<Box<dyn DataObserver>>,
-    /// The interesting origin set by [`Self::conclude_test`], if any.
-    /// `None` for test cases concluded by [`Self::freeze`] directly
-    /// (`Status::Valid`).
-    interesting_origin: Option<InterestingOrigin>,
     /// Optional template applied to every draw past the explicit `prefix`.
     /// `count` is mutated in-place as draws consume the template; when
     /// `count` reaches zero the next draw is overrun
@@ -994,18 +1114,48 @@ impl NativeTestCase {
         max_size: usize,
         observer: Option<Box<dyn DataObserver>>,
     ) -> Self {
+        let max_size = max_size.max(choices.len());
+        let budget = if trailing.is_some() {
+            max_size
+        } else {
+            usize::MAX
+        };
+        Self::new_stream(
+            choices.to_vec(),
+            prefix_nodes.map(|n| n.to_vec()),
+            None,
+            trailing,
+            max_size,
+            observer,
+            Arc::new(FamilyCore::new(budget)),
+            Vec::new(),
+        )
+    }
+
+    /// Build one stream — the root (fresh family) or a clone (shared
+    /// family). The only place a `NativeTestCase` is constructed.
+    #[allow(clippy::too_many_arguments)]
+    fn new_stream(
+        prefix: Vec<ChoiceValue>,
+        prefix_nodes: Option<Vec<ChoiceNode>>,
+        rng: Option<EngineRng>,
+        trailing_template: Option<ChoiceTemplate>,
+        max_size: usize,
+        observer: Option<Box<dyn DataObserver>>,
+        family: Arc<FamilyCore>,
+        clone_id: Vec<usize>,
+    ) -> Self {
         NativeTestCase {
-            prefix: choices.to_vec(),
-            prefix_nodes: prefix_nodes.map(|n| n.to_vec()),
-            rng: None,
-            max_size: max_size.max(choices.len()),
+            prefix,
+            prefix_nodes,
+            rng,
+            max_size,
             nodes: Vec::new(),
-            status: None,
             frozen: false,
-            collections: HashMap::new(),
-            next_collection_id: 0,
-            variable_pools: Vec::new(),
-            state_machines: Vec::new(),
+            family,
+            clone_id,
+            clone_counter: 0,
+            clone_children: Vec::new(),
             spans: Spans::new(),
             span_stack: Vec::new(),
             span_events: Vec::new(),
@@ -1013,8 +1163,7 @@ impl NativeTestCase {
             tags: HashSet::new(),
             labels_for_structure_stack: Vec::new(),
             observer,
-            interesting_origin: None,
-            trailing_template: trailing,
+            trailing_template,
         }
     }
 
@@ -1053,10 +1202,105 @@ impl NativeTestCase {
 
     /// Attach an RNG for post-prefix random draws.  Internal builder used by
     /// `new_random` and `for_probe` to share the [`Self::for_choices_and_template`]
-    /// constructor without duplicating the struct literal.
+    /// constructor without duplicating the struct literal. Random draws can
+    /// extend any stream, so the family budget becomes the requested
+    /// `max_size` rather than the bare-replay `usize::MAX`.
     fn with_random(mut self, rng: EngineRng) -> Self {
         self.rng = Some(rng);
+        self.family.set_budget(self.max_size);
         self
+    }
+
+    /// The family state shared by every stream of this test case.
+    pub(crate) fn family(&self) -> &Arc<FamilyCore> {
+        &self.family
+    }
+
+    /// Create an independent cloned stream of this test case.
+    ///
+    /// The clone occupies one choice position in this stream (a
+    /// [`ChoiceKind::Clone`] node) and gets its own prefix, RNG, and span
+    /// structure, so it can be drawn from concurrently with every other
+    /// stream without perturbing them. On replay, a [`ChoiceValue::Clone`]
+    /// prefix value at this position hands the child its recorded stream; a
+    /// non-clone prefix value puns to an empty child (which overruns on its
+    /// first draw in a bare replay, or extends randomly under a probe).
+    ///
+    /// Fails with the family's verdict if the family has concluded, and
+    /// marks the family invalid when clones nest deeper than
+    /// [`MAX_CLONE_DEPTH`].
+    pub fn clone_stream(&mut self) -> Result<NativeTestCaseHandle, EngineError> {
+        self.pre_choice()?;
+        if self.clone_id.len() + 1 > MAX_CLONE_DEPTH {
+            self.conclude(Status::Invalid, None);
+            self.freeze();
+            return Err(EngineError::InvalidTestCase);
+        }
+        let idx = self.nodes.len();
+        let (child_prefix, child_prefix_nodes) = match self.prefix.get(idx) {
+            Some(ChoiceValue::Clone(record)) => (
+                record.values().cloned().collect::<Vec<_>>(),
+                record.realized_nodes().map(<[ChoiceNode]>::to_vec),
+            ),
+            _ => (Vec::new(), None),
+        };
+        let child_rng = self.rng.as_mut().map(EngineRng::spawn);
+        let child_template = self.trailing_template.as_ref().map(|t| ChoiceTemplate {
+            kind: t.kind,
+            count: None,
+        });
+        let child_max_size = if child_rng.is_some() || child_template.is_some() {
+            usize::MAX
+        } else {
+            child_prefix.len()
+        };
+        let mut child_id = self.clone_id.clone();
+        child_id.push(self.clone_counter);
+        self.clone_counter += 1;
+
+        let child = Self::new_stream(
+            child_prefix,
+            child_prefix_nodes,
+            child_rng,
+            child_template,
+            child_max_size,
+            None,
+            Arc::clone(&self.family),
+            child_id,
+        );
+        let handle = Arc::new(Mutex::new(child));
+        self.nodes.push(ChoiceNode::new(
+            ChoiceKind::Clone,
+            ChoiceValue::Clone(Arc::new(CloneRecord::empty())),
+            false,
+        ));
+        self.clone_children.push((idx, Arc::clone(&handle)));
+        Ok(handle)
+    }
+
+    /// Replace each clone node's placeholder value with the realized record
+    /// of its stream — nodes, spans, and span events — recursively, so
+    /// [`Self::nodes`] becomes the self-contained pieced-together choice
+    /// sequence of the whole family.
+    ///
+    /// A no-op until the family has concluded: streams can still grow while
+    /// the family is running, and a concluded family's streams cannot (every
+    /// draw fails fast), so the records are snapshotted exactly once.
+    pub fn reassemble(&mut self) {
+        if self.family.status().is_none() {
+            return;
+        }
+        for (idx, handle) in std::mem::take(&mut self.clone_children) {
+            let mut child = handle.lock().unwrap_or_else(|e| e.into_inner());
+            child.freeze();
+            child.reassemble();
+            let record = CloneRecord::from_run(
+                child.nodes.clone(),
+                child.spans.clone().into_vec(),
+                child.span_events.clone(),
+            );
+            self.nodes[idx].value = ChoiceValue::Clone(Arc::new(record));
+        }
     }
 
     /// Open a new span at the current choice position, labelled with `label`.
@@ -1145,36 +1389,38 @@ impl NativeTestCase {
         }
         self.conclude(Status::Valid, None);
         if let Some(ref mut obs) = self.observer {
-            let origin = self.interesting_origin.clone();
-            obs.conclude_test(self.status.unwrap(), origin);
+            let (status, origin) = self
+                .family
+                .conclusion()
+                .unwrap_or_else(|| unreachable!("freeze just concluded the family"));
+            obs.conclude_test(status, origin);
         }
     }
 
     /// Conclude the test case with `status` (and `origin`, for an interesting
-    /// verdict). This is the single, write-once status assignment: if the case
-    /// has already concluded — an overrun or failed assume during a draw, a
-    /// too-deep nesting, or the body's reported verdict — that conclusion
-    /// stands and this is a no-op. Every status the engine or the test body
-    /// assigns flows through here, so a concluded case can never be
-    /// re-concluded.
+    /// verdict). This is the single, write-once status assignment for the
+    /// whole family: if any stream has already concluded — an overrun or
+    /// failed assume during a draw, a too-deep nesting, or the body's
+    /// reported verdict — that conclusion stands and this is a no-op. Every
+    /// status the engine or the test body assigns flows through here, so a
+    /// concluded case can never be re-concluded.
     pub fn conclude(&mut self, status: Status, origin: Option<InterestingOrigin>) {
-        if self.status.is_none() {
-            self.status = Some(status);
-            self.interesting_origin = origin;
-        }
+        self.family.conclude(status, origin);
     }
 
-    /// The interesting origin recorded by [`Self::conclude`], if the case
-    /// concluded with [`Status::Interesting`].
-    pub fn interesting_origin(&self) -> Option<&InterestingOrigin> {
-        self.interesting_origin.as_ref()
+    /// The family's concluded status, or `None` while still running.
+    pub fn status(&self) -> Option<Status> {
+        self.family.status()
     }
 
     /// Allocate a new collection ID and store the given state.
     pub fn new_collection(&mut self, state: ManyState) -> i64 {
-        let id = self.next_collection_id;
-        self.next_collection_id += 1;
-        self.collections.insert(id, state);
+        let id = self.family.next_collection_id();
+        self.family
+            .collections
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(id, state);
         id
     }
 
@@ -1453,13 +1699,13 @@ impl NativeTestCase {
         Ok(v)
     }
     fn pre_choice(&mut self) -> Result<(), EngineError> {
-        if let Some(status) = self.status {
+        if let Some(status) = self.family.status() {
             return Err(match status {
                 Status::Invalid => EngineError::InvalidTestCase,
                 _ => EngineError::Overrun,
             });
         }
-        if self.nodes.len() >= self.max_size {
+        if self.nodes.len() >= self.max_size || !self.family.try_take_draw() {
             self.conclude(Status::EarlyStop, None);
             return Err(EngineError::Overrun);
         }
@@ -1520,3 +1766,7 @@ impl NativeTestCase {
 #[cfg(test)]
 #[path = "../../../tests/embedded/native/state_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "../../../tests/embedded/native/state_clone_tests.rs"]
+mod clone_tests;

--- a/hegel-c/src/native/data_source.rs
+++ b/hegel-c/src/native/data_source.rs
@@ -1,35 +1,16 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
 
 use ciborium::Value;
 
 use crate::backend::{DataSource, DataSourceError, Failure, TestCaseResult};
 use crate::native::bignum::{BigInt, ToPrimitive};
 use crate::native::core::{
-    ChoiceNode, EngineError, InterestingOrigin, ManyState, NativeTestCase, Span, SpanEvent, Status,
+    ChoiceNode, EngineError, InterestingOrigin, ManyState, NativeTestCase, NativeTestCaseHandle,
+    Span, SpanEvent, Status,
 };
 use crate::native::schema;
-
-/// Per-test-case state shared between `NativeDataSource` and the engine
-/// that owns the handle.  The engine constructs both halves up-front,
-/// hands the data source into the test body, and then reads back nodes,
-/// spans, and the outcome through the handle.
-///
-/// The outcome lives on `ntc` as its (write-once) status plus interesting
-/// origin — set through [`NativeTestCase::conclude`], whether by a draw
-/// (overrun, assume, too-deep) or by [`DataSource::mark_complete`] — so there
-/// is a single source of truth that a late report cannot overwrite.
-pub struct NativeTestCaseInner {
-    pub ntc: NativeTestCase,
-    /// `tc.target()` observations recorded during the test case, keyed by
-    /// label. Populated by [`DataSource::target_observation`]; read back by
-    /// the targeting phase via [`NativeDataSource::take_target_observations`].
-    pub target_observations: HashMap<String, f64>,
-}
-
-/// Shared handle to the per-test-case inner state.
-pub type NativeTestCaseHandle = Arc<Mutex<NativeTestCaseInner>>;
 
 pub struct NativeDataSource {
     inner: NativeTestCaseHandle,
@@ -37,34 +18,38 @@ pub struct NativeDataSource {
 }
 
 impl NativeDataSource {
-    /// Create a new `NativeDataSource` and return a shared handle.
+    /// Create a new `NativeDataSource` and return a shared handle to its
+    /// stream.
     ///
     /// The handle is the only way the engine reads back per-test-case
     /// state: choice nodes, spans, and the outcome reported by
     /// [`DataSource::mark_complete`].
     pub fn new(ntc: NativeTestCase) -> (Self, NativeTestCaseHandle) {
-        let inner = Arc::new(Mutex::new(NativeTestCaseInner {
-            ntc,
-            target_observations: HashMap::new(),
-        }));
-        let handle = Arc::clone(&inner);
-        (
-            NativeDataSource {
-                inner,
-                aborted: AtomicBool::new(false),
-            },
-            handle,
-        )
+        let handle: NativeTestCaseHandle = Arc::new(std::sync::Mutex::new(ntc));
+        (Self::from_handle(Arc::clone(&handle)), handle)
+    }
+
+    /// Wrap an existing stream handle — used for the root stream (via
+    /// [`Self::new`]) and for cloned streams (via
+    /// [`DataSource::clone_stream`]). Each wrapper has its own abort latch,
+    /// so one stream aborting on overrun doesn't mark its siblings' sources
+    /// aborted.
+    fn from_handle(handle: NativeTestCaseHandle) -> Self {
+        NativeDataSource {
+            inner: handle,
+            aborted: AtomicBool::new(false),
+        }
     }
 
     /// Convenience: extract choice nodes from a handle after a test case.
+    ///
+    /// Reassembles first, so once the family has concluded every clone node
+    /// carries its stream's realized record and the returned sequence is the
+    /// self-contained pieced-together choice sequence of the whole family.
     pub fn take_nodes(handle: &NativeTestCaseHandle) -> Vec<ChoiceNode> {
-        handle
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .ntc
-            .nodes
-            .clone()
+        let mut ntc = handle.lock().unwrap_or_else(|e| e.into_inner());
+        ntc.reassemble();
+        ntc.nodes.clone()
     }
 
     /// Convenience: extract spans from a handle after a test case.
@@ -72,7 +57,6 @@ impl NativeDataSource {
         handle
             .lock()
             .unwrap_or_else(|e| e.into_inner())
-            .ntc
             .spans
             .clone()
             .into_vec()
@@ -85,7 +69,6 @@ impl NativeDataSource {
         handle
             .lock()
             .unwrap_or_else(|e| e.into_inner())
-            .ntc
             .span_events
             .clone()
     }
@@ -100,35 +83,36 @@ impl NativeDataSource {
         handle
             .lock()
             .unwrap_or_else(|e| e.into_inner())
+            .family()
             .target_observations
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
             .clone()
     }
 
-    /// The test case's outcome, reconstructed from its write-once status (and
-    /// interesting origin). Whoever concluded the case first — a draw that
-    /// overran or hit a terminal assume, or the body via `mark_complete` — set
-    /// the status, and a later report could not change it.
+    /// The test case's outcome, reconstructed from its family's write-once
+    /// conclusion. Whoever concluded the family first — a draw that overran
+    /// or hit a terminal assume, or the body via `mark_complete` — set the
+    /// status, and a later report could not change it.
     ///
-    /// Panics only if the case never concluded — i.e. `mark_complete` was never
-    /// called on a case that didn't conclude during a draw, which the
+    /// Panics only if the family never concluded — i.e. `mark_complete` was
+    /// never called on a case that didn't conclude during a draw, which the
     /// cross-backend lifecycle in `run_lifecycle::run_test_case` guarantees
     /// won't occur.
     pub fn take_outcome(handle: &NativeTestCaseHandle) -> TestCaseResult {
-        let inner = handle.lock().unwrap_or_else(|e| e.into_inner());
-        let status = inner
-            .ntc
-            .status
-            .expect("mark_complete must be called for every test case");
+        let conclusion = handle
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .family()
+            .conclusion();
+        let (status, origin) =
+            conclusion.expect("mark_complete must be called for every test case");
         match status {
             Status::Valid => TestCaseResult::Valid,
             Status::Invalid => TestCaseResult::Invalid,
             Status::EarlyStop => TestCaseResult::Overrun,
             Status::Interesting => TestCaseResult::Interesting(Failure {
-                origin: inner
-                    .ntc
-                    .interesting_origin()
-                    .map(|o| o.0.clone())
-                    .unwrap_or_default(),
+                origin: origin.map(|o| o.0).unwrap_or_default(),
                 reproduce_blob: None,
             }),
         }
@@ -145,7 +129,7 @@ impl NativeDataSource {
     /// Acquire the test-case state under the abort guard.  Returns
     /// `DataSourceError::StopTest` immediately if a previous call has already
     /// aborted the test case so subsequent draws short-circuit without
-    /// touching `ntc`.
+    /// touching the stream.
     fn with_ntc<R>(
         &self,
         f: impl FnOnce(&mut NativeTestCase) -> Result<R, EngineError>,
@@ -153,8 +137,8 @@ impl NativeDataSource {
         if self.aborted.load(Ordering::Relaxed) {
             return Err(self.aborted_error());
         }
-        let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        f(&mut inner.ntc).map_err(|e| match e {
+        let mut ntc = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        f(&mut ntc).map_err(|e| match e {
             EngineError::Overrun => {
                 self.aborted.store(true, Ordering::Relaxed);
                 DataSourceError::StopTest
@@ -169,8 +153,12 @@ impl NativeDataSource {
     }
 
     fn aborted_error(&self) -> DataSourceError {
-        let inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        match inner.ntc.status {
+        let status = self
+            .inner
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .status();
+        match status {
             Some(Status::Invalid) => DataSourceError::Assume,
             _ => DataSourceError::StopTest,
         }
@@ -215,6 +203,12 @@ impl DataSource for NativeDataSource {
         })
     }
 
+    fn clone_stream(&self) -> Result<Box<dyn DataSource + Send + Sync>, DataSourceError> {
+        self.with_ntc(|ntc| ntc.clone_stream()).map(|handle| {
+            Box::new(NativeDataSource::from_handle(handle)) as Box<dyn DataSource + Send + Sync>
+        })
+    }
+
     fn new_collection(&self, min_size: u64, max_size: Option<u64>) -> Result<i64, DataSourceError> {
         self.with_ntc(|ntc| {
             let state = ManyState::new(min_size as usize, max_size.map(|n| n as usize));
@@ -224,13 +218,12 @@ impl DataSource for NativeDataSource {
 
     fn collection_more(&self, collection_id: i64) -> Result<bool, DataSourceError> {
         self.with_ntc(|ntc| {
-            let mut state = ntc
-                .collections
-                .remove(&collection_id)
+            let family = Arc::clone(ntc.family());
+            let mut collections = family.collections.lock().unwrap_or_else(|e| e.into_inner());
+            let state = collections
+                .get_mut(&collection_id)
                 .ok_or_else(|| unknown_id_error("collection", collection_id))?;
-            let result = schema::many_more(ntc, &mut state);
-            ntc.collections.insert(collection_id, state);
-            result
+            schema::many_more(ntc, state)
         })
     }
 
@@ -240,13 +233,12 @@ impl DataSource for NativeDataSource {
         _why: Option<&str>,
     ) -> Result<(), DataSourceError> {
         self.with_ntc(|ntc| {
-            let mut state = ntc
-                .collections
-                .remove(&collection_id)
+            let family = Arc::clone(ntc.family());
+            let mut collections = family.collections.lock().unwrap_or_else(|e| e.into_inner());
+            let state = collections
+                .get_mut(&collection_id)
                 .ok_or_else(|| unknown_id_error("collection", collection_id))?;
-            let result = schema::many_reject(ntc, &mut state);
-            ntc.collections.insert(collection_id, state);
-            result
+            schema::many_reject(ntc, state)
         })
     }
 
@@ -263,22 +255,32 @@ impl DataSource for NativeDataSource {
         let rules = rule_names.iter().map(|s| s.to_string()).collect();
         let invariants = invariant_names.iter().map(|s| s.to_string()).collect();
         self.with_ntc(|ntc| {
-            let id = ntc.state_machines.len() as i64;
-            ntc.state_machines
-                .push(crate::native::core::NativeStateMachine::new(
-                    rules, invariants,
-                ));
+            let mut machines = ntc
+                .family()
+                .state_machines
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let id = machines.len() as i64;
+            machines.push(Arc::new(std::sync::Mutex::new(
+                crate::native::core::NativeStateMachine::new(rules, invariants),
+            )));
             Ok(id)
         })
     }
 
     fn state_machine_next_rule(&self, state_machine_id: i64) -> Result<i64, DataSourceError> {
         self.with_ntc(|ntc| {
-            let idx = checked_id("state machine", state_machine_id, ntc.state_machines.len())?;
-            let mut machine = std::mem::take(&mut ntc.state_machines[idx]);
-            let result = machine.next_rule(ntc);
-            ntc.state_machines[idx] = machine;
-            result
+            let machine = {
+                let machines = ntc
+                    .family()
+                    .state_machines
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner());
+                let idx = checked_id("state machine", state_machine_id, machines.len())?;
+                Arc::clone(&machines[idx])
+            };
+            let mut machine = machine.lock().unwrap_or_else(|e| e.into_inner());
+            machine.next_rule(ntc)
         })
     }
 
@@ -305,24 +307,38 @@ impl DataSource for NativeDataSource {
 
     fn new_pool(&self) -> Result<i64, DataSourceError> {
         self.with_ntc(|ntc| {
-            let pool_id = ntc.variable_pools.len() as i64;
-            ntc.variable_pools
-                .push(crate::native::core::NativeVariables::new());
+            let mut pools = ntc
+                .family()
+                .variable_pools
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let pool_id = pools.len() as i64;
+            pools.push(crate::native::core::NativeVariables::new());
             Ok(pool_id)
         })
     }
 
     fn pool_add(&self, pool_id: i64) -> Result<i64, DataSourceError> {
         self.with_ntc(|ntc| {
-            let idx = checked_id("variable pool", pool_id, ntc.variable_pools.len())?;
-            Ok(ntc.variable_pools[idx].next())
+            let mut pools = ntc
+                .family()
+                .variable_pools
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let idx = checked_id("variable pool", pool_id, pools.len())?;
+            Ok(pools[idx].next())
         })
     }
 
     fn pool_generate(&self, pool_id: i64, consume: bool) -> Result<i64, DataSourceError> {
         self.with_ntc(|ntc| {
-            let pool_idx = checked_id("variable pool", pool_id, ntc.variable_pools.len())?;
-            let active = ntc.variable_pools[pool_idx].active();
+            let family = Arc::clone(ntc.family());
+            let mut pools = family
+                .variable_pools
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let pool_idx = checked_id("variable pool", pool_id, pools.len())?;
+            let active = pools[pool_idx].active();
             if active.is_empty() {
                 return Err(EngineError::AssumeViolation);
             }
@@ -333,7 +349,7 @@ impl DataSource for NativeDataSource {
                 .unwrap() as usize;
             let variable_id = active[n - 1 - k];
             if consume {
-                ntc.variable_pools[pool_idx].consume(variable_id);
+                pools[pool_idx].consume(variable_id);
             }
             Ok(variable_id)
         })
@@ -346,20 +362,29 @@ impl DataSource for NativeDataSource {
                  got non-finite value"
             )));
         }
-        let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        if inner.target_observations.contains_key(label) {
+        let family = Arc::clone(
+            self.inner
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .family(),
+        );
+        let mut observations = family
+            .target_observations
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        if observations.contains_key(label) {
             return Err(DataSourceError::InvalidArgument(format!(
                 "tc.target({score}, label={label:?}) would overwrite previous \
                  tc.target(_, label={label:?}); each label can be observed at \
                  most once per test case"
             )));
         }
-        inner.target_observations.insert(label.to_string(), score);
+        observations.insert(label.to_string(), score);
         Ok(())
     }
 
     fn mark_complete(&self, result: &TestCaseResult) {
-        let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let mut ntc = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         let (status, origin) = match result {
             TestCaseResult::Valid => (Status::Valid, None),
             TestCaseResult::Invalid => (Status::Invalid, None),
@@ -369,7 +394,7 @@ impl DataSource for NativeDataSource {
                 Some(InterestingOrigin(failure.origin.clone())),
             ),
         };
-        inner.ntc.conclude(status, origin);
+        ntc.conclude(status, origin);
     }
 }
 

--- a/hegel-c/src/native/data_tree.rs
+++ b/hegel-c/src/native/data_tree.rs
@@ -22,7 +22,10 @@ use crate::native::rng::EngineRng;
 
 /// Hashable choice-value key. `f64` is keyed by its bit pattern so `-0.0`
 /// stays distinct from `0.0` and individual NaN payloads are tracked
-/// separately — both matter for novel-prefix exhaustion accounting.
+/// separately — both matter for novel-prefix exhaustion accounting. Clone
+/// values key by their child value sequence, recursively (the
+/// [`CloneRecord`](crate::native::core::CloneRecord) `Eq`/`Hash` impls
+/// compare values only, so realized info never splits a key).
 #[derive(Clone, PartialEq, Eq, Hash)]
 enum ChoiceValueKey {
     Integer(BigInt),
@@ -30,6 +33,7 @@ enum ChoiceValueKey {
     Float(u64),
     Bytes(Vec<u8>),
     String(Vec<u32>),
+    Clone(Arc<crate::native::core::CloneRecord>),
 }
 
 impl From<&ChoiceValue> for ChoiceValueKey {
@@ -40,6 +44,7 @@ impl From<&ChoiceValue> for ChoiceValueKey {
             ChoiceValue::Float(f) => ChoiceValueKey::Float(f.to_bits()),
             ChoiceValue::Bytes(b) => ChoiceValueKey::Bytes(b.clone()),
             ChoiceValue::String(s) => ChoiceValueKey::String(s.clone()),
+            ChoiceValue::Clone(r) => ChoiceValueKey::Clone(Arc::clone(r)),
         }
     }
 }
@@ -54,6 +59,7 @@ impl ChoiceValueKey {
             ChoiceValueKey::Float(bits) => ChoiceValue::Float(f64::from_bits(*bits)),
             ChoiceValueKey::Bytes(b) => ChoiceValue::Bytes(b.clone()),
             ChoiceValueKey::String(s) => ChoiceValue::String(s.clone()),
+            ChoiceValueKey::Clone(r) => ChoiceValue::Clone(Arc::clone(r)),
         }
     }
 }

--- a/hegel-c/src/native/data_tree.rs
+++ b/hegel-c/src/native/data_tree.rs
@@ -13,11 +13,14 @@ use std::sync::Arc;
 
 use rustc_hash::FxHashMap;
 
+use rand::RngExt;
 use rand::seq::SliceRandom;
 
 use crate::control::hegel_internal_debug_assert;
 use crate::native::bignum::BigInt;
-use crate::native::core::{ChoiceKind, ChoiceNode, ChoiceValue, Span, SpanEvent, Status};
+use crate::native::core::{
+    ChoiceKind, ChoiceNode, ChoiceValue, CloneRecord, Span, SpanEvent, Status,
+};
 use crate::native::rng::EngineRng;
 
 /// Hashable choice-value key. `f64` is keyed by its bit pattern so `-0.0`
@@ -33,7 +36,7 @@ enum ChoiceValueKey {
     Float(u64),
     Bytes(Vec<u8>),
     String(Vec<u32>),
-    Clone(Arc<crate::native::core::CloneRecord>),
+    Clone(Arc<CloneRecord>),
 }
 
 impl From<&ChoiceValue> for ChoiceValueKey {
@@ -106,6 +109,26 @@ pub(crate) struct DataTreeNode {
     conclusion: Option<Conclusion>,
     /// Cached: true iff the subtree rooted here has been fully explored.
     pub(crate) is_exhausted: bool,
+    /// For a `Clone`-kind node: a trie over the cloned stream's own choices,
+    /// recorded from each realized [`CloneRecord`] observed here. Used to
+    /// predict punning inside the clone during [`simulate_full`] and to
+    /// generate novel prefixes *into* the cloned stream. The node's ordinary
+    /// `children` remain keyed by the complete realized record, which is
+    /// what keeps the parent's continuation sound when its behaviour depends
+    /// on values the clone drew.
+    clone_subtree: Option<Box<DataTreeNode>>,
+    /// Set when recording into `clone_subtree` contradicted an earlier
+    /// stream (a changed kind or a changed stream end at the same child
+    /// path). That happens when the cloned stream's behaviour depends on
+    /// values from *other* streams (cross-thread communication), which the
+    /// child-only trie cannot condition on — so prediction inside this clone
+    /// is disabled and only exact realized-record matches are served, rather
+    /// than misreporting the run as non-deterministic.
+    clone_subtree_disabled: bool,
+    /// Within a clone subtree: a recorded cloned stream ended at this node.
+    /// Plays the role a conclusion plays in the main tree — the walk ends
+    /// here, and the node is exhausted.
+    stream_ended: bool,
 }
 
 /// Iterative drop so a thousands-deep single-path tree doesn't blow
@@ -115,8 +138,10 @@ impl Drop for DataTreeNode {
     fn drop(&mut self) {
         let mut stack: Vec<Box<DataTreeNode>> =
             self.children.drain().map(|(_, child)| child).collect();
+        stack.extend(self.clone_subtree.take());
         while let Some(mut node) = stack.pop() {
             stack.extend(node.children.drain().map(|(_, child)| child));
+            stack.extend(node.clone_subtree.take());
         }
     }
 }
@@ -223,6 +248,9 @@ pub(crate) fn record_tree_full(
             }
             _ => {}
         }
+        if let ChoiceValue::Clone(record) = &first.value {
+            record_clone_record(node, record);
+        }
         let key = ChoiceValueKey::from(&first.value);
         let child = node
             .children
@@ -270,6 +298,97 @@ pub(crate) fn record_tree_full(
     None
 }
 
+/// Fold one realized clone record into its clone node's subtree trie,
+/// disabling the subtree on any contradiction (see
+/// [`DataTreeNode::clone_subtree_disabled`]).
+fn record_clone_record(node: &mut DataTreeNode, record: &CloneRecord) {
+    if node.clone_subtree_disabled {
+        return;
+    }
+    let subtree = node
+        .clone_subtree
+        .get_or_insert_with(|| Box::new(DataTreeNode::default()));
+    if record_clone_stream(subtree, record).is_err() {
+        node.clone_subtree = None;
+        node.clone_subtree_disabled = true;
+    }
+}
+
+/// Record one cloned stream's realized record into the clone subtree trie
+/// rooted at `root`: the walk mirrors [`record_tree_full`], with the
+/// stream's end marked by [`DataTreeNode::stream_ended`] (and exhaustion) in
+/// place of a conclusion, and nested clone records recorded recursively.
+///
+/// Returns `Err(())` on any contradiction with a previously recorded stream
+/// — a changed kind at a position, a stream that previously ended here but
+/// now continues (or vice versa), or a record with no realized info. The
+/// caller disables prediction for this clone rather than treating the run
+/// as non-deterministic: a cloned stream's behaviour may legitimately
+/// depend on values from other streams, which this child-only trie cannot
+/// see.
+fn record_clone_stream(root: &mut DataTreeNode, record: &CloneRecord) -> Result<(), ()> {
+    let Some(nodes) = record.realized_nodes() else {
+        return Err(());
+    };
+    let mut path: Vec<*mut DataTreeNode> = Vec::with_capacity(nodes.len() + 1);
+    path.push(root as *mut _);
+
+    for first in nodes {
+        let parent_ptr = *path.last().unwrap();
+        // SAFETY: `parent_ptr` is either `root` or a child reached through
+        // the entry API below; the previous iteration's borrow has ended.
+        let node = unsafe { &mut *parent_ptr };
+        if node.stream_ended {
+            return Err(());
+        }
+        match &node.kind {
+            Some(expected_kind) if *expected_kind != first.kind => return Err(()),
+            None => {
+                node.kind = Some(first.kind.clone());
+                node.forced = first.was_forced;
+            }
+            _ => {}
+        }
+        if let ChoiceValue::Clone(nested) = &first.value {
+            record_clone_record(node, nested);
+        }
+        let key = ChoiceValueKey::from(&first.value);
+        let child = node
+            .children
+            .entry(key)
+            .or_insert_with(|| Box::new(DataTreeNode::default()));
+        path.push(child.as_mut() as *mut _);
+    }
+
+    let mut by_pos: Vec<Vec<SpanEvent>> = vec![Vec::new(); nodes.len() + 1];
+    for (pos, ev) in record.span_events() {
+        if let Some(slot) = by_pos.get_mut(*pos) {
+            slot.push(ev.clone());
+        }
+    }
+    for (depth, events) in by_pos.into_iter().enumerate() {
+        // SAFETY: `path[depth]` is a unique pointer into the subtree; no
+        // other reference into it is live.
+        let node = unsafe { &mut *path[depth] };
+        node.span_events = events;
+    }
+
+    // SAFETY: the just-walked leaf pointer; no other live reference.
+    let leaf = unsafe { &mut **path.last().unwrap() };
+    if leaf.kind.is_some() {
+        return Err(());
+    }
+    leaf.stream_ended = true;
+    leaf.is_exhausted = true;
+
+    while let Some(p) = path.pop() {
+        // SAFETY: the just-popped pointer; no other live reference.
+        let node = unsafe { &mut *p };
+        node.check_exhausted();
+    }
+    Ok(())
+}
+
 /// Small-domain cap for enumeration fallback in
 /// `pick_non_exhausted_value`.
 const ENUMERATION_CAP: u64 = 1024;
@@ -311,6 +430,14 @@ fn pick_non_exhausted_value(
 /// `DataTree.generate_novel_prefix` simplified for hegel's tree shape.
 /// An empty prefix means "draw everything fresh" — correct on the
 /// first call, when the tree is empty.
+///
+/// At a clone node the walk chooses between generating novelty *inside* the
+/// cloned stream (a recursive walk of the clone subtree, after which the
+/// prefix must stop — the resulting continuation has never been seen) and
+/// descending an already-realized record's continuation. When neither is
+/// available the prefix stops before the clone node, leaving the clone (and
+/// everything after it) to fresh random generation; a clone node's child
+/// space is unbounded, so it never exhausts the walk.
 pub(crate) fn generate_novel_prefix(
     tree_root: &DataTreeNode,
     rng: &mut EngineRng,
@@ -329,6 +456,38 @@ pub(crate) fn generate_novel_prefix(
                 .expect("a forced node records its single child in the same run");
             prefix.push(key.to_value());
             hegel_internal_debug_assert!(!child.is_exhausted);
+            current = child;
+            continue;
+        }
+        if matches!(**kind, ChoiceKind::Clone) {
+            let inside = if current.clone_subtree_disabled {
+                None
+            } else {
+                current
+                    .clone_subtree
+                    .as_deref()
+                    .filter(|s| !s.is_exhausted && s.kind.is_some())
+            };
+            let continuations: Vec<(&ChoiceValueKey, &DataTreeNode)> = current
+                .children
+                .iter()
+                .filter(|(_, c)| !c.is_exhausted)
+                .map(|(k, c)| (k, c.as_ref()))
+                .collect();
+            if let Some(subtree) = inside {
+                if continuations.is_empty() || rng.random::<f64>() < 0.5 {
+                    let sub_prefix = generate_novel_prefix(subtree, rng);
+                    prefix.push(ChoiceValue::Clone(Arc::new(CloneRecord::from_values(
+                        sub_prefix,
+                    ))));
+                    break;
+                }
+            }
+            if continuations.is_empty() {
+                break;
+            }
+            let (key, child) = continuations[rng.random_range(0..continuations.len())];
+            prefix.push(key.to_value());
             current = child;
             continue;
         }
@@ -400,34 +559,9 @@ pub(crate) fn simulate_full(
     let mut i = 0usize;
     loop {
         let pos = nodes.len();
-        for ev in &current.span_events {
-            match ev {
-                SpanEvent::Open { label } => {
-                    let parent = span_stack.last().copied();
-                    let depth = span_stack.len() as u32;
-                    let idx = spans.len();
-                    spans.push(Span {
-                        start: pos,
-                        end: pos,
-                        label: label.to_string(),
-                        depth,
-                        parent,
-                        discarded: false,
-                    });
-                    span_stack.push(idx);
-                }
-                SpanEvent::Close { discarded } => {
-                    if let Some(idx) = span_stack.pop() {
-                        spans[idx].end = pos;
-                        spans[idx].discarded = *discarded;
-                    }
-                }
-            }
-        }
+        replay_span_events(&current.span_events, pos, &mut spans, &mut span_stack);
         if let Some(concl) = &current.conclusion {
-            while let Some(idx) = span_stack.pop() {
-                spans[idx].end = pos;
-            }
+            close_open_spans(pos, &mut spans, &mut span_stack);
             return Some(SimulatedOutcome {
                 status: concl.status,
                 nodes,
@@ -443,9 +577,141 @@ pub(crate) fn simulate_full(
         let (realised, next) = if current.forced {
             let (key, next) = current.children.iter().next()?;
             (key.to_value(), next.as_ref())
+        } else if matches!(**kind, ChoiceKind::Clone) {
+            let (record, next) = resolve_clone_position(current, &choices[i])?;
+            (ChoiceValue::Clone(record), next)
         } else {
             let realised = if kind.validate(&choices[i]) {
                 choices[i].clone()
+            } else {
+                kind.unit()
+            };
+            let next = current.children.get(&ChoiceValueKey::from(&realised))?;
+            (realised, next.as_ref())
+        };
+        nodes.push(ChoiceNode::new((**kind).clone(), realised, current.forced));
+        i += 1;
+        current = next;
+    }
+}
+
+/// Apply one node's recorded span events at draw position `pos`, exactly as
+/// `start_span` / `stop_span` would have live.
+fn replay_span_events(
+    events: &[SpanEvent],
+    pos: usize,
+    spans: &mut Vec<Span>,
+    span_stack: &mut Vec<usize>,
+) {
+    for ev in events {
+        match ev {
+            SpanEvent::Open { label } => {
+                let parent = span_stack.last().copied();
+                let depth = span_stack.len() as u32;
+                let idx = spans.len();
+                spans.push(Span {
+                    start: pos,
+                    end: pos,
+                    label: label.to_string(),
+                    depth,
+                    parent,
+                    discarded: false,
+                });
+                span_stack.push(idx);
+            }
+            SpanEvent::Close { discarded } => {
+                if let Some(idx) = span_stack.pop() {
+                    spans[idx].end = pos;
+                    spans[idx].discarded = *discarded;
+                }
+            }
+        }
+    }
+}
+
+/// Close every still-open span at position `pos`, exactly as `freeze` does
+/// at the end of a stream.
+fn close_open_spans(pos: usize, spans: &mut [Span], span_stack: &mut Vec<usize>) {
+    while let Some(idx) = span_stack.pop() {
+        spans[idx].end = pos;
+    }
+}
+
+/// Resolve a clone position during simulation: predict the realized record
+/// the candidate value at this position would produce, and look up the
+/// parent's continuation for it.
+///
+/// With a usable clone subtree the prediction walks the candidate's child
+/// values through it ([`simulate_clone_stream`]), reproducing punning inside
+/// the clone; without one (never recorded, or disabled after a
+/// contradiction) only an exact value match can be served — the lookup keys
+/// on values, so the candidate's own record suffices. Either way the
+/// *stored* key's record is returned, which carries the realized child
+/// nodes and spans. A non-clone candidate puns to the empty clone, exactly
+/// as `clone_stream` does on replay.
+fn resolve_clone_position<'t>(
+    node: &'t DataTreeNode,
+    candidate: &ChoiceValue,
+) -> Option<(Arc<CloneRecord>, &'t DataTreeNode)> {
+    let candidate_values: Vec<ChoiceValue> = match candidate {
+        ChoiceValue::Clone(r) => r.values().cloned().collect(),
+        _ => Vec::new(),
+    };
+    let key = match &node.clone_subtree {
+        Some(subtree) if !node.clone_subtree_disabled => {
+            ChoiceValueKey::Clone(Arc::new(simulate_clone_stream(subtree, &candidate_values)?))
+        }
+        _ => ChoiceValueKey::Clone(Arc::new(CloneRecord::from_values(candidate_values))),
+    };
+    let (stored_key, next) = node.children.get_key_value(&key)?;
+    let ChoiceValueKey::Clone(stored) = stored_key else {
+        unreachable!("clone keys only compare equal to clone keys");
+    };
+    Some((Arc::clone(stored), next.as_ref()))
+}
+
+/// Walk candidate child `values` through a clone subtree trie, reproducing
+/// how the cloned stream would replay them, and return the realized record —
+/// child nodes with kinds from the trie, spans replayed from the trie's span
+/// events, and the span events themselves.
+///
+/// Mirrors [`simulate_full`], with [`DataTreeNode::stream_ended`] playing
+/// the conclusion's role: reaching it realizes the stream (trailing
+/// candidate values are simply never read, like trailing values past a
+/// conclusion). Returns `None` when the walk leaves recorded territory —
+/// a divergent value, an unexplored position, or candidate values running
+/// out while the recorded stream kept drawing (a real child would overrun
+/// or extend randomly; either way the outcome must be executed to learn).
+fn simulate_clone_stream(root: &DataTreeNode, values: &[ChoiceValue]) -> Option<CloneRecord> {
+    let mut current = root;
+    let mut nodes: Vec<ChoiceNode> = Vec::new();
+    let mut spans: Vec<Span> = Vec::new();
+    let mut span_stack: Vec<usize> = Vec::new();
+    let mut events_out: Vec<(usize, SpanEvent)> = Vec::new();
+    let mut i = 0usize;
+    loop {
+        let pos = nodes.len();
+        for ev in &current.span_events {
+            events_out.push((pos, ev.clone()));
+        }
+        replay_span_events(&current.span_events, pos, &mut spans, &mut span_stack);
+        if current.stream_ended {
+            close_open_spans(pos, &mut spans, &mut span_stack);
+            return Some(CloneRecord::from_run(nodes, spans, events_out));
+        }
+        let kind = current.kind.as_ref()?;
+        if i >= values.len() {
+            return None;
+        }
+        let (realised, next) = if current.forced {
+            let (key, next) = current.children.iter().next()?;
+            (key.to_value(), next.as_ref())
+        } else if matches!(**kind, ChoiceKind::Clone) {
+            let (record, next) = resolve_clone_position(current, &values[i])?;
+            (ChoiceValue::Clone(record), next)
+        } else {
+            let realised = if kind.validate(&values[i]) {
+                values[i].clone()
             } else {
                 kind.unit()
             };

--- a/hegel-c/src/native/database.rs
+++ b/hegel-c/src/native/database.rs
@@ -163,7 +163,8 @@ pub(super) fn fnv_hex(s: &[u8]) -> String {
 /// Format:
 /// - 4-byte little-endian u32: number of choices
 /// - For each choice:
-///   - 1-byte type tag: 0=Integer, 1=Boolean, 2=Float, 3=Bytes, 4=String
+///   - 1-byte type tag: 0=Integer, 1=Boolean, 2=Float, 3=Bytes, 4=String,
+///     5=Clone
 ///   - Value bytes:
 ///     - Integer: a 1-byte width sub-tag (always 10=BigInt for new writes;
 ///       sub-tags 0–9 are still accepted on read for backward compat)
@@ -175,15 +176,26 @@ pub(super) fn fnv_hex(s: &[u8]) -> String {
 ///     - Bytes: 4 bytes (u32 little-endian length) followed by the raw bytes
 ///     - String: 4 bytes (u32 little-endian codepoint count) followed by
 ///       4 bytes per codepoint (u32 little-endian)
+///     - Clone: the cloned stream's child choice values in this same
+///       count-then-entries layout, recursively. Only the values are
+///       persisted — spans and kinds are recreated on replay.
 pub fn serialize_choices(choices: &[ChoiceValue]) -> Vec<u8> {
     let mut buf = Vec::with_capacity(4 + choices.len() * 17);
-    let count = choices.len() as u32;
-    buf.extend_from_slice(&count.to_le_bytes());
+    serialize_choice_list(&mut buf, choices.len(), choices.iter());
+    buf
+}
+
+fn serialize_choice_list<'a>(
+    buf: &mut Vec<u8>,
+    count: usize,
+    choices: impl Iterator<Item = &'a ChoiceValue>,
+) {
+    buf.extend_from_slice(&(count as u32).to_le_bytes());
     for choice in choices {
         match choice {
             ChoiceValue::Integer(v) => {
                 buf.push(0);
-                serialize_any_integer(&mut buf, v);
+                serialize_any_integer(buf, v);
             }
             ChoiceValue::Boolean(v) => {
                 buf.push(1);
@@ -207,9 +219,12 @@ pub fn serialize_choices(choices: &[ChoiceValue]) -> Vec<u8> {
                     buf.extend_from_slice(&cp.to_le_bytes());
                 }
             }
+            ChoiceValue::Clone(record) => {
+                buf.push(5);
+                serialize_choice_list(buf, record.len(), record.values());
+            }
         }
     }
-    buf
 }
 
 /// Encode a [`BigInt`] as sub-tag 10 followed by a length-prefixed
@@ -263,15 +278,29 @@ fn deserialize_any_integer(bytes: &[u8], pos: usize) -> Option<(BigInt, usize)> 
 
 /// Decode a byte slice produced by [`serialize_choices`].
 ///
-/// Returns `None` if the data is truncated, malformed, or contains an
-/// unknown type tag (defensive against filesystem corruption).
+/// Returns `None` if the data is truncated, malformed, contains an unknown
+/// type tag, or nests clone values deeper than
+/// [`MAX_CLONE_DEPTH`](crate::native::core::MAX_CLONE_DEPTH) (defensive
+/// against filesystem corruption).
 pub fn deserialize_choices(bytes: &[u8]) -> Option<Vec<ChoiceValue>> {
-    if bytes.len() < 4 {
+    let (choices, _) = deserialize_choice_list(bytes, 0, 0)?;
+    Some(choices)
+}
+
+fn deserialize_choice_list(
+    bytes: &[u8],
+    start: usize,
+    depth: usize,
+) -> Option<(Vec<ChoiceValue>, usize)> {
+    if depth > crate::native::core::MAX_CLONE_DEPTH {
         return None;
     }
-    let count = u32::from_le_bytes(bytes[..4].try_into().ok()?) as usize;
+    if start + 4 > bytes.len() {
+        return None;
+    }
+    let count = u32::from_le_bytes(bytes[start..start + 4].try_into().ok()?) as usize;
     let mut choices = Vec::with_capacity(count.min(bytes.len()));
-    let mut pos = 4;
+    let mut pos = start + 4;
     for _ in 0..count {
         if pos >= bytes.len() {
             return None;
@@ -331,10 +360,18 @@ pub fn deserialize_choices(bytes: &[u8]) -> Option<Vec<ChoiceValue>> {
                 }
                 choices.push(ChoiceValue::String(cps));
             }
+            5 => {
+                pos += 1;
+                let (children, new_pos) = deserialize_choice_list(bytes, pos, depth + 1)?;
+                pos = new_pos;
+                choices.push(ChoiceValue::Clone(std::sync::Arc::new(
+                    crate::native::core::CloneRecord::from_values(children),
+                )));
+            }
             _ => return None,
         }
     }
-    Some(choices)
+    Some((choices, pos))
 }
 
 #[cfg(test)]

--- a/hegel-c/src/native/shrinker/clones.rs
+++ b/hegel-c/src/native/shrinker/clones.rs
@@ -1,0 +1,114 @@
+//! Nested shrinking of cloned streams.
+//!
+//! The flat passes treat a clone node as an opaque unit: they can delete it
+//! or replace it with the empty clone, but never touch the choices *inside*
+//! it. This pass gives each clone node its own nested [`Shrinker`] over the
+//! child stream: every nested candidate is spliced into the current parent
+//! sequence at the clone's position and replayed through the outer test
+//! function, and the realized child stream is read back out of the run's
+//! clone node. Clones nested inside the child recurse through the same pass
+//! of the nested shrinker.
+
+use std::sync::Arc;
+
+use crate::native::core::{ChoiceNode, ChoiceValue, CloneRecord, Spans, flattened_values_len};
+
+use super::{ShrinkResult, ShrinkRun, Shrinker};
+
+/// `template` with the clone node at `i` carrying `child` as its stream.
+/// The spliced record has no span info — replay recreates spans — and
+/// carries the candidate's nodes so replay puns against the child kinds.
+fn splice_child(template: &[ChoiceNode], i: usize, child: &[ChoiceNode]) -> Vec<ChoiceNode> {
+    let mut candidate = template.to_vec();
+    candidate[i] = candidate[i].with_value(ChoiceValue::Clone(Arc::new(CloneRecord::from_run(
+        child.to_vec(),
+        Vec::new(),
+        Vec::new(),
+    ))));
+    candidate
+}
+
+impl<'a> Shrinker<'a> {
+    /// Run a full nested shrink over the stream inside each clone node of
+    /// the current best sequence.
+    pub(super) fn shrink_clone_streams(&mut self) -> ShrinkResult<()> {
+        let mut i = 0;
+        while i < self.current_nodes.len() {
+            self.shrink_clone_stream_at(i)?;
+            i += 1;
+        }
+        Ok(())
+    }
+
+    /// Nested-shrink the clone node at `i`, if the node is one (with a
+    /// non-empty realized stream); a no-op otherwise.
+    fn shrink_clone_stream_at(&mut self, i: usize) -> ShrinkResult<()> {
+        let (child_nodes, child_spans) = {
+            let ChoiceValue::Clone(record) = &self.current_nodes[i].value else {
+                return Ok(());
+            };
+            let Some(nodes) = record.realized_nodes() else {
+                return Ok(());
+            };
+            if nodes.is_empty() {
+                return Ok(());
+            }
+            (nodes.to_vec(), record.spans().to_vec())
+        };
+        let template = self.current_nodes.clone();
+        let outer_values: Vec<ChoiceValue> = template.iter().map(|n| n.value.clone()).collect();
+        let deadline = self.deadline;
+
+        let (final_child, nested_timed_out) = {
+            let test_fn = &mut self.test_fn;
+            let mut nested = Shrinker::with_probe(
+                Box::new(|req: ShrinkRun| {
+                    let (matched, actual) = match req {
+                        ShrinkRun::Full(child) => {
+                            let candidate = splice_child(&template, i, child);
+                            let (matched, actual, _) = (test_fn)(ShrinkRun::Full(&candidate));
+                            (matched, actual)
+                        }
+                        ShrinkRun::Probe { prefix, max_size } => {
+                            let mut values = outer_values.clone();
+                            values[i] = ChoiceValue::Clone(Arc::new(CloneRecord::from_values(
+                                prefix.to_vec(),
+                            )));
+                            let child_extend = max_size.saturating_sub(prefix.len());
+                            let (matched, actual, _) = (test_fn)(ShrinkRun::Probe {
+                                max_size: flattened_values_len(&values) + child_extend,
+                                prefix: &values,
+                            });
+                            (matched, actual)
+                        }
+                    };
+                    match actual.get(i).map(|n| &n.value) {
+                        Some(ChoiceValue::Clone(record)) if record.realized_nodes().is_some() => {
+                            let nodes = record
+                                .realized_nodes()
+                                .unwrap_or_else(|| unreachable!("guarded by the match arm"))
+                                .to_vec();
+                            let spans = Spans::from(record.spans().to_vec());
+                            (matched, nodes, spans)
+                        }
+                        _ => (false, Vec::new(), Spans::new()),
+                    }
+                }),
+                child_nodes,
+                Spans::from(child_spans),
+            );
+            nested.deadline = deadline;
+            nested.shrink();
+            (nested.current_nodes, nested.timed_out)
+        };
+        self.timed_out |= nested_timed_out;
+
+        let spliced = splice_child(&self.current_nodes, i, &final_child);
+        self.consider(&spliced)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[path = "../../../tests/embedded/native/shrinker_clones_tests.rs"]
+mod tests;

--- a/hegel-c/src/native/shrinker/coarse.rs
+++ b/hegel-c/src/native/shrinker/coarse.rs
@@ -87,7 +87,7 @@ impl<'a> Shrinker<'a> {
             .map(|n| n.value.clone())
             .collect();
         prefix.push(ChoiceValue::Integer(v.clone()));
-        let max_size = self.current_nodes.len() + 16;
+        let max_size = crate::native::core::flattened_len(&self.current_nodes) + 16;
         let epoch = self.improvements;
         for _ in 0..3 {
             self.probe(&prefix, max_size)?;

--- a/hegel-c/src/native/shrinker/floats.rs
+++ b/hegel-c/src/native/shrinker/floats.rs
@@ -339,7 +339,10 @@ fn can_choose_for_redistribute(node: &ChoiceNode) -> bool {
 fn is_float_or_integer(k: &ChoiceKind) -> bool {
     match k {
         ChoiceKind::Float(_) | ChoiceKind::Integer(_) => true,
-        ChoiceKind::Boolean(_) | ChoiceKind::Bytes(_) | ChoiceKind::String(_) => false,
+        ChoiceKind::Boolean(_)
+        | ChoiceKind::Bytes(_)
+        | ChoiceKind::String(_)
+        | ChoiceKind::Clone => false,
     }
 }
 

--- a/hegel-c/src/native/shrinker/index_passes.rs
+++ b/hegel-c/src/native/shrinker/index_passes.rs
@@ -10,8 +10,13 @@ use crate::native::core::{ChoiceKind, ChoiceValue};
 
 use super::{ShrinkResult, Shrinker};
 
-fn is_sequence(kind: &std::sync::Arc<ChoiceKind>) -> bool {
-    matches!(**kind, ChoiceKind::Bytes(_) | ChoiceKind::String(_))
+/// Nodes the index passes skip: sequence kinds get their own dedicated
+/// passes, and clone nodes are opaque containers with no dense index.
+fn is_unindexed(kind: &std::sync::Arc<ChoiceKind>) -> bool {
+    matches!(
+        **kind,
+        ChoiceKind::Bytes(_) | ChoiceKind::String(_) | ChoiceKind::Clone
+    )
 }
 
 impl<'a> Shrinker<'a> {
@@ -29,7 +34,7 @@ impl<'a> Shrinker<'a> {
                 let i = idx;
                 let node_i = self.current_nodes[i].clone();
                 let kind_i = node_i.kind.clone();
-                if is_sequence(&kind_i) {
+                if is_unindexed(&kind_i) {
                     idx += 1;
                     continue;
                 }
@@ -70,7 +75,7 @@ impl<'a> Shrinker<'a> {
                     }
                     self.consider(&zeroed)?;
 
-                    if j < self.current_nodes.len() && !is_sequence(&self.current_nodes[j].kind) {
+                    if j < self.current_nodes.len() && !is_unindexed(&self.current_nodes[j].kind) {
                         let kind_j = self.current_nodes[j].kind.clone();
                         let target_idx = kind_j.to_index(&self.current_nodes[j].value);
                         let mut bumped_any_relative = false;
@@ -119,7 +124,7 @@ impl<'a> Shrinker<'a> {
         while i < self.current_nodes.len() {
             let node = self.current_nodes[i].clone();
             let kind = node.kind.clone();
-            if is_sequence(&kind) {
+            if is_unindexed(&kind) {
                 i += 1;
                 continue;
             }

--- a/hegel-c/src/native/shrinker/mod.rs
+++ b/hegel-c/src/native/shrinker/mod.rs
@@ -1,4 +1,5 @@
 mod bytes;
+mod clones;
 mod coarse;
 mod deletion;
 mod floats;
@@ -503,6 +504,10 @@ impl<'a> Shrinker<'a> {
             ShrinkPass::new(
                 "try_shortening_via_increment",
                 Box::new(|sh| sh.try_shortening_via_increment()),
+            ),
+            ShrinkPass::new(
+                "shrink_clone_streams",
+                Box::new(|sh| sh.shrink_clone_streams()),
             ),
             ShrinkPass::new("mutate_and_shrink", Box::new(|sh| sh.mutate_and_shrink())),
         ];

--- a/hegel-c/src/native/shrinker/mutation.rs
+++ b/hegel-c/src/native/shrinker/mutation.rs
@@ -36,6 +36,7 @@ impl<'a> Shrinker<'a> {
                 *kind.as_ref(),
                 crate::native::core::ChoiceKind::Bytes(_)
                     | crate::native::core::ChoiceKind::String(_)
+                    | crate::native::core::ChoiceKind::Clone
             ) {
                 i += 1;
                 continue;
@@ -63,7 +64,7 @@ impl<'a> Shrinker<'a> {
                     .map(|n| n.value.clone())
                     .chain(std::iter::once(new_val.clone()))
                     .collect();
-                let max_size = self.current_nodes.len();
+                let max_size = crate::native::core::flattened_len(&self.current_nodes);
 
                 for _ in 0..=RANDOM_ATTEMPTS {
                     self.probe(&prefix, max_size)?;
@@ -75,6 +76,9 @@ impl<'a> Shrinker<'a> {
                     j_offset += 1;
 
                     let kind_j = self.current_nodes[j].kind.clone();
+                    if matches!(*kind_j.as_ref(), crate::native::core::ChoiceKind::Clone) {
+                        continue;
+                    }
                     let Some(unit_val) = kind_j.from_index(BigUint::from(1u32)) else {
                         continue;
                     };

--- a/hegel-c/src/native/test_runner.rs
+++ b/hegel-c/src/native/test_runner.rs
@@ -265,7 +265,7 @@ impl<'a> Engine<'a> {
             if let Some(msg) = large_initial_check(
                 run.status == Status::EarlyStop,
                 run.status,
-                run.nodes.len(),
+                crate::native::core::flattened_len(&run.nodes),
                 settings
                     .suppress_health_check
                     .contains(&HealthCheck::LargeInitialTestCase),
@@ -330,7 +330,7 @@ impl<'a> Engine<'a> {
                         "test case #{}: status = {:?}, choices = {}",
                         self.calls,
                         run.status,
-                        run.nodes.len()
+                        crate::native::core::flattened_len(&run.nodes)
                     );
                 }
 
@@ -1093,7 +1093,8 @@ impl<'a> Engine<'a> {
         let ntc = if extend == 0 {
             NativeTestCase::for_choices(choices, nodes, None)
         } else {
-            NativeTestCase::for_probe(choices, self.rng_spawn(), choices.len() + extend)
+            let budget = crate::native::core::flattened_values_len(choices) + extend;
+            NativeTestCase::for_probe(choices, self.rng_spawn(), budget)
         };
         let (run, _mismatch) = self.test_function(ntc);
         run

--- a/hegel-c/tests/c_abi_inprocess.rs
+++ b/hegel-c/tests/c_abi_inprocess.rs
@@ -1297,7 +1297,6 @@ fn clones_share_a_run_owned_family() {
             HEGEL_OK
         );
 
-        // Cloning a clone creates a further independent stream.
         let mut c1a: *mut HegelTestCase = ptr::null_mut();
         assert_eq!(hegel_test_case_clone(ctx, c1, &mut c1a), HEGEL_OK);
         assert_eq!(
@@ -1327,8 +1326,6 @@ fn clones_share_a_run_owned_family() {
             HEGEL_E_ALREADY_COMPLETE
         );
 
-        // Cloning is a stream operation, so it too reports the family
-        // complete rather than handing out a dead handle.
         let mut c2: *mut HegelTestCase = ptr::null_mut();
         assert_eq!(
             hegel_test_case_clone(ctx, root, &mut c2),
@@ -1370,8 +1367,6 @@ fn clones_share_a_run_owned_family() {
 fn standalone_handles_are_freed_independently() {
     let ctx = hegel_context_new();
     unsafe {
-        // Two recorded choices, so the root stream has room for two clone
-        // nodes (each clone consumes one choice position on its source).
         let blob = shrunk_failure_blob_with_draws(ctx, 2);
         let s = make_settings(ctx);
         let empty = CString::new("").unwrap();

--- a/hegel-c/tests/c_abi_inprocess.rs
+++ b/hegel-c/tests/c_abi_inprocess.rs
@@ -1160,8 +1160,11 @@ fn integer_schema() -> Vec<u8> {
 }
 
 /// Run a small always-interesting property to completion and return an owned
-/// copy of its single shrunk failure's base64 reproduce blob.
-unsafe fn shrunk_failure_blob(ctx: *mut HegelContext) -> CString {
+/// copy of its single shrunk failure's base64 reproduce blob. The property
+/// draws `draws` integers per test case (all must succeed for the case to be
+/// interesting), so the returned blob replays a choice sequence of exactly
+/// `draws` values.
+unsafe fn shrunk_failure_blob_with_draws(ctx: *mut HegelContext, draws: usize) -> CString {
     unsafe {
         let s = make_settings(ctx);
         let empty = CString::new("").unwrap();
@@ -1177,13 +1180,15 @@ unsafe fn shrunk_failure_blob(ctx: *mut HegelContext) -> CString {
             }
             let mut p: *const u8 = ptr::null();
             let mut n = 0usize;
-            let status = if hegel_generate(ctx, tc, schema.as_ptr(), schema.len(), &mut p, &mut n)
-                == HEGEL_OK
-            {
-                hegel_status_t::HEGEL_STATUS_INTERESTING
-            } else {
-                hegel_status_t::HEGEL_STATUS_OVERRUN
-            };
+            let mut status = hegel_status_t::HEGEL_STATUS_INTERESTING;
+            for _ in 0..draws {
+                if hegel_generate(ctx, tc, schema.as_ptr(), schema.len(), &mut p, &mut n)
+                    != HEGEL_OK
+                {
+                    status = hegel_status_t::HEGEL_STATUS_OVERRUN;
+                    break;
+                }
+            }
             ok(hegel_mark_complete(ctx, tc, status, ptr::null()));
             ok(hegel_test_case_free(ctx, tc));
         }
@@ -1292,6 +1297,14 @@ fn clones_share_a_run_owned_family() {
             HEGEL_OK
         );
 
+        // Cloning a clone creates a further independent stream.
+        let mut c1a: *mut HegelTestCase = ptr::null_mut();
+        assert_eq!(hegel_test_case_clone(ctx, c1, &mut c1a), HEGEL_OK);
+        assert_eq!(
+            hegel_generate(ctx, c1a, schema.as_ptr(), schema.len(), &mut p, &mut n),
+            HEGEL_OK
+        );
+
         // The first handle to complete the family wins and records the outcome.
         assert_eq!(
             hegel_mark_complete(ctx, c1, hegel_status_t::HEGEL_STATUS_VALID, ptr::null()),
@@ -1314,20 +1327,17 @@ fn clones_share_a_run_owned_family() {
             HEGEL_E_ALREADY_COMPLETE
         );
 
+        // Cloning is a stream operation, so it too reports the family
+        // complete rather than handing out a dead handle.
         let mut c2: *mut HegelTestCase = ptr::null_mut();
-        assert_eq!(hegel_test_case_clone(ctx, root, &mut c2), HEGEL_OK);
         assert_eq!(
-            hegel_generate(ctx, c2, schema.as_ptr(), schema.len(), &mut p, &mut n),
+            hegel_test_case_clone(ctx, root, &mut c2),
             HEGEL_E_ALREADY_COMPLETE
         );
-        // A fresh clone completing the already-complete family is also a no-op.
-        assert_eq!(
-            hegel_mark_complete(ctx, c2, hegel_status_t::HEGEL_STATUS_VALID, ptr::null()),
-            HEGEL_OK
-        );
+        assert!(c2.is_null());
 
         assert_eq!(hegel_test_case_free(ctx, c1), HEGEL_OK);
-        assert_eq!(hegel_test_case_free(ctx, c2), HEGEL_OK);
+        assert_eq!(hegel_test_case_free(ctx, c1a), HEGEL_OK);
         assert_eq!(hegel_test_case_free(ctx, root), HEGEL_OK);
 
         loop {
@@ -1350,17 +1360,19 @@ fn clones_share_a_run_owned_family() {
     }
 }
 
-/// Every handle in a standalone (`from_blob`) family — the root, a clone, and a
-/// clone of that clone — is freed independently, in any order. The underlying
-/// test case stays alive until its last handle is freed: a clone keeps drawing
-/// after the handle it was cloned from (and even the root) has been freed. Run
+/// Every handle in a standalone (`from_blob`) family — the root and two
+/// clones of it — is freed independently, in any order. The underlying
+/// test case stays alive until its last handle is freed: a clone keeps
+/// working after its sibling (and even the root) has been freed. Run
 /// under Miri this proves there is no leak, double-free, or use-after-free
 /// across the drop orders.
 #[test]
 fn standalone_handles_are_freed_independently() {
     let ctx = hegel_context_new();
     unsafe {
-        let blob = shrunk_failure_blob(ctx);
+        // Two recorded choices, so the root stream has room for two clone
+        // nodes (each clone consumes one choice position on its source).
+        let blob = shrunk_failure_blob_with_draws(ctx, 2);
         let s = make_settings(ctx);
         let empty = CString::new("").unwrap();
         ok(hegel_settings_set_database(ctx, s, empty.as_ptr()));
@@ -1375,11 +1387,11 @@ fn standalone_handles_are_freed_independently() {
         let mut c1: *mut HegelTestCase = ptr::null_mut();
         assert_eq!(hegel_test_case_clone(ctx, root, &mut c1), HEGEL_OK);
         let mut c2: *mut HegelTestCase = ptr::null_mut();
-        assert_eq!(hegel_test_case_clone(ctx, c1, &mut c2), HEGEL_OK);
+        assert_eq!(hegel_test_case_clone(ctx, root, &mut c2), HEGEL_OK);
 
-        // A non-consuming span op proves a handle is live and reaches the
-        // (shared) data source; the blob's finite choice sequence means we
-        // can't keep drawing, so we don't draw here.
+        // A non-consuming span op proves a handle is live and reaches its
+        // stream; the blob's finite choice sequence means we can't keep
+        // drawing, so we don't draw here.
         let alive = |tc: *mut HegelTestCase| {
             assert_eq!(hegel_start_span(ctx, tc, 1), HEGEL_OK);
             assert_eq!(hegel_stop_span(ctx, tc, false), HEGEL_OK);
@@ -1405,10 +1417,9 @@ fn standalone_handles_are_freed_independently() {
 }
 
 /// Two clones drive the same test case from two threads at once. Because each
-/// handle has its own lock, neither draw is rejected with
-/// `HEGEL_E_CONCURRENT_USE` — that is reserved for using a *single* handle from
-/// two threads. (The shared engine state stays internally consistent; the
-/// outcomes are just non-deterministic, which is fine here.)
+/// handle has its own lock and its own independent stream, neither draw is
+/// rejected with `HEGEL_E_CONCURRENT_USE` — that is reserved for using a
+/// *single* handle from two threads.
 #[test]
 fn two_clones_draw_concurrently_without_concurrent_use_errors() {
     use std::sync::{Arc, Barrier};

--- a/hegel-c/tests/c_abi_miri.rs
+++ b/hegel-c/tests/c_abi_miri.rs
@@ -74,7 +74,7 @@ unsafe fn one_case_run() -> (
     }
 }
 
-/// A span op proves a handle is live and reaches the shared data source without
+/// A span op proves a handle is live and reaches its stream without
 /// consuming the choice budget.
 unsafe fn alive(ctx: *mut HegelContext, tc: *mut HegelTestCase) {
     unsafe {

--- a/hegel-c/tests/embedded/native/blob_tests.rs
+++ b/hegel-c/tests/embedded/native/blob_tests.rs
@@ -82,3 +82,20 @@ fn decode_rejects_raw_payload_that_is_not_valid_choices() {
     let blob = base64_encode(&[PREFIX_RAW, 0xAB]);
     assert!(decode_failure(&blob).is_none());
 }
+
+#[test]
+fn blob_roundtrips_clone_values() {
+    let choices = vec![
+        ChoiceValue::Boolean(true),
+        ChoiceValue::Clone(std::sync::Arc::new(
+            crate::native::core::CloneRecord::from_values(vec![
+                ChoiceValue::Integer(crate::native::bignum::BigInt::from(7)),
+                ChoiceValue::Clone(std::sync::Arc::new(
+                    crate::native::core::CloneRecord::from_values(Vec::new()),
+                )),
+            ]),
+        )),
+    ];
+    let blob = encode_failure(&choices);
+    assert_eq!(decode_failure(&blob), Some(choices));
+}

--- a/hegel-c/tests/embedded/native/choices_tests.rs
+++ b/hegel-c/tests/embedded/native/choices_tests.rs
@@ -1262,3 +1262,23 @@ fn clone_record_accessors_expose_children_and_realized_info() {
     assert!(empty.is_empty());
     assert_eq!(empty.flat_len(), 0);
 }
+
+#[test]
+fn clone_vs_clone_ordering_compares_flat_len_then_child_count() {
+    use crate::native::core::sort_key;
+    let a = vec![
+        clone_node(vec![boolean_node(false)]),
+        clone_node(vec![boolean_node(false), boolean_node(false)]),
+    ];
+    let b = vec![
+        clone_node(vec![boolean_node(false), boolean_node(false)]),
+        clone_node(vec![boolean_node(false)]),
+    ];
+    assert_eq!(flattened_len(&a), flattened_len(&b));
+    assert!(sort_key(&a) < sort_key(&b));
+
+    let shallow = vec![clone_node(vec![boolean_node(true), boolean_node(true)])];
+    let deep = vec![clone_node(vec![clone_node(vec![boolean_node(true)])])];
+    assert_eq!(flattened_len(&deep), flattened_len(&shallow));
+    assert!(sort_key(&deep) < sort_key(&shallow));
+}

--- a/hegel-c/tests/embedded/native/choices_tests.rs
+++ b/hegel-c/tests/embedded/native/choices_tests.rs
@@ -1097,6 +1097,14 @@ fn clone_kind_simplest_and_unit_are_the_empty_clone() {
 }
 
 #[test]
+fn simplest_clone_value_sort_key_compares_equal_to_an_executed_empty_stream() {
+    let punned = ChoiceNode::new(ChoiceKind::Clone, ChoiceKind::Clone.simplest(), false);
+    let executed = clone_node(Vec::new());
+    assert!(punned.sort_key_ref() == executed.sort_key_ref());
+    assert!(executed.sort_key_ref() == punned.sort_key_ref());
+}
+
+#[test]
 fn clone_kind_max_children_saturating_is_cap() {
     assert_eq!(ChoiceKind::Clone.max_children_saturating(17), 17);
     assert_eq!(

--- a/hegel-c/tests/embedded/native/choices_tests.rs
+++ b/hegel-c/tests/embedded/native/choices_tests.rs
@@ -1039,3 +1039,226 @@ fn string_choice_simplest_on_empty_alphabet_is_an_internal_error() {
     assert!(msg.contains("empty alphabet"), "{msg}");
     assert!(msg.contains("bug in hegel"), "{msg}");
 }
+
+fn boolean_node(value: bool) -> ChoiceNode {
+    ChoiceNode::new(
+        ChoiceKind::Boolean(BooleanChoice),
+        ChoiceValue::Boolean(value),
+        false,
+    )
+}
+
+fn clone_node(children: Vec<ChoiceNode>) -> ChoiceNode {
+    ChoiceNode::new(
+        ChoiceKind::Clone,
+        ChoiceValue::Clone(std::sync::Arc::new(CloneRecord::from_run(
+            children,
+            Vec::new(),
+            Vec::new(),
+        ))),
+        false,
+    )
+}
+
+fn values_clone_value(values: Vec<ChoiceValue>) -> ChoiceValue {
+    ChoiceValue::Clone(std::sync::Arc::new(CloneRecord::from_values(values)))
+}
+
+fn value_hash(v: &ChoiceValue) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    v.hash(&mut h);
+    h.finish()
+}
+
+#[test]
+fn clone_kind_validate_accepts_only_clone_values() {
+    let kind = ChoiceKind::Clone;
+    assert!(kind.validate(&clone_node(Vec::new()).value));
+    assert!(kind.validate(&values_clone_value(Vec::new())));
+    assert!(!kind.validate(&ChoiceValue::Integer(BigInt::from(0))));
+    assert!(!kind.validate(&ChoiceValue::Boolean(false)));
+    assert!(!ChoiceKind::Boolean(BooleanChoice).validate(&clone_node(Vec::new()).value));
+    assert!(
+        !ChoiceKind::Integer(IntegerChoice {
+            min_value: BigInt::from(0),
+            max_value: BigInt::from(10),
+            shrink_towards: BigInt::from(0),
+        })
+        .validate(&clone_node(Vec::new()).value)
+    );
+}
+
+#[test]
+fn clone_kind_simplest_and_unit_are_the_empty_clone() {
+    let empty = values_clone_value(Vec::new());
+    assert_eq!(ChoiceKind::Clone.simplest(), empty);
+    assert_eq!(ChoiceKind::Clone.unit(), empty);
+}
+
+#[test]
+fn clone_kind_max_children_saturating_is_cap() {
+    assert_eq!(ChoiceKind::Clone.max_children_saturating(17), 17);
+    assert_eq!(
+        ChoiceKind::Clone.max_children_saturating(u128::MAX),
+        u128::MAX
+    );
+}
+
+#[test]
+fn clone_kind_enumerate_returns_none() {
+    assert!(ChoiceKind::Clone.enumerate(1024).is_none());
+}
+
+#[test]
+fn clone_value_equality_ignores_realized_info() {
+    let children = vec![boolean_node(true), integer_node(0, 10, 3)];
+    let realized = ChoiceValue::Clone(std::sync::Arc::new(CloneRecord::from_run(
+        children.clone(),
+        vec![Span {
+            start: 0,
+            end: 2,
+            label: "17".to_string(),
+            depth: 0,
+            parent: None,
+            discarded: false,
+        }],
+        vec![(0, SpanEvent::Open { label: 17 })],
+    )));
+    let values_only = values_clone_value(children.iter().map(|n| n.value.clone()).collect());
+    assert_eq!(realized, values_only);
+    assert_eq!(value_hash(&realized), value_hash(&values_only));
+}
+
+#[test]
+fn clone_value_equality_compares_child_values_recursively() {
+    let a = clone_node(vec![
+        boolean_node(true),
+        clone_node(vec![integer_node(0, 10, 3)]),
+    ])
+    .value;
+    let same = clone_node(vec![
+        boolean_node(true),
+        clone_node(vec![integer_node(0, 10, 3)]),
+    ])
+    .value;
+    let different = clone_node(vec![
+        boolean_node(true),
+        clone_node(vec![integer_node(0, 10, 4)]),
+    ])
+    .value;
+    let shorter = clone_node(vec![boolean_node(true)]).value;
+    assert_eq!(a, same);
+    assert_eq!(value_hash(&a), value_hash(&same));
+    assert_ne!(a, different);
+    assert_ne!(a, shorter);
+    assert_ne!(a, ChoiceValue::Boolean(true));
+}
+
+#[test]
+fn flattened_len_counts_clone_children_recursively() {
+    let nodes = vec![
+        boolean_node(false),
+        clone_node(vec![
+            boolean_node(true),
+            clone_node(vec![integer_node(0, 10, 1)]),
+        ]),
+    ];
+    assert_eq!(flattened_len(&nodes), 5);
+    assert_eq!(flattened_len(&[boolean_node(true)]), 1);
+    assert_eq!(flattened_len(&[clone_node(Vec::new())]), 1);
+    assert_eq!(flattened_len(&[]), 0);
+}
+
+#[test]
+fn clone_record_flat_len_agrees_across_representations() {
+    let children = vec![boolean_node(true), clone_node(vec![boolean_node(false)])];
+    let from_values = CloneRecord::from_values(children.iter().map(|n| n.value.clone()).collect());
+    let from_run = CloneRecord::from_run(children, Vec::new(), Vec::new());
+    assert_eq!(from_values.flat_len(), 3);
+    assert_eq!(from_run.flat_len(), 3);
+}
+
+#[test]
+fn nodes_sort_key_orders_by_flattened_count_first() {
+    use crate::native::core::sort_key;
+    let wrapped = vec![clone_node(vec![boolean_node(false), boolean_node(false)])];
+    let flat = vec![boolean_node(true), boolean_node(true)];
+    assert!(sort_key(&flat) < sort_key(&wrapped));
+}
+
+#[test]
+fn nodes_sort_key_shrinking_inside_clone_is_smaller() {
+    use crate::native::core::sort_key;
+    let big = vec![clone_node(vec![integer_node(0, 10, 5)])];
+    let small = vec![clone_node(vec![integer_node(0, 10, 2)])];
+    assert!(sort_key(&small) < sort_key(&big));
+    let fewer = vec![clone_node(vec![boolean_node(true)])];
+    let more = vec![clone_node(vec![boolean_node(false), boolean_node(false)])];
+    assert!(sort_key(&fewer) < sort_key(&more));
+}
+
+#[test]
+fn nodes_sort_key_equal_flat_count_shorter_top_level_wins() {
+    use crate::native::core::sort_key;
+    let nested = vec![clone_node(vec![boolean_node(true)]), boolean_node(true)];
+    let flat = vec![
+        boolean_node(false),
+        boolean_node(false),
+        boolean_node(false),
+    ];
+    assert_eq!(flattened_len(&nested), flattened_len(&flat));
+    assert!(sort_key(&nested) < sort_key(&flat));
+}
+
+#[test]
+fn node_sort_key_ref_clone_category_above_scalars_and_sequences() {
+    let scalar = boolean_node(true);
+    let bytes = bytes_node(0, 4, vec![1, 2]);
+    let clone = clone_node(vec![boolean_node(true)]);
+    assert!(scalar.sort_key_ref() < clone.sort_key_ref());
+    assert!(bytes.sort_key_ref() < clone.sort_key_ref());
+    assert!(clone.sort_key_ref() == clone_node(vec![boolean_node(true)]).sort_key_ref());
+}
+
+#[test]
+fn clone_record_accessors_expose_children_and_realized_info() {
+    let span = Span {
+        start: 0,
+        end: 1,
+        label: "42".to_string(),
+        depth: 0,
+        parent: None,
+        discarded: false,
+    };
+    let record = CloneRecord::from_run(
+        vec![boolean_node(true)],
+        vec![span.clone()],
+        vec![(0, SpanEvent::Open { label: 42 })],
+    );
+    assert_eq!(record.len(), 1);
+    assert!(!record.is_empty());
+    assert_eq!(record.value_at(0), &ChoiceValue::Boolean(true));
+    assert_eq!(
+        record.values().cloned().collect::<Vec<_>>(),
+        vec![ChoiceValue::Boolean(true)]
+    );
+    assert_eq!(record.realized_nodes().unwrap().len(), 1);
+    assert_eq!(record.spans(), &[span]);
+    assert_eq!(record.span_events(), &[(0, SpanEvent::Open { label: 42 })]);
+
+    let values_only = CloneRecord::from_values(vec![ChoiceValue::Boolean(true)]);
+    assert_eq!(values_only.len(), 1);
+    assert_eq!(values_only.value_at(0), &ChoiceValue::Boolean(true));
+    assert_eq!(
+        values_only.values().cloned().collect::<Vec<_>>(),
+        vec![ChoiceValue::Boolean(true)]
+    );
+    assert!(values_only.realized_nodes().is_none());
+    assert!(values_only.spans().is_empty());
+    assert!(values_only.span_events().is_empty());
+
+    let empty = CloneRecord::empty();
+    assert!(empty.is_empty());
+    assert_eq!(empty.flat_len(), 0);
+}

--- a/hegel-c/tests/embedded/native/data_source_tests.rs
+++ b/hegel-c/tests/embedded/native/data_source_tests.rs
@@ -1,6 +1,7 @@
 use super::*;
-use crate::backend::{DataSource, DataSourceError};
+use crate::backend::{DataSource, DataSourceError, TestCaseResult};
 use crate::cbor_utils::{cbor_map, map_get};
+use crate::native::core::ChoiceValue;
 use crate::native::core::NativeTestCase;
 use crate::native::rng::EngineRng;
 
@@ -302,4 +303,93 @@ fn target_observation_rejects_duplicate_label() {
         matches!(&err, DataSourceError::InvalidArgument(m) if m.contains("would overwrite previous")),
         "{err:?}"
     );
+}
+
+#[test]
+fn clone_stream_draws_independently_and_reassembles() {
+    let (ds, handle) = random_source();
+    let schema = cbor_map! {
+        "type" => "integer",
+        "min_value" => 0,
+        "max_value" => 1000,
+    };
+    ds.generate(&schema).unwrap();
+    let child = ds.clone_stream().unwrap();
+    child.generate(&schema).unwrap();
+    ds.generate(&schema).unwrap();
+    ds.mark_complete(&TestCaseResult::Valid);
+
+    let nodes = NativeDataSource::take_nodes(&handle);
+    assert_eq!(nodes.len(), 3);
+    let ChoiceValue::Clone(record) = &nodes[1].value else {
+        panic!("expected the clone node to carry its stream");
+    };
+    assert_eq!(record.realized_nodes().unwrap().len(), 1);
+}
+
+#[test]
+fn pools_are_shared_across_cloned_streams() {
+    let (ds, _handle) = random_source();
+    let pool = ds.new_pool().unwrap();
+    let v1 = ds.pool_add(pool).unwrap();
+    let child = ds.clone_stream().unwrap();
+    let got = child.pool_generate(pool, true).unwrap();
+    assert_eq!(got, v1);
+    assert!(matches!(
+        ds.pool_generate(pool, false),
+        Err(DataSourceError::Assume)
+    ));
+}
+
+#[test]
+fn collections_are_shared_across_cloned_streams() {
+    let (ds, _handle) = random_source();
+    let collection = ds.new_collection(1, Some(1)).unwrap();
+    let child = ds.clone_stream().unwrap();
+    assert!(child.collection_more(collection).unwrap());
+    assert!(!child.collection_more(collection).unwrap());
+}
+
+#[test]
+fn state_machines_are_shared_across_cloned_streams() {
+    let (ds, _handle) = random_source();
+    let machine = ds.new_state_machine(&["a", "b", "c"], &[]).unwrap();
+    let child = ds.clone_stream().unwrap();
+    assert!(child.state_machine_next_rule(machine).unwrap() < 3);
+    assert!(ds.state_machine_next_rule(machine).unwrap() < 3);
+}
+
+#[test]
+fn target_labels_are_unique_across_cloned_streams() {
+    let (ds, _handle) = random_source();
+    let child = ds.clone_stream().unwrap();
+    ds.target_observation(1.0, "score").unwrap();
+    let err = child.target_observation(2.0, "score").unwrap_err();
+    assert!(matches!(err, DataSourceError::InvalidArgument(_)));
+    child.target_observation(2.0, "other").unwrap();
+
+    let (_, handle) = random_source();
+    let observations = NativeDataSource::take_target_observations(&handle);
+    assert!(observations.is_empty());
+}
+
+#[test]
+fn mark_complete_from_a_clone_concludes_the_family() {
+    let (ds, handle) = random_source();
+    let child = ds.clone_stream().unwrap();
+    child.mark_complete(&TestCaseResult::Invalid);
+    let schema = cbor_map! {
+        "type" => "boolean",
+    };
+    assert!(matches!(ds.generate(&schema), Err(DataSourceError::Assume)));
+    assert!(matches!(
+        NativeDataSource::take_outcome(&handle),
+        TestCaseResult::Invalid
+    ));
+}
+
+#[test]
+fn clone_stream_on_an_exhausted_source_stops_the_test() {
+    let (ds, _handle) = exhausted_source();
+    assert!(matches!(ds.clone_stream(), Err(DataSourceError::StopTest)));
 }

--- a/hegel-c/tests/embedded/native/data_source_tests.rs
+++ b/hegel-c/tests/embedded/native/data_source_tests.rs
@@ -361,16 +361,17 @@ fn state_machines_are_shared_across_cloned_streams() {
 
 #[test]
 fn target_labels_are_unique_across_cloned_streams() {
-    let (ds, _handle) = random_source();
+    let (ds, handle) = random_source();
     let child = ds.clone_stream().unwrap();
     ds.target_observation(1.0, "score").unwrap();
     let err = child.target_observation(2.0, "score").unwrap_err();
     assert!(matches!(err, DataSourceError::InvalidArgument(_)));
     child.target_observation(2.0, "other").unwrap();
 
-    let (_, handle) = random_source();
     let observations = NativeDataSource::take_target_observations(&handle);
-    assert!(observations.is_empty());
+    assert_eq!(observations.len(), 2);
+    assert_eq!(observations["score"], 1.0);
+    assert_eq!(observations["other"], 2.0);
 }
 
 #[test]

--- a/hegel-c/tests/embedded/native/data_tree_tests.rs
+++ b/hegel-c/tests/embedded/native/data_tree_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::native::bignum::BigInt;
 use crate::native::core::choices::{BooleanChoice, IntegerChoice};
-use crate::native::core::{ChoiceKind, ChoiceNode, ChoiceValue, Status};
+use crate::native::core::{ChoiceKind, ChoiceNode, ChoiceValue, CloneRecord, Status};
 use crate::native::rng::EngineRng;
 
 fn int_kind(min: i128, max: i128) -> ChoiceKind {
@@ -280,4 +280,387 @@ fn generate_novel_prefix_replays_forced_values_of_every_kind() {
             ChoiceValue::String(vec![b'h' as u32, b'i' as u32])
         );
     }
+}
+
+fn realized_clone_node(children: Vec<ChoiceNode>) -> ChoiceNode {
+    ChoiceNode::new(
+        ChoiceKind::Clone,
+        ChoiceValue::Clone(Arc::new(CloneRecord::from_run(
+            children,
+            Vec::new(),
+            Vec::new(),
+        ))),
+        false,
+    )
+}
+
+fn clone_prefix_value(values: Vec<ChoiceValue>) -> ChoiceValue {
+    ChoiceValue::Clone(Arc::new(CloneRecord::from_values(values)))
+}
+
+#[test]
+fn record_and_simulate_roundtrip_with_clone_nodes() {
+    let nodes = vec![
+        int_node(0, 10, 3),
+        realized_clone_node(vec![bool_node(true), int_node(0, 5, 2)]),
+        bool_node(false),
+    ];
+    let mut root = DataTreeNode::default();
+    assert!(record_tree(&mut root, &nodes, Status::Interesting, &[]).is_none());
+
+    let values: Vec<ChoiceValue> = nodes.iter().map(|n| n.value.clone()).collect();
+    let outcome = simulate_full(&root, &values).unwrap();
+    assert_eq!(outcome.status, Status::Interesting);
+    assert_eq!(outcome.nodes.len(), 3);
+    let ChoiceValue::Clone(record) = &outcome.nodes[1].value else {
+        panic!("simulated clone node lost its record");
+    };
+    let realized = record.realized_nodes().unwrap();
+    assert_eq!(realized.len(), 2);
+    assert_eq!(*realized[0].kind, ChoiceKind::Boolean(BooleanChoice));
+    assert_eq!(realized[1].value, ChoiceValue::Integer(BigInt::from(2)));
+
+    let values_only: Vec<ChoiceValue> = vec![
+        ChoiceValue::Integer(BigInt::from(3)),
+        clone_prefix_value(vec![
+            ChoiceValue::Boolean(true),
+            ChoiceValue::Integer(BigInt::from(2)),
+        ]),
+        ChoiceValue::Boolean(false),
+    ];
+    assert_eq!(simulate(&root, &values_only), Some(Status::Interesting));
+}
+
+#[test]
+fn simulate_puns_invalid_values_inside_clone_streams() {
+    let nodes = vec![realized_clone_node(vec![int_node(0, 10, 1)])];
+    let mut root = DataTreeNode::default();
+    record_tree(&mut root, &nodes, Status::Valid, &[]);
+
+    let punned = vec![clone_prefix_value(vec![ChoiceValue::Integer(
+        BigInt::from(999),
+    )])];
+    assert_eq!(simulate(&root, &punned), Some(Status::Valid));
+
+    let divergent = vec![clone_prefix_value(vec![ChoiceValue::Integer(
+        BigInt::from(7),
+    )])];
+    assert_eq!(simulate(&root, &divergent), None);
+}
+
+#[test]
+fn simulate_ignores_trailing_unread_child_values() {
+    let nodes = vec![realized_clone_node(vec![bool_node(false)])];
+    let mut root = DataTreeNode::default();
+    record_tree(&mut root, &nodes, Status::Valid, &[]);
+
+    let longer = vec![clone_prefix_value(vec![
+        ChoiceValue::Boolean(false),
+        ChoiceValue::Boolean(true),
+        ChoiceValue::Boolean(true),
+    ])];
+    let outcome = simulate_full(&root, &longer).unwrap();
+    assert_eq!(outcome.status, Status::Valid);
+    let ChoiceValue::Clone(record) = &outcome.nodes[0].value else {
+        panic!("expected a clone node");
+    };
+    assert_eq!(record.len(), 1);
+}
+
+#[test]
+fn simulate_unseen_when_child_values_run_out_mid_stream() {
+    let nodes = vec![realized_clone_node(vec![bool_node(false), bool_node(true)])];
+    let mut root = DataTreeNode::default();
+    record_tree(&mut root, &nodes, Status::Valid, &[]);
+
+    let shorter = vec![clone_prefix_value(vec![ChoiceValue::Boolean(false)])];
+    assert_eq!(simulate(&root, &shorter), None);
+}
+
+#[test]
+fn simulate_puns_non_clone_candidates_to_the_empty_clone() {
+    let empty_child = vec![realized_clone_node(Vec::new()), bool_node(true)];
+    let mut root = DataTreeNode::default();
+    record_tree(&mut root, &empty_child, Status::Valid, &[]);
+    assert_eq!(
+        simulate(
+            &root,
+            &[
+                ChoiceValue::Integer(BigInt::from(5)),
+                ChoiceValue::Boolean(true),
+            ]
+        ),
+        Some(Status::Valid)
+    );
+
+    let nonempty_child = vec![realized_clone_node(vec![bool_node(false)])];
+    let mut root = DataTreeNode::default();
+    record_tree(&mut root, &nonempty_child, Status::Valid, &[]);
+    assert_eq!(
+        simulate(&root, &[ChoiceValue::Integer(BigInt::from(5))]),
+        None
+    );
+}
+
+#[test]
+fn clone_streams_with_context_dependent_children_disable_prediction_quietly() {
+    let run1 = vec![
+        realized_clone_node(vec![bool_node(true)]),
+        int_node(0, 10, 1),
+    ];
+    let run2 = vec![
+        realized_clone_node(vec![int_node(0, 5, 2)]),
+        int_node(0, 10, 1),
+    ];
+    let mut root = DataTreeNode::default();
+    assert!(record_tree(&mut root, &run1, Status::Valid, &[]).is_none());
+    assert!(record_tree(&mut root, &run2, Status::Valid, &[]).is_none());
+
+    let exact: Vec<ChoiceValue> = run1.iter().map(|n| n.value.clone()).collect();
+    assert_eq!(simulate(&root, &exact), Some(Status::Valid));
+
+    let punnable = vec![
+        clone_prefix_value(vec![ChoiceValue::Boolean(true)]),
+        ChoiceValue::Integer(BigInt::from(999)),
+    ];
+    assert_eq!(simulate(&root, &punnable), Some(Status::Valid));
+
+    let punned_inside = vec![
+        clone_prefix_value(vec![ChoiceValue::Integer(BigInt::from(999))]),
+        ChoiceValue::Integer(BigInt::from(1)),
+    ];
+    assert_eq!(simulate(&root, &punned_inside), None);
+}
+
+#[test]
+fn record_reports_kind_mismatch_at_clone_positions() {
+    let mut root = DataTreeNode::default();
+    assert!(record_tree(&mut root, &[int_node(0, 10, 0)], Status::Valid, &[]).is_none());
+    let msg = record_tree(
+        &mut root,
+        &[realized_clone_node(Vec::new())],
+        Status::Valid,
+        &[],
+    )
+    .expect("clone-vs-integer at one position is non-deterministic generation");
+    assert!(msg.contains("non-deterministic"), "{msg}");
+}
+
+#[test]
+fn novel_prefix_explores_inside_clone_subtrees() {
+    let mut root = DataTreeNode::default();
+    record_tree(
+        &mut root,
+        &[realized_clone_node(vec![bool_node(false)])],
+        Status::Valid,
+        &[],
+    );
+    let mut rng = EngineRng::seeded(0);
+    for _ in 0..20 {
+        let prefix = generate_novel_prefix(&root, &mut rng);
+        assert_eq!(
+            prefix,
+            vec![clone_prefix_value(vec![ChoiceValue::Boolean(true)])]
+        );
+    }
+}
+
+#[test]
+fn novel_prefix_descends_recorded_continuations_or_recurses() {
+    let mut root = DataTreeNode::default();
+    record_tree(
+        &mut root,
+        &[
+            realized_clone_node(vec![bool_node(false)]),
+            bool_node(false),
+        ],
+        Status::Valid,
+        &[],
+    );
+    let inside = vec![clone_prefix_value(vec![ChoiceValue::Boolean(true)])];
+    let continuation = vec![
+        clone_prefix_value(vec![ChoiceValue::Boolean(false)]),
+        ChoiceValue::Boolean(true),
+    ];
+    let mut rng = EngineRng::seeded(0);
+    let mut seen_inside = false;
+    let mut seen_continuation = false;
+    for _ in 0..100 {
+        let prefix = generate_novel_prefix(&root, &mut rng);
+        if prefix == inside {
+            seen_inside = true;
+        } else if prefix == continuation {
+            seen_continuation = true;
+        } else {
+            panic!("unexpected novel prefix: {prefix:?}");
+        }
+    }
+    assert!(seen_inside);
+    assert!(seen_continuation);
+}
+
+#[test]
+fn novel_prefix_stops_before_a_fully_explored_clone_node() {
+    let mut root = DataTreeNode::default();
+    record_tree(
+        &mut root,
+        &[realized_clone_node(vec![bool_node(false)])],
+        Status::Valid,
+        &[],
+    );
+    record_tree(
+        &mut root,
+        &[realized_clone_node(vec![bool_node(true)])],
+        Status::Valid,
+        &[],
+    );
+    let mut rng = EngineRng::seeded(0);
+    for _ in 0..20 {
+        assert!(generate_novel_prefix(&root, &mut rng).is_empty());
+    }
+    assert!(!root.is_exhausted);
+}
+
+#[test]
+fn a_stream_that_previously_ended_but_now_continues_disables_prediction() {
+    let mut root = DataTreeNode::default();
+    assert!(
+        record_tree(
+            &mut root,
+            &[realized_clone_node(Vec::new()), bool_node(true)],
+            Status::Valid,
+            &[],
+        )
+        .is_none()
+    );
+    assert!(
+        record_tree(
+            &mut root,
+            &[realized_clone_node(vec![bool_node(false)]), bool_node(true)],
+            Status::Valid,
+            &[],
+        )
+        .is_none()
+    );
+    let exact = vec![
+        clone_prefix_value(vec![ChoiceValue::Boolean(false)]),
+        ChoiceValue::Boolean(true),
+    ];
+    assert_eq!(simulate(&root, &exact), Some(Status::Valid));
+    let punned_inside = vec![
+        clone_prefix_value(vec![ChoiceValue::Integer(BigInt::from(999))]),
+        ChoiceValue::Boolean(true),
+    ];
+    assert_eq!(simulate(&root, &punned_inside), None);
+}
+
+#[test]
+fn values_only_clone_records_disable_prediction_quietly() {
+    let node = ChoiceNode::new(
+        ChoiceKind::Clone,
+        clone_prefix_value(vec![ChoiceValue::Boolean(true)]),
+        false,
+    );
+    let mut root = DataTreeNode::default();
+    assert!(record_tree(&mut root, &[node], Status::Valid, &[]).is_none());
+    assert_eq!(
+        simulate(&root, &[clone_prefix_value(vec![ChoiceValue::Boolean(true)])]),
+        Some(Status::Valid)
+    );
+    assert_eq!(
+        simulate(
+            &root,
+            &[clone_prefix_value(vec![ChoiceValue::Integer(BigInt::from(
+                999
+            ))])]
+        ),
+        None
+    );
+}
+
+#[test]
+fn forced_nodes_inside_clone_streams_replay_their_recorded_value() {
+    let mut root = DataTreeNode::default();
+    record_tree(
+        &mut root,
+        &[realized_clone_node(vec![forced_bool_node(true)])],
+        Status::Valid,
+        &[],
+    );
+    let outcome = simulate_full(
+        &root,
+        &[clone_prefix_value(vec![ChoiceValue::Boolean(false)])],
+    )
+    .unwrap();
+    assert_eq!(outcome.status, Status::Valid);
+    let ChoiceValue::Clone(record) = &outcome.nodes[0].value else {
+        panic!("expected a clone node");
+    };
+    assert_eq!(record.value_at(0), &ChoiceValue::Boolean(true));
+}
+
+#[test]
+fn nested_clones_inside_clone_streams_simulate_recursively() {
+    let mut root = DataTreeNode::default();
+    record_tree(
+        &mut root,
+        &[realized_clone_node(vec![realized_clone_node(vec![
+            bool_node(false),
+        ])])],
+        Status::Valid,
+        &[],
+    );
+    let candidate = clone_prefix_value(vec![clone_prefix_value(vec![
+        ChoiceValue::Boolean(false),
+        ChoiceValue::Boolean(true),
+    ])]);
+    let outcome = simulate_full(&root, &[candidate]).unwrap();
+    assert_eq!(outcome.status, Status::Valid);
+    let ChoiceValue::Clone(record) = &outcome.nodes[0].value else {
+        panic!("expected a clone node");
+    };
+    let ChoiceValue::Clone(inner) = record.value_at(0) else {
+        panic!("expected a nested clone value");
+    };
+    assert_eq!(inner.len(), 1);
+}
+
+#[test]
+fn span_events_inside_clone_streams_are_reconstructed() {
+    use crate::native::core::{Span, SpanEvent};
+    let child_record = CloneRecord::from_run(
+        vec![bool_node(true)],
+        vec![Span {
+            start: 0,
+            end: 1,
+            label: "9".to_string(),
+            depth: 0,
+            parent: None,
+            discarded: false,
+        }],
+        vec![
+            (0, SpanEvent::Open { label: 9 }),
+            (1, SpanEvent::Close { discarded: false }),
+        ],
+    );
+    let node = ChoiceNode::new(
+        ChoiceKind::Clone,
+        ChoiceValue::Clone(Arc::new(child_record)),
+        false,
+    );
+    let mut root = DataTreeNode::default();
+    record_tree(&mut root, &[node], Status::Valid, &[]);
+    let outcome = simulate_full(
+        &root,
+        &[clone_prefix_value(vec![ChoiceValue::Boolean(true)])],
+    )
+    .unwrap();
+    let ChoiceValue::Clone(record) = &outcome.nodes[0].value else {
+        panic!("expected a clone node");
+    };
+    assert_eq!(record.spans().len(), 1);
+    assert_eq!(record.spans()[0].label, "9");
+    assert_eq!(record.spans()[0].start, 0);
+    assert_eq!(record.spans()[0].end, 1);
+    assert_eq!(record.span_events().len(), 2);
 }

--- a/hegel-c/tests/embedded/native/data_tree_tests.rs
+++ b/hegel-c/tests/embedded/native/data_tree_tests.rs
@@ -564,15 +564,18 @@ fn values_only_clone_records_disable_prediction_quietly() {
     let mut root = DataTreeNode::default();
     assert!(record_tree(&mut root, &[node], Status::Valid, &[]).is_none());
     assert_eq!(
-        simulate(&root, &[clone_prefix_value(vec![ChoiceValue::Boolean(true)])]),
+        simulate(
+            &root,
+            &[clone_prefix_value(vec![ChoiceValue::Boolean(true)])]
+        ),
         Some(Status::Valid)
     );
     assert_eq!(
         simulate(
             &root,
-            &[clone_prefix_value(vec![ChoiceValue::Integer(BigInt::from(
-                999
-            ))])]
+            &[clone_prefix_value(vec![ChoiceValue::Integer(
+                BigInt::from(999)
+            )])]
         ),
         None
     );

--- a/hegel-c/tests/embedded/native/database_tests.rs
+++ b/hegel-c/tests/embedded/native/database_tests.rs
@@ -364,3 +364,94 @@ fn move_value_falls_back_to_delete_save_when_dst_dir_create_fails() {
     perms.set_mode(0o755);
     std::fs::set_permissions(dir.path(), perms).unwrap();
 }
+
+fn clone_value(children: Vec<ChoiceValue>) -> ChoiceValue {
+    ChoiceValue::Clone(std::sync::Arc::new(
+        crate::native::core::CloneRecord::from_values(children),
+    ))
+}
+
+#[test]
+fn serialize_roundtrips_clone_values() {
+    let choices = vec![
+        ChoiceValue::Boolean(true),
+        clone_value(vec![
+            ChoiceValue::Integer(BigInt::from(42)),
+            clone_value(vec![ChoiceValue::String(vec![0x61, 0x62])]),
+            clone_value(Vec::new()),
+        ]),
+        ChoiceValue::Bytes(vec![7]),
+    ];
+    let bytes = serialize_choices(&choices);
+    assert_eq!(deserialize_choices(&bytes), Some(choices));
+}
+
+#[test]
+fn serialize_clone_drops_realized_info_but_preserves_equality() {
+    use crate::native::core::choices::BooleanChoice;
+    use crate::native::core::{ChoiceKind, ChoiceNode, CloneRecord, Span, SpanEvent};
+    let realized = ChoiceValue::Clone(std::sync::Arc::new(CloneRecord::from_run(
+        vec![ChoiceNode::new(
+            ChoiceKind::Boolean(BooleanChoice),
+            ChoiceValue::Boolean(true),
+            false,
+        )],
+        vec![Span {
+            start: 0,
+            end: 1,
+            label: "9".to_string(),
+            depth: 0,
+            parent: None,
+            discarded: false,
+        }],
+        vec![(0, SpanEvent::Open { label: 9 })],
+    )));
+    let bytes = serialize_choices(std::slice::from_ref(&realized));
+    let round_tripped = deserialize_choices(&bytes).unwrap();
+    assert_eq!(round_tripped.len(), 1);
+    assert_eq!(round_tripped[0], realized);
+    let ChoiceValue::Clone(record) = &round_tripped[0] else {
+        panic!("expected a clone value");
+    };
+    assert!(record.realized_nodes().is_none());
+    assert!(record.spans().is_empty());
+}
+
+#[test]
+fn deserialize_returns_none_on_truncated_clone_children() {
+    let mut bytes = 1u32.to_le_bytes().to_vec();
+    bytes.push(5);
+    bytes.extend_from_slice(&2u32.to_le_bytes());
+    bytes.push(1);
+    bytes.push(1);
+    assert!(deserialize_choices(&bytes).is_none());
+}
+
+#[test]
+fn deserialize_returns_none_on_missing_clone_header() {
+    let mut bytes = 1u32.to_le_bytes().to_vec();
+    bytes.push(5);
+    bytes.extend_from_slice(&[0, 0]);
+    assert!(deserialize_choices(&bytes).is_none());
+}
+
+#[test]
+fn deserialize_rejects_clone_nesting_beyond_max_depth() {
+    let depth = crate::native::core::MAX_CLONE_DEPTH + 1;
+    let mut bytes = Vec::new();
+    for _ in 0..depth {
+        bytes.extend_from_slice(&1u32.to_le_bytes());
+        bytes.push(5);
+    }
+    bytes.extend_from_slice(&0u32.to_le_bytes());
+    assert!(deserialize_choices(&bytes).is_none());
+
+    let mut ok_bytes = Vec::new();
+    for _ in 0..crate::native::core::MAX_CLONE_DEPTH {
+        ok_bytes.extend_from_slice(&1u32.to_le_bytes());
+        ok_bytes.push(5);
+    }
+    ok_bytes.extend_from_slice(&0u32.to_le_bytes());
+    let decoded = deserialize_choices(&ok_bytes).unwrap();
+    assert_eq!(decoded.len(), 1);
+}

--- a/hegel-c/tests/embedded/native/schema/mod_tests.rs
+++ b/hegel-c/tests/embedded/native/schema/mod_tests.rs
@@ -165,7 +165,7 @@ fn many_reject_marks_invalid_when_cannot_reach_min_size() {
         result.is_err(),
         "expected StopTest once rejections overflow"
     );
-    assert_eq!(ntc.status, Some(Status::Invalid));
+    assert_eq!(ntc.status(), Some(Status::Invalid));
 }
 
 #[test]

--- a/hegel-c/tests/embedded/native/schema/regex_tests.rs
+++ b/hegel-c/tests/embedded/native/schema/regex_tests.rs
@@ -678,7 +678,7 @@ fn generate_op_ignorecase_literal_outside_alphabet_marks_invalid() {
     let mut out = String::new();
     let result = generate_op(&mut ntc, &lit('a'), &mut state, &alphabet, &mut out);
     assert!(result.is_err());
-    assert_eq!(ntc.status, Some(Status::Invalid));
+    assert_eq!(ntc.status(), Some(Status::Invalid));
 }
 
 #[test]

--- a/hegel-c/tests/embedded/native/shrinker_clones_tests.rs
+++ b/hegel-c/tests/embedded/native/shrinker_clones_tests.rs
@@ -1,0 +1,192 @@
+use std::sync::Arc;
+
+use crate::native::bignum::BigInt;
+use crate::native::core::choices::{BooleanChoice, IntegerChoice};
+use crate::native::core::{ChoiceKind, ChoiceNode, ChoiceValue, CloneRecord, Spans};
+use crate::native::shrinker::{ShrinkRun, Shrinker};
+
+fn int_node(value: i128) -> ChoiceNode {
+    ChoiceNode::new(
+        ChoiceKind::Integer(IntegerChoice {
+            min_value: BigInt::from(0),
+            max_value: BigInt::from(100),
+            shrink_towards: BigInt::from(0),
+        }),
+        ChoiceValue::Integer(BigInt::from(value)),
+        false,
+    )
+}
+
+fn bool_node(value: bool) -> ChoiceNode {
+    ChoiceNode::new(
+        ChoiceKind::Boolean(BooleanChoice),
+        ChoiceValue::Boolean(value),
+        false,
+    )
+}
+
+fn clone_node(children: Vec<ChoiceNode>) -> ChoiceNode {
+    ChoiceNode::new(
+        ChoiceKind::Clone,
+        ChoiceValue::Clone(Arc::new(CloneRecord::from_run(
+            children,
+            Vec::new(),
+            Vec::new(),
+        ))),
+        false,
+    )
+}
+
+fn child_nodes_of(node: &ChoiceNode) -> &[ChoiceNode] {
+    let ChoiceValue::Clone(record) = &node.value else {
+        panic!("expected a clone node, got {node:?}");
+    };
+    record.realized_nodes().unwrap()
+}
+
+fn int_value(node: &ChoiceNode) -> i128 {
+    match &node.value {
+        ChoiceValue::Integer(v) => i128::try_from(v.clone()).unwrap(),
+        _ => panic!("expected an integer node, got {node:?}"),
+    }
+}
+
+/// Interesting iff the node at `path` (indices through nested clone nodes,
+/// final index into the innermost stream) is an integer >= `min`.
+fn int_at_path_at_least(nodes: &[ChoiceNode], path: &[usize], min: i128) -> bool {
+    let (&last, dirs) = path.split_last().unwrap();
+    let mut current = nodes;
+    for &d in dirs {
+        let Some(node) = current.get(d) else {
+            return false;
+        };
+        let ChoiceValue::Clone(record) = &node.value else {
+            return false;
+        };
+        let Some(children) = record.realized_nodes() else {
+            return false;
+        };
+        current = children;
+    }
+    match current.get(last).map(|n| &n.value) {
+        Some(ChoiceValue::Integer(v)) => *v >= BigInt::from(min),
+        _ => false,
+    }
+}
+
+#[test]
+fn nested_shrink_minimizes_values_inside_clone_nodes() {
+    let initial = vec![clone_node(vec![int_node(47), bool_node(true)])];
+    let mut shrinker = Shrinker::with_probe(
+        Box::new(|run| match run {
+            ShrinkRun::Full(nodes) => (
+                int_at_path_at_least(nodes, &[0, 0], 10),
+                nodes.to_vec(),
+                Spans::new(),
+            ),
+            ShrinkRun::Probe { .. } => (false, Vec::new(), Spans::new()),
+        }),
+        initial,
+        Spans::new(),
+    );
+    shrinker.shrink();
+    assert_eq!(shrinker.current_nodes.len(), 1);
+    let child = child_nodes_of(&shrinker.current_nodes[0]);
+    assert_eq!(child.len(), 1);
+    assert_eq!(int_value(&child[0]), 10);
+}
+
+#[test]
+fn nested_shrink_recurses_into_clones_inside_clones() {
+    let initial = vec![clone_node(vec![
+        int_node(30),
+        clone_node(vec![int_node(20), bool_node(true)]),
+    ])];
+    let mut shrinker = Shrinker::with_probe(
+        Box::new(|run| match run {
+            ShrinkRun::Full(nodes) => (
+                int_at_path_at_least(nodes, &[0, 1, 0], 5),
+                nodes.to_vec(),
+                Spans::new(),
+            ),
+            ShrinkRun::Probe { .. } => (false, Vec::new(), Spans::new()),
+        }),
+        initial,
+        Spans::new(),
+    );
+    shrinker.shrink();
+    assert_eq!(shrinker.current_nodes.len(), 1);
+    let child = child_nodes_of(&shrinker.current_nodes[0]);
+    assert_eq!(child.len(), 2);
+    assert_eq!(int_value(&child[0]), 0);
+    let inner = child_nodes_of(&child[1]);
+    assert_eq!(inner.len(), 1);
+    assert_eq!(int_value(&inner[0]), 5);
+}
+
+#[test]
+fn unconstrained_clone_nodes_are_deleted_outright() {
+    let initial = vec![
+        int_node(3),
+        clone_node(vec![int_node(9), bool_node(true), int_node(2)]),
+    ];
+    let mut shrinker = Shrinker::with_probe(
+        Box::new(|run| match run {
+            ShrinkRun::Full(nodes) => (
+                int_at_path_at_least(nodes, &[0], 3),
+                nodes.to_vec(),
+                Spans::new(),
+            ),
+            ShrinkRun::Probe { .. } => (false, Vec::new(), Spans::new()),
+        }),
+        initial,
+        Spans::new(),
+    );
+    shrinker.shrink();
+    assert_eq!(shrinker.current_nodes.len(), 1);
+    assert_eq!(int_value(&shrinker.current_nodes[0]), 3);
+}
+
+#[test]
+fn nested_shrink_tolerates_runs_that_drop_the_clone_node() {
+    let initial = vec![clone_node(vec![int_node(12)])];
+    let mut shrinker = Shrinker::with_probe(
+        Box::new(|run| match run {
+            ShrinkRun::Full(nodes) => {
+                if int_at_path_at_least(nodes, &[0, 0], 10) {
+                    (true, nodes.to_vec(), Spans::new())
+                } else {
+                    (false, Vec::new(), Spans::new())
+                }
+            }
+            ShrinkRun::Probe { .. } => (false, Vec::new(), Spans::new()),
+        }),
+        initial,
+        Spans::new(),
+    );
+    shrinker.shrink();
+    let child = child_nodes_of(&shrinker.current_nodes[0]);
+    assert_eq!(int_value(&child[0]), 10);
+}
+
+#[test]
+fn values_only_clone_records_are_left_alone() {
+    let initial = vec![ChoiceNode::new(
+        ChoiceKind::Clone,
+        ChoiceValue::Clone(Arc::new(CloneRecord::from_values(vec![
+            ChoiceValue::Boolean(true),
+        ]))),
+        false,
+    )];
+    let mut shrinker = Shrinker::with_probe(
+        Box::new(|run| match run {
+            ShrinkRun::Full(nodes) => (true, nodes.to_vec(), Spans::new()),
+            ShrinkRun::Probe { .. } => (false, Vec::new(), Spans::new()),
+        }),
+        initial.clone(),
+        Spans::new(),
+    );
+    shrinker.shrink_clone_streams().unwrap();
+    assert_eq!(shrinker.calls, 0);
+    assert_eq!(shrinker.current_nodes, initial);
+}

--- a/hegel-c/tests/embedded/native/state_clone_tests.rs
+++ b/hegel-c/tests/embedded/native/state_clone_tests.rs
@@ -1,0 +1,297 @@
+use super::*;
+use crate::native::core::{BUFFER_SIZE, MAX_CLONE_DEPTH};
+use crate::native::rng::EngineRng;
+
+fn draw(ntc: &mut NativeTestCase) -> i128 {
+    ntc.draw_integer::<i128>(0, 1_000_000).unwrap()
+}
+
+#[test]
+fn clone_stream_records_a_clone_node_and_hands_out_a_child() {
+    let mut parent = NativeTestCase::new_random(EngineRng::seeded(3));
+    draw(&mut parent);
+    let child = parent.clone_stream().unwrap();
+    draw(&mut parent);
+    draw(&mut child.lock().unwrap());
+
+    assert_eq!(parent.nodes.len(), 3);
+    assert_eq!(*parent.nodes[1].kind, ChoiceKind::Clone);
+    assert!(!parent.nodes[1].was_forced);
+    assert_eq!(child.lock().unwrap().nodes.len(), 1);
+}
+
+#[test]
+fn clone_ids_count_per_stream_and_nest() {
+    let mut parent = NativeTestCase::new_random(EngineRng::seeded(3));
+    assert!(parent.clone_id.is_empty());
+    let first = parent.clone_stream().unwrap();
+    let second = parent.clone_stream().unwrap();
+    let nested = first.lock().unwrap().clone_stream().unwrap();
+    assert_eq!(first.lock().unwrap().clone_id, vec![0]);
+    assert_eq!(second.lock().unwrap().clone_id, vec![1]);
+    assert_eq!(nested.lock().unwrap().clone_id, vec![0, 0]);
+}
+
+#[test]
+fn clone_streams_are_deterministic_per_seed() {
+    let run = |seed: u64| -> (Vec<i128>, Vec<i128>) {
+        let mut parent = NativeTestCase::new_random(EngineRng::seeded(seed));
+        let mut parent_vals = vec![draw(&mut parent)];
+        let child = parent.clone_stream().unwrap();
+        let mut child_guard = child.lock().unwrap();
+        let child_vals = vec![draw(&mut child_guard), draw(&mut child_guard)];
+        drop(child_guard);
+        parent_vals.push(draw(&mut parent));
+        (parent_vals, child_vals)
+    };
+    assert_eq!(run(99), run(99));
+}
+
+#[test]
+fn child_draws_do_not_perturb_the_parents_stream() {
+    let run = |child_draws: usize| -> Vec<i128> {
+        let mut parent = NativeTestCase::new_random(EngineRng::seeded(21));
+        let first = draw(&mut parent);
+        let child = parent.clone_stream().unwrap();
+        for _ in 0..child_draws {
+            draw(&mut child.lock().unwrap());
+        }
+        vec![first, draw(&mut parent), draw(&mut parent)]
+    };
+    assert_eq!(run(0), run(5));
+}
+
+#[test]
+fn reassemble_embeds_child_records_recursively() {
+    let mut parent = NativeTestCase::new_random(EngineRng::seeded(11));
+    draw(&mut parent);
+    let child = parent.clone_stream().unwrap();
+    {
+        let mut c = child.lock().unwrap();
+        c.start_span(42);
+        draw(&mut c);
+        let grandchild = c.clone_stream().unwrap();
+        draw(&mut grandchild.lock().unwrap());
+        c.stop_span(false);
+    }
+    draw(&mut parent);
+    parent.conclude(Status::Valid, None);
+    parent.reassemble();
+
+    let ChoiceValue::Clone(record) = &parent.nodes[1].value else {
+        panic!("clone node was not realized");
+    };
+    let child_nodes = record.realized_nodes().unwrap();
+    assert_eq!(child_nodes.len(), 2);
+    assert_eq!(*child_nodes[1].kind, ChoiceKind::Clone);
+    let ChoiceValue::Clone(inner) = &child_nodes[1].value else {
+        panic!("nested clone node was not realized");
+    };
+    assert_eq!(inner.realized_nodes().unwrap().len(), 1);
+    assert_eq!(record.spans().len(), 1);
+    assert_eq!(record.spans()[0].label, "42");
+    assert_eq!(record.spans()[0].start, 0);
+    assert_eq!(record.spans()[0].end, 2);
+    assert_eq!(record.span_events().len(), 2);
+}
+
+#[test]
+fn replaying_a_reassembled_sequence_reproduces_every_stream() {
+    let mut parent = NativeTestCase::new_random(EngineRng::seeded(17));
+    let p0 = draw(&mut parent);
+    let child = parent.clone_stream().unwrap();
+    let (c0, c1) = {
+        let mut c = child.lock().unwrap();
+        (draw(&mut c), draw(&mut c))
+    };
+    let p1 = draw(&mut parent);
+    parent.conclude(Status::Valid, None);
+    parent.reassemble();
+    let choices: Vec<ChoiceValue> = parent.nodes.iter().map(|n| n.value.clone()).collect();
+
+    let mut replay = NativeTestCase::for_choices(&choices, None, None);
+    assert_eq!(draw(&mut replay), p0);
+    let replay_child = replay.clone_stream().unwrap();
+    {
+        let mut c = replay_child.lock().unwrap();
+        assert_eq!(draw(&mut c), c0);
+        assert_eq!(draw(&mut c), c1);
+    }
+    assert_eq!(draw(&mut replay), p1);
+    replay.conclude(Status::Valid, None);
+    replay.reassemble();
+    let replayed: Vec<ChoiceValue> = replay.nodes.iter().map(|n| n.value.clone()).collect();
+    assert_eq!(replayed, choices);
+}
+
+#[test]
+fn replay_child_overruns_when_it_draws_past_its_recorded_stream() {
+    let mut parent = NativeTestCase::new_random(EngineRng::seeded(29));
+    let child = parent.clone_stream().unwrap();
+    draw(&mut child.lock().unwrap());
+    parent.conclude(Status::Valid, None);
+    parent.reassemble();
+    let choices: Vec<ChoiceValue> = parent.nodes.iter().map(|n| n.value.clone()).collect();
+
+    let mut replay = NativeTestCase::for_choices(&choices, None, None);
+    let replay_child = replay.clone_stream().unwrap();
+    let mut c = replay_child.lock().unwrap();
+    draw(&mut c);
+    assert!(matches!(
+        c.draw_integer::<i128>(0, 10),
+        Err(EngineError::Overrun)
+    ));
+    assert_eq!(replay.status(), Some(Status::EarlyStop));
+}
+
+#[test]
+fn clone_at_a_non_clone_prefix_position_puns_to_an_empty_child() {
+    let mut replay =
+        NativeTestCase::for_choices(&[ChoiceValue::Integer(BigInt::from(5))], None, None);
+    let child = replay.clone_stream().unwrap();
+    let result = child.lock().unwrap().draw_integer::<i128>(0, 10);
+    assert!(matches!(result, Err(EngineError::Overrun)));
+    assert_eq!(replay.status(), Some(Status::EarlyStop));
+}
+
+#[test]
+fn probe_replay_extends_a_punned_child_randomly() {
+    let mut replay = NativeTestCase::for_probe(
+        &[ChoiceValue::Integer(BigInt::from(5))],
+        EngineRng::seeded(1),
+        BUFFER_SIZE,
+    );
+    let child = replay.clone_stream().unwrap();
+    draw(&mut child.lock().unwrap());
+    assert_eq!(replay.status(), None);
+}
+
+#[test]
+fn family_conclusion_stops_every_stream() {
+    let mut parent = NativeTestCase::new_random(EngineRng::seeded(5));
+    let child = parent.clone_stream().unwrap();
+    child.lock().unwrap().conclude(Status::Invalid, None);
+    assert!(matches!(
+        parent.draw_integer::<i128>(0, 10),
+        Err(EngineError::InvalidTestCase)
+    ));
+    assert_eq!(parent.status(), Some(Status::Invalid));
+    assert_eq!(child.lock().unwrap().status(), Some(Status::Invalid));
+}
+
+#[test]
+fn conclusion_is_write_once_across_streams() {
+    let mut parent = NativeTestCase::new_random(EngineRng::seeded(5));
+    let child = parent.clone_stream().unwrap();
+    parent.conclude(
+        Status::Interesting,
+        Some(InterestingOrigin("first".to_string())),
+    );
+    child.lock().unwrap().conclude(Status::Valid, None);
+    assert_eq!(parent.status(), Some(Status::Interesting));
+    let (_, origin) = parent.family().conclusion().unwrap();
+    assert_eq!(origin, Some(InterestingOrigin("first".to_string())));
+}
+
+#[test]
+fn family_budget_caps_total_draws_across_streams() {
+    let mut parent = NativeTestCase::for_probe(&[], EngineRng::seeded(13), 4);
+    draw(&mut parent);
+    draw(&mut parent);
+    let child = parent.clone_stream().unwrap();
+    let mut c = child.lock().unwrap();
+    draw(&mut c);
+    assert!(matches!(
+        c.draw_integer::<i128>(0, 10),
+        Err(EngineError::Overrun)
+    ));
+    assert_eq!(parent.status(), Some(Status::EarlyStop));
+}
+
+#[test]
+fn clone_nesting_beyond_max_depth_is_invalid() {
+    let mut parent = NativeTestCase::new_random(EngineRng::seeded(7));
+    let mut handles = Vec::new();
+    let mut current = parent.clone_stream().unwrap();
+    for _ in 1..MAX_CLONE_DEPTH {
+        let next = current.lock().unwrap().clone_stream().unwrap();
+        handles.push(current);
+        current = next;
+    }
+    let too_deep = current.lock().unwrap().clone_stream();
+    assert!(matches!(too_deep, Err(EngineError::InvalidTestCase)));
+    assert_eq!(parent.status(), Some(Status::Invalid));
+}
+
+#[test]
+fn clone_stream_fails_after_the_family_has_concluded() {
+    let mut parent = NativeTestCase::new_random(EngineRng::seeded(7));
+    parent.conclude(Status::Valid, None);
+    assert!(matches!(parent.clone_stream(), Err(EngineError::Overrun)));
+}
+
+#[test]
+fn clone_node_consumes_a_slot_in_the_stream_budget() {
+    let mut parent = NativeTestCase::for_probe(&[], EngineRng::seeded(13), 1);
+    parent.clone_stream().unwrap();
+    assert!(matches!(
+        parent.draw_integer::<i128>(0, 10),
+        Err(EngineError::Overrun)
+    ));
+}
+
+#[test]
+fn simplest_template_children_resolve_to_simplest_values() {
+    let mut parent = NativeTestCase::for_simplest(BUFFER_SIZE);
+    assert_eq!(draw(&mut parent), 0);
+    let child = parent.clone_stream().unwrap();
+    assert_eq!(draw(&mut child.lock().unwrap()), 0);
+    assert_eq!(draw(&mut parent), 0);
+}
+
+#[test]
+fn reassembled_values_flow_through_probe_prefixes() {
+    let mut parent = NativeTestCase::new_random(EngineRng::seeded(41));
+    let p0 = draw(&mut parent);
+    let child = parent.clone_stream().unwrap();
+    let c0 = draw(&mut child.lock().unwrap());
+    parent.conclude(Status::Valid, None);
+    parent.reassemble();
+    let choices: Vec<ChoiceValue> = parent.nodes.iter().map(|n| n.value.clone()).collect();
+
+    let mut probe = NativeTestCase::for_probe(&choices, EngineRng::seeded(2), BUFFER_SIZE);
+    assert_eq!(draw(&mut probe), p0);
+    let probe_child = probe.clone_stream().unwrap();
+    {
+        let mut c = probe_child.lock().unwrap();
+        assert_eq!(draw(&mut c), c0);
+        draw(&mut c);
+    }
+    draw(&mut probe);
+    assert_eq!(probe.status(), None);
+}
+
+#[test]
+fn concurrent_draws_on_separate_streams_are_deterministic() {
+    let run = || -> (Vec<i128>, Vec<i128>) {
+        let mut parent = NativeTestCase::new_random(EngineRng::seeded(1234));
+        let child = parent.clone_stream().unwrap();
+        let worker = std::thread::spawn(move || {
+            let mut vals = Vec::new();
+            for _ in 0..100 {
+                vals.push(draw(&mut child.lock().unwrap()));
+            }
+            vals
+        });
+        let mut parent_vals = Vec::new();
+        for _ in 0..100 {
+            parent_vals.push(draw(&mut parent));
+        }
+        let child_vals = worker.join().unwrap();
+        (parent_vals, child_vals)
+    };
+    let (p1, c1) = run();
+    let (p2, c2) = run();
+    assert_eq!(p1, p2);
+    assert_eq!(c1, c2);
+}

--- a/hegel-c/tests/embedded/native/state_machine_tests.rs
+++ b/hegel-c/tests/embedded/native/state_machine_tests.rs
@@ -192,7 +192,7 @@ fn overrun_inside_is_enabled_leaves_the_span_open_until_freeze() {
     let mut ntc = replay(&[int(254), int(0)], 2);
     let mut sm = machine(2);
     assert!(matches!(sm.next_rule(&mut ntc), Err(EngineError::Overrun)));
-    assert_eq!(ntc.status, Some(Status::EarlyStop));
+    assert_eq!(ntc.status(), Some(Status::EarlyStop));
     ntc.freeze();
     assert_eq!(ntc.spans.len(), 1);
     assert_eq!(

--- a/hegel-c/tests/embedded/native/state_tests.rs
+++ b/hegel-c/tests/embedded/native/state_tests.rs
@@ -748,7 +748,7 @@ fn template_simplest_finite_count_n_produces_exactly_n_values() {
         assert_eq!(tc.draw_integer::<i128>(0, 100).ok().unwrap(), 0);
     }
     assert!(tc.draw_integer::<i128>(0, 100).is_err());
-    assert_eq!(tc.status, Some(Status::EarlyStop));
+    assert_eq!(tc.status(), Some(Status::EarlyStop));
 }
 
 #[test]
@@ -830,7 +830,7 @@ fn template_overrun_status_matches_max_size_overrun() {
     assert_eq!(tc_count.draw_integer::<i128>(0, 100).ok().unwrap(), 0);
     assert_eq!(tc_count.draw_integer::<i128>(0, 100).ok().unwrap(), 0);
     assert!(tc_count.draw_integer::<i128>(0, 100).is_err());
-    assert_eq!(tc_count.status, Some(Status::EarlyStop));
+    assert_eq!(tc_count.status(), Some(Status::EarlyStop));
 }
 
 #[test]

--- a/hegel-c/tests/embedded/native/test_runner_tests.rs
+++ b/hegel-c/tests/embedded/native/test_runner_tests.rs
@@ -1025,3 +1025,53 @@ fn run_single_case_derandomize_is_keyed_by_test_identity() {
     assert_eq!(a1, a2, "the same key must replay the same draws");
     assert_ne!(a1, b, "different keys must not share a derandomized stream");
 }
+
+#[test]
+fn run_main_shrinks_a_cloned_stream_failure_to_the_minimal_tree() {
+    let body = |ds: &dyn DataSource| -> TestCaseResult {
+        let child = match ds.clone_stream() {
+            Ok(c) => c,
+            Err(_) => return TestCaseResult::Overrun,
+        };
+        if rint(ds, 0, 1000).is_err() {
+            return TestCaseResult::Overrun;
+        }
+        match rint(&*child, 0, 1000) {
+            Ok(v) if v >= 100 => boom("child too big"),
+            Ok(_) => TestCaseResult::Valid,
+            Err(()) => TestCaseResult::Overrun,
+        }
+    };
+    let mut run_case = |ds: Box<dyn DataSource + Send + Sync>| {
+        let result = body(&*ds);
+        ds.mark_complete(&result);
+    };
+    let settings = Settings::new().test_cases(50).database(None).seed(Some(7));
+    let exploration = run_main(
+        &settings,
+        None,
+        &mut run_case,
+        Duration::from_secs(30),
+        Duration::from_secs(300),
+    );
+    let result = complete_native(exploration).unwrap();
+    assert_eq!(result.failures.len(), 1);
+    assert!(result.failures[0].origin.contains("child too big"));
+
+    let blob = result.failures[0].reproduce_blob.as_ref().unwrap();
+    let choices = crate::native::blob::decode_failure(blob).unwrap();
+    assert_eq!(choices.len(), 2);
+    let crate::native::core::ChoiceValue::Clone(record) = &choices[0] else {
+        panic!("expected the shrunk sequence to keep the clone node: {choices:?}");
+    };
+    assert_eq!(
+        record.values().cloned().collect::<Vec<_>>(),
+        vec![ChoiceValue::Integer(crate::native::bignum::BigInt::from(
+            100
+        ))]
+    );
+    assert_eq!(
+        choices[1],
+        ChoiceValue::Integer(crate::native::bignum::BigInt::from(0))
+    );
+}

--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -150,9 +150,12 @@ pub(crate) struct TestCaseLocalData {
 /// # Threading
 ///
 /// `TestCase` is `Send` but not `Sync`. To drive generation from another
-/// thread, clone the test case and move the clone. Clones share the same
-/// underlying backend connection — they are views onto one test case, not
-/// independent test cases.
+/// thread, clone the test case and move the clone. Each clone generates
+/// from its own *independent stream* of choices: draws on one clone never
+/// perturb the values any other clone (or the original) produces, so
+/// several threads can generate concurrently and the test stays fully
+/// deterministic — the same seed replays the same values on every stream,
+/// failures shrink normally, and the shrunk counterexample replays exactly.
 ///
 /// ```no_run
 /// use hegel::generators as gs;
@@ -163,46 +166,37 @@ pub(crate) struct TestCaseLocalData {
 ///     let handle = std::thread::spawn(move || {
 ///         tc_worker.draw(gs::integers::<i32>())
 ///     });
-///     let n = handle.join().unwrap();
 ///     let _b: bool = tc.draw(gs::booleans());
+///     let n = handle.join().unwrap();
 ///     let _ = n;
 /// }
 /// ```
 ///
 /// ## What is guaranteed
 ///
-/// Each clone owns its own backend handle, so a clone may be moved to and
-/// driven from another thread freely. A *single* handle (one clone) may only
-/// be driven by one thread at a time — the backend rejects concurrent use of
-/// one handle outright — which is why you `clone` to hand work to a thread
-/// rather than sharing one `TestCase` across threads (the type is `!Sync`, so
-/// the compiler enforces this too).
+/// Each clone owns its own stream, so a clone may be moved to and driven
+/// from another thread freely, concurrently with every other clone. A
+/// *single* clone may only be driven by one thread at a time — the backend
+/// rejects concurrent use of one handle outright — which is why you `clone`
+/// to hand work to a thread rather than sharing one `TestCase` across
+/// threads (the type is `!Sync`, so the compiler enforces this too).
 ///
-/// This covers patterns where threads do not race on generation — for example:
-///
-/// - Spawn a worker, let it draw, `join` it, then continue on the main
-///   thread.
-/// - Repeatedly spawn-and-join one worker at a time.
-/// - Any pattern where exactly one thread is drawing at a time, with a
-///   happens-before relationship (join, channel receive, barrier) between
-///   each thread's work.
+/// The clones share the test case's *outcome*: the whole family passes,
+/// fails, or is rejected as one test case, and the choice budget is shared
+/// across all streams. Everything else about generation is per-stream.
 ///
 /// ## What is not guaranteed
 ///
-/// Concurrent generation will get progressively better over time, but
-/// right now should be considered a borderline-internal feature. If
-/// you do not know exactly what you're doing it probably won't work.
+/// Determinism extends exactly as far as your own code's determinism. If
+/// threads race on *your* state — for example, which of two clones first
+/// consumes a value from a shared queue — Hegel replays each stream's
+/// values faithfully, but your test may still behave differently run to
+/// run, and such failures may not reproduce or shrink well.
 ///
-/// Two or more clones drawing *concurrently* is allowed (each has its own
-/// handle, and the backend keeps the shared engine state internally
-/// consistent), but it is **not deterministic**: the order in which draws
-/// interleave depends on thread scheduling, and the backend has no way to
-/// reproduce that order on replay. In practice this means such tests may:
-///
-/// - Produce different values on successive runs of the same seed.
-/// - Shrink poorly or not at all.
-/// - Surface backend errors (e.g. `StopTest`) in one thread caused by
-///   another thread's draws exhausting the budget.
+/// Variable pools and engine-managed collections are shared across clones
+/// (an id from one clone works on any other). Using one such object from
+/// two threads *at the same time* makes the affected draws depend on
+/// scheduling order, which brings back the same replay caveat.
 ///
 /// ## Panics inside spawned threads
 ///
@@ -221,8 +215,9 @@ pub struct TestCase {
     /// that is never joined) keeps the handle alive rather than dangling —
     /// its later draws fail cleanly because the case has finished.
     /// [`clone`](TestCase::clone) instead gets a fresh handle
-    /// (`hegel_test_case_clone`) with its own lock, so two clones can be
-    /// driven from different threads concurrently.
+    /// (`hegel_test_case_clone`) onto an independent stream of the same
+    /// test case, so two clones can be driven from different threads
+    /// concurrently without perturbing each other's values.
     handle: Arc<CTestCase>,
 }
 

--- a/tests/common/utils.rs
+++ b/tests/common/utils.rs
@@ -4,7 +4,7 @@ use std::panic::{UnwindSafe, catch_unwind};
 use std::sync::{Arc, Mutex};
 
 use hegel::generators::Generator;
-use hegel::{HealthCheck, Hegel, Phase, Settings};
+use hegel::{HealthCheck, Hegel, Phase, Settings, TestCase};
 use regex::Regex;
 use std::fmt::Debug;
 
@@ -307,14 +307,74 @@ where
     }
 
     pub fn run(self) -> T {
+        let generator = self.generator;
+        MinimalWith::new(move |tc: &TestCase| tc.draw(&generator), self.condition)
+            .test_cases(self.test_cases)
+            .run()
+    }
+}
+
+/// Find the minimal example produced by a test body that satisfies the given
+/// condition.
+///
+/// Like [`minimal`], but the body receives the [`TestCase`] directly instead
+/// of drawing from a single generator, so it can clone the test case or
+/// interleave draws in shapes a plain generator cannot express.
+#[allow(dead_code)]
+pub fn minimal_with<T, F, P>(body: F, condition: P) -> T
+where
+    F: Fn(&TestCase) -> T + 'static,
+    P: Fn(&T) -> bool + 'static,
+    T: Send + Debug + 'static,
+{
+    MinimalWith::new(body, condition).run()
+}
+
+#[allow(dead_code)]
+pub struct MinimalWith<T, F, P>
+where
+    F: Fn(&TestCase) -> T + 'static,
+    P: Fn(&T) -> bool + 'static,
+    T: Send + Debug + 'static,
+{
+    body: F,
+    condition: P,
+    test_cases: u64,
+    _marker: std::marker::PhantomData<T>,
+}
+
+impl<T, F, P> MinimalWith<T, F, P>
+where
+    F: Fn(&TestCase) -> T + 'static,
+    P: Fn(&T) -> bool + 'static,
+    T: Send + Debug + 'static,
+{
+    pub fn new(body: F, condition: P) -> Self {
+        Self {
+            body,
+            condition,
+            test_cases: 500,
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn test_cases(mut self, n: u64) -> Self {
+        self.test_cases = n;
+        self
+    }
+
+    pub fn run(self) -> T {
         let found: Arc<Mutex<Option<T>>> = Arc::new(Mutex::new(None));
         let found_clone = Arc::clone(&found);
         let test_cases = self.test_cases;
+        let body = self.body;
+        let condition = self.condition;
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             Hegel::new(move |tc| {
-                let value = tc.draw(&self.generator);
-                if (self.condition)(&value) {
+                let value = body(&tc);
+                if condition(&value) {
                     *found_clone.lock().unwrap() = Some(value);
                     panic!("HEGEL_MINIMAL_FOUND");
                 }

--- a/tests/test_shrink_quality/clones.rs
+++ b/tests/test_shrink_quality/clones.rs
@@ -1,0 +1,135 @@
+//! Shrink-quality tests for test bodies that clone the `TestCase` and draw
+//! on the clones. Each test returns a tuple of the per-handle results and
+//! asserts every component is individually minimal.
+
+use crate::common::utils::{minimal, minimal_with};
+use hegel::TestCase;
+use hegel::generators::{self as gs, Generator};
+
+fn small_int(tc: &TestCase) -> i64 {
+    tc.draw(gs::integers::<i64>().min_value(0).max_value(1000))
+}
+
+#[test]
+fn test_original_and_clone_each_shrink_to_their_threshold() {
+    let result = minimal_with(
+        |tc| {
+            let a = small_int(tc);
+            let b = small_int(&tc.clone());
+            (a, b)
+        },
+        |&(a, b): &(i64, i64)| a >= 10 && b >= 10,
+    );
+    assert_eq!(result, (10, 10));
+}
+
+#[test]
+fn test_unconstrained_draws_on_original_and_clone_shrink_to_zero() {
+    let result = minimal_with(
+        |tc| {
+            let a = small_int(tc);
+            let b = small_int(&tc.clone());
+            (a, b)
+        },
+        |_: &(i64, i64)| true,
+    );
+    assert_eq!(result, (0, 0));
+}
+
+#[test]
+fn test_draw_only_on_a_clone_shrinks_to_threshold() {
+    let result = minimal_with(|tc| small_int(&tc.clone()), |&x: &i64| x >= 5);
+    assert_eq!(result, 5);
+}
+
+#[test]
+fn test_three_sibling_clones_shrink_independently() {
+    let result = minimal_with(
+        |tc| {
+            (
+                small_int(&tc.clone()),
+                small_int(&tc.clone()),
+                small_int(&tc.clone()),
+            )
+        },
+        |&(a, b, c): &(i64, i64, i64)| a >= 3 && b >= 7 && c >= 11,
+    );
+    assert_eq!(result, (3, 7, 11));
+}
+
+#[test]
+fn test_nested_clones_shrink_independently() {
+    let result = minimal_with(
+        |tc| {
+            let child = tc.clone();
+            let grandchild = child.clone();
+            (small_int(tc), small_int(&child), small_int(&grandchild))
+        },
+        |&(a, b, c): &(i64, i64, i64)| a >= 1 && b >= 2 && c >= 3,
+    );
+    assert_eq!(result, (1, 2, 3));
+}
+
+#[test]
+fn test_interleaved_draws_on_original_and_clone_shrink_to_thresholds() {
+    let result = minimal_with(
+        |tc| {
+            let clone = tc.clone();
+            let a = small_int(tc);
+            let b = small_int(&clone);
+            let c = small_int(tc);
+            let d = small_int(&clone);
+            (a, b, c, d)
+        },
+        |&(a, b, c, d): &(i64, i64, i64, i64)| a >= 10 && b >= 20 && c >= 30 && d >= 40,
+    );
+    assert_eq!(result, (10, 20, 30, 40));
+}
+
+#[test]
+fn test_collection_drawn_on_a_clone_shrinks_to_minimal() {
+    let result = minimal_with(
+        |tc| {
+            let n = small_int(tc);
+            let v: Vec<i64> = tc
+                .clone()
+                .draw(gs::vecs(gs::integers::<i64>().min_value(0).max_value(100)));
+            (n, v)
+        },
+        |(n, v): &(i64, Vec<i64>)| *n >= 1 && v.len() >= 3,
+    );
+    assert_eq!(result, (1, vec![0, 0, 0]));
+}
+
+#[test]
+fn test_flat_map_drawn_on_a_clone_shrinks_through_the_binding() {
+    let result = minimal_with(
+        |tc| {
+            tc.clone().draw(
+                gs::integers::<i64>()
+                    .min_value(0)
+                    .max_value(100)
+                    .flat_map(|k| {
+                        gs::vecs(gs::booleans())
+                            .min_size(k as usize)
+                            .max_size(k as usize)
+                    }),
+            )
+        },
+        |x: &Vec<bool>| x.iter().filter(|&&b| b).count() >= 3,
+    );
+    assert_eq!(result, vec![true; 3]);
+}
+
+#[test]
+fn test_clone_inside_compose_shrinks_each_component() {
+    let result = minimal(
+        hegel::compose!(|tc| {
+            let a = small_int(&tc);
+            let b = small_int(&tc.clone());
+            (a, b)
+        }),
+        |&(a, b): &(i64, i64)| a >= 10 && b >= 10,
+    );
+    assert_eq!(result, (10, 10));
+}

--- a/tests/test_shrink_quality/main.rs
+++ b/tests/test_shrink_quality/main.rs
@@ -6,6 +6,7 @@
 mod common;
 
 mod bytes;
+mod clones;
 mod collections;
 mod composite;
 mod flatmap;

--- a/tests/test_threading.rs
+++ b/tests/test_threading.rs
@@ -187,3 +187,71 @@ mod threading {
         }
     }
 }
+
+mod independent_streams {
+    use hegel::generators::{self as gs};
+    use hegel::{Hegel, Settings, TestCase};
+    use std::sync::{Arc, Mutex};
+    use std::thread;
+
+    fn small_int(tc: &TestCase) -> i64 {
+        tc.draw(gs::integers::<i64>().min_value(0).max_value(1000))
+    }
+
+    #[test]
+    fn concurrent_clone_streams_replay_deterministically_per_seed() {
+        let run_once = || -> Vec<(i64, i64)> {
+            let seen = Arc::new(Mutex::new(Vec::new()));
+            let seen_in_test = Arc::clone(&seen);
+            Hegel::new(move |tc: TestCase| {
+                let worker = tc.clone();
+                let handle = thread::spawn(move || small_int(&worker));
+                let main_val = small_int(&tc);
+                let child_val = handle.join().unwrap();
+                seen_in_test.lock().unwrap().push((main_val, child_val));
+            })
+            .settings(Settings::new().test_cases(20).database(None).seed(Some(99)))
+            .run();
+            seen.lock().unwrap().clone()
+        };
+        let first = run_once();
+        assert!(!first.is_empty());
+        assert_eq!(first, run_once());
+    }
+
+    #[test]
+    fn concurrent_clone_failure_shrinks_to_the_minimal_counterexample() {
+        let found: Arc<Mutex<Option<(i64, i64)>>> = Arc::new(Mutex::new(None));
+        let found_in_test = Arc::clone(&found);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            Hegel::new(move |tc: TestCase| {
+                let worker = tc.clone();
+                let handle = thread::spawn(move || small_int(&worker));
+                let main_val = small_int(&tc);
+                let child_val = handle.join().unwrap();
+                if child_val >= 100 {
+                    *found_in_test.lock().unwrap() = Some((main_val, child_val));
+                    panic!("HEGEL_CLONE_MINIMAL_FOUND");
+                }
+            })
+            .settings(
+                Settings::new()
+                    .test_cases(200)
+                    .database(None)
+                    .derandomize(true),
+            )
+            .run();
+        }));
+        let payload = result.unwrap_err();
+        let msg = payload
+            .downcast_ref::<&str>()
+            .copied()
+            .or_else(|| payload.downcast_ref::<String>().map(|s| s.as_str()))
+            .unwrap_or_default()
+            .to_string();
+        assert!(msg.contains("HEGEL_CLONE_MINIMAL_FOUND"), "{msg}");
+        let (main_val, child_val) = found.lock().unwrap().take().unwrap();
+        assert_eq!(child_val, 100);
+        assert_eq!(main_val, 0);
+    }
+}


### PR DESCRIPTION
This implements a new representation which tracks clones as their own data-streams, which are independent from each other after the clone. This enables parallel data generation with significantly less non-determinism.

It's still the case that when data-generation depends on things that happen in other-threads in an unsynchronized way you'll get non-determinism and flaky tests. e.g. if we implement concurrent stateful testing, things that use pools from multiple threads will be a problem still.