### PR TITLE
claude: Update RELEASE-sample.md with zerover release-type guidance

### DIFF
--- a/RELEASE-sample.md
+++ b/RELEASE-sample.md
@@ -8,7 +8,7 @@ Every pull request which modifies the source code must include a `RELEASE.md` fi
 
 Changes to the hegel-rust crate go in this root `RELEASE.md`; changes to the libhegel C ABI go in `hegel-c/RELEASE.md`, which feeds `hegel-c/CHANGELOG.md`. The two crates version independently. When a PR releases hegel-c but makes no user-facing change to hegel-rust, the root entry is auto-generated as a dependency bump and you write only the `hegel-c/RELEASE.md` — but that's a judgment call, not an automatic one. See the `changelog` skill for details.
 
-In the example above, "patch" on the first line should be replaced by "minor" if changes are visible in the public API, or "major" if there are breaking changes.  Note that only maintainers should ever make a major release.
+While we are on a `0.x` major version the semver levels are shifted: **breaking changes are "minor"** and **everything else (bug fixes, internal changes, and new non-breaking features / API additions) is "patch"**. So in the example above, "patch" on the first line should be replaced by "minor" only for a breaking change. "major" is reserved for the eventual 1.0 and beyond, and only maintainers should ever make a major release.
 
 The remaining lines are the actual changelog text for this release, which should:
 


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

Updates `RELEASE-sample.md` to reflect the zerover (`0.x.y`) release-type policy: while pre-1.0, breaking changes are a `minor` bump and everything else (bug fixes, internal changes, and new non-breaking features / API additions) is `patch`, with `major` reserved for the eventual 1.0. This replaces the stale classic-semver paragraph ("minor if visible in the public API, major if breaking"), which recently caused a breaking change to be mislabeled `RELEASE_TYPE: major`. Part of syncing this guidance across all seven Hegel library repos; the changelog skill already had correct zerover guidance and is untouched.

Docs-only change, so no `RELEASE.md` is included.

</details>
