### PR TITLE
Keep libhegel resident with -z nodelete to fix a dlclose crash

### DIFF
--- a/hegel-c/RELEASE.md
+++ b/hegel-c/RELEASE.md
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch fixes a crash (SIGSEGV) that could occur when an application `dlopen`s libhegel, runs a test, and then `dlclose`s the library while a thread that called into it is still alive. It was most reliably triggered by a run that persists to the on-disk failure database.
+
+Running the engine registers `std` thread-local destructors — and a global panic hook — whose code lives inside libhegel. glibc runs those thread-local destructors when the thread exits; if the library has already been unloaded by then, the destructor pointers dangle and the process crashes during teardown. libhegel is now built with `-z nodelete` on ELF platforms (Linux/Android), so `dlclose` keeps it resident and those destructors stay valid for the life of the process.

--- a/hegel-c/build.rs
+++ b/hegel-c/build.rs
@@ -1,0 +1,26 @@
+fn main() {
+    // Mark the cdylib as non-deletable so `dlclose` keeps it resident for the
+    // rest of the process's life.
+    //
+    // A Rust cdylib that an embedder `dlopen`s and later `dlclose`s is unsafe to
+    // unload while any thread that called into it is still alive. Running the
+    // engine (in particular persisting to the on-disk database, which pulls in
+    // `tempfile`/`fastrand`) touches `std` thread-locals whose *destructors* —
+    // and the global panic hook — are code inside this library. glibc records
+    // those thread-local destructors in the process-global `__pthread_keys` and
+    // runs them when the thread exits. If the library has been `dlclose`d and
+    // unmapped by then, the destructor pointer dangles and the process
+    // segfaults during thread teardown (see the `libhegel_replays_persisted_
+    // failure_with_same_database_key` smoke test).
+    //
+    // `-z nodelete` turns `dlclose` into a no-op for this library: it stays
+    // mapped, so those destructors remain valid for the process's lifetime. The
+    // flag is ELF-specific (Linux/Android); on macOS and Windows a `dlopen`ed
+    // dynamic library is not eagerly unmapped in the same way, so no equivalent
+    // is needed. It applies only to the cdylib artifact, leaving the
+    // `staticlib` and `rlib` untouched.
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    if target_os == "linux" || target_os == "android" {
+        println!("cargo:rustc-cdylib-link-arg=-Wl,-z,nodelete");
+    }
+}

--- a/hegel-c/tests/smoke.rs
+++ b/hegel-c/tests/smoke.rs
@@ -1316,6 +1316,83 @@ fn run_free_after_early_exit_does_not_hang() {
     }
 }
 
+/// Focused regression test for the `-z nodelete` fix in `build.rs`.
+///
+/// Persisting to the database calls `DirectoryTestCaseDatabase::save`, which
+/// writes atomically via `tempfile`/`fastrand`. Initialising `fastrand`'s
+/// thread-local RNG runs `std::thread::current::init_current`, registering a
+/// `std` thread-local *destructor* pthread key on the calling thread — with the
+/// destructor code living inside libhegel. glibc records that destructor in the
+/// process-global `__pthread_keys` and calls it when the thread exits.
+///
+/// If `dlclose` (dropping `lib` at the end of this function) unmaps libhegel
+/// before the thread exits, that destructor pointer dangles and the process
+/// segfaults during thread teardown — *after* this test returns, when the
+/// libtest worker thread winds down. `-z nodelete` keeps libhegel resident so
+/// the destructor stays valid.
+///
+/// The assertion is therefore implicit: with the fix the process exits cleanly;
+/// without it, this test's thread aborts the whole process with SIGSEGV. The
+/// `assert!` below only confirms the trigger path (a persisting `save`) actually
+/// ran.
+#[test]
+fn dlclose_after_database_save_is_safe_at_thread_exit() {
+    let tempdir = tempfile::TempDir::new().expect("tempdir");
+    let db_path = CString::new(tempdir.path().to_string_lossy().as_bytes()).unwrap();
+    let key = CString::new("nodelete-regression").unwrap();
+
+    let mut persisted = false;
+    {
+        let lib = unsafe { load() };
+        let a = unsafe { bind(&lib) };
+        unsafe {
+            let ctx = (a.context_new)();
+            let s = a.settings_new(ctx);
+            a.settings_test_cases(ctx, s, 50);
+            (a.settings_database)(ctx, s, db_path.as_ptr());
+            (a.settings_database_key)(ctx, s, key.as_ptr());
+            a.settings_derandomize(ctx, s, true);
+            a.settings_seed(ctx, s, 1, true);
+
+            let run = a.run_start(ctx, s);
+            loop {
+                let tc = a.next_test_case(ctx, run);
+                if tc.is_null() {
+                    break;
+                }
+                let mut n: i64 = 0;
+                let rc = (a.generate_integer)(ctx, tc, 0, 2_000_000, &mut n);
+                if rc == HEGEL_E_STOP_TEST {
+                    a.complete_and_free(ctx, tc, CStatus::Overrun, ptr::null());
+                    continue;
+                }
+                assert_eq!(rc, HEGEL_OK);
+                // Report the first test case as interesting so `save` runs at
+                // least once (the path that registers the thread-local
+                // destructor). The rest are valid.
+                if !persisted {
+                    persisted = true;
+                    let origin = CString::new("nodelete-regression").unwrap();
+                    a.complete_and_free(ctx, tc, CStatus::Interesting, origin.as_ptr());
+                } else {
+                    a.complete_and_free(ctx, tc, CStatus::Valid, ptr::null());
+                }
+            }
+            a.run_free(ctx, run);
+            a.settings_free(ctx, s);
+            (a.context_free)(ctx);
+        }
+        // `lib` drops here -> dlclose. Under `-z nodelete` the library stays
+        // mapped, so the thread-local destructor registered by `save` above is
+        // still valid when this test's worker thread exits.
+    }
+
+    assert!(
+        persisted,
+        "expected at least one interesting case so a persisting save() ran"
+    );
+}
+
 /// Reproduces hegel-go report #2 via the C API: persist a failing example
 /// on run 1, then run 2 with the same database + key and confirm the
 /// first test case is a replay of the persisted (shrunk) failing value.


### PR DESCRIPTION
> _Draft — over to you for the title and a short description._

<details>
<summary>AI-generated implementation notes</summary>

### What

Adds `hegel-c/build.rs`, which builds the `libhegel` cdylib with `-Wl,-z,nodelete` on ELF platforms (Linux/Android). The flag applies only to the cdylib artifact; the `staticlib`/`rlib` are untouched.

### Why

An embedder that `dlopen`s libhegel, runs the engine, and then `dlclose`s it while a thread that called into it is still alive could `SIGSEGV` during thread teardown. It was most reliably triggered by a run that persists to the on-disk failure database.

Root cause (from a coredump backtrace):

- `DirectoryTestCaseDatabase::save` writes atomically via `tempfile::NamedTempFile`, which uses `fastrand`'s thread-local RNG.
- Initialising that thread-local runs `std::thread::current::init_current`, which registers std's **thread-local-destructor pthread key** on the *caller's* thread — with the destructor code living inside libhegel.
- glibc records that destructor in the process-global `__pthread_keys` and calls it when the thread exits.
- If the embedder has `dlclose`d libhegel by then, the code is unmapped and the destructor pointer dangles → segfault during thread teardown. (The crashing PC matched `std::sys::thread_local::guard::key::enable::run` in the unmapped range exactly.)

The same hazard applies to the global panic hook the engine installs. `-z nodelete` turns `dlclose` into a no-op for this library, so it stays mapped and all such destructors remain valid for the life of the process — the standard fix for a `dlopen`-able Rust cdylib. On macOS/Windows a `dlopen`ed dynamic library isn't eagerly unmapped the same way, so no equivalent is needed there.

### Regression coverage

The existing `libhegel_replays_persisted_failure_with_same_database_key` smoke test exercises this exact path (persist on run 1, replay on run 2, then drop the `Library`). It segfaulted without the flag and passes with it; a doc comment on the test now records the dependency.

Verified by control: rebuilt the cdylib with the flag removed → the smoke test `SIGSEGV`s again; restored → passes. `FLAGS_1: NOW NODELETE` confirmed via `readelf -d`. Full `hegel-c` suite green (1120 unit + 16 smoke).

### Notes

- This is a pre-existing crash, not introduced by any recent change — it reproduces on `main` (verified on `ecff302d`). It appears to surface on aarch64/glibc; other targets may tear TLS down in an order that hides it.
- `RELEASE_TYPE: patch` (`hegel-c/RELEASE.md`).
</details>
