### PR TITLE
Stop temp-project tests leaking disk space

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -7,10 +7,12 @@ static TEST_CWD: std::sync::OnceLock<tempfile::TempDir> = std::sync::OnceLock::n
 #[cfg(not(miri))]
 #[ctor::ctor]
 fn chdir_to_isolated_tempdir() {
-    let tempdir = tempfile::Builder::new()
-        .prefix("hegel-rust-test-")
-        .tempdir()
-        .expect("Failed to create test cwd tempdir");
+    // Reclaim scratch dirs (temp projects, test cwds, …) orphaned in the
+    // system temp dir by runs that were killed before `TempDir`'s `Drop`
+    // could remove them.
+    project::sweep_stale_scratch_dirs(&std::env::temp_dir(), &project::pid_is_live);
+
+    let tempdir = project::scratch_tempdir();
     std::env::set_current_dir(tempdir.path()).expect("Failed to chdir into test cwd tempdir");
     let _ = TEST_CWD.set(tempdir);
 }

--- a/tests/common/project.rs
+++ b/tests/common/project.rs
@@ -7,7 +7,7 @@ use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 use tempfile::TempDir;
 
-fn shared_target_dir() -> PathBuf {
+pub fn shared_target_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("hegel-shared-target")
 }
 
@@ -54,13 +54,7 @@ pub fn pid_is_live(pid: u32) -> bool {
 /// removal errors are ignored (another test binary may be sweeping the same
 /// entries concurrently).
 pub fn sweep_stale_temp_artifacts(shared_target: &Path, is_live: &dyn Fn(u32) -> bool) {
-    let debug = shared_target.join("debug");
-    for dir in [
-        debug.clone(),
-        debug.join("deps"),
-        debug.join("incremental"),
-        debug.join(".fingerprint"),
-    ] {
+    for dir in artifact_dirs(shared_target) {
         let Ok(entries) = std::fs::read_dir(&dir) else {
             continue;
         };
@@ -72,12 +66,100 @@ pub fn sweep_stale_temp_artifacts(shared_target: &Path, is_live: &dyn Fn(u32) ->
             if pid == std::process::id() || is_live(pid) {
                 continue;
             }
-            let path = entry.path();
-            if path.is_dir() {
-                let _ = std::fs::remove_dir_all(&path);
-            } else {
-                let _ = std::fs::remove_file(&path);
+            remove_entry(&entry.path());
+        }
+    }
+}
+
+/// The directories of a cargo target dir in which a crate leaves artifacts.
+fn artifact_dirs(shared_target: &Path) -> [PathBuf; 4] {
+    let debug = shared_target.join("debug");
+    [
+        debug.clone(),
+        debug.join("deps"),
+        debug.join("incremental"),
+        debug.join(".fingerprint"),
+    ]
+}
+
+fn remove_entry(path: &Path) {
+    if path.is_dir() {
+        let _ = std::fs::remove_dir_all(path);
+    } else {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+/// Remove every artifact this crate left in the shared target directory.
+///
+/// A temp crate's name is unique per (process, counter), so its artifacts
+/// (`{crate}`, `{crate}.d`, `deps/{crate}-{hash}*`, fingerprint dirs, …) can
+/// never be reused by a later build — dropping them as soon as the project is
+/// done keeps a long test-binary run from accumulating one 10-25MB binary per
+/// `TempRustProject`. Matching requires a `-` or `.` right after the crate
+/// name so one temp crate can never sweep a longer-named sibling; removal
+/// errors are ignored (another sweep may run concurrently).
+pub fn remove_crate_artifacts(shared_target: &Path, crate_name: &str) {
+    for dir in artifact_dirs(shared_target) {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else {
+                continue;
+            };
+            let owned_by_crate = name == crate_name
+                || name
+                    .strip_prefix(crate_name)
+                    .is_some_and(|rest| rest.starts_with('-') || rest.starts_with('.'));
+            if owned_by_crate {
+                remove_entry(&entry.path());
             }
+        }
+    }
+}
+
+/// A temp directory in the system temp dir whose name embeds the owning PID
+/// (`hegel_rust_tmp_{pid}_{random}`), so that directories orphaned by killed
+/// runs — `TempDir`'s `Drop` never runs on SIGKILL — can be attributed to a
+/// dead process and swept by a later run instead of accumulating forever.
+pub fn scratch_tempdir() -> TempDir {
+    tempfile::Builder::new()
+        .prefix(&format!("hegel_rust_tmp_{}_", std::process::id()))
+        .tempdir()
+        .unwrap()
+}
+
+/// The PID embedded in a `hegel_rust_tmp_{pid}_{random}` scratch directory
+/// name, or `None` for anything that is not a scratch directory.
+pub fn scratch_dir_pid(dir_name: &str) -> Option<u32> {
+    let rest = dir_name.strip_prefix("hegel_rust_tmp_")?;
+    let (pid, _) = rest.split_once('_')?;
+    pid.parse().ok()
+}
+
+/// Remove scratch directories under `parent` whose owning process is gone.
+///
+/// The current process's directories are always kept, whatever `is_live`
+/// says; entries that are not directories are never touched (our scratch
+/// entries are always directories); removal errors are ignored (another test
+/// binary may be sweeping the same entries concurrently).
+pub fn sweep_stale_scratch_dirs(parent: &Path, is_live: &dyn Fn(u32) -> bool) {
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(pid) = name.to_str().and_then(scratch_dir_pid) else {
+            continue;
+        };
+        if pid == std::process::id() || is_live(pid) {
+            continue;
+        }
+        let path = entry.path();
+        if path.is_dir() {
+            let _ = std::fs::remove_dir_all(&path);
         }
     }
 }
@@ -142,6 +224,12 @@ pub struct TempRustProject {
     expect_failure: Option<String>,
 }
 
+impl Drop for TempRustProject {
+    fn drop(&mut self) {
+        remove_crate_artifacts(&shared_target_dir(), &self.crate_name);
+    }
+}
+
 pub struct RunOutput {
     pub status: ExitStatus,
     #[allow(dead_code)]
@@ -166,7 +254,7 @@ pub struct Invocation<'a> {
 
 impl TempRustProject {
     pub fn new() -> Self {
-        let temp_dir = TempDir::new().unwrap();
+        let temp_dir = scratch_tempdir();
         let project_path = temp_dir.path().to_path_buf();
 
         let id = PACKAGE_NAME_ID.fetch_add(1, Ordering::Relaxed);
@@ -222,6 +310,16 @@ impl TempRustProject {
     pub fn env_remove(mut self, key: &str) -> Self {
         self.env_removes.push(key.to_string());
         self
+    }
+
+    /// The root directory of the temp project.
+    pub fn path(&self) -> &Path {
+        &self.project_path
+    }
+
+    /// The unique (per process, per counter) name of the temp crate.
+    pub fn crate_name(&self) -> &str {
+        &self.crate_name
     }
 
     /// Begin a fresh invocation of this project. Use this when reusing one

--- a/tests/embedded/antithesis_tests.rs
+++ b/tests/embedded/antithesis_tests.rs
@@ -23,7 +23,12 @@ fn require_antithesis_feature_does_not_panic_when_feature_enabled() {
 
 #[test]
 fn check_antithesis_output_dir_accepts_an_existing_directory() {
-    let dir = tempfile::TempDir::new().unwrap();
+    // PID-tagged like tests/common's scratch_tempdir(), so a dir orphaned by
+    // a killed run is swept by a later run instead of leaking forever.
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("hegel_rust_tmp_{}_", std::process::id()))
+        .tempdir()
+        .unwrap();
     assert!(check_antithesis_output_dir(dir.path().to_str().unwrap()));
 }
 

--- a/tests/embedded/runner_tests.rs
+++ b/tests/embedded/runner_tests.rs
@@ -112,7 +112,12 @@ fn test_native_engine_creates_default_dot_hegel_when_database_unset() {
             std::env::remove_var(name);
         }
     }
-    let tmp = tempfile::TempDir::new().unwrap();
+    // PID-tagged like tests/common's scratch_tempdir(), so a dir orphaned by
+    // a killed run is swept by a later run instead of leaking forever.
+    let tmp = tempfile::Builder::new()
+        .prefix(&format!("hegel_rust_tmp_{}_", std::process::id()))
+        .tempdir()
+        .unwrap();
     let prev_cwd = std::env::current_dir().unwrap();
     std::env::set_current_dir(tmp.path()).unwrap();
 

--- a/tests/test_antithesis.rs
+++ b/tests/test_antithesis.rs
@@ -3,11 +3,10 @@
 mod common;
 
 use common::project::TempRustProject;
-use tempfile::TempDir;
 
 #[test]
 fn test_antithesis_jsonl_written_when_env_set() {
-    let output_dir = TempDir::new().unwrap();
+    let output_dir = crate::common::project::scratch_tempdir();
     let output_path = output_dir.path().to_str().unwrap().to_string();
 
     let code = r#"
@@ -79,7 +78,7 @@ fn my_test(tc: hegel::TestCase) {
 
 #[test]
 fn test_antithesis_panics_without_feature() {
-    let output_dir = TempDir::new().unwrap();
+    let output_dir = crate::common::project::scratch_tempdir();
     let output_path = output_dir.path().to_str().unwrap().to_string();
 
     let code = r#"
@@ -103,7 +102,7 @@ fn my_test(tc: hegel::TestCase) {
 /// after a full (potentially long) property run has completed.
 #[test]
 fn test_missing_antithesis_feature_fails_before_running_any_test_case() {
-    let output_dir = TempDir::new().unwrap();
+    let output_dir = crate::common::project::scratch_tempdir();
     let output_path = output_dir.path().to_str().unwrap().to_string();
 
     let code = r#"

--- a/tests/test_combinators.rs
+++ b/tests/test_combinators.rs
@@ -736,7 +736,7 @@ mod nocover_flatmap {
 
     #[test]
     fn test_flatmap_retrieve_from_db() {
-        let temp_dir = tempfile::TempDir::new().unwrap();
+        let temp_dir = crate::common::project::scratch_tempdir();
         let db_path = temp_dir.path().to_str().unwrap().to_string();
 
         let track: Arc<Mutex<Vec<Vec<f64>>>> = Arc::new(Mutex::new(Vec::new()));

--- a/tests/test_database_key.rs
+++ b/tests/test_database_key.rs
@@ -13,7 +13,7 @@ fn read_values(dir: &std::path::Path, label: &str) -> Vec<i64> {
 
 #[test]
 fn test_database_key_replays_failure() {
-    let temp_dir = tempfile::TempDir::new().unwrap();
+    let temp_dir = crate::common::project::scratch_tempdir();
     let db_path = temp_dir.path().join("database");
     std::fs::create_dir_all(&db_path).unwrap();
     let db_str = db_path.to_str().unwrap().replace('\\', "/");
@@ -98,7 +98,7 @@ mod replay_logic {
 
     #[test]
     fn test_does_not_shrink_on_replay() {
-        let temp_dir = tempfile::TempDir::new().unwrap();
+        let temp_dir = crate::common::project::scratch_tempdir();
         let db_path = temp_dir.path().to_str().unwrap().to_string();
 
         let call_count: Arc<Mutex<u64>> = Arc::new(Mutex::new(0));
@@ -149,7 +149,7 @@ mod replay_logic {
 
     #[test]
     fn test_will_always_shrink_if_previous_example_does_not_replay() {
-        let temp_dir = tempfile::TempDir::new().unwrap();
+        let temp_dir = crate::common::project::scratch_tempdir();
         let db_path = temp_dir.path().to_str().unwrap().to_string();
 
         let good: Arc<Mutex<std::collections::HashSet<i64>>> =
@@ -184,7 +184,7 @@ mod replay_logic {
 
     #[test]
     fn test_will_shrink_if_the_previous_example_does_not_look_right() {
-        let temp_dir = tempfile::TempDir::new().unwrap();
+        let temp_dir = crate::common::project::scratch_tempdir();
         let db_path = temp_dir.path().to_str().unwrap().to_string();
 
         let last: Arc<Mutex<Option<i64>>> = Arc::new(Mutex::new(None));
@@ -254,7 +254,7 @@ mod replay_logic {
     /// failing example must already be on disk.
     #[test]
     fn test_failure_persisted_immediately_when_discovered() {
-        let temp_dir = tempfile::TempDir::new().unwrap();
+        let temp_dir = crate::common::project::scratch_tempdir();
         let db_path = temp_dir.path().to_str().unwrap().to_string();
         let db_path_for_check = db_path.clone();
 
@@ -311,7 +311,7 @@ mod replay_logic {
     /// jump from 0 to N on the final replay alone.
     #[test]
     fn test_intermediate_shrinks_update_db_during_run() {
-        let temp_dir = tempfile::TempDir::new().unwrap();
+        let temp_dir = crate::common::project::scratch_tempdir();
         let db_path = temp_dir.path().to_str().unwrap().to_string();
         let db_root = std::path::PathBuf::from(&db_path);
         let db_root_cl = db_root.clone();

--- a/tests/test_output.rs
+++ b/tests/test_output.rs
@@ -73,8 +73,7 @@ fn tree_exhausted_filter_too_much_fires_on_tiny_filtered_domain() {
 fn db_replay_drops_corrupted_stored_entry() {
     use hegel::generators as gs;
     use hegel::{Hegel, Settings};
-    use tempfile::TempDir;
-    let db_dir = TempDir::new().unwrap();
+    let db_dir = crate::common::project::scratch_tempdir();
     let key = b"db_replay_drops_corrupted_stored_entry";
     let mut prefixed = b"native:".to_vec();
     prefixed.extend_from_slice(key);
@@ -101,8 +100,7 @@ fn db_replay_drops_corrupted_stored_entry() {
 fn debug_verbosity_replay_aligned_emits_skipping_shrink_message() {
     use hegel::generators as gs;
     use hegel::{Hegel, Settings, Verbosity};
-    use tempfile::TempDir;
-    let db_dir = TempDir::new().unwrap();
+    let db_dir = crate::common::project::scratch_tempdir();
     let db_path = db_dir.path().to_str().unwrap().to_string();
 
     let run_once = |verbosity: Verbosity| {

--- a/tests/test_runtime_dir_isolation.rs
+++ b/tests/test_runtime_dir_isolation.rs
@@ -25,9 +25,10 @@ fn cwd_is_not_crate_root() {
 fn cwd_is_a_hegel_rust_test_tempdir() {
     let cwd = std::env::current_dir().unwrap();
     let name = cwd.file_name().unwrap().to_string_lossy();
-    assert!(
-        name.starts_with("hegel-rust-test-"),
-        "cwd {cwd:?} should be a tempdir whose name starts with hegel-rust-test-",
+    assert_eq!(
+        common::project::scratch_dir_pid(&name),
+        Some(std::process::id()),
+        "cwd {cwd:?} should be a scratch tempdir (hegel_rust_tmp_{{pid}}_…) owned by this process",
     );
 }
 

--- a/tests/test_temp_project_gc.rs
+++ b/tests/test_temp_project_gc.rs
@@ -1,8 +1,10 @@
-//! Tests for the stale-artifact sweep that keeps the shared
-//! `TempRustProject` target directory (`target/tmp/hegel-shared-target`)
-//! from growing without bound: temp crate names embed the owning test
-//! binary's PID, so artifacts from processes that no longer exist can be
-//! reclaimed.
+//! Tests for the garbage collection that keeps temp-project testing from
+//! leaking disk space: temp crate names and scratch directory names embed
+//! the owning test binary's PID, so artifacts in the shared target
+//! directory (`target/tmp/hegel-shared-target`) and scratch dirs in the
+//! system temp dir left behind by processes that no longer exist can be
+//! reclaimed, and each `TempRustProject` removes its own shared-target
+//! artifacts on drop.
 
 mod common;
 
@@ -37,7 +39,7 @@ fn dir_with_file(path: &Path) {
 
 #[test]
 fn sweep_removes_dead_pid_artifacts_and_keeps_everything_else() {
-    let tmp = tempfile::TempDir::new().unwrap();
+    let tmp = crate::common::project::scratch_tempdir();
     let target = tmp.path();
     let dead = "temp_hegel_test_1234_0";
     let live = "temp_hegel_test_4242_1";
@@ -91,8 +93,118 @@ fn sweep_removes_dead_pid_artifacts_and_keeps_everything_else() {
 }
 
 #[test]
+fn temp_project_dir_name_embeds_owning_pid() {
+    let project = common::project::TempRustProject::new();
+    let dir_name = project
+        .path()
+        .file_name()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_owned();
+    assert!(
+        dir_name.starts_with(&format!("hegel_rust_tmp_{}_", std::process::id())),
+        "temp project dir {dir_name:?} should embed the owning PID so that \
+         dirs left behind by killed runs can be attributed and swept"
+    );
+    assert_eq!(
+        project.path().parent().unwrap(),
+        std::env::temp_dir(),
+        "temp project dirs should live directly in the system temp dir"
+    );
+}
+
+#[test]
+fn dropping_a_project_removes_its_artifacts_from_the_shared_target() {
+    let project = common::project::TempRustProject::new();
+    let crate_name = project.crate_name().to_owned();
+    let target = common::project::shared_target_dir();
+
+    // Plant the artifacts a `cargo run` of this crate would leave behind.
+    let artifacts = [
+        target.join(format!("debug/{crate_name}")),
+        target.join(format!("debug/{crate_name}.d")),
+        target.join(format!("debug/deps/{crate_name}-abc123")),
+        target.join(format!("debug/deps/{crate_name}-abc123.d")),
+    ];
+    for path in &artifacts {
+        touch(path);
+    }
+    let artifact_dirs = [
+        target.join(format!("debug/incremental/{crate_name}-xyz789")),
+        target.join(format!("debug/.fingerprint/{crate_name}-abc123")),
+    ];
+    for path in &artifact_dirs {
+        dir_with_file(path);
+    }
+
+    // An artifact of a *different* temp crate whose name shares this one as a
+    // prefix must survive the drop.
+    let unrelated = target.join(format!("debug/deps/{crate_name}9-abc123"));
+    touch(&unrelated);
+
+    drop(project);
+
+    for path in artifacts.iter().chain(&artifact_dirs) {
+        assert!(
+            !path.exists(),
+            "dropping the project should remove its shared-target artifact: {}",
+            path.display()
+        );
+    }
+    assert!(unrelated.exists(), "prefix-sharing crate must be kept");
+    fs::remove_file(&unrelated).unwrap();
+}
+
+#[test]
+fn scratch_dir_pid_parses_scratch_dir_names() {
+    use common::project::scratch_dir_pid;
+    assert_eq!(scratch_dir_pid("hegel_rust_tmp_1234_Xy1Z9a"), Some(1234));
+    assert_eq!(scratch_dir_pid("hegel_rust_tmp_1_a"), Some(1));
+    assert_eq!(scratch_dir_pid(".tmpAbCdEf"), None);
+    assert_eq!(scratch_dir_pid("hegel_rust_tmp_"), None);
+    assert_eq!(scratch_dir_pid("hegel_rust_tmp_1234"), None);
+    assert_eq!(scratch_dir_pid("hegel_rust_tmp_notapid_x"), None);
+    assert_eq!(scratch_dir_pid("hegel-rust-test-Xy1Z9a"), None);
+}
+
+#[test]
+fn sweep_removes_dead_scratch_dirs_and_keeps_everything_else() {
+    use common::project::sweep_stale_scratch_dirs;
+
+    let tmp = crate::common::project::scratch_tempdir();
+    let parent = tmp.path();
+
+    let dead = parent.join("hegel_rust_tmp_1234_aaaaaa");
+    dir_with_file(&dead);
+
+    let kept_dirs = [
+        // A scratch dir whose owner is still running.
+        parent.join("hegel_rust_tmp_4242_bbbbbb"),
+        // Our own scratch dir is protected even when `is_live` denies our PID.
+        parent.join(format!("hegel_rust_tmp_{}_cccccc", std::process::id())),
+        // Not a scratch dir: someone else's temp dir.
+        parent.join(".tmpAbCdEf"),
+    ];
+    for path in &kept_dirs {
+        dir_with_file(path);
+    }
+    // A plain file that happens to share the naming scheme is not a scratch
+    // dir and must not be touched.
+    let kept_file = parent.join("hegel_rust_tmp_1234_ffffff");
+    touch(&kept_file);
+
+    sweep_stale_scratch_dirs(parent, &|pid| pid == 4242);
+
+    assert!(!dead.exists(), "dead scratch dir should have been swept");
+    for path in kept_dirs.iter().chain([&kept_file]) {
+        assert!(path.exists(), "should have been kept: {}", path.display());
+    }
+}
+
+#[test]
 fn sweep_of_a_missing_target_dir_is_a_no_op() {
-    let tmp = tempfile::TempDir::new().unwrap();
+    let tmp = crate::common::project::scratch_tempdir();
     sweep_stale_temp_artifacts(&tmp.path().join("does-not-exist"), &|_| false);
 }
 


### PR DESCRIPTION
<details>
<summary>Implementation details (AI-generated)</summary>

Two disk leaks in the temp-project test infrastructure:

1. **Shared-target artifact leak.** Each `TempRustProject` builds a uniquely named crate (`temp_hegel_test_{pid}_{counter}`) into `target/tmp/hegel-shared-target`, leaving a 10-25MB binary per test. The existing PID-based sweep only reclaims artifacts of *dead* processes, so a test binary with many temp-project tests accumulated one binary per test for its whole lifetime (~900MB observed in a full suite run). `TempRustProject` now implements `Drop` and removes its own artifacts from `debug/`, `debug/deps/`, `debug/incremental/`, and `debug/.fingerprint/` — safe because the crate name is unique per (process, counter) and can never be reused. Matching requires a `-` or `.` immediately after the crate name so a crate can't sweep a longer-named sibling. `OnceLock`-shared projects (never dropped) still fall back to the next process's warmup sweep.

2. **Orphaned temp-dir leak.** Temp project dirs and each test binary's isolated cwd were anonymous `.tmp*`/`hegel-rust-test-*` dirs in the system temp dir. Runs killed before `TempDir::drop` — and *every* run, for the cwd dir held in a static `OnceLock` — leaked dirs that could never be attributed to an owner (~525 observed). All test temp dirs are now created via `scratch_tempdir()` as `hegel_rust_tmp_{pid}_{random}`, and the `#[ctor]` in `tests/common/mod.rs` sweeps dirs whose owning process is gone (same liveness logic as the artifact sweep; conservative no-op off Linux). The two embedded unit-test tempdir sites inline the same prefix since they can't depend on `tests/common`.

TDD: regression tests added first and observed failing (`temp_project_dir_name_embeds_owning_pid`, `dropping_a_project_removes_its_artifacts_from_the_shared_target`, `scratch_dir_pid_parses_scratch_dir_names`, `sweep_removes_dead_scratch_dirs_and_keeps_everything_else` in `tests/test_temp_project_gc.rs`).

Verification: fmt, clippy `-D warnings` (all features/targets), lib tests (117), gc tests (9), plus end-to-end runs of `test_database_key` and `test_output` — zero `temp_hegel_test_*` artifacts remain after dropped projects, `OnceLock` projects' artifacts are reclaimed by the next process's warmup sweep, and a dead run's scratch dir was observed being swept by the following run.

No RELEASE.md: the change touches only `tests/`, and release.py requires one only for `src/` or `hegel-macros/` changes.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
