### PR TITLE
claude: default from_regex to fullmatch instead of contains-match

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
-RELEASE_TYPE: major
+RELEASE_TYPE: minor
 
 This release changes the default value of `fullmatch` in `from_regex` from `false` to `true`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: major
+
+This release changes the default value of `fullmatch` in `from_regex` from `false` to `true`.

--- a/src/generators/strings.rs
+++ b/src/generators/strings.rs
@@ -325,8 +325,9 @@ pub fn characters() -> CharactersGenerator {
 
 /// Generator for strings matching a regex pattern. Created by [`from_regex()`].
 ///
-/// By default generates strings that contain a match. Use [`fullmatch()`](Self::fullmatch)
-/// to require the entire string to match.
+/// By default the entire string matches the pattern. Use
+/// [`fullmatch(false)`](Self::fullmatch) to generate strings that merely
+/// contain a match.
 pub struct RegexGenerator {
     pattern: String,
     fullmatch: bool,
@@ -335,7 +336,8 @@ pub struct RegexGenerator {
 }
 
 impl RegexGenerator {
-    /// Set whether the entire string must match the pattern, not just contain a match.
+    /// Set whether the entire string must match the pattern (the default), or
+    /// merely contain a match.
     pub fn fullmatch(mut self, fullmatch: bool) -> Self {
         self.handle = OnceLock::new();
         self.fullmatch = fullmatch;
@@ -370,7 +372,7 @@ impl Generator<String> for RegexGenerator {
 pub fn from_regex(pattern: &str) -> RegexGenerator {
     RegexGenerator {
         pattern: pattern.to_string(),
-        fullmatch: false,
+        fullmatch: true,
         alphabet: None,
         handle: OnceLock::new(),
     }

--- a/tests/test_strings.rs
+++ b/tests/test_strings.rs
@@ -986,7 +986,7 @@ mod regex_tests {
     #[test]
     fn test_can_handle_boundaries_nested() {
         Hegel::new(|tc| {
-            let s: String = tc.draw(gs::from_regex(r"(\Afoo\Z)"));
+            let s: String = tc.draw(gs::from_regex(r"(\Afoo\Z)").fullmatch(false));
             assert_eq!(s, "foo");
         })
         .settings(Settings::new().database(None))

--- a/tests/test_strings.rs
+++ b/tests/test_strings.rs
@@ -900,22 +900,28 @@ mod regex_tests {
 
     #[test]
     fn test_end_with_terminator_does_not_pad() {
-        assert_all_examples(gs::from_regex(r"abc\Z"), |s: &String| s.ends_with("abc"));
+        assert_all_examples(gs::from_regex(r"abc\Z").fullmatch(false), |s: &String| {
+            s.ends_with("abc")
+        });
     }
 
     #[test]
     fn test_end() {
-        find_any(gs::from_regex(r"\Aabc$"), |s: &String| s == "abc");
-        find_any(gs::from_regex(r"\Aabc$"), |s: &String| s == "abc\n");
+        find_any(gs::from_regex(r"\Aabc$").fullmatch(false), |s: &String| {
+            s == "abc"
+        });
+        find_any(gs::from_regex(r"\Aabc$").fullmatch(false), |s: &String| {
+            s == "abc\n"
+        });
     }
 
     #[test]
     fn test_groupref_exists() {
         assert_all_examples(gs::from_regex("^(<)?a(?(1)>)$"), |s: &String| {
-            ["a", "a\n", "<a>", "<a>\n"].contains(&s.as_str())
+            ["a", "<a>"].contains(&s.as_str())
         });
         assert_all_examples(gs::from_regex("^(a)?(?(1)b|c)$"), |s: &String| {
-            ["ab", "ab\n", "c", "c\n"].contains(&s.as_str())
+            ["ab", "c"].contains(&s.as_str())
         });
     }
 
@@ -954,7 +960,7 @@ mod regex_tests {
         fn is_word(c: char) -> bool {
             c == '_' || c.is_alphanumeric()
         }
-        assert_all_examples(gs::from_regex(r"\bfoo\b"), |s: &String| {
+        assert_all_examples(gs::from_regex(r"\bfoo\b").fullmatch(false), |s: &String| {
             let cs: Vec<char> = s.chars().collect();
             (0..cs.len().saturating_sub(2)).any(|i| {
                 cs[i..i + 3] == ['f', 'o', 'o']
@@ -999,18 +1005,20 @@ mod regex_tests {
 
     #[test]
     fn test_positive_lookbehind() {
-        FindAny::new(gs::from_regex(".*(?<=ab)c"), |s: &String| {
-            s.ends_with("abc")
-        })
+        FindAny::new(
+            gs::from_regex(".*(?<=ab)c").fullmatch(false),
+            |s: &String| s.ends_with("abc"),
+        )
         .suppress_health_check(HealthCheck::TooSlow)
         .run();
     }
 
     #[test]
     fn test_positive_lookahead() {
-        FindAny::new(gs::from_regex("a(?=bc).*"), |s: &String| {
-            s.starts_with("abc")
-        })
+        FindAny::new(
+            gs::from_regex("a(?=bc).*").fullmatch(false),
+            |s: &String| s.starts_with("abc"),
+        )
         .suppress_health_check(HealthCheck::TooSlow)
         .run();
     }
@@ -1074,47 +1082,63 @@ mod regex_tests {
 
     #[test]
     fn test_can_pad_strings_arbitrarily() {
-        find_any(gs::from_regex("a"), |s: &String| !s.starts_with('a'));
-        find_any(gs::from_regex("a"), |s: &String| !s.ends_with('a'));
+        find_any(gs::from_regex("a").fullmatch(false), |s: &String| {
+            !s.starts_with('a')
+        });
+        find_any(gs::from_regex("a").fullmatch(false), |s: &String| {
+            !s.ends_with('a')
+        });
     }
 
     #[test]
     fn test_can_pad_empty_strings() {
-        find_any(gs::from_regex(""), |s: &String| !s.is_empty());
+        find_any(gs::from_regex("").fullmatch(false), |s: &String| {
+            !s.is_empty()
+        });
     }
 
     #[test]
     fn test_can_pad_strings_with_newlines() {
-        find_any(gs::from_regex("^$"), |s: &String| !s.is_empty());
+        find_any(gs::from_regex("^$").fullmatch(false), |s: &String| {
+            !s.is_empty()
+        });
     }
 
     #[test]
     fn test_given_multiline_regex_can_insert_after_dollar() {
-        find_any(gs::from_regex(r"(?m)\Ahi$"), |s: &String| {
-            s.contains('\n') && s.split('\n').nth(1).is_some_and(|p| !p.is_empty())
-        });
+        find_any(
+            gs::from_regex(r"(?m)\Ahi$").fullmatch(false),
+            |s: &String| s.contains('\n') && s.split('\n').nth(1).is_some_and(|p| !p.is_empty()),
+        );
     }
 
     #[test]
     fn test_given_multiline_regex_can_insert_before_caret() {
-        find_any(gs::from_regex(r"(?m)^hi\Z"), |s: &String| {
-            s.contains('\n') && s.split('\n').next().is_some_and(|p| !p.is_empty())
-        });
+        find_any(
+            gs::from_regex(r"(?m)^hi\Z").fullmatch(false),
+            |s: &String| s.contains('\n') && s.split('\n').next().is_some_and(|p| !p.is_empty()),
+        );
     }
 
     #[test]
     fn test_does_not_left_pad_beginning_of_string_marker() {
-        assert_all_examples(gs::from_regex(r"\Afoo"), |s: &String| s.starts_with("foo"));
+        assert_all_examples(gs::from_regex(r"\Afoo").fullmatch(false), |s: &String| {
+            s.starts_with("foo")
+        });
     }
 
     #[test]
     fn test_bare_caret_can_produce() {
-        find_any(gs::from_regex("^"), |s: &String| !s.is_empty());
+        find_any(gs::from_regex("^").fullmatch(false), |s: &String| {
+            !s.is_empty()
+        });
     }
 
     #[test]
     fn test_bare_dollar_can_produce() {
-        find_any(gs::from_regex("$"), |s: &String| !s.is_empty());
+        find_any(gs::from_regex("$").fullmatch(false), |s: &String| {
+            !s.is_empty()
+        });
     }
 
     #[test]
@@ -1129,6 +1153,12 @@ mod regex_tests {
                 \.    # the decimal point
                 \d *  # some fractional digits",
         ));
+    }
+
+    #[test]
+    fn test_fullmatch_is_the_default() {
+        let re = Regex::new(r"\A[ab]+\z").unwrap();
+        assert_all_examples(gs::from_regex("[ab]+"), move |s: &String| re.is_match(s));
     }
 
     #[test]
@@ -1228,9 +1258,10 @@ mod regex_tests {
 
     #[test]
     fn test_sets_allow_multichar_output_in_ignorecase_mode() {
-        find_any(gs::from_regex("(?i)[\u{0130}_]"), |s: &String| {
-            s.chars().count() > 1
-        });
+        find_any(
+            gs::from_regex("(?i)[\u{0130}_]").fullmatch(false),
+            |s: &String| s.chars().count() > 1,
+        );
     }
 
     #[test]
@@ -1260,7 +1291,7 @@ mod regex_tests {
 
     #[test]
     fn lookahead_with_anchor() {
-        check_can_generate_examples(gs::from_regex(r"abc(?!\Z)"));
+        check_can_generate_examples(gs::from_regex(r"abc(?!\Z)").fullmatch(false));
     }
 
     #[test]
@@ -1424,7 +1455,7 @@ mod regex_tests {
 
     #[test]
     fn anchor_beginning_after_content() {
-        check_can_generate_examples(gs::from_regex(r".*\A"));
+        check_can_generate_examples(gs::from_regex(r".*\A").fullmatch(false));
     }
 
     #[test]
@@ -1459,18 +1490,20 @@ mod regex_tests {
     #[test]
     fn padded_pattern_with_empty_alphabet_intervals() {
         check_can_generate_examples(
-            gs::from_regex(r"a?").alphabet(gs::characters().categories(&[])),
+            gs::from_regex(r"a?")
+                .fullmatch(false)
+                .alphabet(gs::characters().categories(&[])),
         );
     }
 
     #[test]
     fn anchor_at_start_after_content() {
-        check_can_generate_examples(gs::from_regex(r"\Aabc"));
+        check_can_generate_examples(gs::from_regex(r"\Aabc").fullmatch(false));
     }
 
     #[test]
     fn anchor_multiline_with_padding() {
-        check_can_generate_examples(gs::from_regex(r"(?m)^abc"));
+        check_can_generate_examples(gs::from_regex(r"(?m)^abc").fullmatch(false));
     }
 }
 


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

Refs #258.

Flips the default match mode of `gs::from_regex` from "the string contains a match" to "the entire string must match the pattern". The old behavior remains available via `.fullmatch(false)`.

- `from_regex()` now constructs `RegexGenerator` with `fullmatch: true`; the `RegexGenerator` struct doc and `.fullmatch()` builder doc are inverted to match. The hegel-c engine ABI is untouched (`hegel_string_generator_regex` keeps taking `fullmatch` explicitly).
- Tests that exercise contains-mode engine behavior (padding, `$`-trailing-newline semantics, padding-assisted lookarounds, multichar ignorecase expansions, padding with an empty alphabet) now pass `.fullmatch(false)` explicitly; tests whose behavior is identical under fullmatch stay on the default. Added `test_fullmatch_is_the_default` asserting the default now produces only full matches.
- `test_groupref_exists` had its allowed-value lists tightened to `["a", "<a>"]` / `["ab", "c"]`: the `"a\n"`-style entries were contains-mode `$`-newline artifacts that fullmatch can no longer produce, and keeping them would mask an engine bug that wrongly emitted a trailing newline.
- Scope note: the docs additions also discussed in #258 (Unicode `\d` semantics etc.) are intentionally not part of this change.

Self-review findings not acted on: the reviewer found three pre-existing regex tests (`lookahead_with_set_ranges_and_ignorecase`, `lookahead_with_nested_negative_lookaround`, `lookahead_with_dotall_dot`) whose patterns are unsatisfiable in both match modes and pass vacuously because `check_can_generate_examples` suppresses `FilterTooMuch` and doesn't require any valid draw. That predates this PR and is left for a follow-up (making `check_can_generate_examples` assert at least one valid draw would catch this class automatically).

</details>
