### PR TITLE
claude: exclude .agents and AGENTS.md from the published crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,18 +23,18 @@ CLAUDE.local.md
 # Place to put temporary reference material
 resources
 
-# whitelist .claude files, rather than blacklist. Some local claude files
-# (skills, agents) have to live in .claude - as opposed to eg CLAUDE.local.md,
+# whitelist .agents files, rather than blacklist. Some local claude files
+# (skills, agents) have to live in .agents - as opposed to eg CLAUDE.local.md,
 # which we gitignore at the top level.
-.claude/*
-!.claude/CLAUDE.md
-!.claude/skills/
-.claude/skills/*
-!.claude/skills/changelog/
-!.claude/skills/coverage/
-!.claude/skills/self-review/
-!.claude/skills/new-generator/
-!.claude/skills/new-default-generator/
-!.claude/skills/add-library-support/
+.agents/*
+!.agents/CLAUDE.md
+!.agents/skills/
+.agents/skills/*
+!.agents/skills/changelog/
+!.agents/skills/coverage/
+!.agents/skills/self-review/
+!.agents/skills/new-generator/
+!.agents/skills/new-default-generator/
+!.agents/skills/add-library-support/
 
 docs/superpowers

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,9 @@ edition = "2024"
 # if you bump this, also bump ci.yml, hegel-macros/Cargo.toml, and hegel-c/Cargo.toml
 rust-version = "1.86"
 exclude = [
+  "/.agents",
   "/.claude",
+  "/AGENTS.md",
   "/.github",
   "/nix",
   "/RELEASE-sample.md",

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch stops packaging internal agent instruction files (`AGENTS.md` and `.agents/`) in the published crate.


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

The `.claude` → `.agents` rename left `cargo package` shipping the agent instruction files: the `/.claude` entry in the package `exclude` list now only matches the symlink, so the tracked `.agents/**` files and the new root `AGENTS.md` were included in the published crate (verified with `cargo package --list`). This adds `/.agents` and `/AGENTS.md` to the exclude list, and updates the `.gitignore` whitelist patterns (and their comment) from `.claude/*` to `.agents/*` to match the renamed directory.

</details>
