### PR TITLE
Clean up inconsistencies in public API and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ fn test_matches_builtin(tc: TestCase) {
 This test will fail when run with `cargo test`! Hegel will produce a minimal failing test case for us:
 
 ```
-Draw 1: [0, 0]
-thread 'test_matches_builtin' (2) panicked at src/main.rs:15:5:
+---- test_matches_builtin stdout ----
+let vec1 = [0, 0];
+thread 'test_matches_builtin' (2) panicked at tests/readme.rs:16:5:
 assertion `left == right` failed
   left: [0, 0]
  right: [0]

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,7 @@ This release cleans up public-API defects found in a documentation-vs-behavior a
 
 Breaking changes:
 
-- The core string-returning date/time generators are renamed to say what they return: `gs::dates()`, `gs::times()`, and `gs::datetimes()` (which produce Python-isoformat `String`s, unlike the typed chrono/jiff generators of the same names) are now `gs::date_strings()`, `gs::time_strings()`, and `gs::datetime_strings()`, returning `DateStringGenerator`/`TimeStringGenerator`/`DateTimeStringGenerator`. The old function and type names remain as `#[deprecated]` aliases pointing at the new names and at `extras::chrono`/`extras::jiff` for typed, boundable values.
+- The core string-returning date/time generators are renamed to say what they return: `gs::dates()`, `gs::times()`, and `gs::datetimes()` (which produce Python-isoformat `String`s, unlike the typed chrono/jiff generators of the same names) are now `gs::date_strings()`, `gs::time_strings()`, and `gs::datetime_strings()`, returning `DateStringGenerator`/`TimeStringGenerator`/`DateTimeStringGenerator`. The old function and type names are removed; for typed, boundable values see `extras::chrono`/`extras::jiff`.
 - `hegel::extras::jiff::DateGenerator` and `TimeGenerator` are no longer fieldless unit structs; construct them with `dates()`/`times()`.
 - Unknown codec names passed to `text().codec(...)` or `characters().codec(...)` are rejected when the builder is called instead of on the first draw, so the error points at the mistake's call site.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,21 @@
+RELEASE_TYPE: minor
+
+This release cleans up public-API defects found in a documentation-vs-behavior audit: docs that promised APIs that didn't exist now have the APIs (or accurate docs), and doc examples are compiled as part of the test suite.
+
+Breaking changes:
+
+- The core string-returning date/time generators are renamed to say what they return: `gs::dates()`, `gs::times()`, and `gs::datetimes()` (which produce Python-isoformat `String`s, unlike the typed chrono/jiff generators of the same names) are now `gs::date_strings()`, `gs::time_strings()`, and `gs::datetime_strings()`, returning `DateStringGenerator`/`TimeStringGenerator`/`DateTimeStringGenerator`. The old function and type names remain as `#[deprecated]` aliases pointing at the new names and at `extras::chrono`/`extras::jiff` for typed, boundable values.
+- `hegel::extras::jiff::DateGenerator` and `TimeGenerator` are no longer fieldless unit structs; construct them with `dates()`/`times()`.
+- Unknown codec names passed to `text().codec(...)` or `characters().codec(...)` are rejected when the builder is called instead of on the first draw, so the error points at the mistake's call site.
+
+Bug fixes:
+
+- `#[hegel::state_machine]` methods can take `&self`, as the stateful docs always promised for invariants: `#[rule]` and `#[invariant]` methods now accept either `&self` or `&mut self` (a `&self` invariant previously failed with a type error inside macro-generated code). By-value `self` receivers get a targeted compile error.
+- `#[hegel::test]` now expands to `#[cfg_attr(test, test)]`, so the function body is type-checked even in builds without `--test`. In particular doctests: a broken example inside a `#[hegel::test]` function used to sail through `cargo test --doc` because rustc removed the `#[test]` item before checking it. All doc examples showing `#[hegel::test]` are now compiled, which caught and fixed several: the `one_of!` example's test-function signature, the chrono `naive_dates` example, the async (`#[tokio::test]`) example's signature, and the crate-root `#[derive(DefaultGenerator)]` docs, which described enum builder methods (`default_<VariantName>()` / `<VariantName>(generator)`) that never existed — the real API (snake_case variant methods, closure form for struct variants, positional generators plus `<name>_with` for tuple variants) is now documented with compiled examples.
+- The README's quickstart now shows the failure output Hegel really prints (`let vec1 = [0, 0];`, the named-draw replay form) instead of an output format from an older design.
+
+Improvements:
+
+- `hegel::extras::jiff::dates()` and `times()` gained `min_value`/`max_value` builders, matching every other generator in the module (their docs previously pointed at builder methods that didn't exist). Generated `Time`s keep whole-microsecond precision; bounds with sub-microsecond components are honoured by rounding inward, and a non-empty `Time` range containing no whole microsecond is a clean usage error. Date bounds can also widen the default years 1-9999 range down to jiff's minimum of `-9999-01-01`.
+- The `.codec(...)` docs on `text()` and `characters()` now state exactly what each supported value does in Rust terms: `"ascii"` is `.max_codepoint(0x7F)`, `"latin-1"`/`"iso-8859-1"` is `.max_codepoint(0xFF)`, and `"utf-8"` is a no-op (every Rust `char` is UTF-8-encodable).
+- `gs::uuids()`'s doc spells out that it returns hyphen-formatted `String`s.

--- a/hegel-macros/src/hegel_test.rs
+++ b/hegel-macros/src/hegel_test.rs
@@ -150,8 +150,17 @@ pub fn expand_test(attr: TokenStream, item: TokenStream) -> TokenStream {
             #func
         }
     } else {
+        // `#[cfg_attr(test, ...)]` rather than a bare `#[test]`: rustc removes
+        // `#[test]` items entirely when not compiling in test mode, so the
+        // function body would never be type-checked outside `--test` builds.
+        // Doctests are the place that matters: a broken example inside a
+        // `#[hegel::test]` function would silently pass `cargo test --doc`.
+        // Under `cfg(test)` this expands to the same `#[test]` item as
+        // before; otherwise the function is kept (and type-checked) as a
+        // plain uncalled function.
         quote! {
-            #[test]
+            #[cfg_attr(test, ::core::prelude::v1::test)]
+            #[cfg_attr(not(test), allow(dead_code))]
             #func
         }
     }

--- a/hegel-macros/src/stateful.rs
+++ b/hegel-macros/src/stateful.rs
@@ -66,8 +66,7 @@ pub fn expand_state_machine(mut block: ItemImpl) -> TokenStream {
             // would otherwise compile and silently mutate a copy.
             if has_rule || has_invariant {
                 let borrows_self = method.sig.receiver().is_some_and(|receiver| {
-                    receiver.reference.is_some()
-                        || matches!(&*receiver.ty, syn::Type::Reference(_))
+                    receiver.reference.is_some() || matches!(&*receiver.ty, syn::Type::Reference(_))
                 });
                 if !borrows_self {
                     return syn::Error::new_spanned(

--- a/hegel-macros/src/stateful.rs
+++ b/hegel-macros/src/stateful.rs
@@ -30,9 +30,19 @@ fn method_entries(methods: &[MethodInfo]) -> Vec<TokenStream> {
                 .iter()
                 .filter(|a| !a.path().is_ident("doc"))
                 .collect();
+            // Register through a non-capturing closure rather than
+            // `Self::#name` directly: `Rule.apply` is `fn(&mut M, TestCase)`,
+            // and the method-call syntax inside the closure lets methods take
+            // either `&self` or `&mut self` (an `&mut M` auto-coerces to
+            // `&M`), as the `stateful` module docs promise for invariants.
             quote! {
                 #(#attrs)*
-                ::hegel::stateful::Rule::new(#name_str, Self::#name)
+                ::hegel::stateful::Rule::new(
+                    #name_str,
+                    |__hegel_machine: &mut Self, __hegel_tc: ::hegel::TestCase| {
+                        __hegel_machine.#name(__hegel_tc)
+                    },
+                )
             }
         })
         .collect()
@@ -47,6 +57,26 @@ pub fn expand_state_machine(mut block: ItemImpl) -> TokenStream {
             let has_rule = method.attrs.iter().any(&is_rule);
             let has_invariant = method.attrs.iter().any(&is_invariant);
             method.attrs.retain(|a| !is_rule(a) && !is_invariant(a));
+
+            // Rules and invariants are applied through a `&mut M` handle, so
+            // the method must borrow `self` (`&self` or `&mut self`,
+            // including the explicit `self: &Self` / `self: &mut Self`
+            // forms). Reject by-value receivers here with a targeted error:
+            // for a `Copy` state machine, `m.rule(tc)` on a by-value receiver
+            // would otherwise compile and silently mutate a copy.
+            if has_rule || has_invariant {
+                let borrows_self = method.sig.receiver().is_some_and(|receiver| {
+                    receiver.reference.is_some()
+                        || matches!(&*receiver.ty, syn::Type::Reference(_))
+                });
+                if !borrows_self {
+                    return syn::Error::new_spanned(
+                        &method.sig,
+                        "#[rule] and #[invariant] methods must take `&self` or `&mut self`",
+                    )
+                    .to_compile_error();
+                }
+            }
 
             let info = || MethodInfo {
                 name: method.sig.ident.clone(),

--- a/src/extras/chrono/generators.rs
+++ b/src/extras/chrono/generators.rs
@@ -267,7 +267,7 @@ fn hegel_date(d: NaiveDate) -> hegel_c::hegel_date_t {
 ///     let min = NaiveDate::from_ymd_opt(2024, 1, 1).unwrap();
 ///     let max = NaiveDate::from_ymd_opt(2024, 12, 31).unwrap();
 ///     let d = tc.draw(chrono_gs::naive_dates().min_value(min).max_value(max));
-///     assert_eq!(d.iso_week().year(), 2024);
+///     assert!(d >= min && d <= max);
 /// }
 /// ```
 pub fn naive_dates() -> NaiveDateGenerator {

--- a/src/extras/jiff/generators.rs
+++ b/src/extras/jiff/generators.rs
@@ -3,19 +3,53 @@ use jiff::tz::{Offset, TimeZone};
 use jiff::{SignedDuration, Span, Timestamp, Zoned};
 
 use crate::generators::{BoxedGenerator, Generator, TestCase, integers};
-use crate::test_case::{full_ranges, invalid_argument};
+use crate::test_case::invalid_argument;
+
+/// Convert a [`Date`] to the engine's date struct. Every jiff `Date` fits:
+/// jiff spans years ±9999 and the engine accepts ±999999.
+fn hegel_date(d: Date) -> hegel_c::hegel_date_t {
+    hegel_c::hegel_date_t {
+        year: i32::from(d.year()),
+        month: d.month() as u8,
+        day: d.day() as u8,
+    }
+}
 
 /// Generator for [`jiff::civil::Date`] values. Created by [`dates()`].
-pub struct DateGenerator;
+pub struct DateGenerator {
+    min_value: Date,
+    max_value: Date,
+}
+
+impl DateGenerator {
+    /// Set the minimum date (inclusive).
+    pub fn min_value(mut self, min: Date) -> Self {
+        self.min_value = min;
+        self
+    }
+
+    /// Set the maximum date (inclusive).
+    pub fn max_value(mut self, max: Date) -> Self {
+        self.max_value = max;
+        self
+    }
+}
 
 impl Generator<Date> for DateGenerator {
     fn do_draw(&self, tc: &TestCase) -> Date {
-        let d = tc.generate_date(full_ranges::MIN_DATE, full_ranges::MAX_DATE);
+        if self.min_value > self.max_value {
+            invalid_argument!("Cannot have max_value < min_value");
+        }
+        let d = tc.generate_date(hegel_date(self.min_value), hegel_date(self.max_value));
         Date::new(d.year as i16, d.month as i8, d.day as i8).unwrap()
     }
 }
 
 /// Generate [`jiff::civil::Date`] values.
+///
+/// Defaults span years 1–9999 (`0001-01-01` through `9999-12-31`). Use the
+/// builder methods to constrain the range, or to widen it down to jiff's
+/// minimum of `-9999-01-01`.
 ///
 /// See [`DateGenerator`] for builder methods.
 ///
@@ -23,23 +57,77 @@ impl Generator<Date> for DateGenerator {
 ///
 /// ```no_run
 /// use hegel::extras::jiff as jiff_gs;
+/// use jiff::civil::Date;
 ///
 /// #[hegel::test]
 /// fn my_test(tc: hegel::TestCase) {
-///     let d = tc.draw(jiff_gs::dates());
-///     assert!(d.year() >= 1);
+///     let min = Date::constant(2024, 1, 1);
+///     let d = tc.draw(jiff_gs::dates().min_value(min));
+///     assert!(d >= min);
 /// }
 /// ```
 pub fn dates() -> DateGenerator {
-    DateGenerator
+    DateGenerator {
+        min_value: Date::constant(1, 1, 1),
+        max_value: Date::constant(9999, 12, 31),
+    }
+}
+
+/// Total nanoseconds from midnight for a [`Time`].
+fn time_total_nanos(t: Time) -> i64 {
+    (i64::from(t.hour()) * 3_600 + i64::from(t.minute()) * 60 + i64::from(t.second()))
+        * 1_000_000_000
+        + i64::from(t.subsec_nanosecond())
+}
+
+/// Convert whole microseconds from midnight to the engine's time struct.
+fn hegel_time(total_micros: i64) -> hegel_c::hegel_time_t {
+    hegel_c::hegel_time_t {
+        hour: (total_micros / 3_600_000_000) as u8,
+        minute: (total_micros / 60_000_000 % 60) as u8,
+        second: (total_micros / 1_000_000 % 60) as u8,
+        microsecond: (total_micros % 1_000_000) as u32,
+    }
 }
 
 /// Generator for [`jiff::civil::Time`] values. Created by [`times()`].
-pub struct TimeGenerator;
+pub struct TimeGenerator {
+    min_value: Time,
+    max_value: Time,
+}
+
+impl TimeGenerator {
+    /// Set the minimum time (inclusive).
+    pub fn min_value(mut self, min: Time) -> Self {
+        self.min_value = min;
+        self
+    }
+
+    /// Set the maximum time (inclusive).
+    pub fn max_value(mut self, max: Time) -> Self {
+        self.max_value = max;
+        self
+    }
+}
 
 impl Generator<Time> for TimeGenerator {
     fn do_draw(&self, tc: &TestCase) -> Time {
-        let t = tc.generate_time(full_ranges::MIDNIGHT, full_ranges::LAST_MICROSECOND);
+        if self.min_value > self.max_value {
+            invalid_argument!("Cannot have max_value < min_value");
+        }
+        // Generated times are whole microseconds, so round the bounds
+        // inward: min up, max down (totals are non-negative). That can empty
+        // an in-order range whose bounds sit between two consecutive
+        // microseconds.
+        let min_micros = (time_total_nanos(self.min_value) + 999) / 1_000;
+        let max_micros = time_total_nanos(self.max_value) / 1_000;
+        if min_micros > max_micros {
+            invalid_argument!(
+                "times() generates whole-microsecond values, and no whole microsecond \
+                 lies between min_value and max_value"
+            );
+        }
+        let t = tc.generate_time(hegel_time(min_micros), hegel_time(max_micros));
         Time::new(
             t.hour as i8,
             t.minute as i8,
@@ -52,21 +140,31 @@ impl Generator<Time> for TimeGenerator {
 
 /// Generate [`jiff::civil::Time`] values.
 ///
+/// Generated times have whole-microsecond precision (`subsec_nanosecond()`
+/// is always a multiple of 1000). Bounds may carry sub-microsecond
+/// components; they are honoured by rounding inward to the enclosed
+/// microsecond range.
+///
 /// See [`TimeGenerator`] for builder methods.
 ///
 /// # Example
 ///
 /// ```no_run
 /// use hegel::extras::jiff as jiff_gs;
+/// use jiff::civil::Time;
 ///
 /// #[hegel::test]
 /// fn my_test(tc: hegel::TestCase) {
-///     let t = tc.draw(jiff_gs::times());
-///     assert!(t.hour() >= 0 && t.hour() <= 23);
+///     let max = Time::constant(12, 0, 0, 0);
+///     let t = tc.draw(jiff_gs::times().max_value(max));
+///     assert!(t <= max);
 /// }
 /// ```
 pub fn times() -> TimeGenerator {
-    TimeGenerator
+    TimeGenerator {
+        min_value: Time::MIN,
+        max_value: Time::MAX,
+    }
 }
 
 /// Convert a [`DateTime`] to nanoseconds since the Unix epoch, treating it

--- a/src/generators/collections.rs
+++ b/src/generators/collections.rs
@@ -357,11 +357,14 @@ where
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```no_run
 /// use hegel::generators as gs;
 /// use std::collections::HashMap;
 ///
-/// let map: HashMap<i32, String> = tc.draw(gs::hashmaps(gs::integers(), gs::text()));
+/// #[hegel::test]
+/// fn my_test(tc: hegel::TestCase) {
+///     let map: HashMap<i32, String> = tc.draw(gs::hashmaps(gs::integers(), gs::text()));
+/// }
 /// ```
 pub fn hashmaps<KT, VT, K: Generator<KT>, V: Generator<VT>>(
     keys: K,

--- a/src/generators/combinators.rs
+++ b/src/generators/combinators.rs
@@ -95,7 +95,7 @@ where
 /// use hegel::generators as gs;
 ///
 /// #[hegel::test]
-/// fn my_test(tc: &hegel::TestCase) {
+/// fn my_test(tc: hegel::TestCase) {
 ///     let value: i32 = tc.draw(hegel::one_of!(
 ///         gs::integers::<i32>().min_value(0).max_value(10),
 ///         gs::integers::<i32>().min_value(100).max_value(110),

--- a/src/generators/mod.rs
+++ b/src/generators/mod.rs
@@ -46,11 +46,6 @@ pub use strings::{
     UuidsGenerator, binary, characters, date_strings, datetime_strings, domains, emails,
     from_regex, ip_addresses, text, time_strings, urls, uuids,
 };
-// Deprecated aliases for the *_strings generators; re-exported separately so
-// the deprecation attributes are the only thing `#[allow(deprecated)]` here
-// silences.
-#[allow(deprecated)]
-pub use strings::{DateGenerator, DateTimeGenerator, TimeGenerator, dates, datetimes, times};
 pub use time::{DurationGenerator, durations};
 #[doc(hidden)]
 pub use tuples::{

--- a/src/generators/mod.rs
+++ b/src/generators/mod.rs
@@ -40,11 +40,17 @@ pub use generators::{BoxedGenerator, Filtered, FlatMapped, Generator, Mapped};
 pub use misc::{BoolGenerator, JustGenerator, booleans, just, unit};
 pub use numeric::{Float, FloatGenerator, Integer, IntegerGenerator, floats, integers};
 pub use strings::{
-    BinaryGenerator, CharactersGenerator, DateGenerator, DateTimeGenerator, DomainGenerator,
-    EmailGenerator, IpAddressGenerator, Ipv4AddressGenerator, Ipv6AddressGenerator, RegexGenerator,
-    TextGenerator, TimeGenerator, UrlGenerator, UuidsGenerator, binary, characters, dates,
-    datetimes, domains, emails, from_regex, ip_addresses, text, times, urls, uuids,
+    BinaryGenerator, CharactersGenerator, DateStringGenerator, DateTimeStringGenerator,
+    DomainGenerator, EmailGenerator, IpAddressGenerator, Ipv4AddressGenerator,
+    Ipv6AddressGenerator, RegexGenerator, TextGenerator, TimeStringGenerator, UrlGenerator,
+    UuidsGenerator, binary, characters, date_strings, datetime_strings, domains, emails,
+    from_regex, ip_addresses, text, time_strings, urls, uuids,
 };
+// Deprecated aliases for the *_strings generators; re-exported separately so
+// the deprecation attributes are the only thing `#[allow(deprecated)]` here
+// silences.
+#[allow(deprecated)]
+pub use strings::{DateGenerator, DateTimeGenerator, TimeGenerator, dates, datetimes, times};
 pub use time::{DurationGenerator, durations};
 #[doc(hidden)]
 pub use tuples::{

--- a/src/generators/strings.rs
+++ b/src/generators/strings.rs
@@ -12,6 +12,19 @@ const SURROGATE_CATEGORIES: &[&str] = &["Cs", "C"];
 /// Default upper bound for string/byte sizes when the caller doesn't set one.
 const DEFAULT_MAX_SIZE: usize = 100;
 
+/// Codec names accepted by [`TextGenerator::codec`] and
+/// [`CharactersGenerator::codec`], mirroring the engine's supported set.
+const SUPPORTED_CODECS: &[&str] = &["ascii", "latin-1", "iso-8859-1", "utf-8"];
+
+/// Validate a codec name eagerly. The engine rejects unknown codecs too, but
+/// only when the alphabet is built on first draw; checking here surfaces the
+/// mistake at the `.codec(...)` call site instead.
+fn check_codec(codec: &str) {
+    if !SUPPORTED_CODECS.contains(&codec) {
+        invalid_argument!("invalid codec: {codec}");
+    }
+}
+
 /// Shared character filtering fields used by both [`TextGenerator`] and
 /// [`CharactersGenerator`].
 struct CharacterFields {
@@ -120,8 +133,24 @@ impl TextGenerator {
         self
     }
 
-    /// Restrict to characters encodable in this codec (e.g. `"ascii"`, `"utf-8"`, `"latin-1"`).
+    /// Restrict to characters encodable in the named codec.
+    ///
+    /// Supported values, and what each means for Rust strings:
+    ///
+    /// - `"ascii"` — codepoints `U+0000..=U+007F`; equivalent to
+    ///   `.max_codepoint(0x7F)`.
+    /// - `"latin-1"` (alias `"iso-8859-1"`) — codepoints `U+0000..=U+00FF`;
+    ///   equivalent to `.max_codepoint(0xFF)`.
+    /// - `"utf-8"` — no restriction: every Rust `char` is UTF-8-encodable
+    ///   (surrogates are structurally excluded from `char`), so this is a
+    ///   no-op.
+    ///
+    /// The codec's codepoint range intersects with any bounds set via
+    /// [`min_codepoint`](Self::min_codepoint) /
+    /// [`max_codepoint`](Self::max_codepoint). Any other codec name is a
+    /// usage error, reported when `.codec(...)` is called.
     pub fn codec(mut self, codec: &str) -> Self {
+        check_codec(codec);
         self.handle = OnceLock::new();
         self.char_param_called = true;
         self.char_fields.codec = Some(codec.to_string());
@@ -231,8 +260,24 @@ pub struct CharactersGenerator {
 }
 
 impl CharactersGenerator {
-    /// Restrict to characters encodable in this codec (e.g. `"ascii"`, `"utf-8"`, `"latin-1"`).
+    /// Restrict to characters encodable in the named codec.
+    ///
+    /// Supported values, and what each means for Rust `char`s:
+    ///
+    /// - `"ascii"` — codepoints `U+0000..=U+007F`; equivalent to
+    ///   `.max_codepoint(0x7F)`.
+    /// - `"latin-1"` (alias `"iso-8859-1"`) — codepoints `U+0000..=U+00FF`;
+    ///   equivalent to `.max_codepoint(0xFF)`.
+    /// - `"utf-8"` — no restriction: every Rust `char` is UTF-8-encodable
+    ///   (surrogates are structurally excluded from `char`), so this is a
+    ///   no-op.
+    ///
+    /// The codec's codepoint range intersects with any bounds set via
+    /// [`min_codepoint`](Self::min_codepoint) /
+    /// [`max_codepoint`](Self::max_codepoint). Any other codec name is a
+    /// usage error, reported when `.codec(...)` is called.
     pub fn codec(mut self, codec: &str) -> Self {
+        check_codec(codec);
         self.handle = OnceLock::new();
         self.char_fields.codec = Some(codec.to_string());
         self

--- a/src/generators/strings.rs
+++ b/src/generators/strings.rs
@@ -580,47 +580,120 @@ pub(crate) fn format_time(t: hegel_c::hegel_time_t) -> String {
     }
 }
 
-/// Generator for date strings in YYYY-MM-DD format. Created by [`dates()`].
-pub struct DateGenerator;
+/// Generator for date strings in `YYYY-MM-DD` format. Created by
+/// [`date_strings()`].
+pub struct DateStringGenerator;
 
-impl Generator<String> for DateGenerator {
+impl Generator<String> for DateStringGenerator {
     fn do_draw(&self, tc: &TestCase) -> String {
         format_date(tc.generate_date(full_ranges::MIN_DATE, full_ranges::MAX_DATE))
     }
 }
 
-/// Generate date strings in YYYY-MM-DD format.
-pub fn dates() -> DateGenerator {
-    DateGenerator
+/// Generate date `String`s in `YYYY-MM-DD` format (years 1–9999), matching
+/// Python's `date.isoformat()`.
+///
+/// This generator is not configurable. For typed date values with
+/// configurable bounds, see [`extras::chrono`](crate::extras::chrono)
+/// (`naive_dates()`) or [`extras::jiff`](crate::extras::jiff) (`dates()`).
+pub fn date_strings() -> DateStringGenerator {
+    DateStringGenerator
 }
 
-/// Generator for time strings in HH:MM:SS format. Created by [`times()`].
-pub struct TimeGenerator;
+/// Deprecated alias for [`DateStringGenerator`].
+#[deprecated(
+    since = "0.26.0",
+    note = "renamed to `DateStringGenerator` (it generates `String`s); \
+            for typed dates see `hegel::extras::chrono` or `hegel::extras::jiff`"
+)]
+pub type DateGenerator = DateStringGenerator;
 
-impl Generator<String> for TimeGenerator {
+/// Deprecated alias for [`date_strings()`].
+#[deprecated(
+    since = "0.26.0",
+    note = "renamed to `date_strings()` (it generates `String`s); \
+            for typed dates see `hegel::extras::chrono` or `hegel::extras::jiff`"
+)]
+pub fn dates() -> DateStringGenerator {
+    date_strings()
+}
+
+/// Generator for time strings in `HH:MM:SS[.ffffff]` format. Created by
+/// [`time_strings()`].
+pub struct TimeStringGenerator;
+
+impl Generator<String> for TimeStringGenerator {
     fn do_draw(&self, tc: &TestCase) -> String {
         format_time(tc.generate_time(full_ranges::MIDNIGHT, full_ranges::LAST_MICROSECOND))
     }
 }
 
-/// Generate time strings in HH:MM:SS format.
-pub fn times() -> TimeGenerator {
-    TimeGenerator
+/// Generate time `String`s in `HH:MM:SS` format, matching Python's
+/// `time.isoformat()`: a fractional `.ffffff` part (microseconds) is
+/// appended iff it is non-zero.
+///
+/// This generator is not configurable. For typed time values with
+/// configurable bounds, see [`extras::chrono`](crate::extras::chrono)
+/// (`naive_times()`) or [`extras::jiff`](crate::extras::jiff) (`times()`).
+pub fn time_strings() -> TimeStringGenerator {
+    TimeStringGenerator
 }
 
-/// Generator for ISO 8601 datetime strings. Created by [`datetimes()`].
-pub struct DateTimeGenerator;
+/// Deprecated alias for [`TimeStringGenerator`].
+#[deprecated(
+    since = "0.26.0",
+    note = "renamed to `TimeStringGenerator` (it generates `String`s); \
+            for typed times see `hegel::extras::chrono` or `hegel::extras::jiff`"
+)]
+pub type TimeGenerator = TimeStringGenerator;
 
-impl Generator<String> for DateTimeGenerator {
+/// Deprecated alias for [`time_strings()`].
+#[deprecated(
+    since = "0.26.0",
+    note = "renamed to `time_strings()` (it generates `String`s); \
+            for typed times see `hegel::extras::chrono` or `hegel::extras::jiff`"
+)]
+pub fn times() -> TimeStringGenerator {
+    time_strings()
+}
+
+/// Generator for ISO 8601 datetime strings. Created by [`datetime_strings()`].
+pub struct DateTimeStringGenerator;
+
+impl Generator<String> for DateTimeStringGenerator {
     fn do_draw(&self, tc: &TestCase) -> String {
         let dt = tc.generate_datetime(full_ranges::MIN_DATETIME, full_ranges::MAX_DATETIME);
         format!("{}T{}", format_date(dt.date), format_time(dt.time))
     }
 }
 
-/// Generate ISO 8601 datetime strings.
-pub fn datetimes() -> DateTimeGenerator {
-    DateTimeGenerator
+/// Generate ISO 8601 datetime `String`s (`YYYY-MM-DDTHH:MM:SS[.ffffff]`,
+/// years 1–9999), matching Python's `datetime.isoformat()`.
+///
+/// This generator is not configurable. For typed datetime values with
+/// configurable bounds, see [`extras::chrono`](crate::extras::chrono)
+/// (`naive_datetimes()` / `datetimes()`) or
+/// [`extras::jiff`](crate::extras::jiff) (`datetimes()`).
+pub fn datetime_strings() -> DateTimeStringGenerator {
+    DateTimeStringGenerator
+}
+
+/// Deprecated alias for [`DateTimeStringGenerator`].
+#[deprecated(
+    since = "0.26.0",
+    note = "renamed to `DateTimeStringGenerator` (it generates `String`s); for typed \
+            datetimes see `hegel::extras::chrono` or `hegel::extras::jiff`"
+)]
+pub type DateTimeGenerator = DateTimeStringGenerator;
+
+/// Deprecated alias for [`datetime_strings()`].
+#[deprecated(
+    since = "0.26.0",
+    note = "renamed to `datetime_strings()` (it generates `String`s); for typed \
+            datetimes see `hegel::extras::chrono` or `hegel::extras::jiff`"
+)]
+pub fn datetimes() -> DateTimeStringGenerator {
+    datetime_strings()
 }
 
 /// Generator for UUID strings in canonical hyphenated form. Created by [`uuids()`].
@@ -669,7 +742,8 @@ impl Generator<String> for UuidsGenerator {
     }
 }
 
-/// Generate UUID strings in canonical hyphenated form.
+/// Generate UUID `String`s in canonical hyphenated form, e.g.
+/// `"a70f446c-05e3-42a9-a31b-f0d0545d6316"`.
 ///
 /// See [`UuidsGenerator`] for builder methods.
 pub fn uuids() -> UuidsGenerator {

--- a/src/generators/strings.rs
+++ b/src/generators/strings.rs
@@ -645,24 +645,6 @@ pub fn date_strings() -> DateStringGenerator {
     DateStringGenerator
 }
 
-/// Deprecated alias for [`DateStringGenerator`].
-#[deprecated(
-    since = "0.26.0",
-    note = "renamed to `DateStringGenerator` (it generates `String`s); \
-            for typed dates see `hegel::extras::chrono` or `hegel::extras::jiff`"
-)]
-pub type DateGenerator = DateStringGenerator;
-
-/// Deprecated alias for [`date_strings()`].
-#[deprecated(
-    since = "0.26.0",
-    note = "renamed to `date_strings()` (it generates `String`s); \
-            for typed dates see `hegel::extras::chrono` or `hegel::extras::jiff`"
-)]
-pub fn dates() -> DateStringGenerator {
-    date_strings()
-}
-
 /// Generator for time strings in `HH:MM:SS[.ffffff]` format. Created by
 /// [`time_strings()`].
 pub struct TimeStringGenerator;
@@ -684,24 +666,6 @@ pub fn time_strings() -> TimeStringGenerator {
     TimeStringGenerator
 }
 
-/// Deprecated alias for [`TimeStringGenerator`].
-#[deprecated(
-    since = "0.26.0",
-    note = "renamed to `TimeStringGenerator` (it generates `String`s); \
-            for typed times see `hegel::extras::chrono` or `hegel::extras::jiff`"
-)]
-pub type TimeGenerator = TimeStringGenerator;
-
-/// Deprecated alias for [`time_strings()`].
-#[deprecated(
-    since = "0.26.0",
-    note = "renamed to `time_strings()` (it generates `String`s); \
-            for typed times see `hegel::extras::chrono` or `hegel::extras::jiff`"
-)]
-pub fn times() -> TimeStringGenerator {
-    time_strings()
-}
-
 /// Generator for ISO 8601 datetime strings. Created by [`datetime_strings()`].
 pub struct DateTimeStringGenerator;
 
@@ -721,24 +685,6 @@ impl Generator<String> for DateTimeStringGenerator {
 /// [`extras::jiff`](crate::extras::jiff) (`datetimes()`).
 pub fn datetime_strings() -> DateTimeStringGenerator {
     DateTimeStringGenerator
-}
-
-/// Deprecated alias for [`DateTimeStringGenerator`].
-#[deprecated(
-    since = "0.26.0",
-    note = "renamed to `DateTimeStringGenerator` (it generates `String`s); for typed \
-            datetimes see `hegel::extras::chrono` or `hegel::extras::jiff`"
-)]
-pub type DateTimeGenerator = DateTimeStringGenerator;
-
-/// Deprecated alias for [`datetime_strings()`].
-#[deprecated(
-    since = "0.26.0",
-    note = "renamed to `datetime_strings()` (it generates `String`s); for typed \
-            datetimes see `hegel::extras::chrono` or `hegel::extras::jiff`"
-)]
-pub fn datetimes() -> DateTimeStringGenerator {
-    datetime_strings()
 }
 
 /// Generator for UUID strings in canonical hyphenated form. Created by [`uuids()`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,17 +255,26 @@ pub use hegel_c::__bench;
 /// For structs, the generated generator has:
 /// - `<field>(generator)` - builder method to customize each field's generator
 ///
-/// For enums, the generated generator has:
-/// - `default_<VariantName>()` - methods returning default variant generators
-/// - `<VariantName>(generator)` - builder methods to customize variant generation
+/// For enums, the generated generator draws one of the variants at random.
+/// Unit variants need no configuration; every data-carrying variant gets
+/// builder methods named after the variant (snake_cased):
+/// - for a struct variant like `Active { since: String }`, a method
+///   `.active(|g| ...)` whose closure receives that variant's generator
+///   (with a `<field>(generator)` builder per field, like a struct) and
+///   returns the generator to use for the variant;
+/// - for a tuple variant like `Error(i32, String)`, a method
+///   `.error(g0, g1)` taking one generator per field positionally, plus a
+///   closure form `.error_with(|g| ...)` mirroring the struct-variant
+///   method, where the variant generator's fields are configured with
+///   `._0(...)`, `._1(...)`, etc.
 ///
 /// # Struct Example
 ///
-/// ```ignore
+/// ```no_run
 /// use hegel::DefaultGenerator;
-/// use hegel::generators::{self as gs, DefaultGenerator as _, Generator as _};
+/// use hegel::generators as gs;
 ///
-/// #[derive(DefaultGenerator)]
+/// #[derive(Debug, DefaultGenerator)]
 /// struct Person {
 ///     name: String,
 ///     age: u32,
@@ -281,21 +290,27 @@ pub use hegel_c::__bench;
 ///
 /// # Enum Example
 ///
-/// ```ignore
+/// ```no_run
 /// use hegel::DefaultGenerator;
-/// use hegel::generators::{self as gs, DefaultGenerator as _, Generator as _};
+/// use hegel::generators as gs;
 ///
-/// #[derive(DefaultGenerator)]
+/// #[derive(Debug, DefaultGenerator)]
 /// enum Status {
 ///     Pending,
 ///     Active { since: String },
-///     Error { code: i32, message: String },
+///     Error(i32, String),
 /// }
 ///
 /// #[hegel::test]
 /// fn generates_statuses(tc: hegel::TestCase) {
 ///     let generator = gs::default::<Status>()
-///         .active(|g| g.since(gs::text().max_size(20)));
+///         // Struct variant: configure through a closure over the
+///         // variant's own generator.
+///         .active(|g| g.since(gs::text().max_size(20)))
+///         // Tuple variant: pass one generator per field...
+///         .error(gs::integers::<i32>().min_value(400).max_value(599), gs::text())
+///         // ...or use the closure form with positional field builders.
+///         .error_with(|g| g._0(gs::just(500)));
 ///     let status: Status = tc.draw(generator);
 /// }
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,7 +308,7 @@ pub use hegel_macros::DefaultGenerator;
 /// of the returned factory function. The function must have an explicit
 /// return type.
 ///
-/// ```ignore
+/// ```no_run
 /// use hegel::generators as gs;
 ///
 /// #[hegel::composite]
@@ -342,7 +342,7 @@ pub use hegel_macros::explicit_test_case;
 /// Paste that attribute **below** `#[hegel::test]` and the next run will
 /// decode the blob's choice sequence and run *only* that example.
 ///
-/// ```ignore
+/// ```no_run
 /// #[hegel::test]
 /// #[hegel::reproduce_failure("AAEC…")]
 /// fn my_test(tc: hegel::TestCase) {
@@ -354,7 +354,7 @@ pub use hegel_macros::explicit_test_case;
 /// The argument is any expression that resolves to a base64 blob — a string
 /// literal, or a `const`/`static`/variable holding one:
 ///
-/// ```ignore
+/// ```no_run
 /// const REGRESSION: &str = "AAEC…";
 ///
 /// #[hegel::test]
@@ -366,7 +366,7 @@ pub use hegel_macros::explicit_test_case;
 /// the **first** one replays — the rest are bookkeeping. Delete them one by
 /// one as the failures are fixed:
 ///
-/// ```ignore
+/// ```no_run
 /// #[hegel::test]
 /// #[hegel::reproduce_failure("AAEC…")] // replayed
 /// #[hegel::reproduce_failure("AAED…")] // kept for later
@@ -395,7 +395,10 @@ pub use hegel_macros::state_machine;
 ///
 /// The `#[test]` attribute is added automatically and must not be present on the function.
 ///
-/// ```ignore
+/// ```no_run
+/// use hegel::TestCase;
+/// use hegel::generators::integers;
+///
 /// #[hegel::test]
 /// fn my_test(tc: TestCase) {
 ///     let x: i32 = tc.draw(integers());
@@ -405,7 +408,10 @@ pub use hegel_macros::state_machine;
 ///
 /// You can set settings using attributes on [`test`], corresponding to methods on [`Settings`]:
 ///
-/// ```ignore
+/// ```no_run
+/// use hegel::TestCase;
+/// use hegel::generators::integers;
+///
 /// #[hegel::test(test_cases = 500)]
 /// fn test_runs_many_more_times(tc: TestCase) {
 ///     let x: i32 = tc.draw(integers());
@@ -415,11 +421,13 @@ pub use hegel_macros::state_machine;
 ///
 /// You can use other test attribute macros, like `tokio::test`, by putting them *before* `hegel::test`:
 ///
-/// ```ignore
+/// ```no_run
 /// #[tokio::test]
 /// #[hegel::test]
-/// async fn my_async_test() {
-///     // ...
+/// async fn my_async_test(tc: hegel::TestCase) {
+///     let x: bool = tc.draw(hegel::generators::booleans());
+///     let handle = tokio::spawn(async move { x });
+///     assert_eq!(handle.await.unwrap(), x);
 /// }
 /// ```
 pub use hegel_macros::test;
@@ -436,7 +444,7 @@ pub use hegel_macros::test;
 /// `--test-cases`, `--seed`, `--verbosity`, `--derandomize`, `--database`,
 /// `--suppress-health-check`, `-h` / `--help`.
 ///
-/// ```ignore
+/// ```no_run
 /// use hegel::TestCase;
 /// use hegel::generators as gs;
 ///
@@ -456,7 +464,7 @@ pub use hegel_macros::main;
 /// with the `TestCase` parameter removed, and its body is run as an
 /// [`FnMut`] closure inside [`Hegel::run`].
 ///
-/// ```ignore
+/// ```no_run
 /// use hegel::TestCase;
 /// use hegel::generators as gs;
 ///

--- a/src/stateful.rs
+++ b/src/stateful.rs
@@ -3,8 +3,9 @@
 //! State machines are defined using the [`state_machine`](crate::state_machine) attribute macro.
 //! Methods annotated with `#[rule]` become rules (actions applied to the state machine) and
 //! methods annotated with `#[invariant]` become invariants (checked after each successful rule
-//! application). Rules must have signature `fn(&mut self, tc: TestCase)` and invariants must have
-//! signature `fn(&self, tc: TestCase)`.
+//! application). Both take a [`TestCase`] parameter and borrow the state machine: rules
+//! typically have signature `fn(&mut self, tc: TestCase)` and invariants
+//! `fn(&self, tc: TestCase)`, but either kind of method may use `&self` or `&mut self`.
 //!
 //! To run a state machine, call [`run()`] inside a Hegel test.
 //!
@@ -50,6 +51,11 @@
 //!         let element = element.unwrap();
 //!         self.stack.push(element);
 //!         assert_eq!(self.stack, initial);
+//!     }
+//!
+//!     #[invariant]
+//!     fn len_agrees_with_is_empty(&self, _: TestCase) {
+//!         assert_eq!(self.stack.is_empty(), self.stack.len() == 0);
 //!     }
 //! }
 //!

--- a/tests/jiff/civil.rs
+++ b/tests/jiff/civil.rs
@@ -21,6 +21,37 @@ fn test_jiff_dates_in_vec() {
 }
 
 #[test]
+fn test_jiff_dates_min_value() {
+    let min = Date::constant(2024, 6, 1);
+    assert_all_examples(jiff_gs::dates().min_value(min), move |d| *d >= min);
+}
+
+#[test]
+fn test_jiff_dates_max_value() {
+    let max = Date::constant(2024, 6, 30);
+    assert_all_examples(jiff_gs::dates().max_value(max), move |d| *d <= max);
+}
+
+#[test]
+fn test_jiff_dates_bounds_can_extend_below_year_one() {
+    let min = Date::constant(-9999, 1, 1);
+    let max = Date::constant(-1, 12, 31);
+    assert_all_examples(jiff_gs::dates().min_value(min).max_value(max), move |d| {
+        *d >= min && *d <= max
+    });
+}
+
+#[hegel::test]
+#[should_panic(expected = "max_value < min_value")]
+fn test_jiff_dates_min_greater_than_max(tc: hegel::TestCase) {
+    tc.draw(
+        jiff_gs::dates()
+            .min_value(Date::constant(2025, 1, 1))
+            .max_value(Date::constant(2024, 1, 1)),
+    );
+}
+
+#[test]
 fn test_jiff_date_default_generator() {
     check_can_generate_examples(gs::default::<Date>());
 }
@@ -44,6 +75,52 @@ fn test_jiff_times_in_vec() {
     assert_all_examples(gs::vecs(jiff_gs::times()).max_size(5), |v| {
         v.iter().all(|t| (0..=23).contains(&t.hour()))
     });
+}
+
+#[test]
+fn test_jiff_times_min_value() {
+    let min = Time::constant(12, 30, 0, 0);
+    assert_all_examples(jiff_gs::times().min_value(min), move |t| *t >= min);
+}
+
+#[test]
+fn test_jiff_times_max_value() {
+    let max = Time::constant(6, 0, 0, 0);
+    assert_all_examples(jiff_gs::times().max_value(max), move |t| *t <= max);
+}
+
+/// Generated times are whole microseconds, so a min bound with a
+/// sub-microsecond component must round *up* to the next microsecond, not
+/// down past the bound.
+#[test]
+fn test_jiff_times_sub_microsecond_min_bound_rounds_up() {
+    let min = Time::constant(1, 2, 3, 500);
+    let max = Time::constant(1, 2, 3, 10_000);
+    assert_all_examples(jiff_gs::times().min_value(min).max_value(max), move |t| {
+        *t >= min && *t <= max && t.subsec_nanosecond() % 1_000 == 0
+    });
+}
+
+#[hegel::test]
+#[should_panic(expected = "max_value < min_value")]
+fn test_jiff_times_min_greater_than_max(tc: hegel::TestCase) {
+    tc.draw(
+        jiff_gs::times()
+            .min_value(Time::constant(13, 0, 0, 0))
+            .max_value(Time::constant(12, 0, 0, 0)),
+    );
+}
+
+/// `min_value < max_value`, but no whole microsecond lies between them:
+/// a clean usage error rather than an out-of-bounds value.
+#[hegel::test]
+#[should_panic(expected = "whole microsecond")]
+fn test_jiff_times_empty_microsecond_range_is_a_usage_error(tc: hegel::TestCase) {
+    tc.draw(
+        jiff_gs::times()
+            .min_value(Time::constant(12, 0, 0, 100))
+            .max_value(Time::constant(12, 0, 0, 900)),
+    );
 }
 
 #[test]

--- a/tests/test_stateful.rs
+++ b/tests/test_stateful.rs
@@ -153,6 +153,48 @@ fn test_draw_domain(tc: TestCase) {
     hegel::stateful::run(m, tc);
 }
 
+/// Regression test: the module docs promise invariants can take `&self`,
+/// but the macro used to register methods as bare `fn(&mut M, TestCase)`
+/// pointers, so a `&self` invariant failed to compile inside generated code.
+/// Both `&self` and `&mut self` receivers must work, for rules and
+/// invariants alike.
+struct SharedReceiverMachine {
+    counter: u32,
+    observed: u32,
+}
+
+#[hegel::state_machine]
+impl SharedReceiverMachine {
+    #[rule]
+    fn bump(&mut self, _tc: TestCase) {
+        self.counter += 1;
+    }
+
+    #[rule]
+    fn observe(&self, _tc: TestCase) {
+        assert!(self.observed <= self.counter);
+    }
+
+    #[invariant]
+    fn counter_covers_observed(&self, _tc: TestCase) {
+        assert!(self.observed <= self.counter);
+    }
+
+    #[invariant]
+    fn record(&mut self, _tc: TestCase) {
+        self.observed = self.counter;
+    }
+}
+
+#[hegel::test]
+fn test_state_machine_with_shared_receivers(tc: TestCase) {
+    let m = SharedReceiverMachine {
+        counter: 0,
+        observed: 0,
+    };
+    hegel::stateful::run(m, tc);
+}
+
 mod stateful {
     use super::common::utils::expect_panic;
     use hegel::TestCase;

--- a/tests/test_strings.rs
+++ b/tests/test_strings.rs
@@ -130,9 +130,19 @@ fn test_regex_with_alphabet() {
     );
 }
 
+/// The pre-rename names remain available as deprecated aliases and generate
+/// the same shape of string as the `*_strings` generators.
+#[test]
+#[allow(deprecated)]
+fn test_deprecated_date_time_string_aliases_still_generate() {
+    assert_all_examples(gs::dates(), |s: &String| s.split('-').count() == 3);
+    assert_all_examples(gs::times(), |s: &String| s.splitn(3, ':').count() == 3);
+    assert_all_examples(gs::datetimes(), |s: &String| s.contains('T'));
+}
+
 #[test]
 fn test_dates_format() {
-    assert_all_examples(gs::dates(), |s: &String| {
+    assert_all_examples(gs::date_strings(), |s: &String| {
         let parts: Vec<&str> = s.split('-').collect();
         if parts.len() != 3 || parts[0].len() != 4 {
             return false;
@@ -147,7 +157,7 @@ fn test_dates_format() {
 
 #[test]
 fn test_times_format() {
-    assert_all_examples(gs::times(), |s: &String| {
+    assert_all_examples(gs::time_strings(), |s: &String| {
         let parts: Vec<&str> = s.splitn(3, ':').collect();
         if parts.len() != 3 {
             return false;
@@ -166,7 +176,7 @@ fn test_times_format() {
 
 #[test]
 fn test_datetimes_format() {
-    assert_all_examples(gs::datetimes(), |s: &String| {
+    assert_all_examples(gs::datetime_strings(), |s: &String| {
         let parts: Vec<&str> = s.splitn(2, 'T').collect();
         if parts.len() != 2 {
             return false;

--- a/tests/test_strings.rs
+++ b/tests/test_strings.rs
@@ -130,16 +130,6 @@ fn test_regex_with_alphabet() {
     );
 }
 
-/// The pre-rename names remain available as deprecated aliases and generate
-/// the same shape of string as the `*_strings` generators.
-#[test]
-#[allow(deprecated)]
-fn test_deprecated_date_time_string_aliases_still_generate() {
-    assert_all_examples(gs::dates(), |s: &String| s.split('-').count() == 3);
-    assert_all_examples(gs::times(), |s: &String| s.splitn(3, ':').count() == 3);
-    assert_all_examples(gs::datetimes(), |s: &String| s.contains('T'));
-}
-
 #[test]
 fn test_dates_format() {
     assert_all_examples(gs::date_strings(), |s: &String| {

--- a/tests/test_time.rs
+++ b/tests/test_time.rs
@@ -72,7 +72,7 @@ mod datetimes {
 
     #[test]
     fn test_simplifies_towards_millenium() {
-        let d = minimal(gs::datetimes(), |_: &String| true);
+        let d = minimal(gs::datetime_strings(), |_: &String| true);
         let (year, month, day, hour, minute, second, microsecond) = datetime_parts(&d);
         assert_eq!(year, 2000);
         assert_eq!(month, 1);
@@ -85,38 +85,38 @@ mod datetimes {
 
     #[test]
     fn test_default_datetimes_are_naive() {
-        assert_all_examples(gs::datetimes(), |s: &String| {
+        assert_all_examples(gs::datetime_strings(), |s: &String| {
             !s.contains('+') && !s.contains('Z')
         });
     }
 
     #[test]
     fn test_allow_imaginary_is_not_an_error_for_naive_datetimes() {
-        assert_all_examples(gs::datetimes(), |_: &String| true);
+        assert_all_examples(gs::datetime_strings(), |_: &String| true);
     }
 
     #[test]
     fn test_can_find_after_the_year_2000() {
-        let d = minimal(gs::dates(), |s: &String| date_year(s) > 2000);
+        let d = minimal(gs::date_strings(), |s: &String| date_year(s) > 2000);
         assert_eq!(date_year(&d), 2001);
     }
 
     #[test]
     fn test_can_find_before_the_year_2000() {
-        let d = minimal(gs::dates(), |s: &String| date_year(s) < 2000);
+        let d = minimal(gs::date_strings(), |s: &String| date_year(s) < 2000);
         assert_eq!(date_year(&d), 1999);
     }
 
     #[test]
     fn test_can_find_each_month() {
         for month in 1u32..=12 {
-            find_any(gs::dates(), move |s: &String| date_month(s) == month);
+            find_any(gs::date_strings(), move |s: &String| date_month(s) == month);
         }
     }
 
     #[test]
     fn test_can_find_midnight() {
-        find_any(gs::times(), |s: &String| {
+        find_any(gs::time_strings(), |s: &String| {
             let (h, m, sec, _) = parse_time_parts(s);
             h == 0 && m == 0 && sec == 0
         });
@@ -124,23 +124,23 @@ mod datetimes {
 
     #[test]
     fn test_can_find_non_midnight() {
-        let t = minimal(gs::times(), |s: &String| parse_time_parts(s).0 != 0);
+        let t = minimal(gs::time_strings(), |s: &String| parse_time_parts(s).0 != 0);
         assert_eq!(parse_time_parts(&t).0, 1);
     }
 
     #[test]
     fn test_can_find_on_the_minute() {
-        find_any(gs::times(), |s: &String| parse_time_parts(s).2 == 0);
+        find_any(gs::time_strings(), |s: &String| parse_time_parts(s).2 == 0);
     }
 
     #[test]
     fn test_can_find_off_the_minute() {
-        find_any(gs::times(), |s: &String| parse_time_parts(s).2 != 0);
+        find_any(gs::time_strings(), |s: &String| parse_time_parts(s).2 != 0);
     }
 
     #[test]
     fn test_simplifies_towards_midnight() {
-        let t = minimal(gs::times(), |_: &String| true);
+        let t = minimal(gs::time_strings(), |_: &String| true);
         let (hour, minute, second, microsecond) = parse_time_parts(&t);
         assert_eq!(hour, 0);
         assert_eq!(minute, 0);
@@ -150,14 +150,14 @@ mod datetimes {
 
     #[test]
     fn test_can_generate_naive_time() {
-        find_any(gs::times(), |s: &String| {
+        find_any(gs::time_strings(), |s: &String| {
             !s.contains('+') && !s.contains('Z')
         });
     }
 
     #[test]
     fn test_naive_times_are_naive() {
-        assert_all_examples(gs::times(), |s: &String| {
+        assert_all_examples(gs::time_strings(), |s: &String| {
             !s.contains('+') && !s.contains('Z')
         });
     }

--- a/tests/test_validation.rs
+++ b/tests/test_validation.rs
@@ -146,6 +146,38 @@ fn test_characters_categories_including_cs_supercat_panics() {
     );
 }
 
+/// Unknown codec names are rejected eagerly, when `.codec(...)` is called,
+/// rather than on first draw.
+#[test]
+fn test_text_unknown_codec_rejected_eagerly() {
+    expect_panic(
+        || {
+            let _ = gs::text().codec("not-a-real-codec");
+        },
+        "invalid codec: not-a-real-codec",
+    );
+}
+
+/// Same eager rejection for `characters()`.
+#[test]
+fn test_characters_unknown_codec_rejected_eagerly() {
+    expect_panic(
+        || {
+            let _ = gs::characters().codec("not-a-real-codec");
+        },
+        "invalid codec: not-a-real-codec",
+    );
+}
+
+/// All engine-supported codec names pass the client-side check.
+#[test]
+fn test_supported_codecs_accepted() {
+    for codec in ["ascii", "latin-1", "iso-8859-1", "utf-8"] {
+        check_draws(gs::text().codec(codec));
+        check_draws(gs::characters().codec(codec));
+    }
+}
+
 #[test]
 fn test_text_alphabet_with_codec() {
     expect_draw_panic(gs::text().alphabet("abc").codec("ascii"), "Cannot combine");


### PR DESCRIPTION
<details>
<summary>Implementation details (AI-generated)</summary>

Fixes from a documentation-vs-behavior audit of the public API:

- `#[rule]`/`#[invariant]` methods now accept `&self` as well as `&mut self`, as the stateful docs promised; by-value `self` gets a targeted compile error.
- `#[hegel::test]` expands to `#[cfg_attr(test, test)]` so function bodies are type-checked outside `--test` builds (previously broken doc examples sailed through `cargo test --doc`); fixed the doc examples this exposed, including the crate-root `#[derive(DefaultGenerator)]` docs which described an enum builder API that never existed.
- jiff `dates()`/`times()` gained the `min_value`/`max_value` builders their docs pointed at, with microsecond-precision inward rounding for time bounds.
- Renamed string-returning `gs::dates()`/`times()`/`datetimes()` to `date_strings()`/`time_strings()`/`datetime_strings()`; the old names are removed outright (zerover, breaking change).
- `.codec(...)` docs state exactly what each value does; unknown codec names are rejected at the call site instead of on first draw.
- README quickstart shows the failure output actually printed.
- RELEASE.md (`RELEASE_TYPE: minor`) for the release automation.

Verification: 117 lib tests, all 56 integration targets, 67 doctests, clippy `-D warnings`, fmt, trybuild UI tests, and `release.py check` all pass under `--all-features`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
