### PR TITLE
hegel-c: allow setting output per hegel_context_t

### DIFF
--- a/hegel-c/RELEASE.md
+++ b/hegel-c/RELEASE.md
@@ -1,0 +1,20 @@
+RELEASE_TYPE: patch
+
+This patch adds `hegel_context_set_output`, which redirects engine-emitted
+output (verbose / debug progress traces and warnings) for the runs and test
+cases created with a context to a caller-supplied callback instead of stderr
+([#355](https://github.com/hegeldev/hegel-rust/issues/355)):
+
+```c
+void deliver(void *user_data, const char *line, size_t len) { ... }
+
+hegel_context_set_output(ctx, deliver, my_logger);
+```
+
+The callback is invoked once per line of output, together with the registered
+`user_data` pointer passed through verbatim, so a binding can deliver engine
+output to its own test logger (say, a Go `testing.T`) with a single
+library-wide callback. Passing a NULL callback resets the context to stderr.
+The destination is snapshotted when a run or blob replay is created, and the
+callback must be safe to invoke from libhegel's worker thread; see the header
+documentation for the full contract.

--- a/hegel-c/RELEASE.md
+++ b/hegel-c/RELEASE.md
@@ -1,8 +1,8 @@
 RELEASE_TYPE: patch
 
-This patch adds `hegel_context_set_output`, which redirects engine-emitted
-output (verbose / debug progress traces and warnings) for the runs and test
-cases created with a context to a caller-supplied callback instead of stderr
+This patch adds `hegel_context_set_output` and `hegel_context_unset_output`,
+which redirect engine-emitted output (verbose / debug progress traces and
+warnings) to a caller-supplied callback instead of stderr
 ([#355](https://github.com/hegeldev/hegel-rust/issues/355)):
 
 ```c
@@ -14,7 +14,15 @@ hegel_context_set_output(ctx, deliver, my_logger);
 The callback is invoked once per line of output, together with the registered
 `user_data` pointer passed through verbatim, so a binding can deliver engine
 output to its own test logger (say, a Go `testing.T`) with a single
-library-wide callback. Passing a NULL callback resets the context to stderr.
-The destination is snapshotted when a run or blob replay is created, and the
-callback must be safe to invoke from libhegel's worker thread; see the header
-documentation for the full contract.
+library-wide callback.
+
+A run or standalone test case inherits the destination registered on the
+context it was created with, and every later call that passes a context
+together with the run or one of its test cases re-resolves the destination
+from that context: a callback registered on it is used instead of the
+inherited one, and a context with no callback falls back to the inherited
+destination — so a run keeps printing to its creation-time callback when
+driven through fresh (say, thread-local) contexts. `hegel_context_unset_output`
+(or a NULL callback) unsets a context's callback. The callback must be safe
+to invoke from libhegel's worker thread; see the header documentation for the
+full contract.

--- a/hegel-c/RELEASE.md
+++ b/hegel-c/RELEASE.md
@@ -1,28 +1,33 @@
-RELEASE_TYPE: patch
+RELEASE_TYPE: minor
 
-This patch adds `hegel_context_set_output` and `hegel_context_unset_output`,
-which redirect engine-emitted output (verbose / debug progress traces and
-warnings) to a caller-supplied callback instead of stderr
-([#355](https://github.com/hegeldev/hegel-rust/issues/355)):
+This release lets a caller redirect engine-emitted output (verbose / debug
+progress traces and warnings) to a callback instead of stderr, by choosing the
+destination per run or test case at creation
+([#355](https://github.com/hegeldev/hegel-rust/issues/355)).
+
+`hegel_run_start` and `hegel_test_case_from_blob` each take a new
+`hegel_output_callback_t callback` and `void *user_data` before the
+out-parameter. The callback is invoked once per line of output, with
+`user_data` passed through verbatim, so a binding can deliver engine output to
+its own test logger (say, a Go `testing.T`). A NULL `callback` keeps the
+output on stderr.
 
 ```c
 void deliver(void *user_data, const char *line, size_t len) { ... }
 
-hegel_context_set_output(ctx, deliver, my_logger);
+/* before */
+hegel_run_start(ctx, settings, &run);
+hegel_test_case_from_blob(ctx, settings, blob, &tc);
+
+/* after */
+hegel_run_start(ctx, settings, deliver, my_logger, &run);
+hegel_test_case_from_blob(ctx, settings, blob, deliver, my_logger, &tc);
 ```
 
-The callback is invoked once per line of output, together with the registered
-`user_data` pointer passed through verbatim, so a binding can deliver engine
-output to its own test logger (say, a Go `testing.T`) with a single
-library-wide callback.
-
-A run or standalone test case inherits the destination registered on the
-context it was created with, and every later call that passes a context
-together with the run or one of its test cases re-resolves the destination
-from that context: a callback registered on it is used instead of the
-inherited one, and a context with no callback falls back to the inherited
-destination — so a run keeps printing to its creation-time callback when
-driven through fresh (say, thread-local) contexts. `hegel_context_unset_output`
-(or a NULL callback) unsets a context's callback. The callback must be safe
-to invoke from libhegel's worker thread; see the header documentation for the
-full contract.
+The destination is fixed when the run or test case is created — the engine
+emits from its worker thread, and a run's output starts flowing the instant it
+starts, so a per-call setter could not capture it without a race. For a run,
+the callback (and whatever `user_data` points to) must stay valid until the run
+is freed; for a blob replay, whose only line is emitted during the creating
+call, it need not outlive that call. See the header documentation for the full
+contract.

--- a/hegel-c/examples/custom_output.c
+++ b/hegel-c/examples/custom_output.c
@@ -1,12 +1,11 @@
 /*
  * custom_output.c — demo of redirecting libhegel's output.
  *
- * Installs an output callback on the context with hegel_context_set_output,
- * runs a small passing property at debug verbosity, and checks the engine's
- * progress lines arrived at the callback (with the user_data pointer passed
- * through) instead of being written to stderr. This is the mechanism a
- * language binding uses to deliver engine output to its own test logger,
- * e.g. a Go testing.T.
+ * Passes an output callback to hegel_run_start, runs a small passing property
+ * at debug verbosity, and checks the engine's progress lines arrived at the
+ * callback (with the user_data pointer passed through) instead of being
+ * written to stderr. This is the mechanism a language binding uses to deliver
+ * engine output to its own test logger, e.g. a Go testing.T.
  *
  * Build (from this directory, after `cargo build -p hegeltest-c --release`):
  *
@@ -52,7 +51,6 @@ int main(void) {
     hegel_context_t *ctx = hegel_context_new();
 
     capture_t cap = {0, false};
-    HEGEL_CHECK(hegel_context_set_output, ctx, capture_line, &cap);
 
     hegel_settings_t *s;
     HEGEL_CHECK(hegel_settings_new, ctx, &s);
@@ -62,7 +60,7 @@ int main(void) {
     HEGEL_CHECK(hegel_settings_set_verbosity, ctx, s, HEGEL_VERBOSITY_DEBUG);
 
     hegel_run_t *run;
-    HEGEL_CHECK(hegel_run_start, ctx, s, &run);
+    HEGEL_CHECK(hegel_run_start, ctx, s, capture_line, &cap, &run);
 
     while (true) {
         hegel_test_case_t *tc;

--- a/hegel-c/examples/custom_output.c
+++ b/hegel-c/examples/custom_output.c
@@ -1,0 +1,98 @@
+/*
+ * custom_output.c — demo of redirecting libhegel's output.
+ *
+ * Installs an output callback on the context with hegel_context_set_output,
+ * runs a small passing property at debug verbosity, and checks the engine's
+ * progress lines arrived at the callback (with the user_data pointer passed
+ * through) instead of being written to stderr. This is the mechanism a
+ * language binding uses to deliver engine output to its own test logger,
+ * e.g. a Go testing.T.
+ *
+ * Build (from this directory, after `cargo build -p hegeltest-c --release`):
+ *
+ *   cc -o custom_output custom_output.c \
+ *      -I../include \
+ *      -L../../target/release \
+ *      -lhegel \
+ *      -Wl,-rpath,$PWD/../../target/release
+ *
+ * Run:
+ *   ./custom_output
+ */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "hegel.h"
+#include "hegel_check.h"
+
+typedef struct {
+    size_t lines;
+    bool saw_summary;
+} capture_t;
+
+static void capture_line(void *user_data, const char *line, size_t len) {
+    capture_t *cap = user_data;
+    if (strlen(line) != len) {
+        fprintf(stderr, "line/len mismatch: %zu vs %zu\n", strlen(line), len);
+        abort();
+    }
+    cap->lines++;
+    /* The engine ends every run with a "Test done. ..." summary at debug
+       verbosity; remember whether it reached us. */
+    if (strncmp(line, "Test done.", strlen("Test done.")) == 0) {
+        cap->saw_summary = true;
+    }
+}
+
+int main(void) {
+    hegel_context_t *ctx = hegel_context_new();
+
+    capture_t cap = {0, false};
+    HEGEL_CHECK(hegel_context_set_output, ctx, capture_line, &cap);
+
+    hegel_settings_t *s;
+    HEGEL_CHECK(hegel_settings_new, ctx, &s);
+    HEGEL_CHECK(hegel_settings_set_test_cases, ctx, s, 10);
+    HEGEL_CHECK(hegel_settings_set_database, ctx, s, ""); /* disable database */
+    HEGEL_CHECK(hegel_settings_set_seed, ctx, s, 42, true);
+    HEGEL_CHECK(hegel_settings_set_verbosity, ctx, s, HEGEL_VERBOSITY_DEBUG);
+
+    hegel_run_t *run;
+    HEGEL_CHECK(hegel_run_start, ctx, s, &run);
+
+    while (true) {
+        hegel_test_case_t *tc;
+        HEGEL_CHECK(hegel_next_test_case, ctx, run, &tc);
+        if (tc == NULL) break;
+
+        int64_t n;
+        hegel_result_t rc = hegel_generate_integer(ctx, tc, 0, 100, &n);
+        hegel_status_t status =
+            rc == HEGEL_OK ? HEGEL_STATUS_VALID : HEGEL_STATUS_OVERRUN;
+        HEGEL_CHECK(hegel_mark_complete, ctx, tc, status, NULL);
+        HEGEL_CHECK(hegel_test_case_free, ctx, tc);
+    }
+
+    hegel_run_result_t *result;
+    HEGEL_CHECK(hegel_run_result, ctx, run, &result);
+    hegel_run_status_t status;
+    HEGEL_CHECK(hegel_run_result_status, ctx, result, &status);
+    HEGEL_CHECK(hegel_run_result_free, ctx, result);
+    HEGEL_CHECK(hegel_run_free, ctx, run);
+    HEGEL_CHECK(hegel_settings_free, ctx, s);
+    HEGEL_CHECK(hegel_context_free, ctx);
+
+    printf("captured %zu engine output line(s), summary seen: %s\n",
+           cap.lines, cap.saw_summary ? "yes" : "no");
+    if (status != HEGEL_RUN_STATUS_PASSED || cap.lines == 0 ||
+        !cap.saw_summary) {
+        fprintf(stderr, "expected a passing run whose debug output reached "
+                        "the callback\n");
+        return 1;
+    }
+    return 0;
+}

--- a/hegel-c/examples/echo.c
+++ b/hegel-c/examples/echo.c
@@ -36,7 +36,7 @@ int main(void) {
     HEGEL_CHECK(hegel_settings_set_seed, ctx, s, 42, true);
 
     hegel_run_t *run;
-    HEGEL_CHECK(hegel_run_start, ctx, s, &run);
+    HEGEL_CHECK(hegel_run_start, ctx, s, NULL, NULL, &run);
 
     size_t cases = 0;
     while (true) {

--- a/hegel-c/examples/failing.c
+++ b/hegel-c/examples/failing.c
@@ -33,7 +33,7 @@ int main(void) {
     HEGEL_CHECK(hegel_settings_set_seed, ctx, s, 0xc0ffee, true);
 
     hegel_run_t *run;
-    HEGEL_CHECK(hegel_run_start, ctx, s, &run);
+    HEGEL_CHECK(hegel_run_start, ctx, s, NULL, NULL, &run);
 
     while (true) {
         hegel_test_case_t *tc;

--- a/hegel-c/examples/invalid_argument.c
+++ b/hegel-c/examples/invalid_argument.c
@@ -42,7 +42,7 @@ int main(void) {
     HEGEL_CHECK(hegel_settings_set_seed, ctx, s, 1, true);
 
     hegel_run_t *run;
-    HEGEL_CHECK(hegel_run_start, ctx, s, &run);
+    HEGEL_CHECK(hegel_run_start, ctx, s, NULL, NULL, &run);
 
     hegel_test_case_t *tc;
     HEGEL_CHECK(hegel_next_test_case, ctx, run, &tc);

--- a/hegel-c/examples/pool.c
+++ b/hegel-c/examples/pool.c
@@ -70,7 +70,7 @@ int main(void) {
     HEGEL_CHECK(hegel_settings_set_seed, ctx, s, 0x5ca1ab1e, true);
 
     hegel_run_t *run;
-    HEGEL_CHECK(hegel_run_start, ctx, s, &run);
+    HEGEL_CHECK(hegel_run_start, ctx, s, NULL, NULL, &run);
 
     const int STEPS = 12;
     size_t total = 0;

--- a/hegel-c/examples/spans_collections.c
+++ b/hegel-c/examples/spans_collections.c
@@ -73,7 +73,7 @@ int main(void) {
     HEGEL_CHECK(hegel_settings_set_seed, ctx, s, 0xfeedface, true);
 
     hegel_run_t *run;
-    HEGEL_CHECK(hegel_run_start, ctx, s, &run);
+    HEGEL_CHECK(hegel_run_start, ctx, s, NULL, NULL, &run);
 
     const uint64_t MIN_SIZE = 0;
     const uint64_t MAX_SIZE = 8;

--- a/hegel-c/examples/state_machine.c
+++ b/hegel-c/examples/state_machine.c
@@ -42,7 +42,7 @@ int main(void) {
     HEGEL_CHECK(hegel_settings_set_seed, ctx, s, 0x5ca1ab1e, true);
 
     hegel_run_t *run;
-    HEGEL_CHECK(hegel_run_start, ctx, s, &run);
+    HEGEL_CHECK(hegel_run_start, ctx, s, NULL, NULL, &run);
 
     const int STEPS = 20;
     size_t total = 0;

--- a/hegel-c/include/hegel.h
+++ b/hegel-c/include/hegel.h
@@ -476,6 +476,9 @@ typedef enum {
  threads is a data race and unsupported. Passing `NULL` wherever a context
  is accepted is allowed and simply opts out of error messages: the call
  still returns its usual error code, there is just nothing to read back.
+
+ Besides error reporting, a context carries the output destination for the
+ runs and test cases created with it — see `hegel_context_set_output`.
  */
 typedef struct hegel_context_t hegel_context_t;
 
@@ -574,6 +577,16 @@ typedef struct hegel_string_generator_t hegel_string_generator_t;
 typedef struct hegel_test_case_t hegel_test_case_t;
 
 /*
+ Per-line output callback, installed on a context with
+ `hegel_context_set_output` (see there for the full contract). `user_data`
+ is the pointer registered alongside the callback; `line` is one line of
+ engine output, NUL-terminated UTF-8 of `len` bytes (not counting the
+ terminator) without a trailing newline, valid only for the duration of
+ the call.
+ */
+typedef void (*hegel_output_callback_t)(void *user_data, const char *line, size_t len);
+
+/*
  An engine-allocated byte buffer returned by `hegel_generate_bytes`.
 
  The caller owns the buffer and must release it with
@@ -642,6 +655,37 @@ extern "C" {
  Never returns NULL. Must be paired with a `hegel_context_free` call.
  */
 hegel_context_t *hegel_context_new(void);
+
+/*
+ Redirect engine-emitted output (verbose / debug progress traces, warnings)
+ for the runs and test cases subsequently created with `ctx`, instead of
+ writing it to stderr.
+
+ `callback` is invoked once per line of output; `user_data` is passed
+ through to every invocation verbatim, for the caller to resolve to
+ whatever sink the output should reach (say, a Go `testing.T` handle). The
+ `line` argument is NUL-terminated UTF-8 of `len` bytes (not counting the
+ terminator), without a trailing newline; the buffer is owned by libhegel
+ and valid only for the duration of the call — copy it to keep it. Passing
+ a NULL `callback` resets the context to the default stderr output
+ (`user_data` is ignored).
+
+ The destination is snapshotted when a run (`hegel_run_start`) or blob
+ replay (`hegel_test_case_from_blob`) is created, so changing it later
+ only affects subsequently created ones. The engine emits output from a
+ worker thread inside libhegel, so the callback must be safe to invoke
+ from a thread other than the one that registered it, and it — along with
+ whatever `user_data` points to — must stay valid until every run started
+ while it was installed has been freed with `hegel_run_free`.
+
+ This sets only the *destination*; how much output the engine emits is
+ controlled by `hegel_settings_set_verbosity`. Returns
+ `HEGEL_E_INVALID_HANDLE` for a NULL `ctx` (there is no context to store
+ the callback on).
+ */
+hegel_result_t hegel_context_set_output(hegel_context_t *ctx,
+                                        hegel_output_callback_t callback,
+                                        void *user_data);
 
 /*
  Free a context previously returned by `hegel_context_new`. Safe to call
@@ -811,7 +855,9 @@ hegel_result_t hegel_settings_set_suppress_health_check(hegel_context_t *ctx,
  The engine runs on a worker thread inside libhegel; this function
  returns immediately after spawning it. The caller does not need to
  hold the settings handle alive — `hegel_run_start` snapshots the
- settings it needs.
+ settings it needs. The run also snapshots `ctx`'s output destination
+ (see `hegel_context_set_output`): the engine's output for this run keeps
+ going to the callback installed at start time, for the life of the run.
 
  Returns `HEGEL_E_INVALID_ARG` for a NULL `out_run`,
  `HEGEL_E_INVALID_HANDLE` for a NULL `settings`, or `HEGEL_E_BACKEND` if the

--- a/hegel-c/include/hegel.h
+++ b/hegel-c/include/hegel.h
@@ -478,7 +478,8 @@ typedef enum {
  still returns its usual error code, there is just nothing to read back.
 
  Besides error reporting, a context carries the output destination for the
- runs and test cases created with it — see `hegel_context_set_output`.
+ runs and test cases created and driven with it — see
+ `hegel_context_set_output`.
  */
 typedef struct hegel_context_t hegel_context_t;
 
@@ -658,7 +659,7 @@ hegel_context_t *hegel_context_new(void);
 
 /*
  Redirect engine-emitted output (verbose / debug progress traces, warnings)
- for the runs and test cases subsequently created with `ctx`, instead of
+ for the runs and test cases created or driven with `ctx`, instead of
  writing it to stderr.
 
  `callback` is invoked once per line of output; `user_data` is passed
@@ -667,16 +668,25 @@ hegel_context_t *hegel_context_new(void);
  `line` argument is NUL-terminated UTF-8 of `len` bytes (not counting the
  terminator), without a trailing newline; the buffer is owned by libhegel
  and valid only for the duration of the call — copy it to keep it. Passing
- a NULL `callback` resets the context to the default stderr output
- (`user_data` is ignored).
+ a NULL `callback` unsets the context's callback (`user_data` is ignored),
+ like `hegel_context_unset_output`.
 
- The destination is snapshotted when a run (`hegel_run_start`) or blob
- replay (`hegel_test_case_from_blob`) is created, so changing it later
- only affects subsequently created ones. The engine emits output from a
- worker thread inside libhegel, so the callback must be safe to invoke
- from a thread other than the one that registered it, and it — along with
- whatever `user_data` points to — must stay valid until every run started
- while it was installed has been freed with `hegel_run_free`.
+ A run (`hegel_run_start`) or standalone test case
+ (`hegel_test_case_from_blob`) *inherits* the destination registered on the
+ creating context. Afterwards, every call that passes a context together
+ with the run or one of its test cases re-resolves the destination from
+ that context: a callback registered on it is used in place of the
+ inherited destination (which is not modified, merely not used), and a
+ context with no callback — including a NULL `ctx` — falls back to the
+ inherited destination. A run driven through fresh (say, thread-local)
+ contexts with no callback of their own therefore keeps printing to the
+ callback installed when it was created. The engine emits output from a
+ worker thread inside libhegel: each line goes to the most recently
+ resolved destination, and the callback must be safe to invoke from a
+ thread other than the one that registered it. The callback — along with
+ whatever `user_data` points to — must stay valid until every run and test
+ case whose output was routed to it (at creation or by a later call) has
+ been freed.
 
  This sets only the *destination*; how much output the engine emits is
  controlled by `hegel_settings_set_verbosity`. Returns
@@ -686,6 +696,17 @@ hegel_context_t *hegel_context_new(void);
 hegel_result_t hegel_context_set_output(hegel_context_t *ctx,
                                         hegel_output_callback_t callback,
                                         void *user_data);
+
+/*
+ Unset the output callback registered on `ctx` with
+ `hegel_context_set_output`, returning the context to its default
+ behaviour: runs and test cases subsequently created with it write to
+ stderr, and calls made with it on existing runs and test cases fall back
+ to the destination those inherited at creation. Equivalent to passing a
+ NULL `callback` to `hegel_context_set_output`. Returns
+ `HEGEL_E_INVALID_HANDLE` for a NULL `ctx`.
+ */
+hegel_result_t hegel_context_unset_output(hegel_context_t *ctx);
 
 /*
  Free a context previously returned by `hegel_context_new`. Safe to call
@@ -855,9 +876,10 @@ hegel_result_t hegel_settings_set_suppress_health_check(hegel_context_t *ctx,
  The engine runs on a worker thread inside libhegel; this function
  returns immediately after spawning it. The caller does not need to
  hold the settings handle alive — `hegel_run_start` snapshots the
- settings it needs. The run also snapshots `ctx`'s output destination
- (see `hegel_context_set_output`): the engine's output for this run keeps
- going to the callback installed at start time, for the life of the run.
+ settings it needs. The run also inherits `ctx`'s output destination
+ (see `hegel_context_set_output`): the engine's output for this run goes
+ to the callback installed at start time, unless a later call driving the
+ run or one of its test cases passes a context with a callback of its own.
 
  Returns `HEGEL_E_INVALID_ARG` for a NULL `out_run`,
  `HEGEL_E_INVALID_HANDLE` for a NULL `settings`, or `HEGEL_E_BACKEND` if the

--- a/hegel-c/include/hegel.h
+++ b/hegel-c/include/hegel.h
@@ -477,9 +477,8 @@ typedef enum {
  is accepted is allowed and simply opts out of error messages: the call
  still returns its usual error code, there is just nothing to read back.
 
- Besides error reporting, a context carries the output destination for the
- runs and test cases created and driven with it — see
- `hegel_context_set_output`.
+ A context carries no output destination: that is chosen per run or test
+ case at creation (see `hegel_run_start` / `hegel_test_case_from_blob`).
  */
 typedef struct hegel_context_t hegel_context_t;
 
@@ -578,9 +577,9 @@ typedef struct hegel_string_generator_t hegel_string_generator_t;
 typedef struct hegel_test_case_t hegel_test_case_t;
 
 /*
- Per-line output callback, installed on a context with
- `hegel_context_set_output` (see there for the full contract). `user_data`
- is the pointer registered alongside the callback; `line` is one line of
+ Per-line output callback, passed to `hegel_run_start` /
+ `hegel_test_case_from_blob` (see there for the full contract). `user_data`
+ is the pointer supplied alongside the callback; `line` is one line of
  engine output, NUL-terminated UTF-8 of `len` bytes (not counting the
  terminator) without a trailing newline, valid only for the duration of
  the call.
@@ -656,57 +655,6 @@ extern "C" {
  Never returns NULL. Must be paired with a `hegel_context_free` call.
  */
 hegel_context_t *hegel_context_new(void);
-
-/*
- Redirect engine-emitted output (verbose / debug progress traces, warnings)
- for the runs and test cases created or driven with `ctx`, instead of
- writing it to stderr.
-
- `callback` is invoked once per line of output; `user_data` is passed
- through to every invocation verbatim, for the caller to resolve to
- whatever sink the output should reach (say, a Go `testing.T` handle). The
- `line` argument is NUL-terminated UTF-8 of `len` bytes (not counting the
- terminator), without a trailing newline; the buffer is owned by libhegel
- and valid only for the duration of the call — copy it to keep it. Passing
- a NULL `callback` unsets the context's callback (`user_data` is ignored),
- like `hegel_context_unset_output`.
-
- A run (`hegel_run_start`) or standalone test case
- (`hegel_test_case_from_blob`) *inherits* the destination registered on the
- creating context. Afterwards, every call that passes a context together
- with the run or one of its test cases re-resolves the destination from
- that context: a callback registered on it is used in place of the
- inherited destination (which is not modified, merely not used), and a
- context with no callback — including a NULL `ctx` — falls back to the
- inherited destination. A run driven through fresh (say, thread-local)
- contexts with no callback of their own therefore keeps printing to the
- callback installed when it was created. The engine emits output from a
- worker thread inside libhegel: each line goes to the most recently
- resolved destination, and the callback must be safe to invoke from a
- thread other than the one that registered it. The callback — along with
- whatever `user_data` points to — must stay valid until every run and test
- case whose output was routed to it (at creation or by a later call) has
- been freed.
-
- This sets only the *destination*; how much output the engine emits is
- controlled by `hegel_settings_set_verbosity`. Returns
- `HEGEL_E_INVALID_HANDLE` for a NULL `ctx` (there is no context to store
- the callback on).
- */
-hegel_result_t hegel_context_set_output(hegel_context_t *ctx,
-                                        hegel_output_callback_t callback,
-                                        void *user_data);
-
-/*
- Unset the output callback registered on `ctx` with
- `hegel_context_set_output`, returning the context to its default
- behaviour: runs and test cases subsequently created with it write to
- stderr, and calls made with it on existing runs and test cases fall back
- to the destination those inherited at creation. Equivalent to passing a
- NULL `callback` to `hegel_context_set_output`. Returns
- `HEGEL_E_INVALID_HANDLE` for a NULL `ctx`.
- */
-hegel_result_t hegel_context_unset_output(hegel_context_t *ctx);
 
 /*
  Free a context previously returned by `hegel_context_new`. Safe to call
@@ -876,10 +824,19 @@ hegel_result_t hegel_settings_set_suppress_health_check(hegel_context_t *ctx,
  The engine runs on a worker thread inside libhegel; this function
  returns immediately after spawning it. The caller does not need to
  hold the settings handle alive — `hegel_run_start` snapshots the
- settings it needs. The run also inherits `ctx`'s output destination
- (see `hegel_context_set_output`): the engine's output for this run goes
- to the callback installed at start time, unless a later call driving the
- run or one of its test cases passes a context with a callback of its own.
+ settings it needs.
+
+ `callback` sets where the engine's output for this run goes: each line is
+ delivered to it (with `user_data` passed through verbatim) instead of
+ stderr, once per line, NUL-terminated UTF-8 of `len` bytes without a
+ trailing newline, in a buffer owned by libhegel and valid only for the
+ duration of the call. A NULL `callback` leaves the run's output on stderr
+ (`user_data` is ignored). The engine emits from its worker thread, so the
+ callback must be safe to invoke from a thread other than this one, and it
+ — along with whatever `user_data` points to — must stay valid until the
+ run has been freed with `hegel_run_free`. This sets only the
+ *destination*; how much output the engine emits is controlled by
+ `hegel_settings_set_verbosity`.
 
  Returns `HEGEL_E_INVALID_ARG` for a NULL `out_run`,
  `HEGEL_E_INVALID_HANDLE` for a NULL `settings`, or `HEGEL_E_BACKEND` if the
@@ -889,6 +846,8 @@ hegel_result_t hegel_settings_set_suppress_health_check(hegel_context_t *ctx,
  */
 hegel_result_t hegel_run_start(hegel_context_t *ctx,
                                const hegel_settings_t *settings,
+                               hegel_output_callback_t callback,
+                               void *user_data,
                                hegel_run_t **out_run);
 
 /*
@@ -962,6 +921,15 @@ hegel_result_t hegel_run_free(hegel_context_t *ctx, hegel_run_t *run);
  overruns. Replaying a blob is how a caller performs the *final replay* of
  a counterexample.
 
+ `callback` sets where the engine's output for this replay goes — at debug
+ verbosity the blob is decoded with a trace line, emitted synchronously
+ during this call. Each line is delivered to `callback` (with `user_data`
+ passed through verbatim) instead of stderr, NUL-terminated UTF-8 of `len`
+ bytes without a trailing newline, in a buffer valid only for the duration
+ of the call. A NULL `callback` leaves the replay's output on stderr
+ (`user_data` is ignored). There is no worker thread, so the callback is
+ only ever invoked on this thread and need not outlive this call.
+
  Returns `HEGEL_E_INVALID_HANDLE` for a NULL `s`, or `HEGEL_E_INVALID_ARG`
  for a NULL `out_test_case`, a NULL `blob`, or a `blob` that is not a valid
  failure blob (corrupt, non-UTF-8, or from an incompatible Hegel version),
@@ -972,6 +940,8 @@ hegel_result_t hegel_run_free(hegel_context_t *ctx, hegel_run_t *run);
 hegel_result_t hegel_test_case_from_blob(hegel_context_t *ctx,
                                          const hegel_settings_t *s,
                                          const char *blob,
+                                         hegel_output_callback_t callback,
+                                         void *user_data,
                                          hegel_test_case_t **out_test_case);
 
 /*

--- a/hegel-c/src/embed.rs
+++ b/hegel-c/src/embed.rs
@@ -64,9 +64,10 @@ pub fn run_native(
 /// surfaces as a stop-test error from the draw that overruns.
 ///
 /// `settings` accompany the replay — currently only
-/// [`Verbosity::Debug`](crate::Verbosity::Debug) is consulted, logging the
-/// decoded choice count — but they intentionally travel with the blob so
-/// future settings reach the replay path without a signature break.
+/// [`Verbosity::Debug`](crate::Verbosity::Debug) and the output destination
+/// are consulted, logging the decoded choice count — but they intentionally
+/// travel with the blob so future settings reach the replay path without a
+/// signature break.
 #[doc(hidden)]
 pub fn data_source_for_blob(
     settings: &Settings,
@@ -74,7 +75,10 @@ pub fn data_source_for_blob(
 ) -> Option<Box<dyn DataSource + Send + Sync>> {
     let choices = crate::native::blob::decode_failure(blob)?;
     if settings.verbosity == Verbosity::Debug {
-        eprintln!("replaying failure blob: choices = {}", choices.len());
+        settings.output.line(&format!(
+            "replaying failure blob: choices = {}",
+            choices.len()
+        ));
     }
     let ntc = crate::native::core::NativeTestCase::for_choices(&choices, None, None);
     let (data_source, _handle) = crate::native::data_source::NativeDataSource::new(ntc);

--- a/hegel-c/src/lib.rs
+++ b/hegel-c/src/lib.rs
@@ -360,9 +360,9 @@ pub enum hegel_label_t {
     HEGEL_LABEL_STRING = 30,
 }
 
-/// Per-line output callback, installed on a context with
-/// `hegel_context_set_output` (see there for the full contract). `user_data`
-/// is the pointer registered alongside the callback; `line` is one line of
+/// Per-line output callback, passed to `hegel_run_start` /
+/// `hegel_test_case_from_blob` (see there for the full contract). `user_data`
+/// is the pointer supplied alongside the callback; `line` is one line of
 /// engine output, NUL-terminated UTF-8 of `len` bytes (not counting the
 /// terminator) without a trailing newline, valid only for the duration of
 /// the call.
@@ -389,20 +389,14 @@ pub type hegel_output_callback_t =
 /// is accepted is allowed and simply opts out of error messages: the call
 /// still returns its usual error code, there is just nothing to read back.
 ///
-/// Besides error reporting, a context carries the output destination for the
-/// runs and test cases created and driven with it — see
-/// `hegel_context_set_output`.
+/// A context carries no output destination: that is chosen per run or test
+/// case at creation (see `hegel_run_start` / `hegel_test_case_from_blob`).
 pub struct HegelContext {
     last_error: CString,
-    output: Option<OutputTarget>,
 }
 
-/// The output callback registered on a `HegelContext` with
-/// `hegel_context_set_output`, paired with its `user_data` pointer.
-///
-/// A copy of this pair is resolved off the context when a run or blob replay
-/// is created (becoming its inherited destination, see [`OutputCell`]) and
-/// again by every later call that carries the run or one of its test cases.
+/// A caller-supplied output callback paired with its `user_data` pointer,
+/// as passed to `hegel_run_start` / `hegel_test_case_from_blob`.
 #[derive(Copy, Clone)]
 struct OutputTarget {
     callback: unsafe extern "C" fn(user_data: *mut c_void, line: *const c_char, len: usize),
@@ -410,9 +404,9 @@ struct OutputTarget {
 }
 
 // SAFETY: the raw `user_data` pointer is what makes this `!Send + !Sync` by
-// default, but `hegel_context_set_output`'s documented contract is that the
-// callback must be safe to invoke with this `user_data` from any thread, so
-// handing the pair to the engine's worker thread is sound.
+// default, but the documented contract of the output callback is that it must
+// be safe to invoke with this `user_data` from any thread, so handing the
+// pair to the engine's worker thread is sound.
 unsafe impl Send for OutputTarget {}
 unsafe impl Sync for OutputTarget {}
 
@@ -433,68 +427,17 @@ impl OutputTarget {
     }
 }
 
-/// The engine [`Output`] destination for a run or blob replay created with
-/// `ctx`: the context's registered callback when one is installed, stderr
-/// otherwise (including for a NULL `ctx`).
-unsafe fn output_from_ctx(ctx: *const HegelContext) -> Output {
-    match unsafe { ctx.as_ref() }.and_then(|c| c.output) {
-        Some(target) => target.as_output(),
-        None => Output::stderr(),
-    }
-}
-
-/// The live output destination of a run (or standalone `from_blob` test
-/// case), shared between the handles the caller drives and the engine worker
-/// that emits through it.
-///
-/// `inherited` is the destination resolved from the creating context
-/// (`hegel_run_start` / `hegel_test_case_from_blob`) and never changes.
-/// `current` is re-resolved from the context passed to every later call that
-/// carries the run or one of its test cases: a callback set on that context
-/// is used in place of the inherited destination (which is not updated,
-/// merely not used), and a context with no callback — including a NULL
-/// context — falls back to `inherited`. The engine emits from its worker
-/// thread, so each line goes to whichever destination was resolved most
-/// recently.
-struct OutputCell {
-    inherited: Output,
-    current: Mutex<Option<OutputTarget>>,
-}
-
-impl OutputCell {
-    /// A fresh cell whose current destination is `inherited`.
-    fn new(inherited: Output) -> Arc<Self> {
-        Arc::new(OutputCell {
-            inherited,
-            current: Mutex::new(None),
-        })
-    }
-
-    /// The engine-facing [`Output`] sink: each line the engine emits is
-    /// routed to the cell's destination as resolved at emission time.
-    fn as_output(self: &Arc<Self>) -> Output {
-        let cell = Arc::clone(self);
-        Output::callback(move |line| cell.line(line))
-    }
-
-    /// Emit one line to the currently resolved destination.
-    fn line(&self, line: &str) {
-        let current = *self.current.lock();
-        match current {
-            Some(target) => target.emit(line),
-            None => self.inherited.line(line),
+/// The engine [`Output`] destination for a run or blob replay: the supplied
+/// callback when one is given, stderr otherwise (including for a NULL
+/// `callback`, in which case `user_data` is ignored).
+fn output_from_callback(callback: hegel_output_callback_t, user_data: *mut c_void) -> Output {
+    match callback {
+        Some(callback) => OutputTarget {
+            callback,
+            user_data,
         }
-    }
-
-    /// Re-resolve the destination from the context making the current call:
-    /// the context's registered callback, or a fall-back to the inherited
-    /// destination when it has none (including for a NULL `ctx`).
-    ///
-    /// # Safety
-    ///
-    /// `ctx` must be NULL or a pointer to a live `HegelContext`.
-    unsafe fn resolve_from(&self, ctx: *const HegelContext) {
-        *self.current.lock() = unsafe { ctx.as_ref() }.and_then(|c| c.output);
+        .as_output(),
+        None => Output::stderr(),
     }
 }
 
@@ -504,71 +447,7 @@ impl OutputCell {
 pub extern "C" fn hegel_context_new() -> *mut HegelContext {
     Box::into_raw(Box::new(HegelContext {
         last_error: CString::default(),
-        output: None,
     }))
-}
-
-/// Redirect engine-emitted output (verbose / debug progress traces, warnings)
-/// for the runs and test cases created or driven with `ctx`, instead of
-/// writing it to stderr.
-///
-/// `callback` is invoked once per line of output; `user_data` is passed
-/// through to every invocation verbatim, for the caller to resolve to
-/// whatever sink the output should reach (say, a Go `testing.T` handle). The
-/// `line` argument is NUL-terminated UTF-8 of `len` bytes (not counting the
-/// terminator), without a trailing newline; the buffer is owned by libhegel
-/// and valid only for the duration of the call — copy it to keep it. Passing
-/// a NULL `callback` unsets the context's callback (`user_data` is ignored),
-/// like `hegel_context_unset_output`.
-///
-/// A run (`hegel_run_start`) or standalone test case
-/// (`hegel_test_case_from_blob`) *inherits* the destination registered on the
-/// creating context. Afterwards, every call that passes a context together
-/// with the run or one of its test cases re-resolves the destination from
-/// that context: a callback registered on it is used in place of the
-/// inherited destination (which is not modified, merely not used), and a
-/// context with no callback — including a NULL `ctx` — falls back to the
-/// inherited destination. A run driven through fresh (say, thread-local)
-/// contexts with no callback of their own therefore keeps printing to the
-/// callback installed when it was created. The engine emits output from a
-/// worker thread inside libhegel: each line goes to the most recently
-/// resolved destination, and the callback must be safe to invoke from a
-/// thread other than the one that registered it. The callback — along with
-/// whatever `user_data` points to — must stay valid until every run and test
-/// case whose output was routed to it (at creation or by a later call) has
-/// been freed.
-///
-/// This sets only the *destination*; how much output the engine emits is
-/// controlled by `hegel_settings_set_verbosity`. Returns
-/// `HEGEL_E_INVALID_HANDLE` for a NULL `ctx` (there is no context to store
-/// the callback on).
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn hegel_context_set_output(
-    ctx: *mut HegelContext,
-    callback: hegel_output_callback_t,
-    user_data: *mut c_void,
-) -> hegel_result_t {
-    clear_last_error(ctx);
-    let Some(c) = (unsafe { ctx.as_mut() }) else {
-        return HEGEL_E_INVALID_HANDLE;
-    };
-    c.output = callback.map(|callback| OutputTarget {
-        callback,
-        user_data,
-    });
-    HEGEL_OK
-}
-
-/// Unset the output callback registered on `ctx` with
-/// `hegel_context_set_output`, returning the context to its default
-/// behaviour: runs and test cases subsequently created with it write to
-/// stderr, and calls made with it on existing runs and test cases fall back
-/// to the destination those inherited at creation. Equivalent to passing a
-/// NULL `callback` to `hegel_context_set_output`. Returns
-/// `HEGEL_E_INVALID_HANDLE` for a NULL `ctx`.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn hegel_context_unset_output(ctx: *mut HegelContext) -> hegel_result_t {
-    unsafe { hegel_context_set_output(ctx, None, ptr::null_mut()) }
 }
 
 /// Free a context previously returned by `hegel_context_new`. Safe to call
@@ -681,11 +560,6 @@ struct FamilyShared {
     /// completion `compare_exchange` in [`Self::complete`], which is what
     /// guarantees send-once.
     ack: Option<mpsc::Sender<()>>,
-    /// The output destination of the run this family belongs to (shared with
-    /// the run handle and its worker), or the standalone cell of a
-    /// `hegel_test_case_from_blob` family. Re-resolved from the context
-    /// passed to every call that carries one of the family's handles.
-    output: Arc<OutputCell>,
 }
 
 impl FamilyShared {
@@ -785,11 +659,6 @@ pub struct HegelRun {
     /// `from_worker`. Stops `hegel_next_test_case` from blocking forever
     /// on the second post-completion call.
     drained: bool,
-    /// The run's output destination, shared with the worker (which emits
-    /// through it) and with every test-case family the run produces.
-    /// Re-resolved from the context passed to every call that carries the
-    /// run or one of its test cases.
-    output: Arc<OutputCell>,
 }
 
 /// Aggregated outcome of a finished run. `hegel_run_result` writes a
@@ -1310,10 +1179,19 @@ fn install_worker_panic_hook() {
 /// The engine runs on a worker thread inside libhegel; this function
 /// returns immediately after spawning it. The caller does not need to
 /// hold the settings handle alive — `hegel_run_start` snapshots the
-/// settings it needs. The run also inherits `ctx`'s output destination
-/// (see `hegel_context_set_output`): the engine's output for this run goes
-/// to the callback installed at start time, unless a later call driving the
-/// run or one of its test cases passes a context with a callback of its own.
+/// settings it needs.
+///
+/// `callback` sets where the engine's output for this run goes: each line is
+/// delivered to it (with `user_data` passed through verbatim) instead of
+/// stderr, once per line, NUL-terminated UTF-8 of `len` bytes without a
+/// trailing newline, in a buffer owned by libhegel and valid only for the
+/// duration of the call. A NULL `callback` leaves the run's output on stderr
+/// (`user_data` is ignored). The engine emits from its worker thread, so the
+/// callback must be safe to invoke from a thread other than this one, and it
+/// — along with whatever `user_data` points to — must stay valid until the
+/// run has been freed with `hegel_run_free`. This sets only the
+/// *destination*; how much output the engine emits is controlled by
+/// `hegel_settings_set_verbosity`.
 ///
 /// Returns `HEGEL_E_INVALID_ARG` for a NULL `out_run`,
 /// `HEGEL_E_INVALID_HANDLE` for a NULL `settings`, or `HEGEL_E_BACKEND` if the
@@ -1324,6 +1202,8 @@ fn install_worker_panic_hook() {
 pub unsafe extern "C" fn hegel_run_start(
     ctx: *mut HegelContext,
     settings: *const HegelSettings,
+    callback: hegel_output_callback_t,
+    user_data: *mut c_void,
     out_run: *mut *mut HegelRun,
 ) -> hegel_result_t {
     clear_last_error(ctx);
@@ -1336,8 +1216,10 @@ pub unsafe extern "C" fn hegel_run_start(
         set_last_error(ctx, "hegel_run_start: settings pointer is null");
         return HEGEL_E_INVALID_HANDLE;
     };
-    let output = OutputCell::new(unsafe { output_from_ctx(ctx) });
-    let settings = handle.inner.clone().output(output.as_output());
+    let settings = handle
+        .inner
+        .clone()
+        .output(output_from_callback(callback, user_data));
     let database_key = handle.database_key.clone();
 
     let (to_caller, from_worker) = mpsc::channel::<WorkerMessage>();
@@ -1397,7 +1279,6 @@ pub unsafe extern "C" fn hegel_run_start(
         current_family: None,
         result: None,
         drained: false,
-        output,
     }));
     unsafe { *out_run = run };
     HEGEL_OK
@@ -1426,7 +1307,6 @@ pub unsafe extern "C" fn hegel_next_test_case(
         set_last_error(ctx, "hegel_next_test_case: run pointer is null");
         return HEGEL_E_INVALID_HANDLE;
     };
-    unsafe { run.output.resolve_from(ctx) };
     if out_test_case.is_null() {
         set_last_error(ctx, "hegel_next_test_case: out parameter is null");
         return HEGEL_E_INVALID_ARG;
@@ -1455,7 +1335,7 @@ pub unsafe extern "C" fn hegel_next_test_case(
 
     match run.from_worker.recv() {
         Ok(WorkerMessage::TestCase { ds, ack }) => {
-            let family = new_family(ds, Some(ack), Arc::clone(&run.output));
+            let family = new_family(ds, Some(ack));
             let case = handle_from_family(Arc::clone(&family));
             run.current_family = Some(family);
             unsafe { *out_test_case = case };
@@ -1500,7 +1380,6 @@ pub unsafe extern "C" fn hegel_run_result(
         set_last_error(ctx, "hegel_run_result: run pointer is null");
         return HEGEL_E_INVALID_HANDLE;
     };
-    unsafe { run.output.resolve_from(ctx) };
     if out_result.is_null() {
         set_last_error(ctx, "hegel_run_result: out parameter is null");
         return HEGEL_E_INVALID_ARG;
@@ -1557,7 +1436,6 @@ pub unsafe extern "C" fn hegel_run_free(
         return HEGEL_OK;
     }
     let mut run = unsafe { Box::from_raw(run) };
-    unsafe { run.output.resolve_from(ctx) };
 
     run.abort.store(true, Ordering::Release);
 
@@ -1600,6 +1478,15 @@ pub unsafe extern "C" fn hegel_run_free(
 /// overruns. Replaying a blob is how a caller performs the *final replay* of
 /// a counterexample.
 ///
+/// `callback` sets where the engine's output for this replay goes — at debug
+/// verbosity the blob is decoded with a trace line, emitted synchronously
+/// during this call. Each line is delivered to `callback` (with `user_data`
+/// passed through verbatim) instead of stderr, NUL-terminated UTF-8 of `len`
+/// bytes without a trailing newline, in a buffer valid only for the duration
+/// of the call. A NULL `callback` leaves the replay's output on stderr
+/// (`user_data` is ignored). There is no worker thread, so the callback is
+/// only ever invoked on this thread and need not outlive this call.
+///
 /// Returns `HEGEL_E_INVALID_HANDLE` for a NULL `s`, or `HEGEL_E_INVALID_ARG`
 /// for a NULL `out_test_case`, a NULL `blob`, or a `blob` that is not a valid
 /// failure blob (corrupt, non-UTF-8, or from an incompatible Hegel version),
@@ -1611,6 +1498,8 @@ pub unsafe extern "C" fn hegel_test_case_from_blob(
     ctx: *mut HegelContext,
     s: *const HegelSettings,
     blob: *const c_char,
+    callback: hegel_output_callback_t,
+    user_data: *mut c_void,
     out_test_case: *mut *mut HegelTestCase,
 ) -> hegel_result_t {
     clear_last_error(ctx);
@@ -1631,8 +1520,10 @@ pub unsafe extern "C" fn hegel_test_case_from_blob(
         set_last_error(ctx, "hegel_test_case_from_blob: blob is not valid UTF-8");
         return HEGEL_E_INVALID_ARG;
     };
-    let output = OutputCell::new(unsafe { output_from_ctx(ctx) });
-    let settings = handle.inner.clone().output(output.as_output());
+    let settings = handle
+        .inner
+        .clone()
+        .output(output_from_callback(callback, user_data));
     let Some(ds) = data_source_for_blob(&settings, blob) else {
         set_last_error(
             ctx,
@@ -1641,7 +1532,7 @@ pub unsafe extern "C" fn hegel_test_case_from_blob(
         );
         return HEGEL_E_INVALID_ARG;
     };
-    let tc = handle_from_family(new_family(ds, None, output));
+    let tc = handle_from_family(new_family(ds, None));
     unsafe { *out_test_case = tc };
     HEGEL_OK
 }
@@ -1677,9 +1568,7 @@ pub unsafe extern "C" fn hegel_test_case_free(
     // SAFETY: `tc` is a non-null handle from a `hegel_*` constructor that the
     // caller is freeing exactly once; reconstituting the `Box` drops this
     // handle and its reference to the family.
-    let tc = unsafe { Box::from_raw(tc) };
-    unsafe { tc.family.output.resolve_from(ctx) };
-    drop(tc);
+    drop(unsafe { Box::from_raw(tc) });
     HEGEL_OK
 }
 
@@ -1736,20 +1625,17 @@ pub unsafe extern "C" fn hegel_test_case_clone(
     HEGEL_OK
 }
 
-/// Allocate a fresh family from a data source, optional run ack, and the
-/// output cell of the run (or standalone test case) it belongs to. `ack` is
+/// Allocate a fresh family from a data source and optional run ack. `ack` is
 /// `Some` for a run-owned family (the worker blocks on it until completion),
 /// `None` for a standalone (`from_blob`) family.
 fn new_family(
     ds: Box<dyn DataSource + Send + Sync>,
     ack: Option<mpsc::Sender<()>>,
-    output: Arc<OutputCell>,
 ) -> Arc<FamilyShared> {
     Arc::new(FamilyShared {
         ds: Arc::from(ds),
         completed: AtomicBool::new(false),
         ack,
-        output,
     })
 }
 
@@ -1775,9 +1661,7 @@ fn handle_from_stream(
 }
 
 /// Resolve a test-case handle for a per-test-case primitive, returning the
-/// handle and its locked per-instance state. Re-resolves the family's output
-/// destination from `ctx` (see `hegel_context_set_output`) as soon as the
-/// handle checks out, whether or not the call then errors.
+/// handle and its locked per-instance state.
 ///
 /// Takes a *shared* reference (never `&mut`: two threads racing the same
 /// handle pointer would make `&mut` instant UB, whereas `&HegelTestCase` is
@@ -1797,7 +1681,6 @@ unsafe fn tc_guard<'a>(
         set_last_error(ctx, &format!("{fn_name}: test case pointer is null"));
         return Err(HEGEL_E_INVALID_HANDLE);
     };
-    unsafe { tc.family.output.resolve_from(ctx) };
     if tc.family.completed.load(Ordering::Acquire) {
         set_last_error(ctx, &format!("{fn_name}: test case is already complete"));
         return Err(HEGEL_E_ALREADY_COMPLETE);
@@ -1819,8 +1702,7 @@ unsafe fn tc_guard<'a>(
 /// `try_lock`. Completion is first-caller-wins and always succeeds, so an
 /// in-flight operation on the same handle is waited for rather than reported
 /// as `HEGEL_E_CONCURRENT_USE`. Returns `HEGEL_E_INVALID_HANDLE` for a null
-/// pointer. Re-resolves the family's output destination from `ctx` like
-/// [`tc_guard`] does.
+/// pointer.
 unsafe fn tc_lock<'a>(
     ctx: *mut HegelContext,
     fn_name: &str,
@@ -1830,7 +1712,6 @@ unsafe fn tc_lock<'a>(
         set_last_error(ctx, &format!("{fn_name}: test case pointer is null"));
         return Err(HEGEL_E_INVALID_HANDLE);
     };
-    unsafe { tc.family.output.resolve_from(ctx) };
     Ok((tc, tc.local.lock()))
 }
 

--- a/hegel-c/src/lib.rs
+++ b/hegel-c/src/lib.rs
@@ -390,7 +390,8 @@ pub type hegel_output_callback_t =
 /// still returns its usual error code, there is just nothing to read back.
 ///
 /// Besides error reporting, a context carries the output destination for the
-/// runs and test cases created with it — see `hegel_context_set_output`.
+/// runs and test cases created and driven with it — see
+/// `hegel_context_set_output`.
 pub struct HegelContext {
     last_error: CString,
     output: Option<OutputTarget>,
@@ -399,9 +400,9 @@ pub struct HegelContext {
 /// The output callback registered on a `HegelContext` with
 /// `hegel_context_set_output`, paired with its `user_data` pointer.
 ///
-/// A copy of this pair is snapshotted off the context whenever a run or blob
-/// replay is created, and travels to the engine's worker thread inside the
-/// run's settings.
+/// A copy of this pair is resolved off the context when a run or blob replay
+/// is created (becoming its inherited destination, see [`OutputCell`]) and
+/// again by every later call that carries the run or one of its test cases.
 #[derive(Copy, Clone)]
 struct OutputTarget {
     callback: unsafe extern "C" fn(user_data: *mut c_void, line: *const c_char, len: usize),
@@ -416,18 +417,19 @@ unsafe impl Send for OutputTarget {}
 unsafe impl Sync for OutputTarget {}
 
 impl OutputTarget {
+    /// Deliver one line of output to this target's callback.
+    fn emit(self, line: &str) {
+        let line = cstring_lossy(line);
+        unsafe { (self.callback)(self.user_data, line.as_ptr(), line.as_bytes().len()) };
+    }
+
     /// The engine-facing [`Output`] that delivers each line to this target.
     ///
-    /// The closure binds `self` as a whole before touching its fields:
-    /// capturing the fields individually (RFC 2229 disjoint capture) would
-    /// capture a bare `*mut c_void` and lose [`OutputTarget`]'s `Send + Sync`
-    /// impls, which the sink's bounds require.
+    /// The closure captures `self` as a whole (via the by-value `emit`
+    /// receiver) rather than its fields individually, which would capture a
+    /// bare `*mut c_void` and lose [`OutputTarget`]'s `Send + Sync` impls.
     fn as_output(self) -> Output {
-        Output::callback(move |line| {
-            let target = self;
-            let line = cstring_lossy(line);
-            unsafe { (target.callback)(target.user_data, line.as_ptr(), line.as_bytes().len()) };
-        })
+        Output::callback(move |line| self.emit(line))
     }
 }
 
@@ -438,6 +440,61 @@ unsafe fn output_from_ctx(ctx: *const HegelContext) -> Output {
     match unsafe { ctx.as_ref() }.and_then(|c| c.output) {
         Some(target) => target.as_output(),
         None => Output::stderr(),
+    }
+}
+
+/// The live output destination of a run (or standalone `from_blob` test
+/// case), shared between the handles the caller drives and the engine worker
+/// that emits through it.
+///
+/// `inherited` is the destination resolved from the creating context
+/// (`hegel_run_start` / `hegel_test_case_from_blob`) and never changes.
+/// `current` is re-resolved from the context passed to every later call that
+/// carries the run or one of its test cases: a callback set on that context
+/// is used in place of the inherited destination (which is not updated,
+/// merely not used), and a context with no callback — including a NULL
+/// context — falls back to `inherited`. The engine emits from its worker
+/// thread, so each line goes to whichever destination was resolved most
+/// recently.
+struct OutputCell {
+    inherited: Output,
+    current: Mutex<Option<OutputTarget>>,
+}
+
+impl OutputCell {
+    /// A fresh cell whose current destination is `inherited`.
+    fn new(inherited: Output) -> Arc<Self> {
+        Arc::new(OutputCell {
+            inherited,
+            current: Mutex::new(None),
+        })
+    }
+
+    /// The engine-facing [`Output`] sink: each line the engine emits is
+    /// routed to the cell's destination as resolved at emission time.
+    fn as_output(self: &Arc<Self>) -> Output {
+        let cell = Arc::clone(self);
+        Output::callback(move |line| cell.line(line))
+    }
+
+    /// Emit one line to the currently resolved destination.
+    fn line(&self, line: &str) {
+        let current = *self.current.lock();
+        match current {
+            Some(target) => target.emit(line),
+            None => self.inherited.line(line),
+        }
+    }
+
+    /// Re-resolve the destination from the context making the current call:
+    /// the context's registered callback, or a fall-back to the inherited
+    /// destination when it has none (including for a NULL `ctx`).
+    ///
+    /// # Safety
+    ///
+    /// `ctx` must be NULL or a pointer to a live `HegelContext`.
+    unsafe fn resolve_from(&self, ctx: *const HegelContext) {
+        *self.current.lock() = unsafe { ctx.as_ref() }.and_then(|c| c.output);
     }
 }
 
@@ -452,7 +509,7 @@ pub extern "C" fn hegel_context_new() -> *mut HegelContext {
 }
 
 /// Redirect engine-emitted output (verbose / debug progress traces, warnings)
-/// for the runs and test cases subsequently created with `ctx`, instead of
+/// for the runs and test cases created or driven with `ctx`, instead of
 /// writing it to stderr.
 ///
 /// `callback` is invoked once per line of output; `user_data` is passed
@@ -461,16 +518,25 @@ pub extern "C" fn hegel_context_new() -> *mut HegelContext {
 /// `line` argument is NUL-terminated UTF-8 of `len` bytes (not counting the
 /// terminator), without a trailing newline; the buffer is owned by libhegel
 /// and valid only for the duration of the call — copy it to keep it. Passing
-/// a NULL `callback` resets the context to the default stderr output
-/// (`user_data` is ignored).
+/// a NULL `callback` unsets the context's callback (`user_data` is ignored),
+/// like `hegel_context_unset_output`.
 ///
-/// The destination is snapshotted when a run (`hegel_run_start`) or blob
-/// replay (`hegel_test_case_from_blob`) is created, so changing it later
-/// only affects subsequently created ones. The engine emits output from a
-/// worker thread inside libhegel, so the callback must be safe to invoke
-/// from a thread other than the one that registered it, and it — along with
-/// whatever `user_data` points to — must stay valid until every run started
-/// while it was installed has been freed with `hegel_run_free`.
+/// A run (`hegel_run_start`) or standalone test case
+/// (`hegel_test_case_from_blob`) *inherits* the destination registered on the
+/// creating context. Afterwards, every call that passes a context together
+/// with the run or one of its test cases re-resolves the destination from
+/// that context: a callback registered on it is used in place of the
+/// inherited destination (which is not modified, merely not used), and a
+/// context with no callback — including a NULL `ctx` — falls back to the
+/// inherited destination. A run driven through fresh (say, thread-local)
+/// contexts with no callback of their own therefore keeps printing to the
+/// callback installed when it was created. The engine emits output from a
+/// worker thread inside libhegel: each line goes to the most recently
+/// resolved destination, and the callback must be safe to invoke from a
+/// thread other than the one that registered it. The callback — along with
+/// whatever `user_data` points to — must stay valid until every run and test
+/// case whose output was routed to it (at creation or by a later call) has
+/// been freed.
 ///
 /// This sets only the *destination*; how much output the engine emits is
 /// controlled by `hegel_settings_set_verbosity`. Returns
@@ -491,6 +557,18 @@ pub unsafe extern "C" fn hegel_context_set_output(
         user_data,
     });
     HEGEL_OK
+}
+
+/// Unset the output callback registered on `ctx` with
+/// `hegel_context_set_output`, returning the context to its default
+/// behaviour: runs and test cases subsequently created with it write to
+/// stderr, and calls made with it on existing runs and test cases fall back
+/// to the destination those inherited at creation. Equivalent to passing a
+/// NULL `callback` to `hegel_context_set_output`. Returns
+/// `HEGEL_E_INVALID_HANDLE` for a NULL `ctx`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn hegel_context_unset_output(ctx: *mut HegelContext) -> hegel_result_t {
+    unsafe { hegel_context_set_output(ctx, None, ptr::null_mut()) }
 }
 
 /// Free a context previously returned by `hegel_context_new`. Safe to call
@@ -603,6 +681,11 @@ struct FamilyShared {
     /// completion `compare_exchange` in [`Self::complete`], which is what
     /// guarantees send-once.
     ack: Option<mpsc::Sender<()>>,
+    /// The output destination of the run this family belongs to (shared with
+    /// the run handle and its worker), or the standalone cell of a
+    /// `hegel_test_case_from_blob` family. Re-resolved from the context
+    /// passed to every call that carries one of the family's handles.
+    output: Arc<OutputCell>,
 }
 
 impl FamilyShared {
@@ -702,6 +785,11 @@ pub struct HegelRun {
     /// `from_worker`. Stops `hegel_next_test_case` from blocking forever
     /// on the second post-completion call.
     drained: bool,
+    /// The run's output destination, shared with the worker (which emits
+    /// through it) and with every test-case family the run produces.
+    /// Re-resolved from the context passed to every call that carries the
+    /// run or one of its test cases.
+    output: Arc<OutputCell>,
 }
 
 /// Aggregated outcome of a finished run. `hegel_run_result` writes a
@@ -1222,9 +1310,10 @@ fn install_worker_panic_hook() {
 /// The engine runs on a worker thread inside libhegel; this function
 /// returns immediately after spawning it. The caller does not need to
 /// hold the settings handle alive — `hegel_run_start` snapshots the
-/// settings it needs. The run also snapshots `ctx`'s output destination
-/// (see `hegel_context_set_output`): the engine's output for this run keeps
-/// going to the callback installed at start time, for the life of the run.
+/// settings it needs. The run also inherits `ctx`'s output destination
+/// (see `hegel_context_set_output`): the engine's output for this run goes
+/// to the callback installed at start time, unless a later call driving the
+/// run or one of its test cases passes a context with a callback of its own.
 ///
 /// Returns `HEGEL_E_INVALID_ARG` for a NULL `out_run`,
 /// `HEGEL_E_INVALID_HANDLE` for a NULL `settings`, or `HEGEL_E_BACKEND` if the
@@ -1247,7 +1336,8 @@ pub unsafe extern "C" fn hegel_run_start(
         set_last_error(ctx, "hegel_run_start: settings pointer is null");
         return HEGEL_E_INVALID_HANDLE;
     };
-    let settings = handle.inner.clone().output(unsafe { output_from_ctx(ctx) });
+    let output = OutputCell::new(unsafe { output_from_ctx(ctx) });
+    let settings = handle.inner.clone().output(output.as_output());
     let database_key = handle.database_key.clone();
 
     let (to_caller, from_worker) = mpsc::channel::<WorkerMessage>();
@@ -1307,6 +1397,7 @@ pub unsafe extern "C" fn hegel_run_start(
         current_family: None,
         result: None,
         drained: false,
+        output,
     }));
     unsafe { *out_run = run };
     HEGEL_OK
@@ -1335,6 +1426,7 @@ pub unsafe extern "C" fn hegel_next_test_case(
         set_last_error(ctx, "hegel_next_test_case: run pointer is null");
         return HEGEL_E_INVALID_HANDLE;
     };
+    unsafe { run.output.resolve_from(ctx) };
     if out_test_case.is_null() {
         set_last_error(ctx, "hegel_next_test_case: out parameter is null");
         return HEGEL_E_INVALID_ARG;
@@ -1363,7 +1455,7 @@ pub unsafe extern "C" fn hegel_next_test_case(
 
     match run.from_worker.recv() {
         Ok(WorkerMessage::TestCase { ds, ack }) => {
-            let family = new_family(ds, Some(ack));
+            let family = new_family(ds, Some(ack), Arc::clone(&run.output));
             let case = handle_from_family(Arc::clone(&family));
             run.current_family = Some(family);
             unsafe { *out_test_case = case };
@@ -1408,6 +1500,7 @@ pub unsafe extern "C" fn hegel_run_result(
         set_last_error(ctx, "hegel_run_result: run pointer is null");
         return HEGEL_E_INVALID_HANDLE;
     };
+    unsafe { run.output.resolve_from(ctx) };
     if out_result.is_null() {
         set_last_error(ctx, "hegel_run_result: out parameter is null");
         return HEGEL_E_INVALID_ARG;
@@ -1464,6 +1557,7 @@ pub unsafe extern "C" fn hegel_run_free(
         return HEGEL_OK;
     }
     let mut run = unsafe { Box::from_raw(run) };
+    unsafe { run.output.resolve_from(ctx) };
 
     run.abort.store(true, Ordering::Release);
 
@@ -1537,7 +1631,8 @@ pub unsafe extern "C" fn hegel_test_case_from_blob(
         set_last_error(ctx, "hegel_test_case_from_blob: blob is not valid UTF-8");
         return HEGEL_E_INVALID_ARG;
     };
-    let settings = handle.inner.clone().output(unsafe { output_from_ctx(ctx) });
+    let output = OutputCell::new(unsafe { output_from_ctx(ctx) });
+    let settings = handle.inner.clone().output(output.as_output());
     let Some(ds) = data_source_for_blob(&settings, blob) else {
         set_last_error(
             ctx,
@@ -1546,7 +1641,7 @@ pub unsafe extern "C" fn hegel_test_case_from_blob(
         );
         return HEGEL_E_INVALID_ARG;
     };
-    let tc = handle_from_family(new_family(ds, None));
+    let tc = handle_from_family(new_family(ds, None, output));
     unsafe { *out_test_case = tc };
     HEGEL_OK
 }
@@ -1582,7 +1677,9 @@ pub unsafe extern "C" fn hegel_test_case_free(
     // SAFETY: `tc` is a non-null handle from a `hegel_*` constructor that the
     // caller is freeing exactly once; reconstituting the `Box` drops this
     // handle and its reference to the family.
-    drop(unsafe { Box::from_raw(tc) });
+    let tc = unsafe { Box::from_raw(tc) };
+    unsafe { tc.family.output.resolve_from(ctx) };
+    drop(tc);
     HEGEL_OK
 }
 
@@ -1639,17 +1736,20 @@ pub unsafe extern "C" fn hegel_test_case_clone(
     HEGEL_OK
 }
 
-/// Allocate a fresh family from a data source and optional run ack. `ack` is
+/// Allocate a fresh family from a data source, optional run ack, and the
+/// output cell of the run (or standalone test case) it belongs to. `ack` is
 /// `Some` for a run-owned family (the worker blocks on it until completion),
 /// `None` for a standalone (`from_blob`) family.
 fn new_family(
     ds: Box<dyn DataSource + Send + Sync>,
     ack: Option<mpsc::Sender<()>>,
+    output: Arc<OutputCell>,
 ) -> Arc<FamilyShared> {
     Arc::new(FamilyShared {
         ds: Arc::from(ds),
         completed: AtomicBool::new(false),
         ack,
+        output,
     })
 }
 
@@ -1675,7 +1775,9 @@ fn handle_from_stream(
 }
 
 /// Resolve a test-case handle for a per-test-case primitive, returning the
-/// handle and its locked per-instance state.
+/// handle and its locked per-instance state. Re-resolves the family's output
+/// destination from `ctx` (see `hegel_context_set_output`) as soon as the
+/// handle checks out, whether or not the call then errors.
 ///
 /// Takes a *shared* reference (never `&mut`: two threads racing the same
 /// handle pointer would make `&mut` instant UB, whereas `&HegelTestCase` is
@@ -1695,6 +1797,7 @@ unsafe fn tc_guard<'a>(
         set_last_error(ctx, &format!("{fn_name}: test case pointer is null"));
         return Err(HEGEL_E_INVALID_HANDLE);
     };
+    unsafe { tc.family.output.resolve_from(ctx) };
     if tc.family.completed.load(Ordering::Acquire) {
         set_last_error(ctx, &format!("{fn_name}: test case is already complete"));
         return Err(HEGEL_E_ALREADY_COMPLETE);
@@ -1716,7 +1819,8 @@ unsafe fn tc_guard<'a>(
 /// `try_lock`. Completion is first-caller-wins and always succeeds, so an
 /// in-flight operation on the same handle is waited for rather than reported
 /// as `HEGEL_E_CONCURRENT_USE`. Returns `HEGEL_E_INVALID_HANDLE` for a null
-/// pointer.
+/// pointer. Re-resolves the family's output destination from `ctx` like
+/// [`tc_guard`] does.
 unsafe fn tc_lock<'a>(
     ctx: *mut HegelContext,
     fn_name: &str,
@@ -1726,6 +1830,7 @@ unsafe fn tc_lock<'a>(
         set_last_error(ctx, &format!("{fn_name}: test case pointer is null"));
         return Err(HEGEL_E_INVALID_HANDLE);
     };
+    unsafe { tc.family.output.resolve_from(ctx) };
     Ok((tc, tc.local.lock()))
 }
 

--- a/hegel-c/src/lib.rs
+++ b/hegel-c/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::missing_safety_doc)]
 
-use std::ffi::{CStr, CString, c_char};
+use std::ffi::{CStr, CString, c_char, c_void};
 use std::ptr;
 use std::sync::Arc;
 use std::sync::Once;
@@ -56,7 +56,7 @@ pub mod __bench {
 use crate::backend::{DataSource, DataSourceError, Failure, TestCaseResult, TestRunResult};
 use crate::embed::{data_source_for_blob, run_native};
 use crate::native::bignum::BigInt;
-use crate::settings::{Backend, HealthCheck, Mode, Phase, Settings, Verbosity};
+use crate::settings::{Backend, HealthCheck, Mode, Output, Phase, Settings, Verbosity};
 
 /// Result of a libhegel call.
 ///
@@ -360,6 +360,16 @@ pub enum hegel_label_t {
     HEGEL_LABEL_STRING = 30,
 }
 
+/// Per-line output callback, installed on a context with
+/// `hegel_context_set_output` (see there for the full contract). `user_data`
+/// is the pointer registered alongside the callback; `line` is one line of
+/// engine output, NUL-terminated UTF-8 of `len` bytes (not counting the
+/// terminator) without a trailing newline, valid only for the duration of
+/// the call.
+#[allow(non_camel_case_types)]
+pub type hegel_output_callback_t =
+    Option<unsafe extern "C" fn(user_data: *mut c_void, line: *const c_char, len: usize)>;
+
 /// Opaque error-reporting context.
 ///
 /// libhegel records the diagnostic for a failed call on a context the caller
@@ -378,8 +388,57 @@ pub enum hegel_label_t {
 /// threads is a data race and unsupported. Passing `NULL` wherever a context
 /// is accepted is allowed and simply opts out of error messages: the call
 /// still returns its usual error code, there is just nothing to read back.
+///
+/// Besides error reporting, a context carries the output destination for the
+/// runs and test cases created with it — see `hegel_context_set_output`.
 pub struct HegelContext {
     last_error: CString,
+    output: Option<OutputTarget>,
+}
+
+/// The output callback registered on a `HegelContext` with
+/// `hegel_context_set_output`, paired with its `user_data` pointer.
+///
+/// A copy of this pair is snapshotted off the context whenever a run or blob
+/// replay is created, and travels to the engine's worker thread inside the
+/// run's settings.
+#[derive(Copy, Clone)]
+struct OutputTarget {
+    callback: unsafe extern "C" fn(user_data: *mut c_void, line: *const c_char, len: usize),
+    user_data: *mut c_void,
+}
+
+// SAFETY: the raw `user_data` pointer is what makes this `!Send + !Sync` by
+// default, but `hegel_context_set_output`'s documented contract is that the
+// callback must be safe to invoke with this `user_data` from any thread, so
+// handing the pair to the engine's worker thread is sound.
+unsafe impl Send for OutputTarget {}
+unsafe impl Sync for OutputTarget {}
+
+impl OutputTarget {
+    /// The engine-facing [`Output`] that delivers each line to this target.
+    ///
+    /// The closure binds `self` as a whole before touching its fields:
+    /// capturing the fields individually (RFC 2229 disjoint capture) would
+    /// capture a bare `*mut c_void` and lose [`OutputTarget`]'s `Send + Sync`
+    /// impls, which the sink's bounds require.
+    fn as_output(self) -> Output {
+        Output::callback(move |line| {
+            let target = self;
+            let line = cstring_lossy(line);
+            unsafe { (target.callback)(target.user_data, line.as_ptr(), line.as_bytes().len()) };
+        })
+    }
+}
+
+/// The engine [`Output`] destination for a run or blob replay created with
+/// `ctx`: the context's registered callback when one is installed, stderr
+/// otherwise (including for a NULL `ctx`).
+unsafe fn output_from_ctx(ctx: *const HegelContext) -> Output {
+    match unsafe { ctx.as_ref() }.and_then(|c| c.output) {
+        Some(target) => target.as_output(),
+        None => Output::stderr(),
+    }
 }
 
 /// Allocate a new error-reporting context initialised with an empty message.
@@ -388,7 +447,50 @@ pub struct HegelContext {
 pub extern "C" fn hegel_context_new() -> *mut HegelContext {
     Box::into_raw(Box::new(HegelContext {
         last_error: CString::default(),
+        output: None,
     }))
+}
+
+/// Redirect engine-emitted output (verbose / debug progress traces, warnings)
+/// for the runs and test cases subsequently created with `ctx`, instead of
+/// writing it to stderr.
+///
+/// `callback` is invoked once per line of output; `user_data` is passed
+/// through to every invocation verbatim, for the caller to resolve to
+/// whatever sink the output should reach (say, a Go `testing.T` handle). The
+/// `line` argument is NUL-terminated UTF-8 of `len` bytes (not counting the
+/// terminator), without a trailing newline; the buffer is owned by libhegel
+/// and valid only for the duration of the call — copy it to keep it. Passing
+/// a NULL `callback` resets the context to the default stderr output
+/// (`user_data` is ignored).
+///
+/// The destination is snapshotted when a run (`hegel_run_start`) or blob
+/// replay (`hegel_test_case_from_blob`) is created, so changing it later
+/// only affects subsequently created ones. The engine emits output from a
+/// worker thread inside libhegel, so the callback must be safe to invoke
+/// from a thread other than the one that registered it, and it — along with
+/// whatever `user_data` points to — must stay valid until every run started
+/// while it was installed has been freed with `hegel_run_free`.
+///
+/// This sets only the *destination*; how much output the engine emits is
+/// controlled by `hegel_settings_set_verbosity`. Returns
+/// `HEGEL_E_INVALID_HANDLE` for a NULL `ctx` (there is no context to store
+/// the callback on).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn hegel_context_set_output(
+    ctx: *mut HegelContext,
+    callback: hegel_output_callback_t,
+    user_data: *mut c_void,
+) -> hegel_result_t {
+    clear_last_error(ctx);
+    let Some(c) = (unsafe { ctx.as_mut() }) else {
+        return HEGEL_E_INVALID_HANDLE;
+    };
+    c.output = callback.map(|callback| OutputTarget {
+        callback,
+        user_data,
+    });
+    HEGEL_OK
 }
 
 /// Free a context previously returned by `hegel_context_new`. Safe to call
@@ -1120,7 +1222,9 @@ fn install_worker_panic_hook() {
 /// The engine runs on a worker thread inside libhegel; this function
 /// returns immediately after spawning it. The caller does not need to
 /// hold the settings handle alive — `hegel_run_start` snapshots the
-/// settings it needs.
+/// settings it needs. The run also snapshots `ctx`'s output destination
+/// (see `hegel_context_set_output`): the engine's output for this run keeps
+/// going to the callback installed at start time, for the life of the run.
 ///
 /// Returns `HEGEL_E_INVALID_ARG` for a NULL `out_run`,
 /// `HEGEL_E_INVALID_HANDLE` for a NULL `settings`, or `HEGEL_E_BACKEND` if the
@@ -1143,7 +1247,7 @@ pub unsafe extern "C" fn hegel_run_start(
         set_last_error(ctx, "hegel_run_start: settings pointer is null");
         return HEGEL_E_INVALID_HANDLE;
     };
-    let settings = handle.inner.clone();
+    let settings = handle.inner.clone().output(unsafe { output_from_ctx(ctx) });
     let database_key = handle.database_key.clone();
 
     let (to_caller, from_worker) = mpsc::channel::<WorkerMessage>();
@@ -1433,7 +1537,8 @@ pub unsafe extern "C" fn hegel_test_case_from_blob(
         set_last_error(ctx, "hegel_test_case_from_blob: blob is not valid UTF-8");
         return HEGEL_E_INVALID_ARG;
     };
-    let Some(ds) = data_source_for_blob(&handle.inner, blob) else {
+    let settings = handle.inner.clone().output(unsafe { output_from_ctx(ctx) });
+    let Some(ds) = data_source_for_blob(&settings, blob) else {
         set_last_error(
             ctx,
             "hegel_test_case_from_blob: the supplied failure blob could not be decoded. \

--- a/hegel-c/src/native/test_runner.rs
+++ b/hegel-c/src/native/test_runner.rs
@@ -156,9 +156,13 @@ impl<'a> Engine<'a> {
         let database_key = self.database_key;
         let max_test_cases = settings.test_cases;
         let verbosity = settings.verbosity;
-        let log_phase = move |name: &str, edge: &str| {
-            if matches!(verbosity, Verbosity::Verbose | Verbosity::Debug) {
-                eprintln!("{edge}ing phase: {name}");
+        let output = settings.output.clone();
+        let log_phase = {
+            let output = output.clone();
+            move |name: &str, edge: &str| {
+                if matches!(verbosity, Verbosity::Verbose | Verbosity::Debug) {
+                    output.line(&format!("{edge}ing phase: {name}"));
+                }
             }
         };
 
@@ -324,7 +328,7 @@ impl<'a> Engine<'a> {
                     NativeTestCase::for_probe(&prefix, case_rng, BUFFER_SIZE)
                 };
                 if verbosity == Verbosity::Verbose {
-                    eprintln!("Running test case");
+                    output.line("Running test case");
                 }
 
                 let (run, mismatch) = self.test_function(ntc);
@@ -333,12 +337,12 @@ impl<'a> Engine<'a> {
                 }
 
                 if verbosity == Verbosity::Debug {
-                    eprintln!(
+                    output.line(&format!(
                         "test case #{}: status = {:?}, choices = {}",
                         self.calls,
                         run.status,
                         crate::native::core::flattened_len(&run.nodes)
-                    );
+                    ));
                 }
 
                 if self.interesting.is_empty() {
@@ -433,11 +437,11 @@ impl<'a> Engine<'a> {
             log_phase("Shrink", "Start");
             if verbosity == Verbosity::Debug {
                 let total: usize = self.interesting.values().map(|n| n.len()).sum();
-                eprintln!(
+                output.line(&format!(
                     "Shrinking: {} origin(s), initial total length = {}",
                     self.interesting.len(),
                     total
-                );
+                ));
             }
             if let (Some(_), Some(key)) = (self.db(), database_key) {
                 let key_bytes = key.as_bytes().to_vec();
@@ -510,7 +514,7 @@ impl<'a> Engine<'a> {
                     let mut shrinker = Shrinker::with_probe(
                         Box::new(|req: ShrinkRun| {
                             if verbosity == Verbosity::Verbose {
-                                eprintln!("Running test case");
+                                output.line("Running test case");
                             }
                             let run = match req {
                                 ShrinkRun::Full(nodes) => {
@@ -534,7 +538,7 @@ impl<'a> Engine<'a> {
                     shrinker.deadline = Some(shrink_deadline);
                     let _ = shrinker.initial_coarse_reduction();
                     if verbosity == Verbosity::Debug {
-                        shrinker.set_debug(|msg| eprintln!("{msg}"));
+                        shrinker.set_debug(|msg| output.line(msg));
                     }
                     shrinker.shrink();
                     shrink_timed_out |= shrinker.timed_out;
@@ -545,20 +549,20 @@ impl<'a> Engine<'a> {
             }
 
             if shrink_timed_out && verbosity != Verbosity::Quiet {
-                eprintln!("{}", slow_shrink_warning());
+                output.line(&slow_shrink_warning());
             }
 
             if verbosity == Verbosity::Debug {
                 let total: usize = self.interesting.values().map(|n| n.len()).sum();
-                eprintln!(
+                output.line(&format!(
                     "Shrinking complete: {} origin(s), final total length = {}",
                     self.interesting.len(),
                     total
-                );
+                ));
             }
             log_phase("Shrink", "End");
         } else if replay_aligned && verbosity == Verbosity::Debug {
-            eprintln!("Skipping shrink: reused aligned database replay");
+            output.line("Skipping shrink: reused aligned database replay");
         }
 
         if let (Some(db), Some(key)) = (self.db(), database_key) {
@@ -584,10 +588,10 @@ impl<'a> Engine<'a> {
         }
 
         if verbosity == Verbosity::Debug {
-            eprintln!(
+            output.line(&format!(
                 "Test done. interesting_test_cases={}",
                 self.interesting.len()
-            );
+            ));
         }
 
         let mut origins_sorted: Vec<(String, Vec<ChoiceNode>)> =

--- a/hegel-c/src/settings.rs
+++ b/hegel-c/src/settings.rs
@@ -74,6 +74,54 @@ pub enum Backend {
     Urandom,
 }
 
+/// Where engine-emitted output (verbose / debug progress traces, warnings)
+/// is written.
+///
+/// The default is stderr. [`Output::callback`] redirects every line to a
+/// caller-supplied sink instead — this is what backs the C ABI's
+/// `hegel_context_set_output`, letting embeddings (e.g. a Go `testing.T`)
+/// capture engine output in-process. Lines are delivered without a trailing
+/// newline. The engine emits from its worker thread, so the sink must be
+/// `Send + Sync`.
+#[derive(Clone)]
+pub struct Output {
+    sink: Option<OutputSink>,
+}
+
+/// A caller-supplied destination for engine output lines.
+type OutputSink = std::sync::Arc<dyn Fn(&str) + Send + Sync>;
+
+impl Output {
+    /// The default destination: each line goes to stderr via `eprintln!`.
+    pub fn stderr() -> Self {
+        Output { sink: None }
+    }
+
+    /// Deliver each line to `sink` instead of stderr.
+    pub fn callback(sink: impl Fn(&str) + Send + Sync + 'static) -> Self {
+        Output {
+            sink: Some(std::sync::Arc::new(sink)),
+        }
+    }
+
+    /// Emit one line of output to this destination.
+    pub(crate) fn line(&self, line: &str) {
+        match &self.sink {
+            Some(sink) => sink(line),
+            None => eprintln!("{line}"),
+        }
+    }
+}
+
+impl std::fmt::Debug for Output {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.sink {
+            Some(_) => f.write_str("Output(callback)"),
+            None => f.write_str("Output(stderr)"),
+        }
+    }
+}
+
 /// Controls how much output Hegel produces during test runs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Verbosity {
@@ -99,6 +147,7 @@ pub struct Settings {
     pub(crate) mode: Mode,
     pub(crate) test_cases: u64,
     pub(crate) verbosity: Verbosity,
+    pub(crate) output: Output,
     pub(crate) seed: Option<u64>,
     pub(crate) derandomize: bool,
     pub(crate) database: Database,
@@ -119,6 +168,7 @@ impl Settings {
             mode: Mode::TestRun,
             test_cases: 100,
             verbosity: Verbosity::Normal,
+            output: Output::stderr(),
             seed: None,
             derandomize: in_ci,
             database: if in_ci {
@@ -177,6 +227,13 @@ impl Settings {
     /// Set the verbosity level.
     pub fn verbosity(mut self, verbosity: Verbosity) -> Self {
         self.verbosity = verbosity;
+        self
+    }
+
+    /// Set where engine-emitted output is written. Defaults to
+    /// [`Output::stderr`].
+    pub fn output(mut self, output: Output) -> Self {
+        self.output = output;
         self
     }
 

--- a/hegel-c/src/settings.rs
+++ b/hegel-c/src/settings.rs
@@ -78,11 +78,11 @@ pub enum Backend {
 /// is written.
 ///
 /// The default is stderr. [`Output::callback`] redirects every line to a
-/// caller-supplied sink instead — this is what backs the C ABI's
-/// `hegel_context_set_output`, letting embeddings (e.g. a Go `testing.T`)
-/// capture engine output in-process. Lines are delivered without a trailing
-/// newline. The engine emits from its worker thread, so the sink must be
-/// `Send + Sync`.
+/// caller-supplied sink instead — this is what backs the output callback the
+/// C ABI's `hegel_run_start` / `hegel_test_case_from_blob` accept, letting
+/// embeddings (e.g. a Go `testing.T`) capture engine output in-process. Lines
+/// are delivered without a trailing newline. The engine emits from its worker
+/// thread, so the sink must be `Send + Sync`.
 #[derive(Clone)]
 pub struct Output {
     sink: Option<OutputSink>,

--- a/hegel-c/tests/c_abi_inprocess.rs
+++ b/hegel-c/tests/c_abi_inprocess.rs
@@ -15,22 +15,23 @@ use hegel_c::hegel_result_t::*;
 use hegel_c::{
     HegelContext, HegelFailure, HegelRun, HegelRunResult, HegelTestCase, hegel_backend_t,
     hegel_collection_more, hegel_collection_reject, hegel_context_free, hegel_context_last_error,
-    hegel_context_new, hegel_failure_free, hegel_failure_origin, hegel_failure_reproduction_blob,
-    hegel_generate_boolean, hegel_generate_integer, hegel_label_t, hegel_mark_complete,
-    hegel_mode_t, hegel_new_collection, hegel_new_pool, hegel_new_state_machine,
-    hegel_next_test_case, hegel_pool_add, hegel_pool_generate, hegel_run_free, hegel_run_result,
-    hegel_run_result_error, hegel_run_result_failure, hegel_run_result_failure_count,
-    hegel_run_result_free, hegel_run_result_status, hegel_run_start, hegel_run_status_t,
-    hegel_settings_free, hegel_settings_new, hegel_settings_set_backend,
-    hegel_settings_set_database, hegel_settings_set_database_key, hegel_settings_set_mode,
-    hegel_settings_set_phases, hegel_settings_set_report_multiple_failures,
-    hegel_settings_set_suppress_health_check, hegel_start_span, hegel_state_machine_next_rule,
-    hegel_status_t, hegel_stop_span, hegel_target, hegel_test_case_clone, hegel_test_case_free,
-    hegel_test_case_from_blob, hegel_version,
+    hegel_context_new, hegel_context_set_output, hegel_failure_free, hegel_failure_origin,
+    hegel_failure_reproduction_blob, hegel_generate_boolean, hegel_generate_integer, hegel_label_t,
+    hegel_mark_complete, hegel_mode_t, hegel_new_collection, hegel_new_pool,
+    hegel_new_state_machine, hegel_next_test_case, hegel_pool_add, hegel_pool_generate,
+    hegel_run_free, hegel_run_result, hegel_run_result_error, hegel_run_result_failure,
+    hegel_run_result_failure_count, hegel_run_result_free, hegel_run_result_status,
+    hegel_run_start, hegel_run_status_t, hegel_settings_free, hegel_settings_new,
+    hegel_settings_set_backend, hegel_settings_set_database, hegel_settings_set_database_key,
+    hegel_settings_set_mode, hegel_settings_set_phases,
+    hegel_settings_set_report_multiple_failures, hegel_settings_set_suppress_health_check,
+    hegel_start_span, hegel_state_machine_next_rule, hegel_status_t, hegel_stop_span, hegel_target,
+    hegel_test_case_clone, hegel_test_case_free, hegel_test_case_from_blob, hegel_version,
 };
-use std::ffi::CString;
+use std::ffi::{CString, c_void};
 use std::os::raw::c_char;
 use std::ptr;
+use std::sync::Mutex;
 
 unsafe fn result(ctx: *mut HegelContext, run: *mut HegelRun) -> *mut HegelRunResult {
     let mut r: *mut HegelRunResult = ptr::null_mut();
@@ -1467,4 +1468,232 @@ fn two_clones_draw_concurrently_without_concurrent_use_errors() {
         ok(hegel_settings_free(ctx, s));
         ok(hegel_context_free(ctx));
     }
+}
+
+/// Output callback for the `hegel_context_set_output` tests: `user_data`
+/// points at a `Mutex<Vec<String>>` that collects every line, checking on the
+/// way that `line` is NUL-terminated UTF-8 whose length matches `len`.
+unsafe extern "C" fn capture_output(user_data: *mut c_void, line: *const c_char, len: usize) {
+    let lines = unsafe { &*user_data.cast::<Mutex<Vec<String>>>() };
+    let text = unsafe { std::ffi::CStr::from_ptr(line) }
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert_eq!(text.len(), len);
+    lines.lock().unwrap().push(text);
+}
+
+/// A debug-verbosity failing run started from a context with an output
+/// callback delivers the engine's progress lines (phase edges, per-case
+/// traces, shrink progress, the final summary) to the callback, passing the
+/// caller's `user_data` through.
+#[test]
+fn output_callback_receives_engine_output() {
+    let lines: Mutex<Vec<String>> = Mutex::new(Vec::new());
+    let ctx = hegel_context_new();
+    unsafe {
+        ok(hegel_context_set_output(
+            ctx,
+            Some(capture_output),
+            (&raw const lines).cast_mut().cast(),
+        ));
+        let s = make_settings(ctx);
+        let empty = CString::new("").unwrap();
+        ok(hegel_settings_set_database(ctx, s, empty.as_ptr()));
+        ok(hegel_c::hegel_settings_set_test_cases(ctx, s, 5));
+        ok(hegel_c::hegel_settings_set_seed(ctx, s, 1, true));
+        ok(hegel_c::hegel_settings_set_verbosity(
+            ctx,
+            s,
+            hegel_c::hegel_verbosity_t::HEGEL_VERBOSITY_DEBUG as u32,
+        ));
+        let run = start(ctx, s);
+        loop {
+            let tc = next_case(ctx, run);
+            if tc.is_null() {
+                break;
+            }
+            let mut value = 0i64;
+            let status = if hegel_generate_integer(ctx, tc, 0, 100, &mut value) == HEGEL_OK {
+                hegel_status_t::HEGEL_STATUS_INTERESTING as u32
+            } else {
+                hegel_status_t::HEGEL_STATUS_OVERRUN as u32
+            };
+            ok(hegel_mark_complete(ctx, tc, status, ptr::null()));
+            ok(hegel_test_case_free(ctx, tc));
+        }
+        ok(hegel_run_result_free(ctx, result(ctx, run)));
+        ok(hegel_run_free(ctx, run));
+        ok(hegel_settings_free(ctx, s));
+        ok(hegel_context_free(ctx));
+    }
+    let lines = lines.into_inner().unwrap();
+    let all = lines.join("\n");
+    assert!(
+        lines.iter().any(|l| l == "Starting phase: Generate"),
+        "got {all:?}"
+    );
+    assert!(
+        lines.iter().any(|l| l.starts_with("test case #")),
+        "got {all:?}"
+    );
+    assert!(
+        lines.iter().any(|l| l.starts_with("Shrinking:")),
+        "got {all:?}"
+    );
+    assert!(
+        lines
+            .iter()
+            .any(|l| l == "Test done. interesting_test_cases=1"),
+        "got {all:?}"
+    );
+}
+
+/// Passing a NULL callback to `hegel_context_set_output` resets the context
+/// to the default stderr output: a later run delivers nothing to the
+/// previously-installed callback.
+#[test]
+fn null_output_callback_resets_to_stderr() {
+    let lines: Mutex<Vec<String>> = Mutex::new(Vec::new());
+    let ctx = hegel_context_new();
+    unsafe {
+        ok(hegel_context_set_output(
+            ctx,
+            Some(capture_output),
+            (&raw const lines).cast_mut().cast(),
+        ));
+        ok(hegel_context_set_output(ctx, None, ptr::null_mut()));
+        let s = make_settings(ctx);
+        let empty = CString::new("").unwrap();
+        ok(hegel_settings_set_database(ctx, s, empty.as_ptr()));
+        ok(hegel_c::hegel_settings_set_test_cases(ctx, s, 2));
+        ok(hegel_c::hegel_settings_set_seed(ctx, s, 1, true));
+        ok(hegel_c::hegel_settings_set_verbosity(
+            ctx,
+            s,
+            hegel_c::hegel_verbosity_t::HEGEL_VERBOSITY_DEBUG as u32,
+        ));
+        let run = start(ctx, s);
+        loop {
+            let tc = next_case(ctx, run);
+            if tc.is_null() {
+                break;
+            }
+            let mut value = 0i64;
+            let status = if hegel_generate_integer(ctx, tc, 0, 100, &mut value) == HEGEL_OK {
+                hegel_status_t::HEGEL_STATUS_VALID as u32
+            } else {
+                hegel_status_t::HEGEL_STATUS_OVERRUN as u32
+            };
+            ok(hegel_mark_complete(ctx, tc, status, ptr::null()));
+            ok(hegel_test_case_free(ctx, tc));
+        }
+        ok(hegel_run_result_free(ctx, result(ctx, run)));
+        ok(hegel_run_free(ctx, run));
+        ok(hegel_settings_free(ctx, s));
+        ok(hegel_context_free(ctx));
+    }
+    assert!(lines.into_inner().unwrap().is_empty());
+}
+
+/// `hegel_context_set_output` on a NULL context is rejected: there is no
+/// context to store the callback on.
+#[test]
+fn set_output_on_null_context_is_rejected() {
+    unsafe {
+        assert_eq!(
+            hegel_context_set_output(ptr::null_mut(), Some(capture_output), ptr::null_mut()),
+            HEGEL_E_INVALID_HANDLE
+        );
+    }
+}
+
+/// `hegel_run_start` snapshots the context's output destination: resetting
+/// the callback after the run has started does not redirect the in-flight
+/// run's output back to stderr.
+#[test]
+fn run_start_snapshots_the_output_destination() {
+    let lines: Mutex<Vec<String>> = Mutex::new(Vec::new());
+    let ctx = hegel_context_new();
+    unsafe {
+        ok(hegel_context_set_output(
+            ctx,
+            Some(capture_output),
+            (&raw const lines).cast_mut().cast(),
+        ));
+        let s = make_settings(ctx);
+        let empty = CString::new("").unwrap();
+        ok(hegel_settings_set_database(ctx, s, empty.as_ptr()));
+        ok(hegel_c::hegel_settings_set_test_cases(ctx, s, 2));
+        ok(hegel_c::hegel_settings_set_seed(ctx, s, 1, true));
+        ok(hegel_c::hegel_settings_set_verbosity(
+            ctx,
+            s,
+            hegel_c::hegel_verbosity_t::HEGEL_VERBOSITY_DEBUG as u32,
+        ));
+        let run = start(ctx, s);
+        ok(hegel_context_set_output(ctx, None, ptr::null_mut()));
+        loop {
+            let tc = next_case(ctx, run);
+            if tc.is_null() {
+                break;
+            }
+            let mut value = 0i64;
+            let status = if hegel_generate_integer(ctx, tc, 0, 100, &mut value) == HEGEL_OK {
+                hegel_status_t::HEGEL_STATUS_VALID as u32
+            } else {
+                hegel_status_t::HEGEL_STATUS_OVERRUN as u32
+            };
+            ok(hegel_mark_complete(ctx, tc, status, ptr::null()));
+            ok(hegel_test_case_free(ctx, tc));
+        }
+        ok(hegel_run_result_free(ctx, result(ctx, run)));
+        ok(hegel_run_free(ctx, run));
+        ok(hegel_settings_free(ctx, s));
+        ok(hegel_context_free(ctx));
+    }
+    let lines = lines.into_inner().unwrap();
+    assert!(
+        lines
+            .iter()
+            .any(|l| l == "Test done. interesting_test_cases=0"),
+        "got {lines:?}"
+    );
+}
+
+/// `hegel_test_case_from_blob` inherits the context's output callback too:
+/// at debug verbosity the blob-replay trace line is delivered to the
+/// callback instead of stderr.
+#[test]
+fn from_blob_replay_trace_goes_to_the_output_callback() {
+    let lines: Mutex<Vec<String>> = Mutex::new(Vec::new());
+    let ctx = hegel_context_new();
+    unsafe {
+        let blob = shrunk_failure_blob_with_draws(ctx, 2);
+        ok(hegel_context_set_output(
+            ctx,
+            Some(capture_output),
+            (&raw const lines).cast_mut().cast(),
+        ));
+        let s = make_settings(ctx);
+        ok(hegel_c::hegel_settings_set_verbosity(
+            ctx,
+            s,
+            hegel_c::hegel_verbosity_t::HEGEL_VERBOSITY_DEBUG as u32,
+        ));
+        let mut tc: *mut HegelTestCase = ptr::null_mut();
+        ok(hegel_test_case_from_blob(ctx, s, blob.as_ptr(), &mut tc));
+        assert!(!tc.is_null());
+        ok(hegel_mark_complete(
+            ctx,
+            tc,
+            hegel_status_t::HEGEL_STATUS_VALID as u32,
+            ptr::null(),
+        ));
+        ok(hegel_test_case_free(ctx, tc));
+        ok(hegel_settings_free(ctx, s));
+        ok(hegel_context_free(ctx));
+    }
+    let lines = lines.into_inner().unwrap();
+    assert_eq!(lines, ["replaying failure blob: choices = 2"]);
 }

--- a/hegel-c/tests/c_abi_inprocess.rs
+++ b/hegel-c/tests/c_abi_inprocess.rs
@@ -10,23 +10,23 @@
 
 mod common;
 
-use common::{last_error, make_settings, next_case, ok, start};
+use common::{last_error, make_settings, next_case, ok, start, start_with_output};
 use hegel_c::hegel_result_t::*;
 use hegel_c::{
     HegelContext, HegelFailure, HegelRun, HegelRunResult, HegelTestCase, hegel_backend_t,
     hegel_collection_more, hegel_collection_reject, hegel_context_free, hegel_context_last_error,
-    hegel_context_new, hegel_context_set_output, hegel_context_unset_output, hegel_failure_free,
-    hegel_failure_origin, hegel_failure_reproduction_blob, hegel_generate_boolean,
-    hegel_generate_integer, hegel_label_t, hegel_mark_complete, hegel_mode_t, hegel_new_collection,
-    hegel_new_pool, hegel_new_state_machine, hegel_next_test_case, hegel_pool_add,
-    hegel_pool_generate, hegel_run_free, hegel_run_result, hegel_run_result_error,
-    hegel_run_result_failure, hegel_run_result_failure_count, hegel_run_result_free,
-    hegel_run_result_status, hegel_run_start, hegel_run_status_t, hegel_settings_free,
-    hegel_settings_new, hegel_settings_set_backend, hegel_settings_set_database,
-    hegel_settings_set_database_key, hegel_settings_set_mode, hegel_settings_set_phases,
-    hegel_settings_set_report_multiple_failures, hegel_settings_set_suppress_health_check,
-    hegel_start_span, hegel_state_machine_next_rule, hegel_status_t, hegel_stop_span, hegel_target,
-    hegel_test_case_clone, hegel_test_case_free, hegel_test_case_from_blob, hegel_version,
+    hegel_context_new, hegel_failure_free, hegel_failure_origin, hegel_failure_reproduction_blob,
+    hegel_generate_boolean, hegel_generate_integer, hegel_label_t, hegel_mark_complete,
+    hegel_mode_t, hegel_new_collection, hegel_new_pool, hegel_new_state_machine,
+    hegel_next_test_case, hegel_pool_add, hegel_pool_generate, hegel_run_free, hegel_run_result,
+    hegel_run_result_error, hegel_run_result_failure, hegel_run_result_failure_count,
+    hegel_run_result_free, hegel_run_result_status, hegel_run_start, hegel_run_status_t,
+    hegel_settings_free, hegel_settings_new, hegel_settings_set_backend,
+    hegel_settings_set_database, hegel_settings_set_database_key, hegel_settings_set_mode,
+    hegel_settings_set_phases, hegel_settings_set_report_multiple_failures,
+    hegel_settings_set_suppress_health_check, hegel_start_span, hegel_state_machine_next_rule,
+    hegel_status_t, hegel_stop_span, hegel_target, hegel_test_case_clone, hegel_test_case_free,
+    hegel_test_case_from_blob, hegel_version,
 };
 use std::ffi::{CString, c_void};
 use std::os::raw::c_char;
@@ -157,7 +157,7 @@ fn null_handles_are_rejected_without_crashing() {
 
         let mut run: *mut HegelRun = ptr::null_mut();
         assert_eq!(
-            hegel_run_start(ctx, ptr::null(), &mut run),
+            hegel_run_start(ctx, ptr::null(), None, ptr::null_mut(), &mut run),
             HEGEL_E_INVALID_HANDLE
         );
         assert!(run.is_null());
@@ -173,7 +173,14 @@ fn null_handles_are_rejected_without_crashing() {
             HEGEL_E_INVALID_HANDLE
         );
         assert_eq!(
-            hegel_test_case_from_blob(ctx, ptr::null(), c"AAEC".as_ptr(), &mut tc),
+            hegel_test_case_from_blob(
+                ctx,
+                ptr::null(),
+                c"AAEC".as_ptr(),
+                None,
+                ptr::null_mut(),
+                &mut tc
+            ),
             HEGEL_E_INVALID_HANDLE
         );
 
@@ -267,7 +274,13 @@ fn null_handles_are_rejected_without_crashing() {
         );
 
         assert_eq!(
-            hegel_run_start(ptr::null_mut(), ptr::null(), &mut run),
+            hegel_run_start(
+                ptr::null_mut(),
+                ptr::null(),
+                None,
+                ptr::null_mut(),
+                &mut run
+            ),
             HEGEL_E_INVALID_HANDLE
         );
         assert!(hegel_context_last_error(ptr::null()).is_null());
@@ -289,7 +302,7 @@ fn out_parameters_are_rejected_when_null() {
         let empty = CString::new("").unwrap();
         ok(hegel_settings_set_database(ctx, s, empty.as_ptr()));
         assert_eq!(
-            hegel_run_start(ctx, s, ptr::null_mut()),
+            hegel_run_start(ctx, s, None, ptr::null_mut(), ptr::null_mut()),
             HEGEL_E_INVALID_ARG
         );
         let run = start(ctx, s);
@@ -302,7 +315,14 @@ fn out_parameters_are_rejected_when_null() {
             HEGEL_E_INVALID_ARG
         );
         assert_eq!(
-            hegel_test_case_from_blob(ctx, s, c"AAEC".as_ptr(), ptr::null_mut()),
+            hegel_test_case_from_blob(
+                ctx,
+                s,
+                c"AAEC".as_ptr(),
+                None,
+                ptr::null_mut(),
+                ptr::null_mut()
+            ),
             HEGEL_E_INVALID_ARG
         );
 
@@ -383,19 +403,19 @@ fn from_blob_rejects_bad_input() {
         let s = make_settings(ctx);
         let mut tc: *mut HegelTestCase = ptr::null_mut();
         assert_eq!(
-            hegel_test_case_from_blob(ctx, s, ptr::null(), &mut tc),
+            hegel_test_case_from_blob(ctx, s, ptr::null(), None, ptr::null_mut(), &mut tc),
             HEGEL_E_INVALID_ARG
         );
         assert!(last_error(ctx).contains("null"));
         let bad: [c_char; 2] = [0xFFu8 as c_char, 0];
         assert_eq!(
-            hegel_test_case_from_blob(ctx, s, bad.as_ptr(), &mut tc),
+            hegel_test_case_from_blob(ctx, s, bad.as_ptr(), None, ptr::null_mut(), &mut tc),
             HEGEL_E_INVALID_ARG
         );
         assert!(last_error(ctx).contains("UTF-8"));
         let garbage = CString::new("!!! not a blob !!!").unwrap();
         assert_eq!(
-            hegel_test_case_from_blob(ctx, s, garbage.as_ptr(), &mut tc),
+            hegel_test_case_from_blob(ctx, s, garbage.as_ptr(), None, ptr::null_mut(), &mut tc),
             HEGEL_E_INVALID_ARG
         );
         assert!(last_error(ctx).contains("could not be decoded"));
@@ -1349,7 +1369,7 @@ fn standalone_handles_are_freed_independently() {
 
         let mut root: *mut HegelTestCase = ptr::null_mut();
         assert_eq!(
-            hegel_test_case_from_blob(ctx, s, blob.as_ptr(), &mut root),
+            hegel_test_case_from_blob(ctx, s, blob.as_ptr(), None, ptr::null_mut(), &mut root),
             HEGEL_OK
         );
         assert!(!root.is_null());
@@ -1470,9 +1490,10 @@ fn two_clones_draw_concurrently_without_concurrent_use_errors() {
     }
 }
 
-/// Output callback for the `hegel_context_set_output` tests: `user_data`
-/// points at a `Mutex<Vec<String>>` that collects every line, checking on the
-/// way that `line` is NUL-terminated UTF-8 whose length matches `len`.
+/// Output callback for the `hegel_run_start` / `hegel_test_case_from_blob`
+/// output tests: `user_data` points at a `Mutex<Vec<String>>` that collects
+/// every line, checking on the way that `line` is NUL-terminated UTF-8 whose
+/// length matches `len`.
 unsafe extern "C" fn capture_output(user_data: *mut c_void, line: *const c_char, len: usize) {
     let lines = unsafe { &*user_data.cast::<Mutex<Vec<String>>>() };
     let text = unsafe { std::ffi::CStr::from_ptr(line) }
@@ -1483,20 +1504,15 @@ unsafe extern "C" fn capture_output(user_data: *mut c_void, line: *const c_char,
     lines.lock().unwrap().push(text);
 }
 
-/// A debug-verbosity failing run started from a context with an output
-/// callback delivers the engine's progress lines (phase edges, per-case
-/// traces, shrink progress, the final summary) to the callback, passing the
-/// caller's `user_data` through.
+/// A debug-verbosity failing run started with an output callback delivers the
+/// engine's progress lines (phase edges, per-case traces, shrink progress,
+/// the final summary) to the callback, passing the caller's `user_data`
+/// through.
 #[test]
 fn output_callback_receives_engine_output() {
     let lines: Mutex<Vec<String>> = Mutex::new(Vec::new());
     let ctx = hegel_context_new();
     unsafe {
-        ok(hegel_context_set_output(
-            ctx,
-            Some(capture_output),
-            (&raw const lines).cast_mut().cast(),
-        ));
         let s = make_settings(ctx);
         let empty = CString::new("").unwrap();
         ok(hegel_settings_set_database(ctx, s, empty.as_ptr()));
@@ -1507,7 +1523,12 @@ fn output_callback_receives_engine_output() {
             s,
             hegel_c::hegel_verbosity_t::HEGEL_VERBOSITY_DEBUG as u32,
         ));
-        let run = start(ctx, s);
+        let run = start_with_output(
+            ctx,
+            s,
+            Some(capture_output),
+            (&raw const lines).cast_mut().cast(),
+        );
         loop {
             let tc = next_case(ctx, run);
             if tc.is_null() {
@@ -1549,20 +1570,13 @@ fn output_callback_receives_engine_output() {
     );
 }
 
-/// Passing a NULL callback to `hegel_context_set_output` resets the context
-/// to the default stderr output: a later run delivers nothing to the
-/// previously-installed callback.
+/// A run started with a NULL callback writes its output to stderr and
+/// delivers nothing to any callback — exercising the stderr default of
+/// `hegel_run_start`.
 #[test]
-fn null_output_callback_resets_to_stderr() {
-    let lines: Mutex<Vec<String>> = Mutex::new(Vec::new());
+fn null_output_callback_writes_to_stderr() {
     let ctx = hegel_context_new();
     unsafe {
-        ok(hegel_context_set_output(
-            ctx,
-            Some(capture_output),
-            (&raw const lines).cast_mut().cast(),
-        ));
-        ok(hegel_context_set_output(ctx, None, ptr::null_mut()));
         let s = make_settings(ctx);
         let empty = CString::new("").unwrap();
         ok(hegel_settings_set_database(ctx, s, empty.as_ptr()));
@@ -1573,7 +1587,7 @@ fn null_output_callback_resets_to_stderr() {
             s,
             hegel_c::hegel_verbosity_t::HEGEL_VERBOSITY_DEBUG as u32,
         ));
-        let run = start(ctx, s);
+        let run = start_with_output(ctx, s, None, ptr::null_mut());
         loop {
             let tc = next_case(ctx, run);
             if tc.is_null() {
@@ -1593,76 +1607,9 @@ fn null_output_callback_resets_to_stderr() {
         ok(hegel_settings_free(ctx, s));
         ok(hegel_context_free(ctx));
     }
-    assert!(lines.into_inner().unwrap().is_empty());
 }
 
-/// `hegel_context_set_output` on a NULL context is rejected: there is no
-/// context to store the callback on.
-#[test]
-fn set_output_on_null_context_is_rejected() {
-    unsafe {
-        assert_eq!(
-            hegel_context_set_output(ptr::null_mut(), Some(capture_output), ptr::null_mut()),
-            HEGEL_E_INVALID_HANDLE
-        );
-    }
-}
-
-/// A run inherits the context's output destination at `hegel_run_start`:
-/// unsetting the callback after the run has started leaves the context with
-/// no callback, and calls made with it fall back to the inherited
-/// destination rather than redirecting the in-flight run's output to stderr.
-#[test]
-fn unset_context_falls_back_to_the_inherited_destination() {
-    let lines: Mutex<Vec<String>> = Mutex::new(Vec::new());
-    let ctx = hegel_context_new();
-    unsafe {
-        ok(hegel_context_set_output(
-            ctx,
-            Some(capture_output),
-            (&raw const lines).cast_mut().cast(),
-        ));
-        let s = make_settings(ctx);
-        let empty = CString::new("").unwrap();
-        ok(hegel_settings_set_database(ctx, s, empty.as_ptr()));
-        ok(hegel_c::hegel_settings_set_test_cases(ctx, s, 2));
-        ok(hegel_c::hegel_settings_set_seed(ctx, s, 1, true));
-        ok(hegel_c::hegel_settings_set_verbosity(
-            ctx,
-            s,
-            hegel_c::hegel_verbosity_t::HEGEL_VERBOSITY_DEBUG as u32,
-        ));
-        let run = start(ctx, s);
-        ok(hegel_context_set_output(ctx, None, ptr::null_mut()));
-        loop {
-            let tc = next_case(ctx, run);
-            if tc.is_null() {
-                break;
-            }
-            let mut value = 0i64;
-            let status = if hegel_generate_integer(ctx, tc, 0, 100, &mut value) == HEGEL_OK {
-                hegel_status_t::HEGEL_STATUS_VALID as u32
-            } else {
-                hegel_status_t::HEGEL_STATUS_OVERRUN as u32
-            };
-            ok(hegel_mark_complete(ctx, tc, status, ptr::null()));
-            ok(hegel_test_case_free(ctx, tc));
-        }
-        ok(hegel_run_result_free(ctx, result(ctx, run)));
-        ok(hegel_run_free(ctx, run));
-        ok(hegel_settings_free(ctx, s));
-        ok(hegel_context_free(ctx));
-    }
-    let lines = lines.into_inner().unwrap();
-    assert!(
-        lines
-            .iter()
-            .any(|l| l == "Test done. interesting_test_cases=0"),
-        "got {lines:?}"
-    );
-}
-
-/// `hegel_test_case_from_blob` inherits the context's output callback too:
+/// `hegel_test_case_from_blob` routes its output to the supplied callback:
 /// at debug verbosity the blob-replay trace line is delivered to the
 /// callback instead of stderr.
 #[test]
@@ -1671,11 +1618,6 @@ fn from_blob_replay_trace_goes_to_the_output_callback() {
     let ctx = hegel_context_new();
     unsafe {
         let blob = shrunk_failure_blob_with_draws(ctx, 2);
-        ok(hegel_context_set_output(
-            ctx,
-            Some(capture_output),
-            (&raw const lines).cast_mut().cast(),
-        ));
         let s = make_settings(ctx);
         ok(hegel_c::hegel_settings_set_verbosity(
             ctx,
@@ -1683,7 +1625,14 @@ fn from_blob_replay_trace_goes_to_the_output_callback() {
             hegel_c::hegel_verbosity_t::HEGEL_VERBOSITY_DEBUG as u32,
         ));
         let mut tc: *mut HegelTestCase = ptr::null_mut();
-        ok(hegel_test_case_from_blob(ctx, s, blob.as_ptr(), &mut tc));
+        ok(hegel_test_case_from_blob(
+            ctx,
+            s,
+            blob.as_ptr(),
+            Some(capture_output),
+            (&raw const lines).cast_mut().cast(),
+            &mut tc,
+        ));
         assert!(!tc.is_null());
         ok(hegel_mark_complete(
             ctx,
@@ -1697,159 +1646,4 @@ fn from_blob_replay_trace_goes_to_the_output_callback() {
     }
     let lines = lines.into_inner().unwrap();
     assert_eq!(lines, ["replaying failure blob: choices = 2"]);
-}
-
-/// Setting a *different* callback on the context mid-run redirects the
-/// engine output emitted after that call to it, without touching the
-/// destination the run inherited at start; unsetting the callback again
-/// (`hegel_context_unset_output`) falls back to the inherited one.
-///
-/// The engine emits from its worker thread, which blocks on the caller's
-/// `hegel_mark_complete` ack between test cases, so switching the callback
-/// just before `hegel_mark_complete` (and keeping it for the following
-/// `hegel_next_test_case`) makes the destination of every line
-/// deterministic: the per-case trace for case N is emitted after case N's
-/// completion was acked and before case N+1 is handed over. Case 1 is the
-/// engine's initial trivial probe, which emits no per-case trace; the first
-/// generated case is `test case #2`.
-#[test]
-fn setting_a_different_callback_mid_run_redirects_engine_output() {
-    let inherited: Mutex<Vec<String>> = Mutex::new(Vec::new());
-    let redirected: Mutex<Vec<String>> = Mutex::new(Vec::new());
-    let ctx = hegel_context_new();
-    unsafe {
-        ok(hegel_context_set_output(
-            ctx,
-            Some(capture_output),
-            (&raw const inherited).cast_mut().cast(),
-        ));
-        let s = make_settings(ctx);
-        let empty = CString::new("").unwrap();
-        ok(hegel_settings_set_database(ctx, s, empty.as_ptr()));
-        ok(hegel_c::hegel_settings_set_test_cases(ctx, s, 3));
-        ok(hegel_c::hegel_settings_set_seed(ctx, s, 1, true));
-        ok(hegel_c::hegel_settings_set_verbosity(
-            ctx,
-            s,
-            hegel_c::hegel_verbosity_t::HEGEL_VERBOSITY_DEBUG as u32,
-        ));
-        let run = start(ctx, s);
-        let mut case_number = 0;
-        loop {
-            let tc = next_case(ctx, run);
-            if tc.is_null() {
-                break;
-            }
-            case_number += 1;
-            let mut value = 0i64;
-            let status = if hegel_generate_integer(ctx, tc, 0, 100, &mut value) == HEGEL_OK {
-                hegel_status_t::HEGEL_STATUS_VALID as u32
-            } else {
-                hegel_status_t::HEGEL_STATUS_OVERRUN as u32
-            };
-            if case_number == 2 {
-                ok(hegel_context_set_output(
-                    ctx,
-                    Some(capture_output),
-                    (&raw const redirected).cast_mut().cast(),
-                ));
-            } else if case_number == 3 {
-                ok(hegel_context_unset_output(ctx));
-            }
-            ok(hegel_mark_complete(ctx, tc, status, ptr::null()));
-            ok(hegel_test_case_free(ctx, tc));
-        }
-        ok(hegel_run_result_free(ctx, result(ctx, run)));
-        ok(hegel_run_free(ctx, run));
-        ok(hegel_settings_free(ctx, s));
-        ok(hegel_context_free(ctx));
-    }
-    let inherited = inherited.into_inner().unwrap();
-    let redirected = redirected.into_inner().unwrap();
-    assert!(
-        inherited.iter().any(|l| l == "Starting phase: Generate"),
-        "output before the switch goes to the inherited callback; got {inherited:?}"
-    );
-    assert!(
-        redirected.iter().any(|l| l.starts_with("test case #2:")),
-        "output after the switch goes to the new callback; got {redirected:?}"
-    );
-    assert!(
-        !inherited.iter().any(|l| l.starts_with("test case #2:")),
-        "the redirected trace does not also reach the inherited callback; got {inherited:?}"
-    );
-    assert!(
-        inherited.iter().any(|l| l.starts_with("test case #3:")),
-        "output after the unset falls back to the inherited callback; got {inherited:?}"
-    );
-    assert!(
-        !redirected.iter().any(|l| l.starts_with("test case #3:")),
-        "the fallback trace does not also reach the redirect callback; got {redirected:?}"
-    );
-    assert!(
-        inherited
-            .iter()
-            .any(|l| l == "Test done. interesting_test_cases=0"),
-        "the run summary follows the fallback too; got {inherited:?}"
-    );
-}
-
-/// `hegel_context_unset_output` clears the callback registered on the
-/// context, restoring its default behaviour: a run created afterwards
-/// writes to stderr and delivers nothing to the previously-installed
-/// callback.
-#[test]
-fn unset_output_resets_new_runs_to_stderr() {
-    let lines: Mutex<Vec<String>> = Mutex::new(Vec::new());
-    let ctx = hegel_context_new();
-    unsafe {
-        ok(hegel_context_set_output(
-            ctx,
-            Some(capture_output),
-            (&raw const lines).cast_mut().cast(),
-        ));
-        ok(hegel_context_unset_output(ctx));
-        let s = make_settings(ctx);
-        let empty = CString::new("").unwrap();
-        ok(hegel_settings_set_database(ctx, s, empty.as_ptr()));
-        ok(hegel_c::hegel_settings_set_test_cases(ctx, s, 2));
-        ok(hegel_c::hegel_settings_set_seed(ctx, s, 1, true));
-        ok(hegel_c::hegel_settings_set_verbosity(
-            ctx,
-            s,
-            hegel_c::hegel_verbosity_t::HEGEL_VERBOSITY_DEBUG as u32,
-        ));
-        let run = start(ctx, s);
-        loop {
-            let tc = next_case(ctx, run);
-            if tc.is_null() {
-                break;
-            }
-            let mut value = 0i64;
-            let status = if hegel_generate_integer(ctx, tc, 0, 100, &mut value) == HEGEL_OK {
-                hegel_status_t::HEGEL_STATUS_VALID as u32
-            } else {
-                hegel_status_t::HEGEL_STATUS_OVERRUN as u32
-            };
-            ok(hegel_mark_complete(ctx, tc, status, ptr::null()));
-            ok(hegel_test_case_free(ctx, tc));
-        }
-        ok(hegel_run_result_free(ctx, result(ctx, run)));
-        ok(hegel_run_free(ctx, run));
-        ok(hegel_settings_free(ctx, s));
-        ok(hegel_context_free(ctx));
-    }
-    assert!(lines.into_inner().unwrap().is_empty());
-}
-
-/// `hegel_context_unset_output` on a NULL context is rejected, like
-/// `hegel_context_set_output`: there is no context to clear.
-#[test]
-fn unset_output_on_null_context_is_rejected() {
-    unsafe {
-        assert_eq!(
-            hegel_context_unset_output(ptr::null_mut()),
-            HEGEL_E_INVALID_HANDLE
-        );
-    }
 }

--- a/hegel-c/tests/c_abi_inprocess.rs
+++ b/hegel-c/tests/c_abi_inprocess.rs
@@ -15,15 +15,15 @@ use hegel_c::hegel_result_t::*;
 use hegel_c::{
     HegelContext, HegelFailure, HegelRun, HegelRunResult, HegelTestCase, hegel_backend_t,
     hegel_collection_more, hegel_collection_reject, hegel_context_free, hegel_context_last_error,
-    hegel_context_new, hegel_context_set_output, hegel_failure_free, hegel_failure_origin,
-    hegel_failure_reproduction_blob, hegel_generate_boolean, hegel_generate_integer, hegel_label_t,
-    hegel_mark_complete, hegel_mode_t, hegel_new_collection, hegel_new_pool,
-    hegel_new_state_machine, hegel_next_test_case, hegel_pool_add, hegel_pool_generate,
-    hegel_run_free, hegel_run_result, hegel_run_result_error, hegel_run_result_failure,
-    hegel_run_result_failure_count, hegel_run_result_free, hegel_run_result_status,
-    hegel_run_start, hegel_run_status_t, hegel_settings_free, hegel_settings_new,
-    hegel_settings_set_backend, hegel_settings_set_database, hegel_settings_set_database_key,
-    hegel_settings_set_mode, hegel_settings_set_phases,
+    hegel_context_new, hegel_context_set_output, hegel_context_unset_output, hegel_failure_free,
+    hegel_failure_origin, hegel_failure_reproduction_blob, hegel_generate_boolean,
+    hegel_generate_integer, hegel_label_t, hegel_mark_complete, hegel_mode_t, hegel_new_collection,
+    hegel_new_pool, hegel_new_state_machine, hegel_next_test_case, hegel_pool_add,
+    hegel_pool_generate, hegel_run_free, hegel_run_result, hegel_run_result_error,
+    hegel_run_result_failure, hegel_run_result_failure_count, hegel_run_result_free,
+    hegel_run_result_status, hegel_run_start, hegel_run_status_t, hegel_settings_free,
+    hegel_settings_new, hegel_settings_set_backend, hegel_settings_set_database,
+    hegel_settings_set_database_key, hegel_settings_set_mode, hegel_settings_set_phases,
     hegel_settings_set_report_multiple_failures, hegel_settings_set_suppress_health_check,
     hegel_start_span, hegel_state_machine_next_rule, hegel_status_t, hegel_stop_span, hegel_target,
     hegel_test_case_clone, hegel_test_case_free, hegel_test_case_from_blob, hegel_version,
@@ -1608,11 +1608,12 @@ fn set_output_on_null_context_is_rejected() {
     }
 }
 
-/// `hegel_run_start` snapshots the context's output destination: resetting
-/// the callback after the run has started does not redirect the in-flight
-/// run's output back to stderr.
+/// A run inherits the context's output destination at `hegel_run_start`:
+/// unsetting the callback after the run has started leaves the context with
+/// no callback, and calls made with it fall back to the inherited
+/// destination rather than redirecting the in-flight run's output to stderr.
 #[test]
-fn run_start_snapshots_the_output_destination() {
+fn unset_context_falls_back_to_the_inherited_destination() {
     let lines: Mutex<Vec<String>> = Mutex::new(Vec::new());
     let ctx = hegel_context_new();
     unsafe {
@@ -1696,4 +1697,159 @@ fn from_blob_replay_trace_goes_to_the_output_callback() {
     }
     let lines = lines.into_inner().unwrap();
     assert_eq!(lines, ["replaying failure blob: choices = 2"]);
+}
+
+/// Setting a *different* callback on the context mid-run redirects the
+/// engine output emitted after that call to it, without touching the
+/// destination the run inherited at start; unsetting the callback again
+/// (`hegel_context_unset_output`) falls back to the inherited one.
+///
+/// The engine emits from its worker thread, which blocks on the caller's
+/// `hegel_mark_complete` ack between test cases, so switching the callback
+/// just before `hegel_mark_complete` (and keeping it for the following
+/// `hegel_next_test_case`) makes the destination of every line
+/// deterministic: the per-case trace for case N is emitted after case N's
+/// completion was acked and before case N+1 is handed over. Case 1 is the
+/// engine's initial trivial probe, which emits no per-case trace; the first
+/// generated case is `test case #2`.
+#[test]
+fn setting_a_different_callback_mid_run_redirects_engine_output() {
+    let inherited: Mutex<Vec<String>> = Mutex::new(Vec::new());
+    let redirected: Mutex<Vec<String>> = Mutex::new(Vec::new());
+    let ctx = hegel_context_new();
+    unsafe {
+        ok(hegel_context_set_output(
+            ctx,
+            Some(capture_output),
+            (&raw const inherited).cast_mut().cast(),
+        ));
+        let s = make_settings(ctx);
+        let empty = CString::new("").unwrap();
+        ok(hegel_settings_set_database(ctx, s, empty.as_ptr()));
+        ok(hegel_c::hegel_settings_set_test_cases(ctx, s, 3));
+        ok(hegel_c::hegel_settings_set_seed(ctx, s, 1, true));
+        ok(hegel_c::hegel_settings_set_verbosity(
+            ctx,
+            s,
+            hegel_c::hegel_verbosity_t::HEGEL_VERBOSITY_DEBUG as u32,
+        ));
+        let run = start(ctx, s);
+        let mut case_number = 0;
+        loop {
+            let tc = next_case(ctx, run);
+            if tc.is_null() {
+                break;
+            }
+            case_number += 1;
+            let mut value = 0i64;
+            let status = if hegel_generate_integer(ctx, tc, 0, 100, &mut value) == HEGEL_OK {
+                hegel_status_t::HEGEL_STATUS_VALID as u32
+            } else {
+                hegel_status_t::HEGEL_STATUS_OVERRUN as u32
+            };
+            if case_number == 2 {
+                ok(hegel_context_set_output(
+                    ctx,
+                    Some(capture_output),
+                    (&raw const redirected).cast_mut().cast(),
+                ));
+            } else if case_number == 3 {
+                ok(hegel_context_unset_output(ctx));
+            }
+            ok(hegel_mark_complete(ctx, tc, status, ptr::null()));
+            ok(hegel_test_case_free(ctx, tc));
+        }
+        ok(hegel_run_result_free(ctx, result(ctx, run)));
+        ok(hegel_run_free(ctx, run));
+        ok(hegel_settings_free(ctx, s));
+        ok(hegel_context_free(ctx));
+    }
+    let inherited = inherited.into_inner().unwrap();
+    let redirected = redirected.into_inner().unwrap();
+    assert!(
+        inherited.iter().any(|l| l == "Starting phase: Generate"),
+        "output before the switch goes to the inherited callback; got {inherited:?}"
+    );
+    assert!(
+        redirected.iter().any(|l| l.starts_with("test case #2:")),
+        "output after the switch goes to the new callback; got {redirected:?}"
+    );
+    assert!(
+        !inherited.iter().any(|l| l.starts_with("test case #2:")),
+        "the redirected trace does not also reach the inherited callback; got {inherited:?}"
+    );
+    assert!(
+        inherited.iter().any(|l| l.starts_with("test case #3:")),
+        "output after the unset falls back to the inherited callback; got {inherited:?}"
+    );
+    assert!(
+        !redirected.iter().any(|l| l.starts_with("test case #3:")),
+        "the fallback trace does not also reach the redirect callback; got {redirected:?}"
+    );
+    assert!(
+        inherited
+            .iter()
+            .any(|l| l == "Test done. interesting_test_cases=0"),
+        "the run summary follows the fallback too; got {inherited:?}"
+    );
+}
+
+/// `hegel_context_unset_output` clears the callback registered on the
+/// context, restoring its default behaviour: a run created afterwards
+/// writes to stderr and delivers nothing to the previously-installed
+/// callback.
+#[test]
+fn unset_output_resets_new_runs_to_stderr() {
+    let lines: Mutex<Vec<String>> = Mutex::new(Vec::new());
+    let ctx = hegel_context_new();
+    unsafe {
+        ok(hegel_context_set_output(
+            ctx,
+            Some(capture_output),
+            (&raw const lines).cast_mut().cast(),
+        ));
+        ok(hegel_context_unset_output(ctx));
+        let s = make_settings(ctx);
+        let empty = CString::new("").unwrap();
+        ok(hegel_settings_set_database(ctx, s, empty.as_ptr()));
+        ok(hegel_c::hegel_settings_set_test_cases(ctx, s, 2));
+        ok(hegel_c::hegel_settings_set_seed(ctx, s, 1, true));
+        ok(hegel_c::hegel_settings_set_verbosity(
+            ctx,
+            s,
+            hegel_c::hegel_verbosity_t::HEGEL_VERBOSITY_DEBUG as u32,
+        ));
+        let run = start(ctx, s);
+        loop {
+            let tc = next_case(ctx, run);
+            if tc.is_null() {
+                break;
+            }
+            let mut value = 0i64;
+            let status = if hegel_generate_integer(ctx, tc, 0, 100, &mut value) == HEGEL_OK {
+                hegel_status_t::HEGEL_STATUS_VALID as u32
+            } else {
+                hegel_status_t::HEGEL_STATUS_OVERRUN as u32
+            };
+            ok(hegel_mark_complete(ctx, tc, status, ptr::null()));
+            ok(hegel_test_case_free(ctx, tc));
+        }
+        ok(hegel_run_result_free(ctx, result(ctx, run)));
+        ok(hegel_run_free(ctx, run));
+        ok(hegel_settings_free(ctx, s));
+        ok(hegel_context_free(ctx));
+    }
+    assert!(lines.into_inner().unwrap().is_empty());
+}
+
+/// `hegel_context_unset_output` on a NULL context is rejected, like
+/// `hegel_context_set_output`: there is no context to clear.
+#[test]
+fn unset_output_on_null_context_is_rejected() {
+    unsafe {
+        assert_eq!(
+            hegel_context_unset_output(ptr::null_mut()),
+            HEGEL_E_INVALID_HANDLE
+        );
+    }
 }

--- a/hegel-c/tests/c_abi_miri.rs
+++ b/hegel-c/tests/c_abi_miri.rs
@@ -17,16 +17,18 @@ use common::ok;
 use hegel_c::hegel_result_t::*;
 use hegel_c::{
     HegelContext, HegelRun, HegelRunResult, HegelSettings, HegelTestCase, hegel_context_free,
-    hegel_context_new, hegel_failure_free, hegel_failure_reproduction_blob, hegel_generate_integer,
-    hegel_mark_complete, hegel_next_test_case, hegel_run_free, hegel_run_result,
-    hegel_run_result_failure, hegel_run_result_failure_count, hegel_run_result_free,
-    hegel_run_result_status, hegel_run_start, hegel_run_status_t, hegel_settings_free,
-    hegel_settings_new, hegel_settings_set_database, hegel_settings_set_seed,
-    hegel_settings_set_test_cases, hegel_start_span, hegel_status_t, hegel_stop_span,
-    hegel_test_case_clone, hegel_test_case_free,
+    hegel_context_new, hegel_context_set_output, hegel_failure_free,
+    hegel_failure_reproduction_blob, hegel_generate_integer, hegel_mark_complete,
+    hegel_next_test_case, hegel_run_free, hegel_run_result, hegel_run_result_failure,
+    hegel_run_result_failure_count, hegel_run_result_free, hegel_run_result_status,
+    hegel_run_start, hegel_run_status_t, hegel_settings_free, hegel_settings_new,
+    hegel_settings_set_database, hegel_settings_set_seed, hegel_settings_set_test_cases,
+    hegel_settings_set_verbosity, hegel_start_span, hegel_status_t, hegel_stop_span,
+    hegel_test_case_clone, hegel_test_case_free, hegel_verbosity_t,
 };
-use std::ffi::CString;
+use std::ffi::{CString, c_void};
 use std::ptr;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// Carries a test-case handle into a spawned thread.
 struct SendPtr(*mut HegelTestCase);
@@ -227,16 +229,33 @@ fn concurrent_mark_complete_from_two_clones_is_safe() {
 /// handle-lifecycle tests above never generate or shrink). A small example
 /// count and the minimal `[0, 100]` integer keep the shrink tractable for
 /// Miri's interpreter, as the engine/shrinking tests in `test_miri` do.
+///
+/// The run also installs an output callback (`hegel_context_set_output`) and
+/// runs at debug verbosity, so the engine invokes the callback — a raw
+/// function pointer with a raw `user_data` pointer — from its worker thread
+/// on every progress line, and Miri checks that cross-thread path for
+/// use-after-free and data races too.
 #[test]
 fn full_run_generates_fails_and_shrinks() {
+    let lines = AtomicUsize::new(0);
     unsafe {
         let ctx = hegel_context_new();
+        ok(hegel_context_set_output(
+            ctx,
+            Some(count_output_line),
+            (&raw const lines).cast_mut().cast(),
+        ));
         let mut s: *mut HegelSettings = ptr::null_mut();
         ok(hegel_settings_new(ctx, &mut s));
         let empty = CString::new("").unwrap();
         ok(hegel_settings_set_database(ctx, s, empty.as_ptr()));
         ok(hegel_settings_set_test_cases(ctx, s, 5));
         ok(hegel_settings_set_seed(ctx, s, 1, true));
+        ok(hegel_settings_set_verbosity(
+            ctx,
+            s,
+            hegel_verbosity_t::HEGEL_VERBOSITY_DEBUG as u32,
+        ));
         let mut run: *mut HegelRun = ptr::null_mut();
         ok(hegel_run_start(ctx, s, &mut run));
 
@@ -285,4 +304,22 @@ fn full_run_generates_fails_and_shrinks() {
         ok(hegel_run_result_free(ctx, res));
         ok(hegel_context_free(ctx));
     }
+    assert!(
+        lines.load(Ordering::Relaxed) > 0,
+        "a debug-verbosity run delivers output to the callback"
+    );
+}
+
+/// The output callback for [`full_run_generates_fails_and_shrinks`]:
+/// `user_data` points at an `AtomicUsize` counting the lines delivered, and
+/// the line buffer is read back in full so Miri validates it.
+unsafe extern "C" fn count_output_line(
+    user_data: *mut c_void,
+    line: *const std::os::raw::c_char,
+    len: usize,
+) {
+    let text = unsafe { std::ffi::CStr::from_ptr(line) };
+    assert_eq!(text.to_bytes().len(), len);
+    let count = unsafe { &*user_data.cast::<AtomicUsize>() };
+    count.fetch_add(1, Ordering::Relaxed);
 }

--- a/hegel-c/tests/c_abi_miri.rs
+++ b/hegel-c/tests/c_abi_miri.rs
@@ -17,14 +17,13 @@ use common::ok;
 use hegel_c::hegel_result_t::*;
 use hegel_c::{
     HegelContext, HegelRun, HegelRunResult, HegelSettings, HegelTestCase, hegel_context_free,
-    hegel_context_new, hegel_context_set_output, hegel_context_unset_output, hegel_failure_free,
-    hegel_failure_reproduction_blob, hegel_generate_integer, hegel_mark_complete,
-    hegel_next_test_case, hegel_run_free, hegel_run_result, hegel_run_result_failure,
-    hegel_run_result_failure_count, hegel_run_result_free, hegel_run_result_status,
-    hegel_run_start, hegel_run_status_t, hegel_settings_free, hegel_settings_new,
-    hegel_settings_set_database, hegel_settings_set_seed, hegel_settings_set_test_cases,
-    hegel_settings_set_verbosity, hegel_start_span, hegel_status_t, hegel_stop_span,
-    hegel_test_case_clone, hegel_test_case_free, hegel_verbosity_t,
+    hegel_context_new, hegel_failure_free, hegel_failure_reproduction_blob, hegel_generate_integer,
+    hegel_mark_complete, hegel_next_test_case, hegel_run_free, hegel_run_result,
+    hegel_run_result_failure, hegel_run_result_failure_count, hegel_run_result_free,
+    hegel_run_result_status, hegel_run_start, hegel_run_status_t, hegel_settings_free,
+    hegel_settings_new, hegel_settings_set_database, hegel_settings_set_seed,
+    hegel_settings_set_test_cases, hegel_settings_set_verbosity, hegel_start_span, hegel_status_t,
+    hegel_stop_span, hegel_test_case_clone, hegel_test_case_free, hegel_verbosity_t,
 };
 use std::ffi::{CString, c_void};
 use std::ptr;
@@ -53,7 +52,10 @@ unsafe fn one_case_run() -> (
         ok(hegel_settings_set_test_cases(ctx, s, 1));
         ok(hegel_settings_set_seed(ctx, s, 1, true));
         let mut run: *mut HegelRun = ptr::null_mut();
-        assert_eq!(hegel_run_start(ctx, s, &mut run), HEGEL_OK);
+        assert_eq!(
+            hegel_run_start(ctx, s, None, ptr::null_mut(), &mut run),
+            HEGEL_OK
+        );
         let mut tc: *mut HegelTestCase = ptr::null_mut();
         assert_eq!(hegel_next_test_case(ctx, run, &mut tc), HEGEL_OK);
         assert!(!tc.is_null());
@@ -230,24 +232,16 @@ fn concurrent_mark_complete_from_two_clones_is_safe() {
 /// count and the minimal `[0, 100]` integer keep the shrink tractable for
 /// Miri's interpreter, as the engine/shrinking tests in `test_miri` do.
 ///
-/// The run also installs an output callback (`hegel_context_set_output`) and
+/// The run is also started with an output callback (`hegel_run_start`) and
 /// runs at debug verbosity, so the engine invokes the callback — a raw
 /// function pointer with a raw `user_data` pointer — from its worker thread
 /// on every progress line, and Miri checks that cross-thread path for
-/// use-after-free and data races too. After each completed case the callback
-/// is unset (`hegel_context_unset_output`), so later calls fall back to the
-/// destination the run inherited at start — the same callback — exercising
-/// both sides of the per-call output re-resolution under Miri.
+/// use-after-free and data races too.
 #[test]
 fn full_run_generates_fails_and_shrinks() {
     let lines = AtomicUsize::new(0);
     unsafe {
         let ctx = hegel_context_new();
-        ok(hegel_context_set_output(
-            ctx,
-            Some(count_output_line),
-            (&raw const lines).cast_mut().cast(),
-        ));
         let mut s: *mut HegelSettings = ptr::null_mut();
         ok(hegel_settings_new(ctx, &mut s));
         let empty = CString::new("").unwrap();
@@ -260,7 +254,13 @@ fn full_run_generates_fails_and_shrinks() {
             hegel_verbosity_t::HEGEL_VERBOSITY_DEBUG as u32,
         ));
         let mut run: *mut HegelRun = ptr::null_mut();
-        ok(hegel_run_start(ctx, s, &mut run));
+        ok(hegel_run_start(
+            ctx,
+            s,
+            Some(count_output_line),
+            (&raw const lines).cast_mut().cast(),
+            &mut run,
+        ));
 
         loop {
             let mut tc: *mut HegelTestCase = ptr::null_mut();
@@ -278,7 +278,6 @@ fn full_run_generates_fails_and_shrinks() {
             };
             ok(hegel_mark_complete(ctx, tc, status, ptr::null()));
             ok(hegel_test_case_free(ctx, tc));
-            ok(hegel_context_unset_output(ctx));
         }
 
         let mut res: *mut HegelRunResult = ptr::null_mut();

--- a/hegel-c/tests/c_abi_miri.rs
+++ b/hegel-c/tests/c_abi_miri.rs
@@ -17,7 +17,7 @@ use common::ok;
 use hegel_c::hegel_result_t::*;
 use hegel_c::{
     HegelContext, HegelRun, HegelRunResult, HegelSettings, HegelTestCase, hegel_context_free,
-    hegel_context_new, hegel_context_set_output, hegel_failure_free,
+    hegel_context_new, hegel_context_set_output, hegel_context_unset_output, hegel_failure_free,
     hegel_failure_reproduction_blob, hegel_generate_integer, hegel_mark_complete,
     hegel_next_test_case, hegel_run_free, hegel_run_result, hegel_run_result_failure,
     hegel_run_result_failure_count, hegel_run_result_free, hegel_run_result_status,
@@ -234,7 +234,10 @@ fn concurrent_mark_complete_from_two_clones_is_safe() {
 /// runs at debug verbosity, so the engine invokes the callback — a raw
 /// function pointer with a raw `user_data` pointer — from its worker thread
 /// on every progress line, and Miri checks that cross-thread path for
-/// use-after-free and data races too.
+/// use-after-free and data races too. After each completed case the callback
+/// is unset (`hegel_context_unset_output`), so later calls fall back to the
+/// destination the run inherited at start — the same callback — exercising
+/// both sides of the per-call output re-resolution under Miri.
 #[test]
 fn full_run_generates_fails_and_shrinks() {
     let lines = AtomicUsize::new(0);
@@ -275,6 +278,7 @@ fn full_run_generates_fails_and_shrinks() {
             };
             ok(hegel_mark_complete(ctx, tc, status, ptr::null()));
             ok(hegel_test_case_free(ctx, tc));
+            ok(hegel_context_unset_output(ctx));
         }
 
         let mut res: *mut HegelRunResult = ptr::null_mut();

--- a/hegel-c/tests/common/mod.rs
+++ b/hegel-c/tests/common/mod.rs
@@ -3,9 +3,11 @@
 use hegel_c::hegel_result_t::*;
 use hegel_c::{
     HegelContext, HegelRun, HegelSettings, HegelTestCase, hegel_context_last_error,
-    hegel_next_test_case, hegel_run_start, hegel_settings_new, hegel_settings_set_database,
+    hegel_next_test_case, hegel_output_callback_t, hegel_run_start, hegel_settings_new,
+    hegel_settings_set_database,
 };
 use std::ffi::CString;
+use std::os::raw::c_void;
 use std::ptr;
 
 /// Assert a call that should always succeed in these tests returned `HEGEL_OK`.
@@ -48,8 +50,23 @@ pub unsafe fn make_settings_no_db(ctx: *mut HegelContext) -> *mut HegelSettings 
 
 #[allow(dead_code)]
 pub unsafe fn start(ctx: *mut HegelContext, s: *const HegelSettings) -> *mut HegelRun {
+    unsafe { start_with_output(ctx, s, None, ptr::null_mut()) }
+}
+
+/// Like [`start`], but routing the run's engine output to `callback` /
+/// `user_data` (see `hegel_run_start`).
+#[allow(dead_code)]
+pub unsafe fn start_with_output(
+    ctx: *mut HegelContext,
+    s: *const HegelSettings,
+    callback: hegel_output_callback_t,
+    user_data: *mut c_void,
+) -> *mut HegelRun {
     let mut run: *mut HegelRun = ptr::null_mut();
-    assert_eq!(unsafe { hegel_run_start(ctx, s, &mut run) }, HEGEL_OK);
+    assert_eq!(
+        unsafe { hegel_run_start(ctx, s, callback, user_data, &mut run) },
+        HEGEL_OK
+    );
     assert!(!run.is_null());
     run
 }

--- a/hegel-c/tests/embedded/lib_tests.rs
+++ b/hegel-c/tests/embedded/lib_tests.rs
@@ -26,7 +26,10 @@ unsafe fn start_run_and_first_case() -> (
     ok(unsafe { hegel_settings_set_database(ctx, s, empty.as_ptr()) });
     ok(unsafe { hegel_settings_set_seed(ctx, s, 1, true) });
     let mut run: *mut HegelRun = ptr::null_mut();
-    assert_eq!(unsafe { hegel_run_start(ctx, s, &mut run) }, HEGEL_OK);
+    assert_eq!(
+        unsafe { hegel_run_start(ctx, s, None, ptr::null_mut(), &mut run) },
+        HEGEL_OK
+    );
     let mut tc: *mut HegelTestCase = ptr::null_mut();
     assert_eq!(unsafe { hegel_next_test_case(ctx, run, &mut tc) }, HEGEL_OK);
     assert!(!tc.is_null());

--- a/hegel-c/tests/embedded/settings_tests.rs
+++ b/hegel-c/tests/embedded/settings_tests.rs
@@ -48,3 +48,29 @@ fn new_disables_database_in_ci() {
     assert!(matches!(settings.database, Database::Disabled));
     assert!(settings.derandomize);
 }
+
+#[test]
+fn output_debug_names_the_destination() {
+    assert_eq!(format!("{:?}", Output::stderr()), "Output(stderr)");
+    assert_eq!(
+        format!("{:?}", Output::callback(|_| {})),
+        "Output(callback)"
+    );
+}
+
+#[test]
+fn output_line_routes_to_the_callback_when_set() {
+    let lines = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let sink = std::sync::Arc::clone(&lines);
+    let out = Output::callback(move |line| sink.lock().unwrap().push(line.to_string()));
+    out.line("routed");
+    assert_eq!(lines.lock().unwrap().as_slice(), ["routed".to_string()]);
+    Output::stderr().line("this line goes to the test harness's stderr");
+}
+
+#[test]
+fn settings_default_to_stderr_output_and_carry_a_configured_one() {
+    assert_eq!(format!("{:?}", Settings::new().output), "Output(stderr)");
+    let s = Settings::new().output(Output::callback(|_| {}));
+    assert_eq!(format!("{:?}", s.output), "Output(callback)");
+}

--- a/hegel-c/tests/smoke.rs
+++ b/hegel-c/tests/smoke.rs
@@ -107,7 +107,8 @@ type FnSettingsDatabaseKey = unsafe extern "C" fn(*mut u8, *mut u8, *const c_cha
 type FnSettingsSeed = unsafe extern "C" fn(*mut u8, *mut u8, u64, bool) -> c_int;
 type FnSettingsDerandomize = unsafe extern "C" fn(*mut u8, *mut u8, bool) -> c_int;
 type FnSettingsBackend = unsafe extern "C" fn(*mut u8, *mut u8, CBackend) -> c_int;
-type FnRunStart = unsafe extern "C" fn(*mut u8, *const u8, *mut *mut u8) -> c_int;
+type FnRunStart =
+    unsafe extern "C" fn(*mut u8, *const u8, *const u8, *mut u8, *mut *mut u8) -> c_int;
 type FnNextTestCase = unsafe extern "C" fn(*mut u8, *mut u8, *mut *mut u8) -> c_int;
 type FnRunResult = unsafe extern "C" fn(*mut u8, *mut u8, *mut *mut u8) -> c_int;
 type FnRunResultFree = unsafe extern "C" fn(*mut u8, *mut u8) -> c_int;
@@ -155,8 +156,14 @@ type FnRunResultFailureCount = unsafe extern "C" fn(*mut u8, *const u8, *mut usi
 type FnRunResultFailure = unsafe extern "C" fn(*mut u8, *const u8, usize, *mut *mut u8) -> c_int;
 type FnFailureOrigin = unsafe extern "C" fn(*mut u8, *const u8, *mut *const c_char) -> c_int;
 type FnFailureReproduceBlob = unsafe extern "C" fn(*mut u8, *const u8, *mut *const c_char) -> c_int;
-type FnTestCaseFromBlob =
-    unsafe extern "C" fn(*mut u8, *const u8, *const c_char, *mut *mut u8) -> c_int;
+type FnTestCaseFromBlob = unsafe extern "C" fn(
+    *mut u8,
+    *const u8,
+    *const c_char,
+    *const u8,
+    *mut u8,
+    *mut *mut u8,
+) -> c_int;
 type FnTestCaseFree = unsafe extern "C" fn(*mut u8, *mut u8) -> c_int;
 
 struct Api<'a> {
@@ -282,7 +289,7 @@ impl Api<'_> {
     }
     unsafe fn run_start(&self, ctx: *mut u8, s: *const u8) -> *mut u8 {
         let mut run: *mut u8 = ptr::null_mut();
-        let rc = unsafe { (self.run_start)(ctx, s, &mut run) };
+        let rc = unsafe { (self.run_start)(ctx, s, ptr::null(), ptr::null_mut(), &mut run) };
         unsafe { self.expect_ok(ctx, rc, "hegel_run_start") };
         run
     }
@@ -389,7 +396,7 @@ impl Api<'_> {
         blob: *const c_char,
     ) -> *mut u8 {
         let mut tc: *mut u8 = ptr::null_mut();
-        unsafe { (self.test_case_from_blob)(ctx, s, blob, &mut tc) };
+        unsafe { (self.test_case_from_blob)(ctx, s, blob, ptr::null(), ptr::null_mut(), &mut tc) };
         tc
     }
 }

--- a/src/explicit_test_case.rs
+++ b/src/explicit_test_case.rs
@@ -168,7 +168,7 @@ impl ExplicitTestCase {
             Err(payload) => {
                 let notes = self.notes.borrow();
                 for note in notes.iter() {
-                    eprintln!("{}", note);
+                    crate::test_case::emit_verbose_line(note);
                 }
                 std::panic::resume_unwind(payload);
             }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -15,8 +15,9 @@
 //! small and the control-flow policy stays with the test lifecycle.
 
 use crate::runner::{Backend, Database, HealthCheck, Mode, Phase, Settings, Verbosity};
+use crate::test_case::OutputSink;
 use hegel_c::hegel_result_t;
-use std::ffi::{CStr, CString};
+use std::ffi::{CStr, CString, c_void};
 use std::os::raw::c_char;
 use std::ptr;
 
@@ -220,26 +221,90 @@ impl Drop for SettingsHandle {
     }
 }
 
+/// Engine-output trampoline installed with `hegel_context_set_output` while
+/// a run or blob replay is being created: `user_data` points at the
+/// [`OutputSink`] the run resolved at start, and each engine output line is
+/// forwarded to it. The engine invokes this from its worker thread; the sink
+/// is `Send + Sync`, and the pointee stays alive for as long as the engine
+/// can emit — owned by the [`RunHandle`] for a run, borrowed across the
+/// creating call for a blob replay (whose only line is emitted during it).
+unsafe extern "C" fn engine_output_trampoline(
+    user_data: *mut c_void,
+    line: *const c_char,
+    len: usize,
+) {
+    let sink = unsafe { &*user_data.cast::<OutputSink>() };
+    let bytes = unsafe { std::slice::from_raw_parts(line.cast::<u8>(), len) };
+    sink(&String::from_utf8_lossy(bytes));
+}
+
+/// Install `sink` as `ctx`'s engine-output destination, run `f`, and restore
+/// the default. The engine snapshots the destination when a run or blob
+/// replay is created, so the installation only needs to span the creating
+/// call; `user_data` is `sink_ptr`, which the caller keeps alive for as long
+/// as the engine can emit through it. A `None` `sink_ptr` leaves the context
+/// alone (output stays on stderr).
+fn with_engine_output<R>(
+    ctx: *mut hegel_c::HegelContext,
+    sink_ptr: Option<*const OutputSink>,
+    f: impl FnOnce() -> R,
+) -> R {
+    if let Some(p) = sink_ptr {
+        // SAFETY: ctx is this thread's live context; the trampoline contract
+        // (thread-safe callback, pointee outlives the engine's emissions) is
+        // upheld by the caller keeping the sink alive.
+        require_ok(unsafe {
+            hegel_c::hegel_context_set_output(
+                ctx,
+                Some(engine_output_trampoline),
+                p.cast_mut().cast(),
+            )
+        });
+    }
+    let result = f();
+    if sink_ptr.is_some() {
+        // SAFETY: ctx is this thread's live context; a NULL callback resets
+        // it to the default stderr output.
+        require_ok(unsafe { hegel_c::hegel_context_set_output(ctx, None, ptr::null_mut()) });
+    }
+    result
+}
+
 /// Owns a `*mut HegelRun` and frees it on drop (which aborts and joins the
 /// engine worker if the run was not drained to completion).
 pub(crate) struct RunHandle {
     raw: *mut hegel_c::HegelRun,
+    /// The engine-output sink registered for this run, or `None` when the
+    /// run writes to stderr. The engine worker holds the raw `user_data`
+    /// pointer to this allocation for the life of the run, so it is freed
+    /// only in `Drop`, after `hegel_run_free` has joined the worker.
+    output: Option<*mut OutputSink>,
 }
 
 impl RunHandle {
-    /// Start a run. Returns `Err` with libhegel's diagnostic if the engine
-    /// could not be started.
-    pub(crate) fn start(settings: &SettingsHandle) -> Result<Self, String> {
+    /// Start a run whose engine output goes to `sink` (stderr when `None`).
+    /// Returns `Err` with libhegel's diagnostic if the engine could not be
+    /// started.
+    pub(crate) fn start(
+        settings: &SettingsHandle,
+        sink: Option<&OutputSink>,
+    ) -> Result<Self, String> {
+        let output = sink.map(|s| Box::into_raw(Box::new(s.clone())));
         let mut raw: *mut hegel_c::HegelRun = ptr::null_mut();
         // SAFETY: settings.as_ptr() is a live, non-null handle; &mut raw is a
         // valid out-parameter.
-        let rc = with_context(|ctx| unsafe {
-            hegel_c::hegel_run_start(ctx, settings.as_ptr(), &mut raw)
+        let rc = with_context(|ctx| {
+            with_engine_output(ctx, output.map(|p| p.cast_const()), || unsafe {
+                hegel_c::hegel_run_start(ctx, settings.as_ptr(), &mut raw)
+            })
         });
+        // Construct the handle before checking rc so the error path (raw is
+        // still null, which hegel_run_free accepts) releases the sink box.
+        let run = RunHandle { raw, output };
         if rc != hegel_result_t::HEGEL_OK {
             return Err(last_error_string()); // nocov
         }
-        Ok(RunHandle { raw })
+        Ok(run)
     }
 
     /// Pull the next test case the engine wants to run, or `None` when the run
@@ -276,6 +341,13 @@ impl Drop for RunHandle {
     fn drop(&mut self) {
         // SAFETY: `raw` came from hegel_run_start and is freed exactly once;
         free_on_drop(|ctx| unsafe { hegel_c::hegel_run_free(ctx, self.raw) });
+        if let Some(p) = self.output {
+            // SAFETY: hegel_run_free joined the engine worker above, so
+            // nothing can invoke the trampoline with this pointer any more;
+            // the box came from Box::into_raw in `start` and is
+            // reconstituted and freed exactly once.
+            drop(unsafe { Box::from_raw(p) });
+        }
     }
 }
 
@@ -302,15 +374,28 @@ unsafe impl Send for CTestCase {}
 unsafe impl Sync for CTestCase {}
 
 impl CTestCase {
-    /// Build a standalone test case that replays a base64 failure blob. Owned
-    /// by the caller (freed on drop). Returns `Err` with libhegel's diagnostic
-    /// if the blob is null/non-UTF-8/undecodable.
-    pub(crate) fn from_blob(settings: &SettingsHandle, blob: &str) -> Result<Self, String> {
+    /// Build a standalone test case that replays a base64 failure blob, with
+    /// engine output (the debug-verbosity replay trace) going to `sink`
+    /// (stderr when `None`). Owned by the caller (freed on drop). Returns
+    /// `Err` with libhegel's diagnostic if the blob is
+    /// null/non-UTF-8/undecodable.
+    pub(crate) fn from_blob(
+        settings: &SettingsHandle,
+        blob: &str,
+        sink: Option<&OutputSink>,
+    ) -> Result<Self, String> {
         let c_blob = cstring_lossy(blob);
         let mut raw: *mut hegel_c::HegelTestCase = ptr::null_mut();
         // SAFETY: settings is live; c_blob is a valid NUL-terminated string;
-        let rc = with_context(|ctx| unsafe {
-            hegel_c::hegel_test_case_from_blob(ctx, settings.as_ptr(), c_blob.as_ptr(), &mut raw)
+        let rc = with_context(|ctx| {
+            with_engine_output(ctx, sink.map(ptr::from_ref), || unsafe {
+                hegel_c::hegel_test_case_from_blob(
+                    ctx,
+                    settings.as_ptr(),
+                    c_blob.as_ptr(),
+                    &mut raw,
+                )
+            })
         });
         if rc != hegel_result_t::HEGEL_OK {
             return Err(last_error_string());

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -239,10 +239,12 @@ unsafe extern "C" fn engine_output_trampoline(
 }
 
 /// Install `sink` as `ctx`'s engine-output destination, run `f`, and restore
-/// the default. The engine snapshots the destination when a run or blob
-/// replay is created, so the installation only needs to span the creating
-/// call; `user_data` is `sink_ptr`, which the caller keeps alive for as long
-/// as the engine can emit through it. A `None` `sink_ptr` leaves the context
+/// the default. A run or blob replay inherits the destination from the
+/// creating context, and every context this crate passes to later calls has
+/// no callback of its own — the engine then falls back to that inherited
+/// destination — so the installation only needs to span the creating call;
+/// `user_data` is `sink_ptr`, which the caller keeps alive for as long as
+/// the engine can emit through it. A `None` `sink_ptr` leaves the context
 /// alone (output stays on stderr).
 fn with_engine_output<R>(
     ctx: *mut hegel_c::HegelContext,
@@ -263,8 +265,9 @@ fn with_engine_output<R>(
     }
     let result = f();
     if sink_ptr.is_some() {
-        // SAFETY: ctx is this thread's live context; a NULL callback resets
-        // it to the default stderr output.
+        // SAFETY: ctx is this thread's live context; a NULL callback unsets
+        // its output callback, so later calls made with it fall back to each
+        // run's inherited destination.
         require_ok(unsafe { hegel_c::hegel_context_set_output(ctx, None, ptr::null_mut()) });
     }
     result

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -221,13 +221,13 @@ impl Drop for SettingsHandle {
     }
 }
 
-/// Engine-output trampoline installed with `hegel_context_set_output` while
-/// a run or blob replay is being created: `user_data` points at the
-/// [`OutputSink`] the run resolved at start, and each engine output line is
-/// forwarded to it. The engine invokes this from its worker thread; the sink
-/// is `Send + Sync`, and the pointee stays alive for as long as the engine
-/// can emit — owned by the [`RunHandle`] for a run, borrowed across the
-/// creating call for a blob replay (whose only line is emitted during it).
+/// Engine-output trampoline passed to `hegel_run_start` /
+/// `hegel_test_case_from_blob`: `user_data` points at the [`OutputSink`] the
+/// run resolved at start, and each engine output line is forwarded to it. The
+/// engine invokes this from its worker thread; the sink is `Send + Sync`, and
+/// the pointee stays alive for as long as the engine can emit — owned by the
+/// [`RunHandle`] for a run, borrowed across the creating call for a blob
+/// replay (whose only line is emitted during it).
 unsafe extern "C" fn engine_output_trampoline(
     user_data: *mut c_void,
     line: *const c_char,
@@ -238,39 +238,17 @@ unsafe extern "C" fn engine_output_trampoline(
     sink(&String::from_utf8_lossy(bytes));
 }
 
-/// Install `sink` as `ctx`'s engine-output destination, run `f`, and restore
-/// the default. A run or blob replay inherits the destination from the
-/// creating context, and every context this crate passes to later calls has
-/// no callback of its own — the engine then falls back to that inherited
-/// destination — so the installation only needs to span the creating call;
-/// `user_data` is `sink_ptr`, which the caller keeps alive for as long as
-/// the engine can emit through it. A `None` `sink_ptr` leaves the context
-/// alone (output stays on stderr).
-fn with_engine_output<R>(
-    ctx: *mut hegel_c::HegelContext,
+/// The `(callback, user_data)` pair to pass to a creation call for output
+/// going to the [`OutputSink`] at `sink_ptr`, or `(None, null)` to leave
+/// output on stderr when `sink_ptr` is `None`. The pointee must stay valid
+/// for as long as the engine can emit through it (the caller's concern).
+fn output_args(
     sink_ptr: Option<*const OutputSink>,
-    f: impl FnOnce() -> R,
-) -> R {
-    if let Some(p) = sink_ptr {
-        // SAFETY: ctx is this thread's live context; the trampoline contract
-        // (thread-safe callback, pointee outlives the engine's emissions) is
-        // upheld by the caller keeping the sink alive.
-        require_ok(unsafe {
-            hegel_c::hegel_context_set_output(
-                ctx,
-                Some(engine_output_trampoline),
-                p.cast_mut().cast(),
-            )
-        });
+) -> (hegel_c::hegel_output_callback_t, *mut c_void) {
+    match sink_ptr {
+        Some(p) => (Some(engine_output_trampoline), p.cast_mut().cast()),
+        None => (None, ptr::null_mut()),
     }
-    let result = f();
-    if sink_ptr.is_some() {
-        // SAFETY: ctx is this thread's live context; a NULL callback unsets
-        // its output callback, so later calls made with it fall back to each
-        // run's inherited destination.
-        require_ok(unsafe { hegel_c::hegel_context_set_output(ctx, None, ptr::null_mut()) });
-    }
-    result
 }
 
 /// Owns a `*mut HegelRun` and frees it on drop (which aborts and joins the
@@ -293,13 +271,14 @@ impl RunHandle {
         sink: Option<&OutputSink>,
     ) -> Result<Self, String> {
         let output = sink.map(|s| Box::into_raw(Box::new(s.clone())));
+        let (callback, user_data) = output_args(output.map(|p| p.cast_const()));
         let mut raw: *mut hegel_c::HegelRun = ptr::null_mut();
         // SAFETY: settings.as_ptr() is a live, non-null handle; &mut raw is a
-        // valid out-parameter.
-        let rc = with_context(|ctx| {
-            with_engine_output(ctx, output.map(|p| p.cast_const()), || unsafe {
-                hegel_c::hegel_run_start(ctx, settings.as_ptr(), &mut raw)
-            })
+        // valid out-parameter. The trampoline contract (thread-safe callback,
+        // pointee outlives the engine's emissions) is upheld by holding the
+        // sink box in `output` until Drop, after the worker is joined.
+        let rc = with_context(|ctx| unsafe {
+            hegel_c::hegel_run_start(ctx, settings.as_ptr(), callback, user_data, &mut raw)
         });
         // Construct the handle before checking rc so the error path (raw is
         // still null, which hegel_run_free accepts) releases the sink box.
@@ -388,17 +367,20 @@ impl CTestCase {
         sink: Option<&OutputSink>,
     ) -> Result<Self, String> {
         let c_blob = cstring_lossy(blob);
+        let (callback, user_data) = output_args(sink.map(ptr::from_ref));
         let mut raw: *mut hegel_c::HegelTestCase = ptr::null_mut();
-        // SAFETY: settings is live; c_blob is a valid NUL-terminated string;
-        let rc = with_context(|ctx| {
-            with_engine_output(ctx, sink.map(ptr::from_ref), || unsafe {
-                hegel_c::hegel_test_case_from_blob(
-                    ctx,
-                    settings.as_ptr(),
-                    c_blob.as_ptr(),
-                    &mut raw,
-                )
-            })
+        // SAFETY: settings is live; c_blob is a valid NUL-terminated string.
+        // The blob-replay trace is emitted synchronously during this call, so
+        // borrowing `sink` for its duration satisfies the trampoline contract.
+        let rc = with_context(|ctx| unsafe {
+            hegel_c::hegel_test_case_from_blob(
+                ctx,
+                settings.as_ptr(),
+                c_blob.as_ptr(),
+                callback,
+                user_data,
+                &mut raw,
+            )
         });
         if rc != hegel_result_t::HEGEL_OK {
             return Err(last_error_string());

--- a/src/run_lifecycle.rs
+++ b/src/run_lifecycle.rs
@@ -24,7 +24,7 @@ use crate::control::{
 };
 use crate::ffi::{CTestCase, RunHandle, SettingsHandle};
 use crate::runner::{Mode, Settings, Verbosity};
-use crate::test_case::TestCase;
+use crate::test_case::{RunOutput, TestCase};
 
 static PANIC_HOOK_INIT: Once = Once::new();
 
@@ -222,9 +222,10 @@ pub fn panic_message(payload: &Box<dyn std::any::Any + Send>) -> String {
 /// `file:line:col` string and stored on the [`Failure`] so per-origin
 /// shrinking can key on it, and the rendered diagnostic block (panic
 /// location, message, backtrace) is printed here, at the moment the panic
-/// is caught — to stderr on a non-quiet final replay (right after the live
-/// draw/note lines, which is what keeps each failure one block), or
-/// through the verbose output sink for a non-final case in verbose mode.
+/// is caught — on a non-quiet final replay it is returned to the caller to
+/// print (right after the live draw/note lines, which is what keeps each
+/// failure one block), and for a non-final case in verbose mode it goes to
+/// `output`, the run's resolved destination.
 ///
 /// Also returns the caught panic payload for an `Interesting` result, so a
 /// final replay's caller can re-raise the test's *own* panic as the run's
@@ -235,6 +236,7 @@ pub(crate) fn run_test_case(
     is_final: bool,
     mode: Mode,
     verbosity: Verbosity,
+    output: &RunOutput,
 ) -> (
     TestCaseResult,
     Option<Box<dyn std::any::Any + Send>>,
@@ -250,7 +252,7 @@ pub(crate) fn run_test_case(
     take_panic_info();
 
     let c_tc = Arc::new(c_tc);
-    let tc = TestCase::new(Arc::clone(&c_tc), should_emit, mode);
+    let tc = TestCase::new(Arc::clone(&c_tc), should_emit, mode, output.sink().cloned());
     let result = with_test_context(|| catch_unwind(AssertUnwindSafe(|| test_fn(tc))));
 
     let (tc_result, payload, diagnostic) = match result {
@@ -287,7 +289,7 @@ pub(crate) fn run_test_case(
                     let diagnostic =
                         render_diagnostic(&thread_name, &thread_id, &location, &msg, &backtrace);
                     for line in diagnostic.trim_end_matches('\n').split('\n') {
-                        crate::test_case::emit_verbose_line(line);
+                        output.line(line);
                     }
                 }
                 None
@@ -300,7 +302,7 @@ pub(crate) fn run_test_case(
     };
 
     if verbose {
-        emit_verbose_stop_reason(&tc_result);
+        emit_verbose_stop_reason(&tc_result, output);
     }
 
     report_outcome(&c_tc, &tc_result);
@@ -333,13 +335,13 @@ fn report_outcome(handle: &CTestCase, result: &TestCaseResult) {
 }
 
 /// Print a per-test-case line describing why this test case stopped.
-fn emit_verbose_stop_reason(result: &TestCaseResult) {
+fn emit_verbose_stop_reason(result: &TestCaseResult, output: &RunOutput) {
     match result {
         TestCaseResult::Invalid => {
-            crate::test_case::emit_verbose_line("Test case stopped: failed assumption");
+            output.line("Test case stopped: failed assumption");
         }
         TestCaseResult::Overrun => {
-            crate::test_case::emit_verbose_line("Test case stopped: out of data");
+            output.line("Test case stopped: out of data");
         }
         TestCaseResult::Valid | TestCaseResult::Interesting(_) => {}
     }
@@ -444,20 +446,21 @@ pub(crate) fn drive<F>(
     let mode = settings.mode;
     let verbosity = settings.verbosity;
     let quiet = verbosity == Verbosity::Quiet;
+    let output = RunOutput::resolve();
 
     let c_settings = SettingsHandle::build(settings, database_key);
-    let run = match RunHandle::start(&c_settings) {
+    let run = match RunHandle::start(&c_settings, output.sink()) {
         Ok(run) => run,
         Err(message) => panic!("{message}"), // nocov
     };
 
     if mode == Mode::SingleTestCase {
-        drive_single_case(&run, &mut test_fn, verbosity, test_location);
+        drive_single_case(&run, &mut test_fn, verbosity, test_location, &output);
         return;
     }
 
     while let Some(c_tc) = run.next_test_case() {
-        run_test_case(c_tc, &mut test_fn, false, mode, verbosity);
+        run_test_case(c_tc, &mut test_fn, false, mode, verbosity, &output);
     }
 
     let result = run.result();
@@ -477,31 +480,33 @@ pub(crate) fn drive<F>(
             let count = result.failure_count();
             let multiple = count > 1;
             if multiple && !quiet {
-                eprintln!("Property-based test failed with {count} distinct failures.");
+                output.line(&format!(
+                    "Property-based test failed with {count} distinct failures."
+                ));
             }
             let mut last_payload: Option<Box<dyn std::any::Any + Send>> = None;
             for index in 0..count {
                 if multiple && !quiet {
-                    eprintln!();
+                    output.line("");
                 }
                 let blob = result
                     .failure(index)
                     .reproduce_blob
                     .unwrap_or_else(|| hegel_internal_error!("failure {index} has no blob"));
-                let c_tc = match CTestCase::from_blob(&c_settings, &blob) {
+                let c_tc = match CTestCase::from_blob(&c_settings, &blob, output.sink()) {
                     Ok(c_tc) => c_tc,
                     Err(message) => panic!("{message}"), // nocov
                 };
                 let (tc_result, payload, diagnostic) =
-                    run_test_case(c_tc, &mut test_fn, true, mode, verbosity);
+                    run_test_case(c_tc, &mut test_fn, true, mode, verbosity, &output);
                 if !matches!(tc_result, TestCaseResult::Interesting(_)) {
                     panic!("{FLAKY_DIAGNOSTIC}");
                 }
                 if let Some(diagnostic) = diagnostic {
-                    eprint!("{diagnostic}");
+                    output.block(&diagnostic);
                 }
                 if let Some(line) = reproducer_line(settings, Some(blob.as_str())) {
-                    eprintln!("{line}");
+                    output.block(&format!("{line}\n"));
                 }
                 last_payload = payload;
             }
@@ -530,16 +535,17 @@ fn drive_single_case(
     test_fn: &mut dyn FnMut(TestCase),
     verbosity: Verbosity,
     test_location: Option<&TestLocation>,
+    output: &RunOutput,
 ) {
     let c_tc = run
         .next_test_case()
         .expect("a SingleTestCase run produces exactly one test case");
     let (result, payload, diagnostic) =
-        run_test_case(c_tc, test_fn, true, Mode::SingleTestCase, verbosity);
+        run_test_case(c_tc, test_fn, true, Mode::SingleTestCase, verbosity, output);
     if matches!(result, TestCaseResult::Interesting(_)) {
         emit_antithesis_assertion(true, test_location);
         if let Some(diagnostic) = diagnostic {
-            eprint!("{diagnostic}");
+            output.block(&diagnostic);
         }
         std::panic::resume_unwind(
             payload.expect("an interesting case carries the caught panic payload"),
@@ -567,15 +573,22 @@ pub(crate) fn drive_blob_replay<F>(
     init_panic_hook();
     require_antithesis_feature();
     let mut test_fn = test_fn;
+    let output = RunOutput::resolve();
     let c_settings = SettingsHandle::build(settings, database_key);
-    let c_tc = match CTestCase::from_blob(&c_settings, blob) {
+    let c_tc = match CTestCase::from_blob(&c_settings, blob, output.sink()) {
         Ok(c_tc) => c_tc,
         Err(message) => panic!("{message}"),
     };
-    let (result, payload, diagnostic) =
-        run_test_case(c_tc, &mut test_fn, true, settings.mode, settings.verbosity);
+    let (result, payload, diagnostic) = run_test_case(
+        c_tc,
+        &mut test_fn,
+        true,
+        settings.mode,
+        settings.verbosity,
+        &output,
+    );
     if let Some(diagnostic) = diagnostic {
-        eprint!("{diagnostic}");
+        output.block(&diagnostic);
     }
     match result {
         TestCaseResult::Interesting(_) => {

--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -234,19 +234,25 @@ impl std::fmt::Debug for TestCase {
     }
 }
 
-/// A callback invoked for each line of draw/note output during the final replay.
+/// A callback invoked for each line of run output — engine progress lines,
+/// draw/note output, verbose diagnostics, and the final failure report.
 pub(crate) type OutputSink = Arc<dyn Fn(&str) + Send + Sync>;
 
 thread_local! {
     static OUTPUT_OVERRIDE: RefCell<Option<OutputSink>> = const { RefCell::new(None) };
 }
 
-/// Install a custom output sink for the duration of `f`, replacing the usual
-/// `eprintln!` behavior of draw and note output. Intended for tests that want
-/// to capture what a test case would print.
+/// Install a custom output sink for the duration of `f`, replacing stderr as
+/// the destination for all of Hegel's run output. Intended for tests that
+/// want to capture what a test run would print.
 ///
-/// While active, notes and draws from the final replay go to `sink` instead of
-/// stderr. Non-final test cases still drop their draw/note output as usual.
+/// A run started while the override is active resolves it once, at start,
+/// and routes everything through it for the run's lifetime: the engine's own
+/// progress lines (emitted from its worker thread), draw and note output —
+/// including from clones driven on other threads — verbose per-case
+/// diagnostics and stop reasons, and the final failure report with its
+/// reproducer line. Which of those exist at all is still governed by
+/// [`Verbosity`](crate::Verbosity); the override only changes where they go.
 #[doc(hidden)]
 pub fn with_output_override<R>(sink: OutputSink, f: impl FnOnce() -> R) -> R {
     struct Restore(Option<OutputSink>);
@@ -269,6 +275,11 @@ pub(crate) fn current_output_sink() -> Option<OutputSink> {
 
 /// Emit a single line of verbose runner output, going through the
 /// installed output sink if there is one and otherwise to stderr.
+///
+/// Resolves the sink thread-locally at emit time, so it is only correct for
+/// output produced synchronously on the thread that installed the override
+/// (e.g. an explicit test case). A run resolves its destination once up
+/// front instead — see [`RunOutput`].
 pub(crate) fn emit_verbose_line(msg: &str) {
     if let Some(sink) = current_output_sink() {
         sink(msg);
@@ -277,13 +288,69 @@ pub(crate) fn emit_verbose_line(msg: &str) {
     }
 }
 
+/// The output destination a run resolved when it started.
+///
+/// Resolved exactly once, on the thread that starts the run, from the
+/// installed override ([`with_output_override`]) — and then carried by the
+/// run itself. Everything the run emits later flows through this value,
+/// wherever it happens: the engine's worker thread and clones driven on
+/// other threads never see the starting thread's thread-local override, so
+/// resolving lazily at emit time would send their output to the wrong place.
+pub(crate) struct RunOutput {
+    sink: Option<OutputSink>,
+}
+
+impl RunOutput {
+    /// Resolve the destination for a run starting now on this thread: the
+    /// installed override if there is one, stderr otherwise.
+    pub(crate) fn resolve() -> Self {
+        RunOutput {
+            sink: current_output_sink(),
+        }
+    }
+
+    /// The resolved sink, for handing to the engine and to test cases;
+    /// `None` means stderr.
+    pub(crate) fn sink(&self) -> Option<&OutputSink> {
+        self.sink.as_ref()
+    }
+
+    /// Emit one line of output (no trailing newline).
+    pub(crate) fn line(&self, msg: &str) {
+        match &self.sink {
+            Some(sink) => sink(msg),
+            None => eprintln!("{msg}"),
+        }
+    }
+
+    /// Emit a pre-rendered, newline-terminated block exactly as it would
+    /// appear on stderr; the sink receives it as individual lines.
+    pub(crate) fn block(&self, text: &str) {
+        match &self.sink {
+            Some(sink) => {
+                for line in text.trim_end_matches('\n').split('\n') {
+                    sink(line);
+                }
+            }
+            None => eprint!("{text}"),
+        }
+    }
+}
+
 impl TestCase {
     /// `emit` is decided by the lifecycle (`run_lifecycle::run_test_case`):
     /// true on a non-quiet final replay or in verbose mode, where drawn
-    /// values and notes should be surfaced.
-    pub(crate) fn new(handle: Arc<CTestCase>, emit: bool, mode: Mode) -> Self {
-        let override_sink = current_output_sink();
-        let on_draw: OutputSink = match override_sink {
+    /// values and notes should be surfaced. `sink` is the run's resolved
+    /// output destination ([`RunOutput::sink`]) — passed in rather than read
+    /// from the thread-local override so that a test case created here and
+    /// then driven from another thread still prints to the right place.
+    pub(crate) fn new(
+        handle: Arc<CTestCase>,
+        emit: bool,
+        mode: Mode,
+        sink: Option<OutputSink>,
+    ) -> Self {
+        let on_draw: OutputSink = match sink {
             Some(sink) if emit => sink,
             _ if emit => Arc::new(|msg| eprintln!("{}", msg)),
             _ => Arc::new(|_| {}),

--- a/tests/embedded/ffi_tests.rs
+++ b/tests/embedded/ffi_tests.rs
@@ -47,7 +47,7 @@ fn drive_run(run: &RunHandle, mut f: impl FnMut(&CTestCase) -> Result<(), hegel_
 fn ffi_drives_a_passing_run_exercising_every_primitive() {
     let settings = test_settings(1);
     let sh = SettingsHandle::build(&settings, None);
-    let run = RunHandle::start(&sh).unwrap();
+    let run = RunHandle::start(&sh, None).unwrap();
     let text = StringGenerator::text(0, 5, None, 0, None, None, None, None, None).unwrap();
 
     let mut cases = 0usize;
@@ -171,7 +171,7 @@ fn ffi_string_generator_constructors_cover_every_kind() {
 fn ffi_reports_failure_with_blob_then_replays_it() {
     let settings = test_settings(7);
     let sh = SettingsHandle::build(&settings, None);
-    let run = RunHandle::start(&sh).unwrap();
+    let run = RunHandle::start(&sh, None).unwrap();
 
     let origin = "n != 0";
     while let Some(tc) = run.next_test_case() {
@@ -199,7 +199,7 @@ fn ffi_reports_failure_with_blob_then_replays_it() {
         .expect("a shrunk failure carries a blob");
 
     let sh2 = SettingsHandle::build(&settings, None);
-    let replay = CTestCase::from_blob(&sh2, &blob).unwrap();
+    let replay = CTestCase::from_blob(&sh2, &blob, None).unwrap();
     assert_eq!(
         replay.generate_integer(0, 100).unwrap(),
         1,
@@ -217,7 +217,7 @@ fn ffi_reports_failure_with_blob_then_replays_it() {
 fn ffi_clone_handle_shares_the_test_case() {
     let settings = test_settings(1);
     let sh = SettingsHandle::build(&settings, None);
-    let run = RunHandle::start(&sh).unwrap();
+    let run = RunHandle::start(&sh, None).unwrap();
 
     let tc = run.next_test_case().unwrap();
     let clone = tc.clone_handle();
@@ -237,7 +237,7 @@ fn ffi_clone_handle_shares_the_test_case() {
 fn ffi_from_blob_rejects_undecodable_input() {
     let settings = test_settings(1);
     let sh = SettingsHandle::build(&settings, None);
-    let err = match CTestCase::from_blob(&sh, "not a valid base64 hegel blob!!!") {
+    let err = match CTestCase::from_blob(&sh, "not a valid base64 hegel blob!!!", None) {
         Err(e) => e,
         Ok(_) => panic!("expected an undecodable blob to be rejected"),
     };
@@ -275,7 +275,7 @@ fn ffi_handle_dropped_after_context_teardown_does_not_abort() {
 fn ffi_next_test_case_surfaces_engine_errors_instead_of_ending_the_run() {
     let settings = test_settings(1);
     let sh = SettingsHandle::build(&settings, None);
-    let run = RunHandle::start(&sh).unwrap();
+    let run = RunHandle::start(&sh, None).unwrap();
     let _first = run.next_test_case().unwrap();
     run.next_test_case();
 }

--- a/tests/embedded/run_lifecycle_tests.rs
+++ b/tests/embedded/run_lifecycle_tests.rs
@@ -156,11 +156,18 @@ fn run_one_case(
 ) {
     init_panic_hook();
     let c_settings = SettingsHandle::build(&test_settings(), None);
-    let run = RunHandle::start(&c_settings).expect("the engine starts");
+    let run = RunHandle::start(&c_settings, None).expect("the engine starts");
     let c_tc = run
         .next_test_case()
         .expect("the engine schedules at least one case");
-    run_test_case(c_tc, body, is_final, Mode::TestRun, verbosity)
+    run_test_case(
+        c_tc,
+        body,
+        is_final,
+        Mode::TestRun,
+        verbosity,
+        &RunOutput::resolve(),
+    )
 }
 
 fn run_case_capturing(

--- a/tests/embedded/runner_tests.rs
+++ b/tests/embedded/runner_tests.rs
@@ -208,7 +208,7 @@ mod reproduce {
             .database(None)
             .verbosity(Verbosity::Quiet);
         let c_settings = SettingsHandle::build(&settings, None);
-        let run = RunHandle::start(&c_settings).expect("the engine starts");
+        let run = RunHandle::start(&c_settings, None).expect("the engine starts");
         while let Some(c_tc) = run.next_test_case() {
             crate::run_lifecycle::run_test_case(
                 c_tc,
@@ -216,6 +216,7 @@ mod reproduce {
                 false,
                 Mode::TestRun,
                 Verbosity::Quiet,
+                &crate::test_case::RunOutput::resolve(),
             );
         }
         let result = run.result();

--- a/tests/embedded/test_case_tests.rs
+++ b/tests/embedded/test_case_tests.rs
@@ -15,11 +15,11 @@ use crate::runner::{Mode, Settings};
 fn emitting_test_case() -> (RunHandle, TestCase) {
     let settings = Settings::new().database(None);
     let c_settings = SettingsHandle::build(&settings, None);
-    let run = RunHandle::start(&c_settings).expect("the engine starts");
+    let run = RunHandle::start(&c_settings, None).expect("the engine starts");
     let c_tc = run
         .next_test_case()
         .expect("the engine schedules at least one case");
-    let tc = TestCase::new(Arc::new(c_tc), true, Mode::TestRun);
+    let tc = TestCase::new(Arc::new(c_tc), true, Mode::TestRun, current_output_sink());
     (run, tc)
 }
 

--- a/tests/test_explicit_test_case.rs
+++ b/tests/test_explicit_test_case.rs
@@ -318,3 +318,32 @@ fn test_macro_explicit_case_with_computed_expression(tc: TestCase) {
     let n: i32 = tc.draw(generators::integers());
     panic!("fail: {}", n);
 }
+
+#[test]
+fn test_explicit_output_goes_to_the_output_override() {
+    use std::sync::{Arc, Mutex};
+    let buf: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let buf_writer = buf.clone();
+    let sink: Arc<dyn Fn(&str) + Send + Sync> =
+        Arc::new(move |s: &str| buf_writer.lock().unwrap().push(s.to_string()));
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        hegel::with_output_override(sink, || {
+            let etc = hegel::ExplicitTestCase::new().with_value("x", "42", 42i32);
+            etc.run(|tc: &hegel::ExplicitTestCase| {
+                let _: i32 = tc.__draw_named(generators::integers(), "x", false);
+                tc.note("a captured note");
+                panic!("intentional");
+            });
+        });
+    }));
+    assert!(result.is_err());
+    let lines = buf.lock().unwrap().clone();
+    assert!(
+        lines.iter().any(|l| l == "let x = 42;"),
+        "expected the drawn-value line in the sink, got {lines:?}"
+    );
+    assert!(
+        lines.iter().any(|l| l == "a captured note"),
+        "expected the note in the sink, got {lines:?}"
+    );
+}

--- a/tests/test_loop.rs
+++ b/tests/test_loop.rs
@@ -20,6 +20,10 @@ use hegel::{Hegel, Settings};
 /// Run `body` as a Hegel property test and return the lines captured during
 /// the final replay of the shrunk failing case. `body` is expected to trigger
 /// a failure (otherwise no final replay is emitted and the snapshot is empty).
+/// The override receives the whole run's output, including the failure
+/// diagnostic that follows the draw/note lines; everything from the
+/// diagnostic header on is trimmed off, since these snapshots pin only the
+/// loop output (and the diagnostic's backtrace is machine-specific).
 fn capture_loop_output<F>(body: F) -> String
 where
     F: FnMut(hegel::TestCase) + 'static,
@@ -43,7 +47,12 @@ where
     }));
 
     let lines = buf.lock().unwrap().clone();
-    lines.join("\n")
+    lines
+        .iter()
+        .take_while(|line| !line.starts_with("thread '"))
+        .map(String::as_str)
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 #[test]

--- a/tests/test_miri.rs
+++ b/tests/test_miri.rs
@@ -298,6 +298,7 @@ fn output_override_captures_engine_output() {
                 Settings::new()
                     .test_cases(2)
                     .database(None)
+                    .report_multiple_failures(true)
                     .verbosity(hegel::Verbosity::Debug),
             )
             .run();

--- a/tests/test_miri.rs
+++ b/tests/test_miri.rs
@@ -281,3 +281,32 @@ fn a_test_case_leaked_to_a_thread_outlives_its_case_safely() {
     release_tx.send(()).unwrap();
     assert!(handle.join().is_err());
 }
+
+#[test]
+fn output_override_captures_engine_output() {
+    let buf: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let buf_writer = Arc::clone(&buf);
+    let sink: Arc<dyn Fn(&str) + Send + Sync> =
+        Arc::new(move |s: &str| buf_writer.lock().unwrap().push(s.to_string()));
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        hegel::with_output_override(sink, || {
+            Hegel::new(|tc: TestCase| {
+                let _ = tc.draw(gs::booleans());
+                panic!("always fails");
+            })
+            .settings(
+                Settings::new()
+                    .test_cases(2)
+                    .database(None)
+                    .verbosity(hegel::Verbosity::Debug),
+            )
+            .run();
+        });
+    }));
+    assert!(result.is_err());
+    let lines = buf.lock().unwrap();
+    assert!(
+        lines.iter().any(|l| l.starts_with("test case #")),
+        "expected engine debug lines through the override, got {lines:?}"
+    );
+}

--- a/tests/test_output.rs
+++ b/tests/test_output.rs
@@ -168,6 +168,12 @@ fn test_failing_test_output() {
 /// The `at <file>:line[:col]` anchor is therefore what proves the right
 /// frame is present (Windows backtraces omit the column); `name` narrows the
 /// symbol text where it survives.
+///
+/// A frame can also be inlined away entirely rather than merely losing its
+/// name: on aarch64 dev builds the fixture's trivial `main` is folded into
+/// the runtime's `fn()` call, leaving no `main` frame at all. Callers wrap
+/// such optional frames in `(?:…)?` so the assertion still holds where the
+/// frame survives (e.g. x86_64) without requiring it where it does not.
 fn frame_at(name: &str, file: &str) -> String {
     format!(
         r"(?:[^\n]*(?:{name})[^\n]*|__covrec_[0-9A-Fa-f]+u?|<unknown>)\n\s+at [^\n]*{file}:\d+(?::\d+)?\n"
@@ -198,7 +204,7 @@ fn test_failing_test_output_with_backtrace() {
                 r".*",
                 r"{hegel_internals}",
                 r".*",
-                r"{user_main}",
+                r"(?:{user_main})?",
                 r".*",
                 r"note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace\.",
             ),
@@ -234,7 +240,7 @@ fn test_failing_test_output_with_full_backtrace() {
                 r".*",
                 r"{hegel_internals}",
                 r".*",
-                r"{user_main}",
+                r"(?:{user_main})?",
                 r".*$",
             ),
             user_closure = frame_at(closure_name, r"tests[/\\]fixtures[/\\]output_failing\.rs"),

--- a/tests/test_output.rs
+++ b/tests/test_output.rs
@@ -541,3 +541,151 @@ mod snapshots_shrinking {
         assert_eq!(x, 1.0);
     }
 }
+
+mod override_captures_run_output {
+    //! `with_output_override` captures *all* of a run's output — the engine's
+    //! own progress lines (which historically went straight to stderr from
+    //! the engine worker thread), the final failure diagnostics with the
+    //! reproducer line, the multi-failure headline, and output produced by
+    //! clones driven on other threads. The sink is resolved once when the
+    //! run starts, so it travels with the run rather than being looked up
+    //! thread-locally at each emit site.
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+    use std::sync::{Arc, Mutex};
+
+    use hegel::generators as gs;
+    use hegel::{Hegel, Settings, Verbosity};
+
+    fn collect_with<F>(settings: Settings, body: F) -> Vec<String>
+    where
+        F: FnMut(hegel::TestCase) + 'static,
+    {
+        let buf: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let buf_writer = buf.clone();
+        let sink: Arc<dyn Fn(&str) + Send + Sync> =
+            Arc::new(move |s: &str| buf_writer.lock().unwrap().push(s.to_string()));
+
+        let _ = catch_unwind(AssertUnwindSafe(|| {
+            hegel::with_output_override(sink, || {
+                Hegel::new(body).settings(settings).run();
+            });
+        }));
+
+        buf.lock().unwrap().clone()
+    }
+
+    fn settings(verbosity: Verbosity) -> Settings {
+        Settings::new()
+            .verbosity(verbosity)
+            .test_cases(5)
+            .database(None)
+            .derandomize(true)
+    }
+
+    #[test]
+    fn engine_progress_lines_reach_the_sink() {
+        let lines = collect_with(settings(Verbosity::Debug), |tc| {
+            let _ = tc.draw(gs::booleans());
+        });
+        assert!(
+            lines.iter().any(|l| l == "Starting phase: Generate"),
+            "expected the engine's phase line in the sink, got {lines:?}"
+        );
+        assert!(
+            lines.iter().any(|l| l.starts_with("test case #")),
+            "expected the engine's per-case debug lines in the sink, got {lines:?}"
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|l| l == "Test done. interesting_test_cases=0"),
+            "expected the engine's summary line in the sink, got {lines:?}"
+        );
+    }
+
+    #[test]
+    fn engine_shrink_and_blob_replay_lines_reach_the_sink() {
+        let lines = collect_with(settings(Verbosity::Debug), |tc| {
+            let _ = tc.draw(gs::integers::<i64>());
+            panic!("always fails");
+        });
+        assert!(
+            lines.iter().any(|l| l.starts_with("Shrinking:")),
+            "expected the engine's shrink progress in the sink, got {lines:?}"
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.starts_with("replaying failure blob:")),
+            "expected the final replay's blob trace in the sink, got {lines:?}"
+        );
+    }
+
+    #[test]
+    fn failure_diagnostic_and_reproducer_reach_the_sink() {
+        let lines = collect_with(settings(Verbosity::Normal).print_blob(true), |tc| {
+            let _ = tc.draw(gs::booleans());
+            panic!("canary for the sink");
+        });
+        assert!(
+            lines.iter().any(|l| l.contains("panicked at")),
+            "expected the diagnostic header in the sink, got {lines:?}"
+        );
+        assert!(
+            lines.iter().any(|l| l.contains("canary for the sink")),
+            "expected the panic message in the sink, got {lines:?}"
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains("To reproduce this failure")),
+            "expected the reproducer line in the sink, got {lines:?}"
+        );
+        assert!(
+            lines.iter().any(|l| l.contains("hegel::reproduce_failure")),
+            "expected the reproduce_failure attribute in the sink, got {lines:?}"
+        );
+    }
+
+    #[test]
+    fn multi_failure_headline_reaches_the_sink() {
+        let lines = collect_with(settings(Verbosity::Normal).test_cases(20), |tc| {
+            if tc.draw(gs::booleans()) {
+                panic!("first distinct bug");
+            } else {
+                panic!("second distinct bug");
+            }
+        });
+        assert!(
+            lines
+                .iter()
+                .any(|l| l == "Property-based test failed with 2 distinct failures."),
+            "expected the multi-failure headline in the sink, got {lines:?}"
+        );
+        assert!(
+            lines.iter().any(|l| l.contains("first distinct bug")),
+            "expected the first bug's diagnostic in the sink, got {lines:?}"
+        );
+        assert!(
+            lines.iter().any(|l| l.contains("second distinct bug")),
+            "expected the second bug's diagnostic in the sink, got {lines:?}"
+        );
+    }
+
+    #[test]
+    fn notes_from_a_clone_on_another_thread_reach_the_sink() {
+        let lines = collect_with(settings(Verbosity::Verbose), |tc| {
+            let clone = tc.clone();
+            std::thread::spawn(move || {
+                let _ = clone.draw(gs::booleans());
+                clone.note("note from another thread");
+            })
+            .join()
+            .unwrap();
+        });
+        assert!(
+            lines.iter().any(|l| l.contains("note from another thread")),
+            "expected the spawned thread's note in the sink, got {lines:?}"
+        );
+    }
+}

--- a/tests/test_output.rs
+++ b/tests/test_output.rs
@@ -649,13 +649,18 @@ mod override_captures_run_output {
 
     #[test]
     fn multi_failure_headline_reaches_the_sink() {
-        let lines = collect_with(settings(Verbosity::Normal).test_cases(20), |tc| {
-            if tc.draw(gs::booleans()) {
-                panic!("first distinct bug");
-            } else {
-                panic!("second distinct bug");
-            }
-        });
+        let lines = collect_with(
+            settings(Verbosity::Normal)
+                .test_cases(20)
+                .report_multiple_failures(true),
+            |tc| {
+                if tc.draw(gs::booleans()) {
+                    panic!("first distinct bug");
+                } else {
+                    panic!("second distinct bug");
+                }
+            },
+        );
         assert!(
             lines
                 .iter()


### PR DESCRIPTION
Closes #355.

<details>
<summary>Implementation notes (AI-generated)</summary>

## C ABI

- `hegel_context_t` grows an output destination — a `callback` function pointer plus an arbitrary `user_data` pointer — set with the new `hegel_context_set_output(ctx, callback, user_data)`. Passing a NULL callback resets to the default stderr output.
- The callback is invoked once per line of engine output (NUL-terminated UTF-8 plus explicit length, no trailing newline), with `user_data` passed through verbatim — so Go can register one library-wide function and resolve `user_data` to a `testing.T` handle.
- `hegel_run_start` and `hegel_test_case_from_blob` snapshot the context's destination at creation time; the engine's worker thread emits through the snapshot for the life of the run, so re-pointing or resetting the context later never races an in-flight run.
- Internally the engine's `Settings` carry an `Output` sink (default stderr); every `eprintln!` in `test_runner.rs` and the blob-replay path in `embed.rs` goes through it.

## Rust frontend

No new public API. The crate-internal `with_output_override` now captures *all* of a run's output, not just the frontend's draw/note lines:

- A run resolves the override **once, at start**, into a `RunOutput` it carries for its lifetime — never reading the thread-local at emit time, which would misroute output produced off the starting thread (the engine's worker, test-case clones driven on other threads).
- Engine output is wired in by installing the run's sink as the context callback around `hegel_run_start` / `hegel_test_case_from_blob` (trampoline in `ffi.rs`; the boxed sink is owned by the `RunHandle` and freed after `hegel_run_free` joins the worker).
- The final failure diagnostics, reproducer line, and multi-failure headline now also flow through the run's sink (unchanged on stderr when no override is installed).
- Explicit test cases emit through the same mechanism.

## Testing

- In-process C-ABI tests: callback receives generation/shrink debug lines with `user_data` passed through, NULL callback resets to stderr, NULL ctx rejected, run-start snapshot semantics, blob-replay trace routing.
- Frontend tests: `with_output_override` captures engine progress/shrink/replay lines, failure diagnostic + reproducer, multi-failure headline, and notes from a clone on another thread.
- Miri: the C-ABI full-run test installs the callback (cross-thread raw-pointer path), and a new `test_miri` case drives the frontend trampoline; `just check-miri` passes.
- New `hegel-c/examples/custom_output.c` exercises the feature end-to-end through the generated header under `just c-test` (shared + static).
- `just check`, `just c-test`, and `just check-coverage` (0 uncovered lines, nocov count unchanged) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>