### PR TITLE
Fix reorder_spans panic when an improvement shortens the span list

### DIFF
--- a/hegel-c/RELEASE.md
+++ b/hegel-c/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch fixes an engine panic during shrinking. When the span-reordering pass ran against a test case with several groups of same-label sibling spans, and reordering one group produced an improvement that shortened the recorded span list, the pass went on to index the remaining groups with positions from the old, longer list. The run then aborted with `Engine panic: index out of bounds` instead of reporting the shrunk counterexample (re-running the test recovered via the failure database, but the first run's result was lost). Span groups are now re-validated against the current spans after each improvement, and groups that no longer exist are skipped.

--- a/hegel-c/src/native/shrinker/spans.rs
+++ b/hegel-c/src/native/shrinker/spans.rs
@@ -228,7 +228,15 @@ impl<'a> Shrinker<'a> {
                 }
             }
 
-            for (_label, child_indices) in by_label {
+            for (label, child_indices) in by_label {
+                let child_indices: Vec<usize> = child_indices
+                    .into_iter()
+                    .filter(|&i| {
+                        self.current_spans
+                            .get(i)
+                            .is_some_and(|s| s.parent == parent && s.label == label)
+                    })
+                    .collect();
                 if child_indices.len() <= 1 {
                     continue;
                 }

--- a/hegel-c/tests/embedded/native/shrinker_reorder_spans_tests.rs
+++ b/hegel-c/tests/embedded/native/shrinker_reorder_spans_tests.rs
@@ -157,3 +157,38 @@ fn reorder_spans_safe_with_stale_endpoints() {
     drive_no_yield(shrinker.reorder_spans()).unwrap();
     assert_eq!(shrinker.current_nodes.len(), 2);
 }
+
+#[test]
+fn reorder_spans_survives_spans_shrinking_between_label_groups() {
+    let initial = vec![int_node(3), int_node(1), int_node(9), int_node(7)];
+    let mut spans = Spans::new();
+    spans.push(sib(0, 1, "a", None));
+    spans.push(sib(1, 2, "a", None));
+    spans.push(sib(2, 3, "b", None));
+    spans.push(sib(3, 4, "b", None));
+
+    let mut shrinker = Shrinker::with_probe(
+        Box::new(|run: ShrinkRun<'_>| match run {
+            ShrinkRun::Full(nodes) => {
+                let mut new_spans = Spans::new();
+                new_spans.push(sib(0, 1, "z", None));
+                new_spans.push(sib(1, 2, "z", None));
+                new_spans.push(sib(2, 3, "z", None));
+                (true, nodes.to_vec(), new_spans)
+            }
+            ShrinkRun::Probe { .. } => (false, Vec::new(), Spans::new()),
+        }),
+        initial,
+        spans,
+    );
+    drive_no_yield(shrinker.reorder_spans()).unwrap();
+    let values: Vec<_> = shrinker
+        .current_nodes
+        .iter()
+        .map(|n| match &n.value {
+            ChoiceValue::Integer(v) => i128::try_from(v.clone()).unwrap(),
+            _ => unreachable!(),
+        })
+        .collect();
+    assert_eq!(values, vec![1, 3, 9, 7]);
+}


### PR DESCRIPTION
Fixes an engine panic during shrinking (found while field-testing the hegel skill against iri-string).

<details>
<summary>Details (AI-generated)</summary>

**Symptom:** a run aborted mid-shrink with `Engine panic: index out of bounds: the len is 18 but the index is 20`, hiding the counterexample until a re-run replayed the failure database.

**Cause:** `Shrinker::reorder_spans` computes its same-label sibling groups (`by_label`, span indices) once per parent. A successful improvement inside the first group's `shrink_ordering` replaces `current_spans` (via `consider`), so later groups indexed the new — possibly shorter — span list with stale positions: `&self.current_spans[i]` panics.

**Fix:** re-validate each group's indices against `current_spans` immediately before use, keeping only spans that still exist with the same parent and label (the same revalidation idiom `try_sort_group` uses). Groups invalidated by an improvement are skipped; the pass re-runs on the next fixpoint iteration with fresh spans.

**Testing:** TDD — `reorder_spans_survives_spans_shrinking_between_label_groups` (embedded unit test) reproduces the exact panic before the fix by having the probe install a shorter, relabeled span list on improvement; it covers both the out-of-range and the parent/label-mismatch filter branches. Full `just check` green (1120 hegel-c tests, root suite, clippy, fmt, docs).

**Release note:** `hegel-c/RELEASE.md` (patch).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)