### PR TITLE
Fix stateful stop condition

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This patch adds a `stateful_step_count` setting controlling how many steps a stateful (`#[state_machine]`) test case runs. It defaults to 50, and each case now runs at least one step and at most `stateful_step_count`.
+
+```rust
+Settings::new().stateful_step_count(20)
+```

--- a/hegel-c/RELEASE.md
+++ b/hegel-c/RELEASE.md
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch adds `hegel_settings_set_stateful_step_count`, which sets the target number of steps a stateful test case runs (default 50).
+
+The stateful stop generation decision has changed. Instead of drawing a single per-case step cap up front, `hegel_state_machine_next_rule` makes a per-step stop decision, forced to keep going before the first step and forced to halt once `stateful_step_count` steps have been handed out. Every stateful case therefore runs at least one step and at most `stateful_step_count`.

--- a/hegel-c/include/hegel.h
+++ b/hegel-c/include/hegel.h
@@ -386,6 +386,12 @@ typedef enum {
      text generator).
      */
     HEGEL_LABEL_STRING = 30,
+    /*
+     Outer span around one stateful-testing rule invocation, grouping all
+     the draws a single rule makes so the shrinker can delete a whole step
+     at once. Opened by the frontend's state-machine driver.
+     */
+    HEGEL_LABEL_STATEFUL_RULE = 31,
 } hegel_label_t;
 
 /*

--- a/hegel-c/include/hegel.h
+++ b/hegel-c/include/hegel.h
@@ -744,6 +744,15 @@ hegel_result_t hegel_settings_set_backend(hegel_context_t *ctx,
 hegel_result_t hegel_settings_set_test_cases(hegel_context_t *ctx, hegel_settings_t *s, uint64_t n);
 
 /*
+ Target number of steps to run per stateful test case. The default is
+ 50. Each stateful case runs at least one step and at most `n`; the
+ engine chooses where in that range to stop.
+ */
+hegel_result_t hegel_settings_set_stateful_step_count(hegel_context_t *ctx,
+                                                      hegel_settings_t *s,
+                                                      int64_t n);
+
+/*
  Set the engine's output verbosity. `v` is a `hegel_verbosity_t` value;
  the parameter is typed as `uint32_t` so an out-of-range value is a
  reportable `HEGEL_E_INVALID_ARG` instead of undefined behavior.

--- a/hegel-c/include/hegel.h
+++ b/hegel-c/include/hegel.h
@@ -746,7 +746,8 @@ hegel_result_t hegel_settings_set_test_cases(hegel_context_t *ctx, hegel_setting
 /*
  Target number of steps to run per stateful test case. The default is
  50. Each stateful case runs at least one step and at most `n`; the
- engine chooses where in that range to stop.
+ engine chooses where in that range to stop. `n` must be at least 1.
+ A smaller value is a reportable `HEGEL_E_INVALID_ARG`.
  */
 hegel_result_t hegel_settings_set_stateful_step_count(hegel_context_t *ctx,
                                                       hegel_settings_t *s,

--- a/hegel-c/src/lib.rs
+++ b/hegel-c/src/lib.rs
@@ -897,7 +897,8 @@ pub unsafe extern "C" fn hegel_settings_set_test_cases(
 
 /// Target number of steps to run per stateful test case. The default is
 /// 50. Each stateful case runs at least one step and at most `n`; the
-/// engine chooses where in that range to stop.
+/// engine chooses where in that range to stop. `n` must be at least 1.
+/// A smaller value is a reportable `HEGEL_E_INVALID_ARG`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hegel_settings_set_stateful_step_count(
     ctx: *mut HegelContext,
@@ -909,6 +910,15 @@ pub unsafe extern "C" fn hegel_settings_set_stateful_step_count(
         Ok(h) => h,
         Err(rc) => return rc,
     };
+    if n < 1 {
+        set_last_error(
+            ctx,
+            &format!(
+                "hegel_settings_set_stateful_step_count: step count must be at least 1, got {n}"
+            ),
+        );
+        return HEGEL_E_INVALID_ARG;
+    }
     handle.inner = handle.inner.clone().stateful_step_count(n);
     HEGEL_OK
 }

--- a/hegel-c/src/lib.rs
+++ b/hegel-c/src/lib.rs
@@ -364,6 +364,10 @@ pub enum hegel_label_t {
     /// Span around one text string draw (`hegel_generate_string` with a
     /// text generator).
     HEGEL_LABEL_STRING = 30,
+    /// Outer span around one stateful-testing rule invocation, grouping all
+    /// the draws a single rule makes so the shrinker can delete a whole step
+    /// at once. Opened by the frontend's state-machine driver.
+    HEGEL_LABEL_STATEFUL_RULE = 31,
 }
 
 /// Per-line output callback, passed to `hegel_run_start` /

--- a/hegel-c/src/lib.rs
+++ b/hegel-c/src/lib.rs
@@ -895,6 +895,24 @@ pub unsafe extern "C" fn hegel_settings_set_test_cases(
     HEGEL_OK
 }
 
+/// Target number of steps to run per stateful test case. The default is
+/// 50. Each stateful case runs at least one step and at most `n`; the
+/// engine chooses where in that range to stop.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn hegel_settings_set_stateful_step_count(
+    ctx: *mut HegelContext,
+    s: *mut HegelSettings,
+    n: i64,
+) -> hegel_result_t {
+    clear_last_error(ctx);
+    let handle = match unsafe { settings_mut(ctx, s, "hegel_settings_set_stateful_step_count") } {
+        Ok(h) => h,
+        Err(rc) => return rc,
+    };
+    handle.inner = handle.inner.clone().stateful_step_count(n);
+    HEGEL_OK
+}
+
 /// Set the engine's output verbosity. `v` is a `hegel_verbosity_t` value;
 /// the parameter is typed as `uint32_t` so an out-of-range value is a
 /// reportable `HEGEL_E_INVALID_ARG` instead of undefined behavior.

--- a/hegel-c/src/native/core/state.rs
+++ b/hegel-c/src/native/core/state.rs
@@ -975,6 +975,11 @@ pub struct FamilyCore {
     /// rule sequence as done. Set for single-test-case runs, which explore
     /// one unbounded test case instead of many capped ones.
     state_machine_steps_unbounded: AtomicBool,
+    /// Target number of steps a stateful test case runs. Bounds the
+    /// per-step stop decision in [`NativeStateMachine::next_rule`]; ignored
+    /// when [`Self::state_machine_steps_unbounded`] is set. Defaults to 50,
+    /// overridden per run from the `stateful_step_count` setting.
+    stateful_step_count: AtomicI64,
 }
 
 impl FamilyCore {
@@ -990,6 +995,7 @@ impl FamilyCore {
             variable_pools: Mutex::new(Vec::new()),
             state_machines: Mutex::new(Vec::new()),
             state_machine_steps_unbounded: AtomicBool::new(false),
+            stateful_step_count: AtomicI64::new(50),
         }
     }
 
@@ -1002,6 +1008,16 @@ impl FamilyCore {
     /// Whether state machines of this family run without a step cap.
     pub(crate) fn state_machine_steps_unbounded(&self) -> bool {
         self.state_machine_steps_unbounded.load(Ordering::Relaxed)
+    }
+
+    /// Set the target number of steps a stateful test case runs.
+    pub(crate) fn set_stateful_step_count(&self, count: i64) {
+        self.stateful_step_count.store(count, Ordering::Relaxed);
+    }
+
+    /// The target number of steps a stateful test case runs.
+    pub(crate) fn stateful_step_count(&self) -> i64 {
+        self.stateful_step_count.load(Ordering::Relaxed)
     }
 
     /// The family's concluded status, or `None` while still running.

--- a/hegel-c/src/native/core/state_machine.rs
+++ b/hegel-c/src/native/core/state_machine.rs
@@ -1,4 +1,3 @@
-use std::cmp::min;
 use std::collections::HashSet;
 
 use super::choices::EngineError;
@@ -6,11 +5,11 @@ use super::state::NativeTestCase;
 use crate::control::hegel_internal_assert;
 use crate::hegel_label_t::HEGEL_LABEL_FEATURE_FLAG;
 use crate::native::bignum::{BigInt, ToPrimitive};
-use crate::native::draws;
 
-/// Upper bound on the per-test-case step cap drawn by
-/// [`NativeStateMachine::next_rule`].
-const MAX_STEP_CAP: i64 = 50;
+/// Probability that the per-step stop decision in
+/// [`NativeStateMachine::next_rule`] halts a stateful test case, when the
+/// engine is free to choose (2^-16).
+const P_STOP: f64 = 1.0 / 65536.0;
 
 /// Draw a uniform index in `[0, n)`.
 fn draw_index(ntc: &mut NativeTestCase, n: usize) -> Result<usize, EngineError> {
@@ -79,10 +78,6 @@ pub struct NativeStateMachine {
     #[allow(dead_code)]
     invariant_names: Vec<String>,
     flags: Option<FeatureFlags>,
-    /// Per-test-case cap on the number of rules handed out, drawn on the
-    /// first `next_rule` call: an integer in `[1, i64::MAX]` truncated to
-    /// [`MAX_STEP_CAP`] (so usually exactly [`MAX_STEP_CAP`]).
-    step_cap: Option<i64>,
     /// Number of rules handed out so far.
     steps_drawn: i64,
 }
@@ -98,32 +93,28 @@ impl NativeStateMachine {
             rule_names,
             invariant_names,
             flags: None,
-            step_cap: None,
             steps_drawn: 0,
         }
     }
 
     /// Draw the index of the next rule to run, in `[0, num_rules)`, or
-    /// `None` once the test case has run enough steps.
+    /// `None` once the test case decides to stop.
     ///
-    /// The first call draws the test case's step cap. Once `step_cap` rules
-    /// have been handed out, every further call returns `None` without
-    /// drawing. Families marked as unbounded (single-test-case runs) draw
-    /// no cap and never return `None`.
+    /// Each call first makes a per-step stop decision: a boolean draw with
+    /// probability [`P_STOP`] of halting. Every test case runs at least one step
+    /// and at most `stateful_step_count`. Families marked as unbounded
+    /// (single-test-case runs) never force a stop.
     pub fn next_rule(&mut self, ntc: &mut NativeTestCase) -> Result<Option<i64>, EngineError> {
-        if ntc.family().state_machine_steps_unbounded() {
-            return Ok(Some(self.select_rule(ntc)?));
-        }
-        let step_cap = match self.step_cap {
-            Some(cap) => cap,
-            None => {
-                let raw = draws::generate_integer(ntc, &BigInt::from(1), &BigInt::from(i64::MAX))?;
-                let cap = min(raw.to_i128().unwrap() as i64, MAX_STEP_CAP);
-                self.step_cap = Some(cap);
-                cap
-            }
+        let forced = if ntc.family().state_machine_steps_unbounded() {
+            Some(false)
+        } else if self.steps_drawn >= ntc.family().stateful_step_count() {
+            Some(true)
+        } else if self.steps_drawn == 0 {
+            Some(false)
+        } else {
+            None
         };
-        if self.steps_drawn >= step_cap {
+        if ntc.weighted_precise(P_STOP, forced)? {
             return Ok(None);
         }
         let index = self.select_rule(ntc)?;

--- a/hegel-c/src/native/core/state_machine.rs
+++ b/hegel-c/src/native/core/state_machine.rs
@@ -1,16 +1,15 @@
 use crate::native::HashSet;
-use std::cmp::min;
 
 use super::choices::EngineError;
 use super::state::NativeTestCase;
 use crate::control::hegel_internal_assert;
 use crate::hegel_label_t::HEGEL_LABEL_FEATURE_FLAG;
 use crate::native::bignum::{BigInt, ToPrimitive};
-use crate::native::draws;
 
-/// Upper bound on the per-test-case step cap drawn by
-/// [`NativeStateMachine::next_rule`].
-const MAX_STEP_CAP: i64 = 50;
+/// Probability that the per-step stop decision in
+/// [`NativeStateMachine::next_rule`] halts a stateful test case, when the
+/// engine is free to choose (2^-16).
+const P_STOP: f64 = 1.0 / 65536.0;
 
 /// Draw a uniform index in `[0, n)`.
 fn draw_index(ntc: &mut NativeTestCase, n: usize) -> Result<usize, EngineError> {
@@ -79,10 +78,6 @@ pub struct NativeStateMachine {
     #[allow(dead_code)]
     invariant_names: Vec<String>,
     flags: Option<FeatureFlags>,
-    /// Per-test-case cap on the number of rules handed out, drawn on the
-    /// first `next_rule` call: an integer in `[1, i64::MAX]` truncated to
-    /// [`MAX_STEP_CAP`] (so usually exactly [`MAX_STEP_CAP`]).
-    step_cap: Option<i64>,
     /// Number of rules handed out so far.
     steps_drawn: i64,
 }
@@ -98,32 +93,28 @@ impl NativeStateMachine {
             rule_names,
             invariant_names,
             flags: None,
-            step_cap: None,
             steps_drawn: 0,
         }
     }
 
     /// Draw the index of the next rule to run, in `[0, num_rules)`, or
-    /// `None` once the test case has run enough steps.
+    /// `None` once the test case decides to stop.
     ///
-    /// The first call draws the test case's step cap. Once `step_cap` rules
-    /// have been handed out, every further call returns `None` without
-    /// drawing. Families marked as unbounded (single-test-case runs) draw
-    /// no cap and never return `None`.
+    /// Each call first makes a per-step stop decision: a boolean draw with
+    /// probability [`P_STOP`] of halting. Every test case runs at least one step
+    /// and at most `stateful_step_count`. Families marked as unbounded
+    /// (single-test-case runs) never force a stop.
     pub fn next_rule(&mut self, ntc: &mut NativeTestCase) -> Result<Option<i64>, EngineError> {
-        if ntc.family().state_machine_steps_unbounded() {
-            return Ok(Some(self.select_rule(ntc)?));
-        }
-        let step_cap = match self.step_cap {
-            Some(cap) => cap,
-            None => {
-                let raw = draws::generate_integer(ntc, &BigInt::from(1), &BigInt::from(i64::MAX))?;
-                let cap = min(raw.to_i128().unwrap() as i64, MAX_STEP_CAP);
-                self.step_cap = Some(cap);
-                cap
-            }
+        let forced = if ntc.family().state_machine_steps_unbounded() {
+            Some(false)
+        } else if self.steps_drawn >= ntc.family().stateful_step_count() {
+            Some(true)
+        } else if self.steps_drawn == 0 {
+            Some(false)
+        } else {
+            None
         };
-        if self.steps_drawn >= step_cap {
+        if ntc.weighted_precise(P_STOP, forced)? {
             return Ok(None);
         }
         let index = self.select_rule(ntc)?;

--- a/hegel-c/src/native/test_runner.rs
+++ b/hegel-c/src/native/test_runner.rs
@@ -975,7 +975,10 @@ impl<'a> Engine<'a> {
     /// Hypothesis's `ConjectureRunner.test_function`. Returns the run plus
     /// the choice-tree non-determinism diagnostic, if recording the run's
     /// path contradicted an earlier run.
-    pub(crate) fn test_function(&mut self, ntc: NativeTestCase) -> (RunResult, Option<String>) {
+    pub(crate) async fn test_function(
+        &mut self,
+        ntc: NativeTestCase,
+    ) -> (RunResult, Option<String>) {
         ntc.family()
             .set_stateful_step_count(self.settings.stateful_step_count);
         let tc_start = std::time::Instant::now();

--- a/hegel-c/src/native/test_runner.rs
+++ b/hegel-c/src/native/test_runner.rs
@@ -975,10 +975,9 @@ impl<'a> Engine<'a> {
     /// Hypothesis's `ConjectureRunner.test_function`. Returns the run plus
     /// the choice-tree non-determinism diagnostic, if recording the run's
     /// path contradicted an earlier run.
-    pub(crate) async fn test_function(
-        &mut self,
-        ntc: NativeTestCase,
-    ) -> (RunResult, Option<String>) {
+    pub(crate) fn test_function(&mut self, ntc: NativeTestCase) -> (RunResult, Option<String>) {
+        ntc.family()
+            .set_stateful_step_count(self.settings.stateful_step_count);
         let tc_start = std::time::Instant::now();
         let run = self.execute(ntc).await;
         let mismatch = self.record_run(&run, tc_start.elapsed());

--- a/hegel-c/src/native/test_runner.rs
+++ b/hegel-c/src/native/test_runner.rs
@@ -976,10 +976,9 @@ impl<'a> Engine<'a> {
     /// Hypothesis's `ConjectureRunner.test_function`. Returns the run plus
     /// the choice-tree non-determinism diagnostic, if recording the run's
     /// path contradicted an earlier run.
-    pub(crate) async fn test_function(
-        &mut self,
-        ntc: NativeTestCase,
-    ) -> (RunResult, Option<String>) {
+    pub(crate) fn test_function(&mut self, ntc: NativeTestCase) -> (RunResult, Option<String>) {
+        ntc.family()
+            .set_stateful_step_count(self.settings.stateful_step_count);
         let tc_start = std::time::Instant::now();
         let run = self.execute(ntc).await;
         let mismatch = self.record_run(&run, tc_start.elapsed());

--- a/hegel-c/src/native/test_runner.rs
+++ b/hegel-c/src/native/test_runner.rs
@@ -976,7 +976,10 @@ impl<'a> Engine<'a> {
     /// Hypothesis's `ConjectureRunner.test_function`. Returns the run plus
     /// the choice-tree non-determinism diagnostic, if recording the run's
     /// path contradicted an earlier run.
-    pub(crate) fn test_function(&mut self, ntc: NativeTestCase) -> (RunResult, Option<String>) {
+    pub(crate) async fn test_function(
+        &mut self,
+        ntc: NativeTestCase,
+    ) -> (RunResult, Option<String>) {
         ntc.family()
             .set_stateful_step_count(self.settings.stateful_step_count);
         let tc_start = std::time::Instant::now();

--- a/hegel-c/src/settings.rs
+++ b/hegel-c/src/settings.rs
@@ -146,6 +146,7 @@ pub enum Verbosity {
 pub struct Settings {
     pub(crate) mode: Mode,
     pub(crate) test_cases: u64,
+    pub(crate) stateful_step_count: i64,
     pub(crate) verbosity: Verbosity,
     pub(crate) output: Output,
     pub(crate) seed: Option<u64>,
@@ -167,6 +168,7 @@ impl Settings {
         Self {
             mode: Mode::TestRun,
             test_cases: 100,
+            stateful_step_count: 50,
             verbosity: Verbosity::Normal,
             output: Output::stderr(),
             seed: None,
@@ -221,6 +223,13 @@ impl Settings {
     /// Set the number of test cases to run (default: 100).
     pub fn test_cases(mut self, n: u64) -> Self {
         self.test_cases = n;
+        self
+    }
+
+    /// Set the target number of steps run per stateful test case (default:
+    /// 50). Each case runs at least one step and at most this many.
+    pub fn stateful_step_count(mut self, n: i64) -> Self {
+        self.stateful_step_count = n;
         self
     }
 

--- a/hegel-c/tests/c_abi_inprocess.rs
+++ b/hegel-c/tests/c_abi_inprocess.rs
@@ -139,6 +139,10 @@ fn null_handles_are_rejected_without_crashing() {
             HEGEL_E_INVALID_HANDLE
         );
         assert_eq!(
+            hegel_c::hegel_settings_set_stateful_step_count(ctx, ptr::null_mut(), 1),
+            HEGEL_E_INVALID_HANDLE
+        );
+        assert_eq!(
             hegel_c::hegel_settings_set_verbosity(
                 ctx,
                 ptr::null_mut(),
@@ -1059,6 +1063,7 @@ fn state_machine_and_primitive_boolean_paths() {
         let empty = CString::new("").unwrap();
         ok(hegel_settings_set_database(ctx, s, empty.as_ptr()));
         ok(hegel_c::hegel_settings_set_test_cases(ctx, s, 5));
+        ok(hegel_c::hegel_settings_set_stateful_step_count(ctx, s, 10));
         let run = start(ctx, s);
         let tc = next_case(ctx, run);
         assert!(!tc.is_null());

--- a/hegel-c/tests/c_abi_inprocess.rs
+++ b/hegel-c/tests/c_abi_inprocess.rs
@@ -629,6 +629,15 @@ fn out_of_range_enum_values_are_invalid_arguments() {
             HEGEL_E_INVALID_ARG
         );
         assert!(last_error(ctx).contains("unknown verbosity"));
+        assert_eq!(
+            hegel_c::hegel_settings_set_stateful_step_count(ctx, s, 0),
+            HEGEL_E_INVALID_ARG
+        );
+        assert!(last_error(ctx).contains("step count must be at least 1"));
+        assert_eq!(
+            hegel_c::hegel_settings_set_stateful_step_count(ctx, s, -3),
+            HEGEL_E_INVALID_ARG
+        );
 
         let empty = CString::new("").unwrap();
         ok(hegel_settings_set_database(ctx, s, empty.as_ptr()));

--- a/hegel-c/tests/embedded/native/state_machine_tests.rs
+++ b/hegel-c/tests/embedded/native/state_machine_tests.rs
@@ -16,10 +16,9 @@ fn int(v: i64) -> ChoiceValue {
     ChoiceValue::Integer(BigInt::from(v))
 }
 
-/// A step-cap choice larger than `MAX_STEP_CAP`, so the cap truncates to
-/// `MAX_STEP_CAP` and never makes `next_rule` halt within a test.
-fn cap() -> ChoiceValue {
-    int(1_000_000)
+/// always run at least one step
+fn go() -> ChoiceValue {
+    ChoiceValue::Boolean(false)
 }
 
 /// The node recording the rule index chosen by the enumeration fallback:
@@ -32,75 +31,85 @@ fn assert_forced_index_node(ntc: &NativeTestCase, pos: usize, n: i64, index: i64
 }
 
 #[test]
+fn first_step_stop_decision_is_a_forced_keep_going_boolean() {
+    let mut ntc = replay(&[go(), int(0), int(2)], 8);
+    machine(3).next_rule(&mut ntc).unwrap();
+    assert!(ntc.nodes[0].was_forced);
+    assert_eq!(ntc.nodes[0].value, ChoiceValue::Boolean(false));
+}
+
+#[test]
 fn zero_p_disabled_enables_every_rule() {
-    let mut ntc = replay(&[cap(), int(0), int(2)], 8);
+    let mut ntc = replay(&[go(), int(0), int(2)], 8);
     let rule = machine(3).next_rule(&mut ntc).unwrap();
     assert_eq!(rule, Some(2));
     assert_eq!(ntc.nodes.len(), 4);
     assert!(ntc.nodes[3].was_forced);
     assert_eq!(ntc.nodes[3].value, ChoiceValue::Boolean(false));
-    assert_eq!(ntc.spans.len(), 2);
+    assert_eq!(ntc.spans.len(), 1);
     assert_eq!(
         ntc.spans[0usize].label,
-        (crate::hegel_label_t::HEGEL_LABEL_INTEGER as u64).to_string()
-    );
-    assert_eq!(
-        ntc.spans[1usize].label,
         (crate::hegel_label_t::HEGEL_LABEL_FEATURE_FLAG as u64).to_string()
     );
-    assert!(!ntc.spans[1usize].discarded);
+    assert!(!ntc.spans[0usize].discarded);
 }
 
 #[test]
-fn step_cap_truncates_to_max_and_halts_after_that_many_steps() {
+fn bounded_case_runs_exactly_step_count_steps_under_simplest_template() {
     let mut ntc = NativeTestCase::for_choices_and_template(
-        &[cap()],
+        &[],
         None,
         Some(ChoiceTemplate::simplest(None)),
         4096,
         None,
     );
+    ntc.family().set_stateful_step_count(5);
     let mut sm = machine(2);
-    for _ in 0..MAX_STEP_CAP {
+    for _ in 0..5 {
         assert_eq!(sm.next_rule(&mut ntc).unwrap(), Some(0));
     }
-    let drawn = ntc.nodes.len();
     assert_eq!(sm.next_rule(&mut ntc).unwrap(), None);
     assert_eq!(sm.next_rule(&mut ntc).unwrap(), None);
-    assert_eq!(ntc.nodes.len(), drawn);
 }
 
 #[test]
-fn small_step_cap_halts_after_that_many_steps() {
+fn bounded_case_runs_at_least_one_step_even_with_step_count_one() {
     let mut ntc = NativeTestCase::for_choices_and_template(
-        &[int(2)],
+        &[],
         None,
         Some(ChoiceTemplate::simplest(None)),
         64,
         None,
     );
+    ntc.family().set_stateful_step_count(0);
     let mut sm = machine(2);
-    assert!(sm.next_rule(&mut ntc).unwrap().is_some());
-    assert!(sm.next_rule(&mut ntc).unwrap().is_some());
+    assert_eq!(sm.next_rule(&mut ntc).unwrap(), Some(0));
     assert_eq!(sm.next_rule(&mut ntc).unwrap(), None);
 }
 
 #[test]
-fn unbounded_families_draw_no_step_cap_and_never_halt() {
+fn free_stop_decision_can_halt_before_the_cap() {
+    let prefix = [
+        go(),
+        int(254),
+        int(0),
+        ChoiceValue::Boolean(false),
+        ChoiceValue::Boolean(true),
+    ];
+    let mut ntc = replay(&prefix, 16);
+    let mut sm = machine(2);
+    assert_eq!(sm.next_rule(&mut ntc).unwrap(), Some(0));
+    assert_eq!(sm.next_rule(&mut ntc).unwrap(), None);
+}
+
+#[test]
+fn unbounded_families_never_halt() {
     let mut ntc = NativeTestCase::new_random(EngineRng::seeded(0));
     ntc.family().set_state_machine_steps_unbounded();
     let mut sm = machine(2);
-    for _ in 0..2 * MAX_STEP_CAP {
+    for _ in 0..100 {
         assert!(sm.next_rule(&mut ntc).unwrap().is_some());
     }
-    let cap_draws = ntc
-        .nodes
-        .iter()
-        .filter(
-            |n| matches!(&*n.kind, ChoiceKind::Integer(k) if k.max_value == BigInt::from(i64::MAX)),
-        )
-        .count();
-    assert_eq!(cap_draws, 0);
 }
 
 #[test]
@@ -119,7 +128,7 @@ fn p_disabled_is_drawn_on_first_next_rule_only() {
 
 #[test]
 fn last_undecided_rule_is_forced_enabled() {
-    let prefix = [cap(), int(254), int(0), ChoiceValue::Boolean(true), int(1)];
+    let prefix = [go(), int(254), int(0), ChoiceValue::Boolean(true), int(1)];
     let mut ntc = replay(&prefix, 8);
     let rule = machine(2).next_rule(&mut ntc).unwrap().unwrap();
     assert_eq!(rule, 1);
@@ -130,20 +139,27 @@ fn last_undecided_rule_is_forced_enabled() {
 
 #[test]
 fn decided_flag_is_rewritten_as_forced_draw_on_later_queries() {
-    let prefix = [cap(), int(254), int(0), ChoiceValue::Boolean(false), int(0)];
+    let prefix = [
+        go(),
+        int(254),
+        int(0),
+        ChoiceValue::Boolean(false),
+        ChoiceValue::Boolean(false),
+        int(0),
+    ];
     let mut ntc = replay(&prefix, 8);
     let mut sm = machine(2);
     assert_eq!(sm.next_rule(&mut ntc).unwrap().unwrap(), 0);
     assert_eq!(sm.next_rule(&mut ntc).unwrap().unwrap(), 0);
-    assert_eq!(ntc.nodes.len(), 6);
-    assert!(ntc.nodes[5].was_forced);
-    assert_eq!(ntc.nodes[5].value, ChoiceValue::Boolean(false));
+    assert_eq!(ntc.nodes.len(), 7);
+    assert!(ntc.nodes[6].was_forced);
+    assert_eq!(ntc.nodes[6].value, ChoiceValue::Boolean(false));
 }
 
 #[test]
 fn known_disabled_rule_is_skipped_without_redrawing_its_flag() {
     let prefix = [
-        cap(),
+        go(),
         int(254),
         int(1),
         ChoiceValue::Boolean(true),
@@ -160,7 +176,7 @@ fn known_disabled_rule_is_skipped_without_redrawing_its_flag() {
 #[test]
 fn fallback_early_exits_at_the_speculative_index() {
     let prefix = [
-        cap(),
+        go(),
         int(254),
         int(0),
         ChoiceValue::Boolean(true),
@@ -179,7 +195,7 @@ fn fallback_early_exits_at_the_speculative_index() {
 #[test]
 fn fallback_draws_from_allowed_when_speculative_index_is_past_the_end() {
     let prefix = [
-        cap(),
+        go(),
         int(254),
         int(0),
         ChoiceValue::Boolean(true),
@@ -200,7 +216,7 @@ fn fallback_draws_from_allowed_when_speculative_index_is_past_the_end() {
 }
 
 #[test]
-fn overrun_while_drawing_the_step_cap_propagates() {
+fn overrun_while_drawing_the_stop_decision_propagates() {
     let mut ntc = replay(&[], 0);
     let mut sm = machine(2);
     assert!(matches!(sm.next_rule(&mut ntc), Err(EngineError::Overrun)));
@@ -208,14 +224,14 @@ fn overrun_while_drawing_the_step_cap_propagates() {
 
 #[test]
 fn overrun_while_drawing_p_disabled_propagates() {
-    let mut ntc = replay(&[cap()], 1);
+    let mut ntc = replay(&[go()], 1);
     let mut sm = machine(2);
     assert!(matches!(sm.next_rule(&mut ntc), Err(EngineError::Overrun)));
 }
 
 #[test]
 fn overrun_while_drawing_a_try_index_propagates() {
-    let mut ntc = replay(&[cap(), int(0)], 2);
+    let mut ntc = replay(&[go(), int(0)], 2);
     let mut sm = machine(2);
     assert!(matches!(sm.next_rule(&mut ntc), Err(EngineError::Overrun)));
 }
@@ -223,7 +239,7 @@ fn overrun_while_drawing_a_try_index_propagates() {
 #[test]
 fn overrun_while_recording_the_early_exit_index_propagates() {
     let prefix = [
-        cap(),
+        go(),
         int(254),
         int(0),
         ChoiceValue::Boolean(true),
@@ -242,7 +258,7 @@ fn overrun_while_recording_the_early_exit_index_propagates() {
 #[test]
 fn overrun_while_recording_the_post_loop_index_propagates() {
     let prefix = [
-        cap(),
+        go(),
         int(254),
         int(0),
         ChoiceValue::Boolean(true),
@@ -263,18 +279,18 @@ fn overrun_while_recording_the_post_loop_index_propagates() {
 
 #[test]
 fn overrun_inside_is_enabled_leaves_the_span_open_until_freeze() {
-    let mut ntc = replay(&[cap(), int(254), int(0)], 3);
+    let mut ntc = replay(&[go(), int(254), int(0)], 3);
     let mut sm = machine(2);
     assert!(matches!(sm.next_rule(&mut ntc), Err(EngineError::Overrun)));
     assert_eq!(ntc.status(), Some(Status::EarlyStop));
     ntc.freeze();
-    assert_eq!(ntc.spans.len(), 2);
+    assert_eq!(ntc.spans.len(), 1);
     assert_eq!(
-        ntc.spans[1usize].label,
+        ntc.spans[0usize].label,
         (crate::hegel_label_t::HEGEL_LABEL_FEATURE_FLAG as u64).to_string()
     );
-    assert_eq!(ntc.spans[1usize].start, 3);
-    assert_eq!(ntc.spans[1usize].end, 3);
+    assert_eq!(ntc.spans[0usize].start, 3);
+    assert_eq!(ntc.spans[0usize].end, 3);
 }
 
 #[test]

--- a/hegel-c/tests/embedded/native/state_machine_tests.rs
+++ b/hegel-c/tests/embedded/native/state_machine_tests.rs
@@ -81,7 +81,7 @@ fn bounded_case_runs_at_least_one_step_even_with_step_count_one() {
         64,
         None,
     );
-    ntc.family().set_stateful_step_count(0);
+    ntc.family().set_stateful_step_count(1);
     let mut sm = machine(2);
     assert_eq!(sm.next_rule(&mut ntc).unwrap(), Some(0));
     assert_eq!(sm.next_rule(&mut ntc).unwrap(), None);

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -147,6 +147,11 @@ impl SettingsHandle {
                     raw,
                     settings.test_cases,
                 ));
+                require_ok(hegel_c::hegel_settings_set_stateful_step_count(
+                    ctx,
+                    raw,
+                    settings.stateful_step_count,
+                ));
                 require_ok(hegel_c::hegel_settings_set_verbosity(
                     ctx,
                     raw,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -193,7 +193,8 @@ impl Settings {
 
     /// Set the target number of steps run per stateful test case (default:
     /// 50). Each stateful case runs at least one step and at most this many.
-    /// Has no effect on non-stateful tests.
+    /// Has no effect on non-stateful tests. `n` must be at least 1; a smaller
+    /// value makes the run fail with a usage error.
     pub fn stateful_step_count(mut self, n: i64) -> Self {
         self.stateful_step_count = n;
         self

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -124,6 +124,7 @@ pub enum Verbosity {
 pub struct Settings {
     pub(crate) mode: Mode,
     pub(crate) test_cases: u64,
+    pub(crate) stateful_step_count: i64,
     pub(crate) verbosity: Verbosity,
     pub(crate) seed: Option<u64>,
     pub(crate) derandomize: bool,
@@ -145,6 +146,7 @@ impl Settings {
         Self {
             mode: Mode::TestRun,
             test_cases: 100,
+            stateful_step_count: 50,
             verbosity: Verbosity::Normal,
             seed: None,
             derandomize: in_ci,
@@ -186,6 +188,14 @@ impl Settings {
     /// Set the number of test cases to run (default: 100).
     pub fn test_cases(mut self, n: u64) -> Self {
         self.test_cases = n;
+        self
+    }
+
+    /// Set the target number of steps run per stateful test case (default:
+    /// 50). Each stateful case runs at least one step and at most this many.
+    /// Has no effect on non-stateful tests.
+    pub fn stateful_step_count(mut self, n: i64) -> Self {
+        self.stateful_step_count = n;
         self
     }
 

--- a/src/stateful.rs
+++ b/src/stateful.rs
@@ -69,7 +69,7 @@
 use crate::TestCase;
 use crate::control::{AssumeFailed, hegel_internal_assert};
 use crate::generators::Generator;
-use crate::test_case::raise_for_rc;
+use crate::test_case::{labels, raise_for_rc};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
@@ -252,6 +252,7 @@ pub fn run<M: StateMachine>(mut m: M, tc: TestCase) {
     let mut steps_attempted: i64 = 0;
 
     loop {
+        tc.start_span(labels::STATEFUL_RULE);
         let rule_index = match tc.with_ctc(|ctc| ctc.state_machine_next_rule(machine_id)) {
             Ok(Some(i)) => i,
             Ok(None) => break,
@@ -271,15 +272,20 @@ pub fn run<M: StateMachine>(mut m: M, tc: TestCase) {
         steps_attempted += 1;
         match result {
             Ok(()) => {
+                tc.stop_span(false);
                 check_invariants(&mut m, &invariants, &tc);
             }
             Err(e) if e.downcast_ref::<AssumeFailed>().is_some() => {
+                tc.stop_span(true);
                 tc.note("Rule stopped early due to violated assumption.");
             }
             // Everything else — including StopTest, so an out-of-data case is
             // reported as an overrun instead of returning normally with a
             // half-applied rule — unwinds through the caller.
-            Err(e) => resume_unwind(e),
+            Err(e) => {
+                tc.stop_span(false);
+                resume_unwind(e)
+            }
         };
     }
 }

--- a/src/stateful.rs
+++ b/src/stateful.rs
@@ -69,7 +69,6 @@
 use crate::TestCase;
 use crate::control::{AssumeFailed, hegel_internal_assert};
 use crate::generators::Generator;
-use crate::runner::Mode;
 use crate::test_case::raise_for_rc;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -250,11 +249,9 @@ pub fn run<M: StateMachine>(mut m: M, tc: TestCase) {
     tc.note("Initial invariant check.");
     check_invariants(&mut m, &invariants, &tc);
 
-    let is_single = tc.mode() == Mode::SingleTestCase;
-
     let mut steps_attempted: i64 = 0;
 
-    while is_single || steps_attempted < 1000 {
+    loop {
         let rule_index = match tc.with_ctc(|ctc| ctc.state_machine_next_rule(machine_id)) {
             Ok(Some(i)) => i,
             Ok(None) => break,

--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -376,10 +376,6 @@ impl TestCase {
         }
     }
 
-    pub(crate) fn mode(&self) -> Mode {
-        self.global.mode
-    }
-
     /// Acquire the shared draw-name bookkeeping for the duration of `f`.
     ///
     /// Held briefly around draw-state updates, never around whole user-visible

--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -956,6 +956,7 @@ pub mod labels {
     pub const SAMPLED_FROM: u64 = hegel_label_t::HEGEL_LABEL_SAMPLED_FROM as u64;
     pub const ENUM_VARIANT: u64 = hegel_label_t::HEGEL_LABEL_ENUM_VARIANT as u64;
     pub const FEATURE_FLAG: u64 = hegel_label_t::HEGEL_LABEL_FEATURE_FLAG as u64;
+    pub const STATEFUL_RULE: u64 = hegel_label_t::HEGEL_LABEL_STATEFUL_RULE as u64;
 }
 
 #[cfg(test)]

--- a/tests/test_stateful.rs
+++ b/tests/test_stateful.rs
@@ -661,9 +661,16 @@ mod stateful {
         }
     }
 
-    fn run_step_recorder(fail_assumption: bool) -> Vec<u64> {
+    fn run_step_recorder(fail_assumption: bool, step_count: Option<i64>) -> Vec<u64> {
         let counts: Arc<Mutex<Vec<u64>>> = Arc::new(Mutex::new(Vec::new()));
         let counts_in_test = Arc::clone(&counts);
+        let mut settings = Settings::new()
+            .test_cases(100)
+            .database(None)
+            .derandomize(true);
+        if let Some(step_count) = step_count {
+            settings = settings.stateful_step_count(step_count);
+        }
         Hegel::new(move |tc: TestCase| {
             counts_in_test.lock().unwrap().push(0);
             let m = StepRecorderMachine {
@@ -672,22 +679,17 @@ mod stateful {
             };
             hegel::stateful::run(m, tc);
         })
-        .settings(
-            Settings::new()
-                .test_cases(100)
-                .database(None)
-                .derandomize(true),
-        )
+        .settings(settings)
         .run();
         let counts = counts.lock().unwrap();
         counts.clone()
     }
 
-    /// The engine owns the step cap: no test case runs more than 50 steps,
-    /// and the unbounded cap draw usually truncates to exactly 50.
+    /// The engine owns the step cap: with the default `stateful_step_count`,
+    /// no test case runs more than 50 steps, and most run exactly 50.
     #[test]
     fn test_step_cap_is_50_most_of_the_time() {
-        let counts = run_step_recorder(false);
+        let counts = run_step_recorder(false, None);
         assert!(counts.iter().all(|&c| c <= 50));
         let full = counts.iter().filter(|&&c| c == 50).count();
         assert!(
@@ -702,12 +704,27 @@ mod stateful {
     /// the engine's cap rather than retrying indefinitely.
     #[test]
     fn test_hopeless_machine_is_bounded_by_the_step_cap() {
-        let counts = run_step_recorder(true);
+        let counts = run_step_recorder(true, None);
         assert!(counts.iter().all(|&c| c <= 50));
         let full = counts.iter().filter(|&&c| c == 50).count();
         assert!(
             full > counts.len() / 2,
             "expected most of {} test cases to attempt exactly 50 rules, got {full}",
+            counts.len()
+        );
+    }
+
+    /// The `stateful_step_count` setting replaces the fixed cap: with a custom
+    /// value, no test case runs more than that many steps, and most run
+    /// exactly that many.
+    #[test]
+    fn test_stateful_step_count_setting_bounds_steps() {
+        let counts = run_step_recorder(false, Some(7));
+        assert!(counts.iter().all(|&c| (1..=7).contains(&c)));
+        let full = counts.iter().filter(|&&c| c == 7).count();
+        assert!(
+            full > counts.len() / 2,
+            "expected most of {} test cases to run exactly 7 steps, got {full}",
             counts.len()
         );
     }

--- a/tests/test_stateful.rs
+++ b/tests/test_stateful.rs
@@ -266,6 +266,40 @@ mod stateful {
         );
     }
 
+    struct BumpMachine {
+        count: i64,
+    }
+
+    impl StateMachine for BumpMachine {
+        fn rules(&self) -> Vec<Rule<Self>> {
+            vec![
+                Rule::new("bump", |m: &mut BumpMachine, _tc| m.count += 1),
+                Rule::new("noop", |_m: &mut BumpMachine, _tc| {}),
+            ]
+        }
+        fn invariants(&self) -> Vec<Rule<Self>> {
+            vec![Rule::new("below_three", |m: &mut BumpMachine, _tc| {
+                assert!(m.count < 3);
+            })]
+        }
+    }
+
+    #[test]
+    fn test_irrelevant_steps_are_shrunk_away() {
+        let output = capture_output(false, |tc: TestCase| {
+            hegel::stateful::run(BumpMachine { count: 0 }, tc);
+        });
+        let step_lines = output.lines().filter(|l| l.contains("Step ")).count();
+        assert_eq!(
+            step_lines, 3,
+            "expected the minimal failure to be exactly three bump steps:\n{output}"
+        );
+        assert!(
+            !output.contains("noop"),
+            "irrelevant noop steps should be shrunk away:\n{output}"
+        );
+    }
+
     struct AssumeSkipMachine;
 
     #[hegel::state_machine]

--- a/tests/test_stateful.rs
+++ b/tests/test_stateful.rs
@@ -565,6 +565,18 @@ mod stateful {
         );
     }
 
+    #[test]
+    fn test_stateful_step_count_below_one_is_a_usage_error() {
+        expect_panic(
+            || {
+                Hegel::new(|_tc: TestCase| {})
+                    .settings(Settings::new().database(None).stateful_step_count(0))
+                    .run();
+            },
+            "step count must be at least 1",
+        );
+    }
+
     /// Records which rule ran at each step, one sequence per test case.
     struct SwarmRecorderMachine {
         runs: Arc<Mutex<Vec<Vec<usize>>>>,

--- a/tests/test_stateful.rs
+++ b/tests/test_stateful.rs
@@ -703,9 +703,16 @@ mod stateful {
         }
     }
 
-    fn run_step_recorder(fail_assumption: bool) -> Vec<u64> {
+    fn run_step_recorder(fail_assumption: bool, step_count: Option<i64>) -> Vec<u64> {
         let counts: Arc<Mutex<Vec<u64>>> = Arc::new(Mutex::new(Vec::new()));
         let counts_in_test = Arc::clone(&counts);
+        let mut settings = Settings::new()
+            .test_cases(100)
+            .database(None)
+            .derandomize(true);
+        if let Some(step_count) = step_count {
+            settings = settings.stateful_step_count(step_count);
+        }
         Hegel::new(move |tc: TestCase| {
             counts_in_test.lock().unwrap().push(0);
             let m = StepRecorderMachine {
@@ -714,22 +721,17 @@ mod stateful {
             };
             hegel::stateful::run(m, tc);
         })
-        .settings(
-            Settings::new()
-                .test_cases(100)
-                .database(None)
-                .derandomize(true),
-        )
+        .settings(settings)
         .run();
         let counts = counts.lock().unwrap();
         counts.clone()
     }
 
-    /// The engine owns the step cap: no test case runs more than 50 steps,
-    /// and the unbounded cap draw usually truncates to exactly 50.
+    /// The engine owns the step cap: with the default `stateful_step_count`,
+    /// no test case runs more than 50 steps, and most run exactly 50.
     #[test]
     fn test_step_cap_is_50_most_of_the_time() {
-        let counts = run_step_recorder(false);
+        let counts = run_step_recorder(false, None);
         assert!(counts.iter().all(|&c| c <= 50));
         let full = counts.iter().filter(|&&c| c == 50).count();
         assert!(
@@ -744,12 +746,27 @@ mod stateful {
     /// the engine's cap rather than retrying indefinitely.
     #[test]
     fn test_hopeless_machine_is_bounded_by_the_step_cap() {
-        let counts = run_step_recorder(true);
+        let counts = run_step_recorder(true, None);
         assert!(counts.iter().all(|&c| c <= 50));
         let full = counts.iter().filter(|&&c| c == 50).count();
         assert!(
             full > counts.len() / 2,
             "expected most of {} test cases to attempt exactly 50 rules, got {full}",
+            counts.len()
+        );
+    }
+
+    /// The `stateful_step_count` setting replaces the fixed cap: with a custom
+    /// value, no test case runs more than that many steps, and most run
+    /// exactly that many.
+    #[test]
+    fn test_stateful_step_count_setting_bounds_steps() {
+        let counts = run_step_recorder(false, Some(7));
+        assert!(counts.iter().all(|&c| (1..=7).contains(&c)));
+        let full = counts.iter().filter(|&&c| c == 7).count();
+        assert!(
+            full > counts.len() / 2,
+            "expected most of {} test cases to run exactly 7 steps, got {full}",
             counts.len()
         );
     }

--- a/tests/test_stateful.rs
+++ b/tests/test_stateful.rs
@@ -607,6 +607,18 @@ mod stateful {
         );
     }
 
+    #[test]
+    fn test_stateful_step_count_below_one_is_a_usage_error() {
+        expect_panic(
+            || {
+                Hegel::new(|_tc: TestCase| {})
+                    .settings(Settings::new().database(None).stateful_step_count(0))
+                    .run();
+            },
+            "step count must be at least 1",
+        );
+    }
+
     /// Records which rule ran at each step, one sequence per test case.
     struct SwarmRecorderMachine {
         runs: Arc<Mutex<Vec<Vec<usize>>>>,

--- a/tests/test_stateful.rs
+++ b/tests/test_stateful.rs
@@ -308,6 +308,40 @@ mod stateful {
         );
     }
 
+    struct BumpMachine {
+        count: i64,
+    }
+
+    impl StateMachine for BumpMachine {
+        fn rules(&self) -> Vec<Rule<Self>> {
+            vec![
+                Rule::new("bump", |m: &mut BumpMachine, _tc| m.count += 1),
+                Rule::new("noop", |_m: &mut BumpMachine, _tc| {}),
+            ]
+        }
+        fn invariants(&self) -> Vec<Rule<Self>> {
+            vec![Rule::new("below_three", |m: &mut BumpMachine, _tc| {
+                assert!(m.count < 3);
+            })]
+        }
+    }
+
+    #[test]
+    fn test_irrelevant_steps_are_shrunk_away() {
+        let output = capture_output(false, |tc: TestCase| {
+            hegel::stateful::run(BumpMachine { count: 0 }, tc);
+        });
+        let step_lines = output.lines().filter(|l| l.contains("Step ")).count();
+        assert_eq!(
+            step_lines, 3,
+            "expected the minimal failure to be exactly three bump steps:\n{output}"
+        );
+        assert!(
+            !output.contains("noop"),
+            "irrelevant noop steps should be shrunk away:\n{output}"
+        );
+    }
+
     struct AssumeSkipMachine;
 
     #[hegel::state_machine]


### PR DESCRIPTION
The previous stateful stop condition moved the existing hegel-rust stateful stop condition. This patch implements the Hypothesis stateful stop condition which should be slightly better for shrinking. 

Resolves #349 and #254