### PR TITLE
no_std prep 1/5: drop crc32fast; move hegel-c to hashbrown, libm, core::net, core::error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, 'no-std-*']
 
 permissions: {}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,6 +382,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
@@ -426,6 +432,7 @@ dependencies = [
  "cbindgen",
  "ctor",
  "dashu-int",
+ "hashbrown 0.16.1",
  "insta",
  "libloading",
  "miniz_oxide",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,6 @@ name = "hegeltest-c"
 version = "0.30.3"
 dependencies = [
  "cbindgen",
- "crc32fast",
  "ctor",
  "dashu-int",
  "insta",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,6 +435,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "insta",
  "libloading",
+ "libm",
  "miniz_oxide",
  "parking_lot",
  "rand",
@@ -566,6 +567,12 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,12 +382,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
@@ -432,7 +426,7 @@ dependencies = [
  "cbindgen",
  "ctor",
  "dashu-int",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "insta",
  "libloading",
  "libm",

--- a/hegel-c/Cargo.toml
+++ b/hegel-c/Cargo.toml
@@ -23,7 +23,8 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 rand = { version = "0.10" }
 dashu-int = { version = "0.4.1", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.8" }
-rustc-hash = { version = "2" }
+rustc-hash = { version = "2", default-features = false }
+hashbrown = { version = "0.16", default-features = false, features = ["inline-more"] }
 parking_lot = "0.12"
 tempfile = "3"
 

--- a/hegel-c/Cargo.toml
+++ b/hegel-c/Cargo.toml
@@ -25,7 +25,7 @@ dashu-int = { version = "0.4.1", default-features = false }
 miniz_oxide = { version = "0.8", default-features = false, features = ["with-alloc"] }
 rustc-hash = { version = "2", default-features = false }
 hashbrown = { version = "0.17", default-features = false, features = ["inline-more"] }
-libm = "0.2"
+libm = { version = "0.2", default-features = false }
 parking_lot = "0.12"
 tempfile = "3"
 

--- a/hegel-c/Cargo.toml
+++ b/hegel-c/Cargo.toml
@@ -24,7 +24,6 @@ rand = { version = "0.10" }
 dashu-int = { version = "0.4.1", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.8" }
 rustc-hash = { version = "2" }
-crc32fast = "1.4"
 parking_lot = "0.12"
 tempfile = "3"
 

--- a/hegel-c/Cargo.toml
+++ b/hegel-c/Cargo.toml
@@ -21,8 +21,8 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
 rand = { version = "0.10" }
-dashu-int = { version = "0.4.1", default-features = false, features = ["std"] }
-miniz_oxide = { version = "0.8" }
+dashu-int = { version = "0.4.1", default-features = false }
+miniz_oxide = { version = "0.8", default-features = false, features = ["with-alloc"] }
 rustc-hash = { version = "2", default-features = false }
 hashbrown = { version = "0.16", default-features = false, features = ["inline-more"] }
 libm = "0.2"

--- a/hegel-c/Cargo.toml
+++ b/hegel-c/Cargo.toml
@@ -25,6 +25,7 @@ dashu-int = { version = "0.4.1", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.8" }
 rustc-hash = { version = "2", default-features = false }
 hashbrown = { version = "0.16", default-features = false, features = ["inline-more"] }
+libm = "0.2"
 parking_lot = "0.12"
 tempfile = "3"
 

--- a/hegel-c/Cargo.toml
+++ b/hegel-c/Cargo.toml
@@ -24,7 +24,7 @@ rand = { version = "0.10" }
 dashu-int = { version = "0.4.1", default-features = false }
 miniz_oxide = { version = "0.8", default-features = false, features = ["with-alloc"] }
 rustc-hash = { version = "2", default-features = false }
-hashbrown = { version = "0.16", default-features = false, features = ["inline-more"] }
+hashbrown = { version = "0.17", default-features = false, features = ["inline-more"] }
 libm = "0.2"
 parking_lot = "0.12"
 tempfile = "3"

--- a/hegel-c/RELEASE.md
+++ b/hegel-c/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Internal preparation for making the engine core `no_std`-compatible: the engine's hash tables now use `hashbrown` and its floating-point math now goes through the `libm` crate instead of the platform math library, and the unused `crc32fast` dependency is gone. `libm` can round differently from a platform math library in the last bit, so on some platforms fixed-seed runs may generate different values than previous releases. Stored failures are unaffected: database replay is value-based, and seed reproducibility has always been build-specific.

--- a/hegel-c/src/backend.rs
+++ b/hegel-c/src/backend.rs
@@ -1,4 +1,4 @@
-use std::net::{Ipv4Addr, Ipv6Addr};
+use core::net::{Ipv4Addr, Ipv6Addr};
 
 use crate::native::bignum::BigInt;
 use crate::native::draws::special::{Date, DateTime, Time};
@@ -37,7 +37,7 @@ impl std::fmt::Display for DataSourceError {
         }
     }
 }
-impl std::error::Error for DataSourceError {}
+impl core::error::Error for DataSourceError {}
 
 /// Data source for test case generation.
 ///
@@ -238,7 +238,7 @@ impl std::fmt::Display for RunError {
     }
 }
 
-impl std::error::Error for RunError {}
+impl core::error::Error for RunError {}
 
 /// Result of a full test run: the run's outcome once generation and
 /// shrinking are done.

--- a/hegel-c/src/native/core/float_index.rs
+++ b/hegel-c/src/native/core/float_index.rs
@@ -108,7 +108,7 @@ pub fn index_to_float(i: u64) -> f64 {
 pub fn simplest_in_range(lo: f64, hi: f64) -> f64 {
     hegel_internal_debug_assert!(lo > 0.0 && lo <= hi && hi.is_finite());
     const MANTISSA_MASK: u64 = (1u64 << 52) - 1;
-    let c = lo.ceil();
+    let c = libm::ceil(lo);
     if c <= hi && c < (1u64 << 56) as f64 {
         return c;
     }

--- a/hegel-c/src/native/core/state.rs
+++ b/hegel-c/src/native/core/state.rs
@@ -116,7 +116,7 @@ fn many_draw_length(rng: &mut EngineRng, min_size: usize, max_size: usize) -> us
     }
     let p_continue = length_p_continue(min_size, Some(max_size));
     let u: f64 = rng.random();
-    let extra = (u.ln() / p_continue.ln()).floor();
+    let extra = libm::floor(libm::log(u) / libm::log(p_continue));
     hegel_internal_assert!(extra >= 0.0);
     min_size.saturating_add(extra as usize).min(max_size)
 }
@@ -157,7 +157,7 @@ fn integer_sample_from_distribution(min_value: i128, max_value: i128, rng: &mut 
         return rng.random_range(min_value..=max_value);
     }
     let p = (lo + rng.random::<f64>() * (hi - lo)).max(f64::MIN_POSITIVE);
-    (dist.inverse_cdf(p).round() as i128).clamp(min_value, max_value)
+    (libm::round(dist.inverse_cdf(p)) as i128).clamp(min_value, max_value)
 }
 
 /// Hand-picked "interesting" boundary values: powers of two and their
@@ -478,7 +478,7 @@ pub(crate) fn biased_bytes_sample(bc: &BytesChoice, rng: &mut EngineRng) -> Vec<
 /// boolean) matters for the urandom backend, where every byte is
 /// fuzzer-controlled entropy and a one-bit decision should cost one byte.
 pub(crate) fn weighted_boolean_sample(p: f64, rng: &mut EngineRng) -> bool {
-    let falsey = ((256.0 * (1.0 - p)).floor().max(1.0) as u32).min(255);
+    let falsey = (libm::floor(256.0 * (1.0 - p)).max(1.0) as u32).min(255);
     let mut byte = [0u8; 1];
     rng.fill_bytes(&mut byte);
     u32::from(byte[0]) >= falsey

--- a/hegel-c/src/native/core/state.rs
+++ b/hegel-c/src/native/core/state.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use crate::native::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU8, AtomicUsize, Ordering};
 use std::sync::{Arc, LazyLock, Mutex};
@@ -597,7 +597,7 @@ fn constants_in_alphabet(intervals: &Arc<IntervalSet>) -> Arc<[bool]> {
     use std::sync::OnceLock;
     type Cache = Mutex<HashMap<usize, (std::sync::Weak<IntervalSet>, Arc<[bool]>)>>;
     static CACHE: OnceLock<Cache> = OnceLock::new();
-    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::default()));
     let key = Arc::as_ptr(intervals) as usize;
     {
         let guard = cache.lock().unwrap_or_else(|e| e.into_inner());
@@ -713,7 +713,7 @@ pub(crate) fn codepoints_to_string(cps: &[u32]) -> String {
 pub struct NativeVariables {
     last_id: i64,
     variables: Vec<i64>,
-    removed: std::collections::HashSet<i64>,
+    removed: crate::native::HashSet<i64>,
 }
 
 impl NativeVariables {
@@ -721,7 +721,7 @@ impl NativeVariables {
         NativeVariables {
             last_id: 0,
             variables: Vec::new(),
-            removed: std::collections::HashSet::new(),
+            removed: crate::native::HashSet::default(),
         }
     }
 
@@ -801,7 +801,7 @@ pub struct CoverageTag {
 }
 
 static STRUCTURAL_COVERAGE_CACHE: LazyLock<Mutex<HashMap<u64, &'static CoverageTag>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
+    LazyLock::new(|| Mutex::new(HashMap::default()));
 
 /// Look up (or insert) the [`CoverageTag`] for `label`.
 ///
@@ -984,8 +984,8 @@ impl FamilyCore {
             concluded_status: AtomicU8::new(STATUS_UNSET),
             total_draws: AtomicUsize::new(0),
             budget: AtomicUsize::new(budget),
-            target_observations: Mutex::new(HashMap::new()),
-            collections: Mutex::new(HashMap::new()),
+            target_observations: Mutex::new(HashMap::default()),
+            collections: Mutex::new(HashMap::default()),
             next_collection_id: AtomicI64::new(0),
             variable_pools: Mutex::new(Vec::new()),
             state_machines: Mutex::new(Vec::new()),
@@ -1186,7 +1186,7 @@ impl NativeTestCase {
             span_stack: Vec::new(),
             span_events: Vec::new(),
             has_discards: false,
-            tags: HashSet::new(),
+            tags: HashSet::default(),
             labels_for_structure_stack: Vec::new(),
             observer,
             trailing_template,
@@ -1354,7 +1354,7 @@ impl NativeTestCase {
         });
         self.span_stack.push(idx);
         self.span_events.push((start, SpanEvent::Open { label }));
-        let mut frame = HashSet::new();
+        let mut frame = HashSet::default();
         frame.insert(label);
         self.labels_for_structure_stack.push(frame);
         if depth + 1 > MAX_DEPTH {

--- a/hegel-c/src/native/core/state_machine.rs
+++ b/hegel-c/src/native/core/state_machine.rs
@@ -1,5 +1,5 @@
+use crate::native::HashSet;
 use std::cmp::min;
-use std::collections::HashSet;
 
 use super::choices::EngineError;
 use super::state::NativeTestCase;
@@ -142,7 +142,7 @@ impl NativeStateMachine {
         }
         let flags = self.flags.as_mut().unwrap();
 
-        let mut known_bad: HashSet<usize> = HashSet::new();
+        let mut known_bad: HashSet<usize> = HashSet::default();
         for _ in 0..3 {
             let i = draw_index(ntc, n)?;
             if !known_bad.contains(&i) {

--- a/hegel-c/src/native/data_source.rs
+++ b/hegel-c/src/native/data_source.rs
@@ -233,11 +233,11 @@ impl DataSource for NativeDataSource {
         self.with_ntc(|ntc| crate::native::draws::special::generate_uuid(ntc, version))
     }
 
-    fn generate_ipv4(&self) -> Result<std::net::Ipv4Addr, DataSourceError> {
+    fn generate_ipv4(&self) -> Result<core::net::Ipv4Addr, DataSourceError> {
         self.with_ntc(crate::native::draws::special::generate_ipv4)
     }
 
-    fn generate_ipv6(&self) -> Result<std::net::Ipv6Addr, DataSourceError> {
+    fn generate_ipv6(&self) -> Result<core::net::Ipv6Addr, DataSourceError> {
         self.with_ntc(crate::native::draws::special::generate_ipv6)
     }
 

--- a/hegel-c/src/native/data_source.rs
+++ b/hegel-c/src/native/data_source.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use crate::native::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 

--- a/hegel-c/src/native/data_tree.rs
+++ b/hegel-c/src/native/data_tree.rs
@@ -8,10 +8,8 @@
 //! drawn, an optional terminal `Status`, and a cached exhaustion flag
 //! so the walker can short-circuit dead branches.
 
-use std::collections::HashMap;
+use crate::native::HashMap;
 use std::sync::Arc;
-
-use rustc_hash::FxHashMap;
 
 use rand::RngExt;
 use rand::seq::SliceRandom;
@@ -98,7 +96,7 @@ pub(crate) struct DataTreeNode {
     /// replay's prefix value at that position is ignored. [`simulate`] needs
     /// this to predict realised values correctly.
     forced: bool,
-    children: FxHashMap<ChoiceValueKey, Box<DataTreeNode>>,
+    children: HashMap<ChoiceValueKey, Box<DataTreeNode>>,
     /// Span open/close events that fired at this node's draw position, in
     /// order. Recorded once (per path) by [`record_tree_full`] and replayed by
     /// [`simulate_full`] to rebuild the [`Span`] list faithfully — including
@@ -207,7 +205,7 @@ pub(crate) fn record_tree(
         nodes,
         status,
         None,
-        &HashMap::new(),
+        &HashMap::default(),
         &[],
         kill_depths,
     )
@@ -404,7 +402,7 @@ const ENUMERATION_CAP: u64 = 1024;
 /// exhausted too).
 fn pick_non_exhausted_value(
     kind: &ChoiceKind,
-    children: &FxHashMap<ChoiceValueKey, Box<DataTreeNode>>,
+    children: &HashMap<ChoiceValueKey, Box<DataTreeNode>>,
     rng: &mut EngineRng,
 ) -> Option<ChoiceValue> {
     for _ in 0..10 {

--- a/hegel-c/src/native/draws/regex.rs
+++ b/hegel-c/src/native/draws/regex.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use crate::native::{HashMap, HashSet};
 use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::native::bignum::{BigInt, ToPrimitive};
@@ -52,8 +52,8 @@ impl CompiledRegex {
         Ok(CompiledRegex {
             parsed,
             alphabet,
-            in_cache: Mutex::new(HashMap::new()),
-            char_cache: Mutex::new(HashMap::new()),
+            in_cache: Mutex::new(HashMap::default()),
+            char_cache: Mutex::new(HashMap::default()),
         })
     }
 }
@@ -93,7 +93,7 @@ fn generate_regex_attempt(
     let alphabet = &re.alphabet;
 
     let mut state = GenState {
-        groups: HashMap::new(),
+        groups: HashMap::default(),
         flags: parsed.flags,
         fullmatch,
         pending_anchors: Vec::new(),
@@ -581,7 +581,7 @@ fn cached_default_in_set(items: &[SetItem], flags: u32) -> Arc<[char]> {
         items.to_vec(),
         flags & (SRE_FLAG_IGNORECASE | SRE_FLAG_ASCII),
     );
-    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::default()));
     {
         let guard = cache.lock().unwrap();
         if let Some(cached) = guard.get(&cache_key) {
@@ -636,7 +636,7 @@ fn cached_default_not_literal(cp: u32, flags: u32) -> Arc<[char]> {
     type Cache = Mutex<HashMap<(u32, u32), Arc<[char]>>>;
     static CACHE: OnceLock<Cache> = OnceLock::new();
     let cache_key = (cp, flags & SRE_FLAG_IGNORECASE);
-    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::default()));
     {
         let guard = cache.lock().unwrap();
         if let Some(cached) = guard.get(&cache_key) {
@@ -686,7 +686,7 @@ fn build_in_set(items: &[SetItem], flags: u32, alphabet: &Option<IntervalSet>) -
 
     if !negate {
         let mut out: Vec<char> = Vec::new();
-        let mut seen: HashSet<char> = HashSet::new();
+        let mut seen: HashSet<char> = HashSet::default();
         for c in positive {
             if ascii_only && (c as u32) >= 128 {
                 continue;
@@ -714,7 +714,7 @@ fn build_in_set(items: &[SetItem], flags: u32, alphabet: &Option<IntervalSet>) -
         out
     } else {
         let cat_blocks: Vec<ChCode> = categories;
-        let mut positive_set: HashSet<char> = HashSet::new();
+        let mut positive_set: HashSet<char> = HashSet::default();
         for c in positive {
             positive_set.extend(swapcase_blacklist(c, flags));
         }

--- a/hegel-c/src/native/draws/special.rs
+++ b/hegel-c/src/native/draws/special.rs
@@ -1,4 +1,4 @@
-use std::net::{Ipv4Addr, Ipv6Addr};
+use core::net::{Ipv4Addr, Ipv6Addr};
 use std::sync::LazyLock;
 
 use crate::control::hegel_internal_assert;

--- a/hegel-c/src/native/draws/text.rs
+++ b/hegel-c/src/native/draws/text.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use crate::native::HashMap;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::native::core::EngineError;
@@ -197,7 +197,7 @@ fn chars_to_intervals(chars: &[char]) -> IntervalSet {
 /// runs once per process per category name.
 fn categories_union(cats: &[String]) -> IntervalSet {
     static CACHE: OnceLock<Mutex<HashMap<String, Arc<IntervalSet>>>> = OnceLock::new();
-    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::default()));
 
     let mut union: Option<IntervalSet> = None;
     for cat in cats {

--- a/hegel-c/src/native/mod.rs
+++ b/hegel-c/src/native/mod.rs
@@ -1,3 +1,6 @@
+pub(crate) type HashMap<K, V> = hashbrown::HashMap<K, V, rustc_hash::FxBuildHasher>;
+pub(crate) type HashSet<T> = hashbrown::HashSet<T, rustc_hash::FxBuildHasher>;
+
 pub mod base64;
 pub mod bignum;
 pub mod blob;

--- a/hegel-c/src/native/re/parser.rs
+++ b/hegel-c/src/native/re/parser.rs
@@ -11,7 +11,7 @@
 //!
 //! Source: `resources/cpython/Lib/re/_parser.py`.
 
-use std::collections::HashMap;
+use crate::native::HashMap;
 
 use super::constants::*;
 use crate::control::{hegel_internal_debug_assert, hegel_internal_debug_assert_eq};
@@ -156,10 +156,10 @@ impl State {
     fn new() -> Self {
         Self {
             flags: 0,
-            groupdict: HashMap::new(),
+            groupdict: HashMap::default(),
             groupwidths: vec![None],
             lookbehindgroups: None,
-            grouprefpos: HashMap::new(),
+            grouprefpos: HashMap::default(),
         }
     }
 
@@ -667,7 +667,7 @@ enum EscapeResult {
 }
 
 fn uniq_set(items: Vec<SetItem>) -> Vec<SetItem> {
-    let mut seen = std::collections::HashSet::new();
+    let mut seen = crate::native::HashSet::default();
     items
         .into_iter()
         .filter(|item| seen.insert(item.clone()))

--- a/hegel-c/src/native/re/parser.rs
+++ b/hegel-c/src/native/re/parser.rs
@@ -137,7 +137,7 @@ impl std::fmt::Display for ParseError {
     }
 }
 
-impl std::error::Error for ParseError {}
+impl core::error::Error for ParseError {}
 
 type ParseResult<T> = Result<T, ParseError>;
 

--- a/hegel-c/src/native/shrinker/bytes.rs
+++ b/hegel-c/src/native/shrinker/bytes.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use crate::native::HashMap;
 
 use crate::native::core::{BytesChoice, ChoiceKind, ChoiceValue};
 
@@ -22,7 +22,7 @@ impl<'a> Shrinker<'a> {
 
             let simplest = vec![0u8; min_size];
             if simplest != current {
-                self.replace(&HashMap::from([(i, ChoiceValue::Bytes(simplest))]))
+                self.replace(&HashMap::from_iter([(i, ChoiceValue::Bytes(simplest))]))
                     .await?;
             }
 
@@ -34,7 +34,7 @@ impl<'a> Shrinker<'a> {
                     let sz = sz as usize;
                     let cand = captured[..sz].to_vec();
                     let ok = self
-                        .replace(&HashMap::from([(i, ChoiceValue::Bytes(cand))]))
+                        .replace(&HashMap::from_iter([(i, ChoiceValue::Bytes(cand))]))
                         .await?;
                     search.record(ok);
                 }
@@ -48,7 +48,7 @@ impl<'a> Shrinker<'a> {
                     break;
                 }
                 let cand = cur[..sz].to_vec();
-                self.replace(&HashMap::from([(i, ChoiceValue::Bytes(cand))]))
+                self.replace(&HashMap::from_iter([(i, ChoiceValue::Bytes(cand))]))
                     .await?;
             }
 
@@ -61,7 +61,7 @@ impl<'a> Shrinker<'a> {
                 }
                 let mut cand = cur.clone();
                 cand.remove(j);
-                self.replace(&HashMap::from([(i, ChoiceValue::Bytes(cand))]))
+                self.replace(&HashMap::from_iter([(i, ChoiceValue::Bytes(cand))]))
                     .await?;
             }
 
@@ -78,7 +78,7 @@ impl<'a> Shrinker<'a> {
                     let mut cand = self.current_byte_value(i);
                     cand[j] = e as u8;
                     let ok = self
-                        .replace(&HashMap::from([(i, ChoiceValue::Bytes(cand))]))
+                        .replace(&HashMap::from_iter([(i, ChoiceValue::Bytes(cand))]))
                         .await?;
                     search.record(ok);
                 }
@@ -99,7 +99,7 @@ impl<'a> Shrinker<'a> {
                     let mut swapped = cur.clone();
                     swapped.swap(j - 1, j);
                     if self
-                        .replace(&HashMap::from([(i, ChoiceValue::Bytes(swapped))]))
+                        .replace(&HashMap::from_iter([(i, ChoiceValue::Bytes(swapped))]))
                         .await?
                     {
                         j -= 1;
@@ -217,7 +217,7 @@ impl<'a> Shrinker<'a> {
         if !kind_j.validate(&new_t) {
             return Ok(false);
         }
-        self.replace(&HashMap::from([
+        self.replace(&HashMap::from_iter([
             (i, ChoiceValue::Bytes(new_s)),
             (j, ChoiceValue::Bytes(new_t)),
         ]))

--- a/hegel-c/src/native/shrinker/deletion.rs
+++ b/hegel-c/src/native/shrinker/deletion.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use crate::native::HashMap;
 
 use crate::native::bignum::BigInt;
 use crate::native::core::{ChoiceKind, ChoiceNode, ChoiceValue};
@@ -104,7 +104,10 @@ impl<'a> Shrinker<'a> {
         value: ChoiceValue,
         expected_len: usize,
     ) -> ShrinkResult<bool> {
-        if self.replace(&HashMap::from([(idx, value.clone())])).await? {
+        if self
+            .replace(&HashMap::from_iter([(idx, value.clone())]))
+            .await?
+        {
             return Ok(true);
         }
 

--- a/hegel-c/src/native/shrinker/floats.rs
+++ b/hegel-c/src/native/shrinker/floats.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use crate::native::HashMap;
 
 use crate::native::bignum::{BigInt, ToPrimitive};
 use crate::native::core::choices::IntegerChoice;
@@ -76,7 +76,7 @@ impl<'a> Shrinker<'a> {
 
                 let s = fc.simplest();
                 if ChoiceValue::Float(s) != ChoiceValue::Float(v) {
-                    self.replace(&HashMap::from([(i, ChoiceValue::Float(s))]))
+                    self.replace(&HashMap::from_iter([(i, ChoiceValue::Float(s))]))
                         .await?;
                 }
 
@@ -84,14 +84,17 @@ impl<'a> Shrinker<'a> {
 
                 if v.is_infinite() {
                     if v < 0.0 && fc.validate(f64::INFINITY) {
-                        self.replace(&HashMap::from([(i, ChoiceValue::Float(f64::INFINITY))]))
-                            .await?;
+                        self.replace(&HashMap::from_iter([(
+                            i,
+                            ChoiceValue::Float(f64::INFINITY),
+                        )]))
+                        .await?;
                     }
                     let v = self.float_at(i);
                     if v.is_infinite() {
                         let cand = if v > 0.0 { f64::MAX } else { -f64::MAX };
                         if fc.validate(cand) {
-                            self.replace(&HashMap::from([(i, ChoiceValue::Float(cand))]))
+                            self.replace(&HashMap::from_iter([(i, ChoiceValue::Float(cand))]))
                                 .await?;
                         }
                     }
@@ -104,7 +107,7 @@ impl<'a> Shrinker<'a> {
                     for cand in [f64::MAX, f64::INFINITY] {
                         if fc.validate(cand)
                             && self
-                                .replace(&HashMap::from([(i, ChoiceValue::Float(cand))]))
+                                .replace(&HashMap::from_iter([(i, ChoiceValue::Float(cand))]))
                                 .await?
                         {
                             stepped = true;
@@ -136,7 +139,7 @@ impl<'a> Shrinker<'a> {
                 if v.is_sign_negative() {
                     let neg = -v;
                     if fc.validate(neg) {
-                        self.replace(&HashMap::from([(i, ChoiceValue::Float(neg))]))
+                        self.replace(&HashMap::from_iter([(i, ChoiceValue::Float(neg))]))
                             .await?;
                     }
                 }
@@ -168,7 +171,7 @@ impl<'a> Shrinker<'a> {
                             if !fc_capture.validate(candidate) {
                                 false
                             } else {
-                                self.replace(&HashMap::from([(
+                                self.replace(&HashMap::from_iter([(
                                     i_capture,
                                     ChoiceValue::Float(candidate),
                                 )]))
@@ -199,7 +202,7 @@ impl<'a> Shrinker<'a> {
                                     } else {
                                         candidate_mag
                                     };
-                                    self.replace(&HashMap::from([(
+                                    self.replace(&HashMap::from_iter([(
                                         i_capture,
                                         ChoiceValue::Float(candidate),
                                     )]))
@@ -227,8 +230,11 @@ impl<'a> Shrinker<'a> {
                                 candidate_mag
                             };
                             if fc.validate(candidate) {
-                                self.replace(&HashMap::from([(i, ChoiceValue::Float(candidate))]))
-                                    .await?;
+                                self.replace(&HashMap::from_iter([(
+                                    i,
+                                    ChoiceValue::Float(candidate),
+                                )]))
+                                .await?;
                             }
                         }
                     }
@@ -248,7 +254,7 @@ impl<'a> Shrinker<'a> {
                             candidate_mag
                         };
                         let ok = if fc.validate(candidate) {
-                            self.replace(&HashMap::from([(i, ChoiceValue::Float(candidate))]))
+                            self.replace(&HashMap::from_iter([(i, ChoiceValue::Float(candidate))]))
                                 .await?
                         } else {
                             false
@@ -277,7 +283,7 @@ impl<'a> Shrinker<'a> {
                                     false
                                 } else {
                                     let epoch = self.improvements;
-                                    self.replace(&HashMap::from([(
+                                    self.replace(&HashMap::from_iter([(
                                         i,
                                         ChoiceValue::Float(candidate),
                                     )]))
@@ -440,7 +446,7 @@ async fn redistribute_pair(shrinker: &mut Shrinker<'_>, i: usize, j: usize) -> S
                 None => false,
                 Some(val_j) => {
                     shrinker
-                        .replace(&HashMap::from([(i, val_i), (j, val_j)]))
+                        .replace(&HashMap::from_iter([(i, val_i), (j, val_j)]))
                         .await?
                 }
             },

--- a/hegel-c/src/native/shrinker/floats.rs
+++ b/hegel-c/src/native/shrinker/floats.rs
@@ -184,9 +184,9 @@ impl<'a> Shrinker<'a> {
                     if cur.is_finite() {
                         let base_after = cur.abs() as i128;
                         let lo: i128 = if is_neg {
-                            (-fc.max_value).max(0.0).ceil() as i128
+                            libm::ceil((-fc.max_value).max(0.0)) as i128
                         } else {
-                            fc.min_value.max(0.0).ceil() as i128
+                            libm::ceil(fc.min_value.max(0.0)) as i128
                         };
                         for step in [2i128, 1] {
                             let i_capture = i;
@@ -215,9 +215,9 @@ impl<'a> Shrinker<'a> {
                 } else if v_abs.is_finite() && v_abs > 0.0 {
                     let cur_abs = self.float_at(i).abs();
                     for p in (0..=10).rev() {
-                        let scale = (2_f64).powi(p);
+                        let scale = libm::exp2(f64::from(p));
                         let scaled = cur_abs * scale;
-                        for rounded in [scaled.floor(), scaled.ceil()] {
+                        for rounded in [libm::floor(scaled), libm::ceil(scaled)] {
                             let candidate_mag = rounded / scale;
                             if !candidate_mag.is_finite()
                                 || float_to_index(candidate_mag) >= float_to_index(cur_abs)

--- a/hegel-c/src/native/shrinker/index_passes.rs
+++ b/hegel-c/src/native/shrinker/index_passes.rs
@@ -3,7 +3,7 @@
 //! Both passes use the `to_index`/`from_index` API on `ChoiceKind` for
 //! type-generic shrinking.
 
-use std::collections::HashMap;
+use crate::native::HashMap;
 
 use crate::native::bignum::{BigInt, BigUint, Zero};
 use crate::native::core::{ChoiceKind, ChoiceValue};

--- a/hegel-c/src/native/shrinker/integers.rs
+++ b/hegel-c/src/native/shrinker/integers.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use crate::native::HashMap;
 
 use crate::native::bignum::{BigInt, Sign, Signed};
 use crate::native::core::choices::IntegerChoice;
@@ -41,7 +41,7 @@ impl<'a> Shrinker<'a> {
     /// node's width (rejecting out-of-range candidates), so this stays correct
     /// for any node width.
     pub(super) async fn replace_int(&mut self, i: usize, candidate: &BigInt) -> ShrinkResult<bool> {
-        self.replace(&HashMap::from([(
+        self.replace(&HashMap::from_iter([(
             i,
             ChoiceValue::Integer(candidate.clone()),
         )]))
@@ -57,7 +57,7 @@ impl<'a> Shrinker<'a> {
         j: usize,
         vj: &BigInt,
     ) -> ShrinkResult<bool> {
-        self.replace(&HashMap::from([
+        self.replace(&HashMap::from_iter([
             (i, ChoiceValue::Integer(vi.clone())),
             (j, ChoiceValue::Integer(vj.clone())),
         ]))
@@ -97,7 +97,7 @@ impl<'a> Shrinker<'a> {
                 let v = v.clone();
                 let simplest = ic.simplest();
                 if v != ic.simplest() {
-                    self.replace(&HashMap::from([(i, ChoiceValue::Integer(simplest))]))
+                    self.replace(&HashMap::from_iter([(i, ChoiceValue::Integer(simplest))]))
                         .await?;
                 }
                 if i < self.current_nodes.len() {
@@ -429,7 +429,7 @@ impl<'a> Shrinker<'a> {
         }
 
         let mut groups: HashMap<(std::mem::Discriminant<ChoiceKind>, ChoiceValue), Vec<usize>> =
-            HashMap::new();
+            HashMap::default();
         for (i, node) in self.current_nodes.iter().enumerate() {
             let key = (
                 std::mem::discriminant(node.kind.as_ref()),
@@ -462,7 +462,7 @@ impl<'a> Shrinker<'a> {
                 self.replace(&replacements).await?;
             }
         }
-        let mut groups: HashMap<BigInt, Vec<usize>> = HashMap::new();
+        let mut groups: HashMap<BigInt, Vec<usize>> = HashMap::default();
         for (i, node) in self.current_nodes.iter().enumerate() {
             if let (ChoiceKind::Integer(_), ChoiceValue::Integer(v)) =
                 (node.kind.as_ref(), &node.value)
@@ -650,7 +650,7 @@ impl<'a> Shrinker<'a> {
                     false
                 } else {
                     let new_offset = &offset - &n_big;
-                    let mut replacements: HashMap<usize, ChoiceValue> = HashMap::new();
+                    let mut replacements: HashMap<usize, ChoiceValue> = HashMap::default();
                     for k in 0..indices.len() {
                         let new_distance = &new_offset + &residual[k];
                         let effective_sign = signs[k] * sign_multiplier;

--- a/hegel-c/src/native/shrinker/mod.rs
+++ b/hegel-c/src/native/shrinker/mod.rs
@@ -15,7 +15,7 @@ mod strings;
 
 pub use scheduling::ShrinkPass;
 
-use std::collections::{HashMap, HashSet};
+use crate::native::{HashMap, HashSet};
 use std::future::Future;
 use std::pin::Pin;
 use std::time::Instant;
@@ -172,7 +172,7 @@ impl<'a> Shrinker<'a> {
             calls: 0,
             calls_at_last_shrink: 0,
             max_stall: MAX_SHRINKS,
-            all_changed_nodes: HashSet::new(),
+            all_changed_nodes: HashSet::default(),
             debug: None,
             deadline: None,
             timed_out: false,

--- a/hegel-c/src/native/shrinker/sequence.rs
+++ b/hegel-c/src/native/shrinker/sequence.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use crate::native::HashMap;
 
 use crate::native::core::{ChoiceKind, ChoiceValue};
 
@@ -101,7 +101,7 @@ impl<'a> Shrinker<'a> {
                 }
                 let v_j = self.current_nodes[idx_j].value.clone();
                 let v_prev = self.current_nodes[idx_prev].value.clone();
-                let mut swap = HashMap::new();
+                let mut swap = HashMap::default();
                 swap.insert(idx_prev, v_j);
                 swap.insert(idx_j, v_prev);
                 if self.replace(&swap).await? {
@@ -149,7 +149,7 @@ impl<'a> Shrinker<'a> {
                     continue;
                 }
 
-                let mut swap = HashMap::new();
+                let mut swap = HashMap::default();
                 for k in 0..block_size {
                     swap.insert(i + k, block_b[k].clone());
                     swap.insert(j + k, block_a[k].clone());

--- a/hegel-c/src/native/shrinker/strings.rs
+++ b/hegel-c/src/native/shrinker/strings.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use crate::native::HashMap;
 
 use crate::native::core::{ChoiceKind, ChoiceValue, StringChoice};
 use crate::unicodedata;
@@ -24,7 +24,7 @@ impl<'a> Shrinker<'a> {
 
             let simplest = kind.simplest();
             if simplest != current {
-                self.replace(&HashMap::from([(i, ChoiceValue::String(simplest))]))
+                self.replace(&HashMap::from_iter([(i, ChoiceValue::String(simplest))]))
                     .await?;
             }
 
@@ -35,7 +35,7 @@ impl<'a> Shrinker<'a> {
                 while let Some(sz) = search.probe() {
                     let cand: Vec<u32> = captured[..sz as usize].to_vec();
                     let ok = self
-                        .replace(&HashMap::from([(i, ChoiceValue::String(cand))]))
+                        .replace(&HashMap::from_iter([(i, ChoiceValue::String(cand))]))
                         .await?;
                     search.record(ok);
                 }
@@ -49,7 +49,7 @@ impl<'a> Shrinker<'a> {
                     break;
                 }
                 let cand: Vec<u32> = cur[..target_len].to_vec();
-                self.replace(&HashMap::from([(i, ChoiceValue::String(cand))]))
+                self.replace(&HashMap::from_iter([(i, ChoiceValue::String(cand))]))
                     .await?;
             }
 
@@ -62,13 +62,13 @@ impl<'a> Shrinker<'a> {
                 }
                 let mut cand = cur.clone();
                 cand.remove(j);
-                self.replace(&HashMap::from([(i, ChoiceValue::String(cand))]))
+                self.replace(&HashMap::from_iter([(i, ChoiceValue::String(cand))]))
                     .await?;
             }
 
             let dup_codepoints: Vec<u32> = {
                 let cur = self.current_string(i);
-                let mut counts: HashMap<u32, usize> = HashMap::new();
+                let mut counts: HashMap<u32, usize> = HashMap::default();
                 for &cp in &cur {
                     *counts.entry(cp).or_default() += 1;
                 }
@@ -97,7 +97,7 @@ impl<'a> Shrinker<'a> {
                 if !changed {
                     return Ok(false);
                 }
-                sh.replace(&HashMap::from([(i, ChoiceValue::String(new_str))]))
+                sh.replace(&HashMap::from_iter([(i, ChoiceValue::String(new_str))]))
                     .await
             }
 
@@ -143,7 +143,7 @@ impl<'a> Shrinker<'a> {
                     }
                     let mut cand = self.current_string(i);
                     cand[j] = cand_cp;
-                    self.replace(&HashMap::from([(i, ChoiceValue::String(cand))]))
+                    self.replace(&HashMap::from_iter([(i, ChoiceValue::String(cand))]))
                         .await?;
                 }
 
@@ -157,7 +157,7 @@ impl<'a> Shrinker<'a> {
                         let mut cand = self.current_string(i);
                         cand[j] = cp;
                         let ok = self
-                            .replace(&HashMap::from([(i, ChoiceValue::String(cand))]))
+                            .replace(&HashMap::from_iter([(i, ChoiceValue::String(cand))]))
                             .await?;
                         search.record(ok);
                     }
@@ -181,7 +181,7 @@ impl<'a> Shrinker<'a> {
                     let mut swapped = cur.clone();
                     swapped.swap(j - 1, j);
                     if self
-                        .replace(&HashMap::from([(i, ChoiceValue::String(swapped))]))
+                        .replace(&HashMap::from_iter([(i, ChoiceValue::String(swapped))]))
                         .await?
                     {
                         j -= 1;
@@ -297,7 +297,7 @@ impl<'a> Shrinker<'a> {
         if !kind_j.validate(&new_t) {
             return Ok(false);
         }
-        self.replace(&HashMap::from([
+        self.replace(&HashMap::from_iter([
             (i, ChoiceValue::String(new_s)),
             (j, ChoiceValue::String(new_t)),
         ]))
@@ -354,7 +354,7 @@ impl<'a> Shrinker<'a> {
                         let ok = if !kind_i.validate(&new_i) || !kind_j.validate(&new_j) {
                             false
                         } else {
-                            self.replace(&HashMap::from([
+                            self.replace(&HashMap::from_iter([
                                 (i, ChoiceValue::String(new_i)),
                                 (j, ChoiceValue::String(new_j)),
                             ]))
@@ -402,7 +402,7 @@ impl<'a> Shrinker<'a> {
                     new_value[pos] = replacement;
                     hegel_internal_debug_assert!(kind.validate(&new_value));
                     if self
-                        .replace(&HashMap::from([(i, ChoiceValue::String(new_value))]))
+                        .replace(&HashMap::from_iter([(i, ChoiceValue::String(new_value))]))
                         .await?
                     {
                         break;

--- a/hegel-c/src/native/statistics.rs
+++ b/hegel-c/src/native/statistics.rs
@@ -13,8 +13,8 @@ pub fn stdtr(df: i32, t: f64) -> f64 {
     let abs_t = t.abs();
     let z = 1.0 + abs_t * abs_t / df as f64;
     let p = if df % 2 == 1 {
-        let u = abs_t / (df as f64).sqrt();
-        let mut p = u.atan();
+        let u = abs_t / libm::sqrt(df as f64);
+        let mut p = libm::atan(u);
         if df > 1 {
             let mut f = 1.0_f64;
             let mut tz = 1.0_f64;
@@ -36,7 +36,7 @@ pub fn stdtr(df: i32, t: f64) -> f64 {
             f += tz;
             j += 2;
         }
-        f * abs_t / (z * df as f64).sqrt()
+        f * abs_t / libm::sqrt(z * df as f64)
     };
     if t < 0.0 {
         0.5 - 0.5 * p
@@ -59,13 +59,13 @@ pub fn stdtrit(df: i32, p: f64) -> f64 {
     hegel_internal_assert!(p > 0.0 && p < 1.0, "stdtrit requires 0 < p < 1, got {p}");
     if df == 1 {
         return if p > 0.5 {
-            (PI * (1.0 - p)).cos() / (PI * (1.0 - p)).sin()
+            libm::cos(PI * (1.0 - p)) / libm::sin(PI * (1.0 - p))
         } else {
-            -(PI * p).cos() / (PI * p).sin()
+            -libm::cos(PI * p) / libm::sin(PI * p)
         };
     }
     if df == 2 {
-        return (2.0 * p - 1.0) / (2.0 * p * (1.0 - p)).sqrt();
+        return (2.0 * p - 1.0) / libm::sqrt(2.0 * p * (1.0 - p));
     }
 
     let sign = if p > 0.5 { 1.0 } else { -1.0 };
@@ -77,8 +77,9 @@ pub fn stdtrit(df: i32, p: f64) -> f64 {
         hi *= 2.0;
     }
 
-    let log_norm =
-        ln_gamma(0.5 * (df as f64 + 1.0)) - 0.5 * (df as f64 * PI).ln() - ln_gamma(0.5 * df as f64);
+    let log_norm = ln_gamma(0.5 * (df as f64 + 1.0))
+        - 0.5 * libm::log(df as f64 * PI)
+        - ln_gamma(0.5 * df as f64);
     let mut t = 0.5 * (lo + hi);
     let eps = 1e-10;
     for _ in 0..50 {
@@ -88,8 +89,8 @@ pub fn stdtrit(df: i32, p: f64) -> f64 {
         } else {
             hi = t;
         }
-        let log_f = log_norm - 0.5 * (df as f64 + 1.0) * (t * t / df as f64).ln_1p();
-        let f = log_f.exp();
+        let log_f = log_norm - 0.5 * (df as f64 + 1.0) * libm::log1p(t * t / df as f64);
+        let f = libm::exp(log_f);
         let t_newton = t - (f_val - q) / f;
         t = if lo <= t_newton && t_newton <= hi {
             t_newton
@@ -129,14 +130,14 @@ fn ln_gamma(x: f64) -> f64 {
         sum += c / (z + i as f64);
     }
     let t = z + 7.5;
-    0.5 * (2.0 * PI).ln() + (z + 0.5) * t.ln() - t + sum.ln()
+    0.5 * libm::log(2.0 * PI) + (z + 0.5) * libm::log(t) - t + libm::log(sum)
 }
 
 /// `Γ(x)`. Same Lanczos series as [`ln_gamma`], exponentiated. Kept
 /// separate so the [`LogStudentTDistribution`] coefficient cache reads
 /// naturally as `Γ((df+1)/2) / (√(df π) · Γ(df/2))`.
 fn gamma(x: f64) -> f64 {
-    ln_gamma(x).exp()
+    libm::exp(ln_gamma(x))
 }
 
 /// Common interface for the primitive distributions composed by
@@ -200,7 +201,7 @@ pub struct LogStudentTDistribution {
 impl LogStudentTDistribution {
     pub fn new(scale_bits: f64, df: i32) -> Self {
         let t_coef =
-            gamma((df as f64 + 1.0) / 2.0) / ((df as f64 * PI).sqrt() * gamma(df as f64 / 2.0));
+            gamma((df as f64 + 1.0) / 2.0) / (libm::sqrt(df as f64 * PI) * gamma(df as f64 / 2.0));
         Self {
             scale_bits,
             df,
@@ -213,20 +214,23 @@ const LN_2: f64 = std::f64::consts::LN_2;
 
 impl Distribution for LogStudentTDistribution {
     fn cdf(&self, x: f64) -> f64 {
-        let y = (1.0 + x.abs()).log2().copysign(x) / self.scale_bits;
+        let y = libm::copysign(libm::log2(1.0 + x.abs()), x) / self.scale_bits;
         stdtr(self.df, y)
     }
 
     fn inverse_cdf(&self, u: f64) -> f64 {
         let mut y = self.scale_bits * stdtrit(self.df, u);
         y = y.clamp(-1023.0, 1023.0);
-        (y.abs() * LN_2).exp_m1().copysign(y)
+        libm::copysign(libm::expm1(y.abs() * LN_2), y)
     }
 
     fn pdf(&self, x: f64) -> f64 {
-        let y = (1.0 + x.abs()).log2().copysign(x) / self.scale_bits;
-        let f_t =
-            self.t_coef * (1.0 + y * y / self.df as f64).powf(-((self.df as f64 + 1.0) / 2.0));
+        let y = libm::copysign(libm::log2(1.0 + x.abs()), x) / self.scale_bits;
+        let f_t = self.t_coef
+            * libm::pow(
+                1.0 + y * y / self.df as f64,
+                -((self.df as f64 + 1.0) / 2.0),
+            );
         f_t / (self.scale_bits * (1.0 + x.abs()) * LN_2)
     }
 }

--- a/hegel-c/src/native/targeting.rs
+++ b/hegel-c/src/native/targeting.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use crate::native::{HashMap, HashSet};
 
 use crate::native::core::{
     BUFFER_SIZE, ChoiceKind, ChoiceNode, ChoiceValue, NativeTestCase, Status,
@@ -15,8 +15,8 @@ pub(crate) struct TargetingState {
 impl TargetingState {
     pub fn new() -> Self {
         Self {
-            best_observed_targets: HashMap::new(),
-            best_choices_for_target: HashMap::new(),
+            best_observed_targets: HashMap::default(),
+            best_choices_for_target: HashMap::default(),
         }
     }
 
@@ -176,7 +176,7 @@ impl Optimiser<'_, '_> {
             .unwrap_or(&f64::NEG_INFINITY);
         let mut improvements: usize = 0;
 
-        let mut nodes_examined: HashSet<usize> = HashSet::new();
+        let mut nodes_examined: HashSet<usize> = HashSet::default();
         let mut i: isize = current_nodes.len() as isize - 1;
         let mut prev_len = current_nodes.len();
         while i >= 0 && improvements <= max_improvements {

--- a/hegel-c/src/native/test_runner.rs
+++ b/hegel-c/src/native/test_runner.rs
@@ -199,7 +199,7 @@ impl<'a> Engine<'a> {
                     1.0
                 };
                 let desired_size =
-                    (((max_test_cases as f64) * desired_factor).ceil() as usize).max(2);
+                    ((libm::ceil((max_test_cases as f64) * desired_factor)) as usize).max(2);
                 if values.len() < desired_size {
                     let mut extra = self
                         .db()
@@ -754,8 +754,8 @@ pub(crate) fn slow_shrink_warning() -> String {
 /// per_valid = ceil(1 / r)
 /// ```
 fn invalid_thresholds(r: f64, c: f64) -> (u64, u64) {
-    let base = ((1.0 - c).ln() / (1.0 - r).ln()).ceil() - 1.0;
-    let per_valid = (1.0 / r).ceil();
+    let base = libm::ceil(libm::log(1.0 - c) / libm::log(1.0 - r)) - 1.0;
+    let per_valid = libm::ceil(1.0 / r);
     (base as u64, per_valid as u64)
 }
 

--- a/hegel-c/src/native/test_runner.rs
+++ b/hegel-c/src/native/test_runner.rs
@@ -19,7 +19,8 @@
 //! `run_probe_with_origin` so the surrounding shrinker
 //! and span-mutation passes can drive replays.
 
-use std::collections::{HashMap, hash_map::Entry};
+use crate::native::HashMap;
+use hashbrown::hash_map::Entry;
 
 use rand::RngExt;
 
@@ -492,8 +493,8 @@ impl<'a> Engine<'a> {
 
             let shrink_deadline = std::time::Instant::now() + shrink_budget;
             let mut shrink_timed_out = false;
-            let mut shrunk_origins: std::collections::HashSet<String> =
-                std::collections::HashSet::new();
+            let mut shrunk_origins: crate::native::HashSet<String> =
+                crate::native::HashSet::default();
             loop {
                 let mut pending: Vec<String> = self
                     .interesting
@@ -564,7 +565,7 @@ impl<'a> Engine<'a> {
         if let (Some(db), Some(key)) = (self.db(), database_key) {
             let key_bytes = key.as_bytes();
             let secondary_key = crate::native::data_tree::sub_key(key_bytes, b"secondary");
-            let new_entries: std::collections::HashSet<Vec<u8>> = self
+            let new_entries: crate::native::HashSet<Vec<u8>> = self
                 .interesting
                 .values()
                 .map(|nodes| {
@@ -850,7 +851,7 @@ impl<'a> Persister<'a> {
         Persister {
             db,
             database_key,
-            last_saved: HashMap::new(),
+            last_saved: HashMap::default(),
         }
     }
 
@@ -946,7 +947,7 @@ impl<'a> Engine<'a> {
             rng: create_rng(settings, database_key),
             persister: Persister::new(db, database_key),
             tree_root: crate::native::data_tree::DataTreeNode::default(),
-            interesting: HashMap::new(),
+            interesting: HashMap::default(),
             targeting: crate::native::targeting::TargetingState::new(),
             calls: 0,
             valid_test_cases: 0,
@@ -1172,8 +1173,8 @@ impl ShrinkProbe for EngineShrinkProbe<'_, '_> {
 /// re-recorded, exactly as Hypothesis's cache hits cost nothing.
 impl<'a> Engine<'a> {
     async fn try_span_mutation(&mut self, nodes: &[ChoiceNode], spans: &[Span]) {
-        let mut by_label: rustc_hash::FxHashMap<&str, rustc_hash::FxHashSet<(usize, usize)>> =
-            rustc_hash::FxHashMap::default();
+        let mut by_label: crate::native::HashMap<&str, crate::native::HashSet<(usize, usize)>> =
+            crate::native::HashMap::default();
         for span in spans.iter() {
             by_label
                 .entry(span.label.as_str())

--- a/hegel-c/tests/embedded/native/draws/regex_tests.rs
+++ b/hegel-c/tests/embedded/native/draws/regex_tests.rs
@@ -9,13 +9,13 @@
 //! generator's draw distribution.
 
 use super::*;
+use crate::native::HashMap;
 use crate::native::bignum::BigInt;
 use crate::native::core::ChoiceValue;
 use crate::native::re::constants::{
     AtCode, ChCode, SRE_FLAG_DOTALL, SRE_FLAG_IGNORECASE, SRE_FLAG_MULTILINE,
 };
 use crate::native::re::parser::{OpCode, SetItem, SubPattern};
-use std::collections::HashMap;
 
 fn chars(s: &str) -> Vec<char> {
     s.chars().collect()
@@ -31,19 +31,19 @@ fn sub(ops: Vec<OpCode>) -> SubPattern {
 
 #[test]
 fn match_seq_literal_match() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     assert_eq!(match_seq(&[lit('a')], 0, &chars("a"), 0, &groups), Some(1));
 }
 
 #[test]
 fn match_seq_literal_no_match() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     assert_eq!(match_seq(&[lit('a')], 0, &chars("b"), 0, &groups), None);
 }
 
 #[test]
 fn match_seq_not_literal_match() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     assert_eq!(
         match_seq(
             &[OpCode::NotLiteral('a' as u32)],
@@ -58,7 +58,7 @@ fn match_seq_not_literal_match() {
 
 #[test]
 fn match_seq_not_literal_no_match() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     assert_eq!(
         match_seq(
             &[OpCode::NotLiteral('a' as u32)],
@@ -73,7 +73,7 @@ fn match_seq_not_literal_no_match() {
 
 #[test]
 fn match_seq_any_matches_non_newline() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     assert_eq!(
         match_seq(&[OpCode::Any], 0, &chars("x"), 0, &groups),
         Some(1)
@@ -82,13 +82,13 @@ fn match_seq_any_matches_non_newline() {
 
 #[test]
 fn match_seq_any_does_not_match_newline_without_dotall() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     assert_eq!(match_seq(&[OpCode::Any], 0, &chars("\n"), 0, &groups), None);
 }
 
 #[test]
 fn match_seq_any_matches_newline_with_dotall() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     assert_eq!(
         match_seq(&[OpCode::Any], 0, &chars("\n"), SRE_FLAG_DOTALL, &groups),
         Some(1)
@@ -97,7 +97,7 @@ fn match_seq_any_matches_newline_with_dotall() {
 
 #[test]
 fn match_seq_in_set_literal_match() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let items = vec![SetItem::Literal('a' as u32), SetItem::Literal('b' as u32)];
     assert_eq!(
         match_seq(&[OpCode::In(items.clone())], 0, &chars("a"), 0, &groups),
@@ -111,7 +111,7 @@ fn match_seq_in_set_literal_match() {
 
 #[test]
 fn match_seq_in_set_range_match() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let items = vec![SetItem::Range('a' as u32, 'z' as u32)];
     assert_eq!(
         match_seq(&[OpCode::In(items.clone())], 0, &chars("m"), 0, &groups),
@@ -125,7 +125,7 @@ fn match_seq_in_set_range_match() {
 
 #[test]
 fn match_seq_in_set_range_ignorecase() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let items = vec![SetItem::Range('a' as u32, 'z' as u32)];
     assert_eq!(
         match_seq(
@@ -141,7 +141,7 @@ fn match_seq_in_set_range_ignorecase() {
 
 #[test]
 fn match_seq_in_set_category_match() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let items = vec![SetItem::Category(ChCode::Digit)];
     assert_eq!(
         match_seq(&[OpCode::In(items.clone())], 0, &chars("5"), 0, &groups),
@@ -155,7 +155,7 @@ fn match_seq_in_set_category_match() {
 
 #[test]
 fn match_seq_in_set_negated() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let items = vec![SetItem::Negate, SetItem::Literal('a' as u32)];
     assert_eq!(
         match_seq(&[OpCode::In(items.clone())], 0, &chars("b"), 0, &groups),
@@ -169,7 +169,7 @@ fn match_seq_in_set_negated() {
 
 #[test]
 fn match_seq_at_beginning_string() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     assert_eq!(
         match_seq(
             &[OpCode::At(AtCode::BeginningString)],
@@ -194,7 +194,7 @@ fn match_seq_at_beginning_string() {
 
 #[test]
 fn match_seq_at_beginning() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     assert_eq!(
         match_seq(&[OpCode::At(AtCode::Beginning)], 0, &chars("a"), 0, &groups),
         Some(0)
@@ -223,7 +223,7 @@ fn match_seq_at_beginning() {
 
 #[test]
 fn match_seq_at_end() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     assert_eq!(
         match_seq(&[OpCode::At(AtCode::End)], 1, &chars("a"), 0, &groups),
         Some(1)
@@ -250,7 +250,7 @@ fn match_seq_at_end() {
 
 #[test]
 fn match_seq_at_end_string() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     assert_eq!(
         match_seq(&[OpCode::At(AtCode::EndString)], 1, &chars("a"), 0, &groups),
         Some(1)
@@ -269,7 +269,7 @@ fn match_seq_at_end_string() {
 
 #[test]
 fn match_seq_at_word_boundary() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     assert_eq!(
         match_seq(&[OpCode::At(AtCode::Boundary)], 1, &chars("ab"), 0, &groups),
         None
@@ -292,7 +292,7 @@ fn match_seq_at_word_boundary() {
 
 #[test]
 fn match_seq_branch_first_arm_matches() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let ops = vec![OpCode::Branch(vec![
         sub(vec![lit('a')]),
         sub(vec![lit('b')]),
@@ -302,7 +302,7 @@ fn match_seq_branch_first_arm_matches() {
 
 #[test]
 fn match_seq_branch_second_arm_matches() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let ops = vec![OpCode::Branch(vec![
         sub(vec![lit('a')]),
         sub(vec![lit('b')]),
@@ -312,7 +312,7 @@ fn match_seq_branch_second_arm_matches() {
 
 #[test]
 fn match_seq_branch_no_match() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let ops = vec![OpCode::Branch(vec![
         sub(vec![lit('a')]),
         sub(vec![lit('b')]),
@@ -322,7 +322,7 @@ fn match_seq_branch_no_match() {
 
 #[test]
 fn match_seq_subpattern() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let ops = vec![OpCode::Subpattern {
         group: Some(1),
         add_flags: 0,
@@ -334,7 +334,7 @@ fn match_seq_subpattern() {
 
 #[test]
 fn match_seq_subpattern_inline_flags() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let ops = vec![OpCode::Subpattern {
         group: None,
         add_flags: SRE_FLAG_IGNORECASE,
@@ -346,7 +346,7 @@ fn match_seq_subpattern_inline_flags() {
 
 #[test]
 fn match_seq_atomic_group() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let ops = vec![OpCode::AtomicGroup(sub(vec![lit('a')]))];
     assert_eq!(match_seq(&ops, 0, &chars("a"), 0, &groups), Some(1));
     assert_eq!(match_seq(&ops, 0, &chars("b"), 0, &groups), None);
@@ -354,7 +354,7 @@ fn match_seq_atomic_group() {
 
 #[test]
 fn match_seq_groupref_match() {
-    let mut groups = HashMap::new();
+    let mut groups = HashMap::default();
     groups.insert(1, "ab".to_string());
     let ops = vec![OpCode::GroupRef(1)];
     assert_eq!(match_seq(&ops, 0, &chars("ab"), 0, &groups), Some(2));
@@ -362,7 +362,7 @@ fn match_seq_groupref_match() {
 
 #[test]
 fn match_seq_groupref_too_short() {
-    let mut groups = HashMap::new();
+    let mut groups = HashMap::default();
     groups.insert(1, "abc".to_string());
     let ops = vec![OpCode::GroupRef(1)];
     assert_eq!(match_seq(&ops, 0, &chars("ab"), 0, &groups), None);
@@ -370,7 +370,7 @@ fn match_seq_groupref_too_short() {
 
 #[test]
 fn match_seq_groupref_mismatched() {
-    let mut groups = HashMap::new();
+    let mut groups = HashMap::default();
     groups.insert(1, "ab".to_string());
     let ops = vec![OpCode::GroupRef(1)];
     assert_eq!(match_seq(&ops, 0, &chars("xy"), 0, &groups), None);
@@ -378,14 +378,14 @@ fn match_seq_groupref_mismatched() {
 
 #[test]
 fn match_seq_groupref_unset() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let ops = vec![OpCode::GroupRef(1)];
     assert_eq!(match_seq(&ops, 0, &chars("ab"), 0, &groups), None);
 }
 
 #[test]
 fn match_seq_groupref_exists_yes_arm() {
-    let mut groups = HashMap::new();
+    let mut groups = HashMap::default();
     groups.insert(1, "x".to_string());
     let ops = vec![OpCode::GroupRefExists {
         cond_group: 1,
@@ -397,7 +397,7 @@ fn match_seq_groupref_exists_yes_arm() {
 
 #[test]
 fn match_seq_groupref_exists_no_arm() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let ops = vec![OpCode::GroupRefExists {
         cond_group: 1,
         yes: sub(vec![lit('a')]),
@@ -408,7 +408,7 @@ fn match_seq_groupref_exists_no_arm() {
 
 #[test]
 fn match_seq_groupref_exists_no_arm_missing() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let ops = vec![OpCode::GroupRefExists {
         cond_group: 1,
         yes: sub(vec![lit('a')]),
@@ -419,7 +419,7 @@ fn match_seq_groupref_exists_no_arm_missing() {
 
 #[test]
 fn match_seq_positive_lookaround_match() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let ops = vec![
         OpCode::Assert {
             direction: 1,
@@ -432,7 +432,7 @@ fn match_seq_positive_lookaround_match() {
 
 #[test]
 fn match_seq_positive_lookaround_no_match() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let ops = vec![OpCode::Assert {
         direction: 1,
         p: sub(vec![lit('a')]),
@@ -442,7 +442,7 @@ fn match_seq_positive_lookaround_no_match() {
 
 #[test]
 fn match_seq_negative_lookaround_match() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let ops = vec![
         OpCode::AssertNot {
             direction: 1,
@@ -455,7 +455,7 @@ fn match_seq_negative_lookaround_match() {
 
 #[test]
 fn match_seq_negative_lookaround_blocks() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let ops = vec![OpCode::AssertNot {
         direction: 1,
         p: sub(vec![lit('a')]),
@@ -465,7 +465,7 @@ fn match_seq_negative_lookaround_blocks() {
 
 #[test]
 fn match_seq_failure_never_matches() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     assert_eq!(
         match_seq(&[OpCode::Failure], 0, &chars(""), 0, &groups),
         None
@@ -474,7 +474,7 @@ fn match_seq_failure_never_matches() {
 
 #[test]
 fn match_seq_max_repeat_unbounded() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let ops = vec![OpCode::MaxRepeat {
         min: 0,
         max: u32::MAX,
@@ -486,7 +486,7 @@ fn match_seq_max_repeat_unbounded() {
 
 #[test]
 fn match_seq_max_repeat_bounded() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let ops = vec![OpCode::MaxRepeat {
         min: 2,
         max: 3,
@@ -497,7 +497,7 @@ fn match_seq_max_repeat_bounded() {
 
 #[test]
 fn match_seq_max_repeat_min_unsatisfied() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let ops = vec![OpCode::MaxRepeat {
         min: 3,
         max: 5,
@@ -508,7 +508,7 @@ fn match_seq_max_repeat_min_unsatisfied() {
 
 #[test]
 fn match_seq_max_repeat_with_trailing() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let ops = vec![
         OpCode::MaxRepeat {
             min: 1,
@@ -522,7 +522,7 @@ fn match_seq_max_repeat_with_trailing() {
 
 #[test]
 fn match_seq_min_repeat_lazy() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let ops = vec![
         OpCode::MinRepeat {
             min: 0,
@@ -536,7 +536,7 @@ fn match_seq_min_repeat_lazy() {
 
 #[test]
 fn match_seq_min_repeat_bounded() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let ops = vec![OpCode::MinRepeat {
         min: 1,
         max: 2,
@@ -547,7 +547,7 @@ fn match_seq_min_repeat_bounded() {
 
 #[test]
 fn match_seq_min_repeat_no_match() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let ops = vec![
         OpCode::MinRepeat {
             min: 0,
@@ -561,7 +561,7 @@ fn match_seq_min_repeat_no_match() {
 
 #[test]
 fn match_seq_min_repeat_min_unsatisfied() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let ops = vec![OpCode::MinRepeat {
         min: 3,
         max: 5,
@@ -572,7 +572,7 @@ fn match_seq_min_repeat_min_unsatisfied() {
 
 #[test]
 fn match_seq_min_repeat_max_exhausted() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let ops = vec![
         OpCode::MinRepeat {
             min: 0,
@@ -586,7 +586,7 @@ fn match_seq_min_repeat_max_exhausted() {
 
 #[test]
 fn match_seq_possessive_repeat() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let ops = vec![OpCode::PossessiveRepeat {
         min: 0,
         max: u32::MAX,
@@ -597,7 +597,7 @@ fn match_seq_possessive_repeat() {
 
 #[test]
 fn match_seq_possessive_repeat_bounded() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let ops = vec![OpCode::PossessiveRepeat {
         min: 0,
         max: 2,
@@ -608,7 +608,7 @@ fn match_seq_possessive_repeat_bounded() {
 
 #[test]
 fn match_seq_possessive_repeat_min_unsatisfied() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let ops = vec![OpCode::PossessiveRepeat {
         min: 3,
         max: 5,
@@ -619,7 +619,7 @@ fn match_seq_possessive_repeat_min_unsatisfied() {
 
 #[test]
 fn match_seq_min_repeat_zero_width_item_at_min() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let ops = vec![OpCode::MinRepeat {
         min: 1,
         max: u32::MAX,
@@ -630,7 +630,7 @@ fn match_seq_min_repeat_zero_width_item_at_min() {
 
 #[test]
 fn match_seq_min_repeat_zero_width_item_after_min() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let ops = vec![
         OpCode::MinRepeat {
             min: 0,
@@ -668,8 +668,8 @@ fn build_in_set_negated_ascii_only_excludes_nonascii() {
 #[test]
 fn generate_op_ignorecase_literal_outside_alphabet_marks_invalid() {
     let mut ntc = NativeTestCase::for_choices(&[ChoiceValue::Integer(BigInt::from(0))], None, None);
-    let cache = Mutex::new(HashMap::new());
-    let char_cache = Mutex::new(HashMap::new());
+    let cache = Mutex::new(HashMap::default());
+    let char_cache = Mutex::new(HashMap::default());
     let mut state = ignorecase_state(&cache, &char_cache);
     let alphabet = Some(IntervalSet::new(vec![('A' as u32, 'A' as u32)]));
     let mut out = String::new();
@@ -691,7 +691,7 @@ fn ignorecase_state<'a>(
     char_cache: &'a Mutex<HashMap<CharKey, Arc<[char]>>>,
 ) -> GenState<'a> {
     GenState {
-        groups: HashMap::new(),
+        groups: HashMap::default(),
         flags: SRE_FLAG_IGNORECASE,
         fullmatch: false,
         pending_anchors: Vec::new(),
@@ -706,8 +706,8 @@ fn ignorecase_state<'a>(
 #[test]
 fn generate_op_ignorecase_eszett_never_emits_truncated_uppercase() {
     use crate::native::rng::EngineRng;
-    let cache = Mutex::new(HashMap::new());
-    let char_cache = Mutex::new(HashMap::new());
+    let cache = Mutex::new(HashMap::default());
+    let char_cache = Mutex::new(HashMap::default());
     for seed in 0..50 {
         let mut ntc = NativeTestCase::new_random(EngineRng::seeded(seed));
         let mut state = ignorecase_state(&cache, &char_cache);
@@ -720,9 +720,9 @@ fn generate_op_ignorecase_eszett_never_emits_truncated_uppercase() {
 #[test]
 fn generate_op_ignorecase_plain_letter_emits_both_cases() {
     use crate::native::rng::EngineRng;
-    let mut seen = std::collections::HashSet::new();
-    let cache = Mutex::new(HashMap::new());
-    let char_cache = Mutex::new(HashMap::new());
+    let mut seen = HashSet::default();
+    let cache = Mutex::new(HashMap::default());
+    let char_cache = Mutex::new(HashMap::default());
     for seed in 0..50 {
         let mut ntc = NativeTestCase::new_random(EngineRng::seeded(seed));
         let mut state = ignorecase_state(&cache, &char_cache);
@@ -743,8 +743,8 @@ fn generate_op_ignorecase_not_literal_blacklists_swapcase_fixpoint() {
         (0x130, 0x130),
         (0x307, 0x307),
     ]));
-    let cache = Mutex::new(HashMap::new());
-    let char_cache = Mutex::new(HashMap::new());
+    let cache = Mutex::new(HashMap::default());
+    let char_cache = Mutex::new(HashMap::default());
     for seed in 0..100 {
         let mut ntc = NativeTestCase::new_random(EngineRng::seeded(seed));
         let mut state = ignorecase_state(&cache, &char_cache);
@@ -874,7 +874,7 @@ fn generate_regex_ignorecase_negated_class_excludes_swapcase_fixpoint() {
 
 #[test]
 fn match_seq_max_repeat_counts_zero_width_iterations_toward_min() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let optional_a = sub(vec![OpCode::MaxRepeat {
         min: 0,
         max: 1,
@@ -891,7 +891,7 @@ fn match_seq_max_repeat_counts_zero_width_iterations_toward_min() {
 
 #[test]
 fn match_seq_min_repeat_counts_zero_width_iterations_toward_min() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let optional_a = sub(vec![OpCode::MaxRepeat {
         min: 0,
         max: 1,
@@ -961,7 +961,7 @@ fn generate_regex_multiline_caret_in_the_middle_generates_nothing() {
 
 #[test]
 fn match_seq_possessive_repeat_counts_zero_width_iterations_toward_min() {
-    let groups = HashMap::new();
+    let groups = HashMap::default();
     let optional_a = sub(vec![OpCode::MaxRepeat {
         min: 0,
         max: 1,

--- a/hegel-c/tests/embedded/native/shrinker_cache_tests.rs
+++ b/hegel-c/tests/embedded/native/shrinker_cache_tests.rs
@@ -6,8 +6,8 @@
 //! the test closure, the single source of truth, matching Hypothesis's
 //! `Shrinker.cached_test_function`.)
 
+use crate::native::HashMap;
 use crate::native::bignum::BigInt;
-use std::collections::HashMap;
 
 use crate::exchange::drive_no_yield;
 use crate::native::core::choices::{BooleanChoice, IntegerChoice};
@@ -45,7 +45,7 @@ fn replace_rejects_index_past_end_of_current_nodes() {
         vec![int_node(5), int_node(10)],
         Spans::new(),
     );
-    let mut values = HashMap::new();
+    let mut values = HashMap::default();
     values.insert(99, ChoiceValue::Integer(BigInt::from(0)));
     assert!(!drive_no_yield(shrinker.replace(&values)).unwrap());
 }
@@ -60,7 +60,7 @@ fn replace_rejects_value_that_fails_kind_validate() {
         vec![bool_node(true)],
         Spans::new(),
     );
-    let mut values = HashMap::new();
+    let mut values = HashMap::default();
     values.insert(0, ChoiceValue::Integer(BigInt::from(42)));
     assert!(!drive_no_yield(shrinker.replace(&values)).unwrap());
 }

--- a/hegel-c/tests/embedded/native/shrinker_defensive_branch_tests.rs
+++ b/hegel-c/tests/embedded/native/shrinker_defensive_branch_tests.rs
@@ -1,8 +1,8 @@
 //! Tests covering defensive branches in deletion.rs and sequence.rs
 //! that were previously masked by `// nocov` annotations.
 
+use crate::native::HashMap;
 use crate::native::bignum::BigInt;
-use std::collections::HashMap;
 
 use crate::exchange::drive_no_yield;
 use crate::native::core::choices::IntegerChoice;
@@ -200,7 +200,7 @@ fn try_shortening_via_increment_break_on_concurrent_shrink() {
 #[test]
 fn replace_short_circuits_on_index_past_end_of_attempt() {
     let mut shrinker = accepting_shrinker(vec![int_node(5)]);
-    let mut values = HashMap::new();
+    let mut values = HashMap::default();
     values.insert(0, ChoiceValue::Integer(BigInt::from(0)));
     values.insert(10, ChoiceValue::Integer(BigInt::from(0)));
     assert!(!drive_no_yield(shrinker.replace(&values)).unwrap());

--- a/hegel-c/tests/embedded/native/state_tests.rs
+++ b/hegel-c/tests/embedded/native/state_tests.rs
@@ -734,7 +734,7 @@ fn biased_integer_sample_collapses_when_min_equals_max() {
 #[test]
 fn biased_integer_sample_produces_diverse_magnitudes_unbounded() {
     let mut rng = EngineRng::seeded(5);
-    let mut magnitudes: HashSet<i32> = HashSet::new();
+    let mut magnitudes: HashSet<i32> = HashSet::default();
     for _ in 0..2000 {
         let v = biased_i128_sample(i64::MIN as i128, i64::MAX as i128, &mut rng);
         let mag = if v == 0 {

--- a/hegel-c/tests/embedded/native/targeting_tests.rs
+++ b/hegel-c/tests/embedded/native/targeting_tests.rs
@@ -48,7 +48,7 @@ fn targeting_state_starts_empty() {
 fn targeting_state_records_first_observation() {
     let mut state = TargetingState::new();
     let choices = vec![ChoiceValue::Integer(BigInt::from(7))];
-    let obs = std::collections::HashMap::from([("score".to_string(), 1.5)]);
+    let obs = HashMap::from_iter([("score".to_string(), 1.5)]);
     state.record(&choices, &obs);
     assert!(!state.is_empty());
     assert_eq!(state.best_score("score"), Some(1.5));
@@ -59,24 +59,12 @@ fn targeting_state_overwrites_only_on_strict_improvement() {
     let mut state = TargetingState::new();
     let choices_a = vec![ChoiceValue::Integer(BigInt::from(1))];
     let choices_b = vec![ChoiceValue::Integer(BigInt::from(2))];
-    state.record(
-        &choices_a,
-        &std::collections::HashMap::from([("s".to_string(), 1.0)]),
-    );
-    state.record(
-        &choices_b,
-        &std::collections::HashMap::from([("s".to_string(), 1.0)]),
-    );
+    state.record(&choices_a, &HashMap::from_iter([("s".to_string(), 1.0)]));
+    state.record(&choices_b, &HashMap::from_iter([("s".to_string(), 1.0)]));
     assert_eq!(state.best_score("s"), Some(1.0));
-    state.record(
-        &choices_b,
-        &std::collections::HashMap::from([("s".to_string(), 0.5)]),
-    );
+    state.record(&choices_b, &HashMap::from_iter([("s".to_string(), 0.5)]));
     assert_eq!(state.best_score("s"), Some(1.0));
-    state.record(
-        &choices_b,
-        &std::collections::HashMap::from([("s".to_string(), 2.0)]),
-    );
+    state.record(&choices_b, &HashMap::from_iter([("s".to_string(), 2.0)]));
     assert_eq!(state.best_score("s"), Some(2.0));
 }
 
@@ -86,7 +74,7 @@ fn targeting_state_tracks_multiple_labels_independently() {
     let choices = vec![ChoiceValue::Integer(BigInt::from(0))];
     state.record(
         &choices,
-        &std::collections::HashMap::from([("a".to_string(), 1.0), ("b".to_string(), 2.0)]),
+        &HashMap::from_iter([("a".to_string(), 1.0), ("b".to_string(), 2.0)]),
     );
     assert_eq!(state.best_score("a"), Some(1.0));
     assert_eq!(state.best_score("b"), Some(2.0));
@@ -263,7 +251,6 @@ fn step_choice_rejects_mismatched_value_and_kind() {
 
 use crate::backend::{DataSource, Failure, TestCaseResult};
 use crate::native::test_runner::Engine;
-use std::collections::HashMap as StdHashMap;
 
 /// A drawn boolean, or `Err(())` if the case overran / was aborted.
 fn draw_bool(ds: &dyn DataSource) -> Result<bool, ()> {
@@ -295,7 +282,7 @@ where
         let mut engine = Engine::new(&settings, None, &exchange);
         engine
             .targeting
-            .record(&start, &StdHashMap::from([("".to_string(), start_score)]));
+            .record(&start, &HashMap::from_iter([("".to_string(), start_score)]));
 
         let mut optimiser = Optimiser {
             engine: &mut engine,


### PR DESCRIPTION
I'm in the process of moving libhegel over to compiling as no-std so that the shared library can be safely unloaded.

This is step 1, which removes some dependencies, and replaces other dependencies on std with no-std friendly versions.

<details><summary>AI-generated implementation notes</summary>

## What

Mechanical, behavior-preserving ports that remove `std`-only APIs from the hegel-c engine ahead of the `#![no_std]` switch:

- **Drop `crc32fast`** from hegel-c (it was declared but never referenced).
- **Hash tables → `hashbrown`** with `rustc_hash::FxBuildHasher`, via `pub(crate)` type aliases `HashMap`/`HashSet` in `hegel-c/src/native/mod.rs` so call sites stay clean. `HashMap::from([...])` became `HashMap::from_iter([...])` (the `From<[T; N]>` impl only exists for default-hasher maps); `test_runner.rs` imports `hashbrown::hash_map::Entry`.
- **`std::net` → `core::net`, `std::error` → `core::error`** throughout hegel-c.
- **Float math → `libm`** for every `f64` method with no `core` equivalent (log/log2/log1p/exp/exp2/expm1/sqrt/pow/floor/ceil/round/copysign/atan/sin/cos); `(2_f64).powi(p)` became `libm::exp2(f64::from(p))`, exact for the integer range used.
- **Trim `std`-implying features** from `dashu-int` and `miniz_oxide`.

## Why

The series goal is to make hegel-c `#![no_std]` so the built libhegel has no thread-locals, no TLS destructors, and no process-global hooks, making it safe to `dlclose` (the current SIGSEGV-at-thread-teardown bug), and so all OS access later sits behind one narrow platform module for a future wasm port. This stage does the API-level ports that don't change behavior; later stages remove the remaining `std` dependencies (parking_lot, tempfile, rand thread-locals, panic hook) and flip the crate to `no_std`.

Seeded generation streams did not shift on aarch64/glibc — all pinned-value tests passed unchanged — but `libm` can round differently from other platforms' math libraries in the last bit, so `hegel-c/RELEASE.md` (patch) notes that fixed-seed runs may generate different values on some platforms. Database replay is value-based and unaffected.

## Review findings and resolutions

Three reviewer findings, all low severity:

1. *hegel-c pins hashbrown 0.16, adding a third duplicate hashbrown to Cargo.lock; 0.17.1 (already present via indexmap) has rust-version 1.85.0, within the 1.86 MSRV.* — **Fixed.** Bumped hegel-c to `hashbrown = "0.17"`; verified 0.17.1 declares `rust-version = "1.85.0"` and still has the `inline-more` feature. `cargo update -p hashbrown@0.16.1 --precise 0.17.1` removed the 0.16.1 entry, so hegel-c now shares 0.17.1 with indexmap (a cbindgen dev-dependency transitive). The remaining 0.15.5 entry comes via `wasmparser`/`wit-*` lockfile entries that are not reachable from the workspace graph and were not introduced by this branch.
2. *Root crate still declares `crc32fast` with zero references (pre-existing on main, outside this stage's hegel-c-only scope; should be removed in a later stage).* — **Deferred, as the finding itself recommends.** Confirmed: the only reference in the repo is the root `Cargo.toml` declaration, pre-existing on main. This stage touches only hegel-c; the root-crate removal belongs in a later stage of the series (it needs its own root RELEASE.md entry).
3. *Workspace carries two hashbrown versions (0.16.1 + 0.17.1).* — **Fixed** by the same change as finding 1.

## Verification

All run on this branch after the hashbrown bump (aarch64 Linux):

- `just lint` — pass
- `cargo test --workspace` — pass
- `cargo test --workspace --all-features` — pass
- `just c-test` — pass; the known dlclose segfault in `libhegel_replays_persisted_failure_with_same_database_key` (the bug this series fixes, expected fixed by stage 4/5) did not occur on this run

## Open questions for David

- None on coverage: no `// nocov` added, no ratchet numbers touched; the only new lines are non-executable (type aliases, dependency edits).
- The unused root-crate `crc32fast` dependency (finding 2) is left for a later stage — flag if you'd rather it go in this one.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
