### PR TITLE
Fix slice-index panic in short-backtrace filtering

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch fixes a panic in Hegel's backtrace formatting. When a failing test's short backtrace contained the `__rust_end_short_backtrace` and `__rust_begin_short_backtrace` markers in an arrangement where the frame the end marker selected came after the begin marker, the formatter computed a start index greater than its end index and panicked with `slice index starts at N but ends at M` while slicing the frame list. That panic replaced the real test failure with an unrelated engine-side crash. The formatter now detects the inconsistent range and falls back to keeping the full backtrace instead of panicking.

--- a/src/run_lifecycle.rs
+++ b/src/run_lifecycle.rs
@@ -149,6 +149,10 @@ fn filter_short_backtrace(backtrace_str: &str) -> String {
         }
     }
 
+    if start_idx > end_idx {
+        start_idx = 0;
+        end_idx = lines.len();
+    }
     let filtered: Vec<&str> = lines[start_idx..end_idx].to_vec();
     let mut new_frame_num = 0usize;
     let mut result = Vec::new();

--- a/src/run_lifecycle.rs
+++ b/src/run_lifecycle.rs
@@ -177,6 +177,10 @@ fn filter_short_backtrace(backtrace_str: &str) -> String {
         }
     }
 
+    if start_idx > end_idx {
+        start_idx = 0;
+        end_idx = lines.len();
+    }
     let filtered: Vec<&str> = lines[start_idx..end_idx].to_vec();
     let mut new_frame_num = 0usize;
     let mut result = Vec::new();

--- a/tests/embedded/run_lifecycle_tests.rs
+++ b/tests/embedded/run_lifecycle_tests.rs
@@ -98,6 +98,20 @@ fn filter_short_backtrace_trims_at_begin_marker() {
 }
 
 #[test]
+fn filter_short_backtrace_does_not_panic_when_markers_invert_indices() {
+    let input = "  0: first_frame at /tmp/a.rs:1\n\
+                 stuff: __rust_end_short_backtrace\n\
+                 stuff: __rust_begin_short_backtrace\n  \
+                 1: last_frame at /tmp/b.rs:2";
+    let out = filter_short_backtrace(input);
+    assert!(
+        out.contains("first_frame") || out.contains("last_frame"),
+        "expected some frame to survive, got {:?}",
+        out
+    );
+}
+
+#[test]
 fn format_backtrace_full_returns_display_verbatim() {
     let bt = std::backtrace::Backtrace::disabled();
     let out = format_backtrace(&bt, true);


### PR DESCRIPTION
<!-- Human: please replace this line with the PR title and a short description of the change. -->

<details>
<summary>AI-generated implementation notes</summary>

**Bug.** `filter_short_backtrace` (`src/run_lifecycle.rs`) trims a panic backtrace to the user frames by finding a `start_idx` (the first numbered frame after `__rust_end_short_backtrace`) and an `end_idx` (the last numbered frame at/before `__rust_begin_short_backtrace`), then slicing `lines[start_idx..end_idx]`. When the two markers appear in an arrangement where the end-marker's forward scan selects a frame *after* the begin-marker line — e.g. both markers sit on non-numbered continuation lines with a numbered frame only after the begin marker — `start_idx` ends up greater than `end_idx`, and the slice panics with `slice index starts at N but ends at M`.

Because this runs while formatting a *failing* test's backtrace, the formatter's own panic replaces the real test failure with an unrelated engine-side crash (surfaced as an `index out of bounds` abort). It was hit in practice while formatting the backtrace of a replayed failure during property-based testing.

**Fix.** Guard the slice: if `start_idx > end_idx` the marker detection is inconsistent, so fall back to keeping the full backtrace (`start_idx = 0; end_idx = lines.len()`) rather than panicking. A panic-formatter should never itself panic.

**Test.** `tests/embedded/run_lifecycle_tests.rs::filter_short_backtrace_does_not_panic_when_markers_invert_indices` constructs a backtrace with the marker arrangement that inverts the indices; it panics on the unpatched code (`slice index starts at 3 but ends at 0`) and passes with the fix. The four existing `filter_short_backtrace_*` tests still pass, and the new guard is exercised by the regression test.

`just check` passes (lint + tests + all-features + doctests + coverage). `RELEASE.md` added (RELEASE_TYPE: patch).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
