### PR TITLE
Forward only expression-valid attributes to state machine rule entries

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch fixes incorrect attribute forwarding on some `#[rule]` and `#[invariant]` methods.

--- a/hegel-macros/src/stateful.rs
+++ b/hegel-macros/src/stateful.rs
@@ -21,14 +21,15 @@ fn method_entries(methods: &[MethodInfo]) -> Vec<TokenStream> {
         .map(|m| {
             let name_str = m.name.to_string();
             let name = &m.name;
-            // Forward the method's attributes (cfg gates, user attribute
-            // macros, ...) onto the generated vec entry, except doc
-            // comments: those would land on an expression and trip
-            // unused_doc_comments in the user's crate.
+            // Only forward attributes that are valid on expressions, which is a subset of all
+            // attributes. See https://github.com/hegeldev/hegel-rust/pull/353.
+            const FORWARDED: [&str; 7] = [
+                "cfg", "cfg_attr", "allow", "expect", "warn", "deny", "forbid",
+            ];
             let attrs: Vec<&Attribute> = m
                 .attrs
                 .iter()
-                .filter(|a| !a.path().is_ident("doc"))
+                .filter(|a| FORWARDED.iter().any(|name| a.path().is_ident(name)))
                 .collect();
             // Register through a non-capturing closure rather than
             // `Self::#name` directly: `Rule.apply` is `fn(&mut M, TestCase)`,

--- a/tests/test_stateful.rs
+++ b/tests/test_stateful.rs
@@ -195,6 +195,48 @@ fn test_state_machine_with_shared_receivers(tc: TestCase) {
     hegel::stateful::run(m, tc);
 }
 
+mod attrs_on_rules {
+    #![allow(unexpected_cfgs)]
+    #![forbid(unused_doc_comments)]
+
+    use hegel::TestCase;
+
+    struct AttrMachine {
+        count: u32,
+    }
+
+    #[hegel::state_machine]
+    impl AttrMachine {
+        /// This is a doc comment.
+        #[rule]
+        fn increment(&mut self, _tc: TestCase) {
+            self.count += 1;
+        }
+
+        #[rustfmt::skip]
+        #[rule]
+        fn unformatted(&mut self, _tc: TestCase) {
+            self.count += 1;
+        }
+
+        #[cfg(nonexistent_config)]
+        #[rule]
+        fn never(&mut self, _tc: TestCase) {
+            compile_error!("should be compiled out");
+        }
+
+        /// This is a doc comment.
+        #[invariant]
+        fn documented_invariant(&self, _tc: TestCase) {}
+    }
+
+    #[hegel::test]
+    fn test_attrs_on_rules(tc: TestCase) {
+        let m = AttrMachine { count: 0 };
+        hegel::stateful::run(m, tc);
+    }
+}
+
 mod stateful {
     use super::common::utils::expect_panic;
     use hegel::TestCase;


### PR DESCRIPTION
Closes #353.

<details>

`#[hegel::state_machine]` copies attributes from `#[rule]`/`#[invariant]` methods onto the generated rules-vec entries, which are expressions. Only `cfg`/`cfg_attr` and the lint check attributes are valid there; everything else is a hard error today (`#[rustfmt::skip]`, custom attribute macros like `#[tracing::instrument]`) or a future-incompat warning (`#[cold]`, `#[deprecated]`, ...). Forwarding custom attribute macros can never work on stable — E0658 rejects them in expression position before expansion — so they now stay on the method only, where they expand as written.

Switch the denylist (everything but `doc`) to an allowlist of `cfg`, `cfg_attr`, and the lint check attributes, per [the discussion in #353](https://github.com/hegeldev/hegel-rust/pull/353#issuecomment-5111233277). Ports the regression test from #353, extended with a `#[rustfmt::skip]` rule.

Closes #353.

</details>