### PR TITLE
no_std prep 2/5: replace collection/pool/state-machine ids with opaque handles (C ABI break)

### DIFF
--- a/hegel-c/RELEASE.md
+++ b/hegel-c/RELEASE.md
@@ -1,0 +1,20 @@
+RELEASE_TYPE: minor
+
+This release replaces the `int64_t` ids for collections, variable pools, and state machines with opaque caller-owned handles, matching how every other libhegel object works. This is a breaking change to the C ABI.
+
+`hegel_new_collection`, `hegel_new_pool`, and `hegel_new_state_machine` now write a handle (`hegel_collection_t*`, `hegel_pool_t*`, `hegel_state_machine_t*`) through their out-parameter instead of an id, and `hegel_collection_more`, `hegel_collection_reject`, `hegel_pool_add`, `hegel_pool_generate`, and `hegel_state_machine_next_rule` take that handle instead of an id (still alongside the test-case handle, whose stream the draws come from — any clone of the creating test case works, as before). Each handle must be released with its new matching free function — `hegel_collection_free`, `hegel_pool_free`, or `hegel_state_machine_free` — exactly once. The handles are independent of the test case and run they were created under, so the frees are safe in any order, including after `hegel_run_free`. A NULL handle is reported as `HEGEL_E_INVALID_HANDLE`, and the ids' `HEGEL_E_INVALID_ARG` "unknown id" errors are gone.
+
+```c
+/* before */
+int64_t collection;
+hegel_new_collection(ctx, tc, 0, 10, &collection);
+hegel_collection_more(ctx, tc, collection, &more);
+
+/* after */
+hegel_collection_t *collection;
+hegel_new_collection(ctx, tc, 0, 10, &collection);
+hegel_collection_more(ctx, tc, collection, &more);
+hegel_collection_free(ctx, collection);
+```
+
+The threading contract is now per object rather than per family. A collection may be driven by at most one thread at a time: concurrent use reports `HEGEL_E_CONCURRENT_USE`, like a test-case handle. Pools and state machines may be shared between clone handles driven from parallel threads; their operations serialize internally. This also removes a hidden serialization point — collection and pool operations from parallel clones previously contended on one family-wide lock even when touching different objects.

--- a/hegel-c/cbindgen.toml
+++ b/hegel-c/cbindgen.toml
@@ -36,6 +36,9 @@ header = """
  *     hegel_run_result           ->  hegel_run_result_free
  *     hegel_run_result_failure   ->  hegel_failure_free
  *     hegel_string_generator_*   ->  hegel_string_generator_free
+ *     hegel_new_collection       ->  hegel_collection_free
+ *     hegel_new_pool             ->  hegel_pool_free
+ *     hegel_new_state_machine    ->  hegel_state_machine_free
  *     hegel_generate_bytes       ->  hegel_generate_bytes_result_free
  *     hegel_generate_string      ->  hegel_generate_string_result_free
  *
@@ -111,6 +114,9 @@ include = [
 "HegelRunResult" = "hegel_run_result_t"
 "HegelFailure" = "hegel_failure_t"
 "HegelStringGenerator" = "hegel_string_generator_t"
+"HegelCollection" = "hegel_collection_t"
+"HegelPool" = "hegel_pool_t"
+"HegelStateMachine" = "hegel_state_machine_t"
 
 # Enum types are named hegel_*_t directly in the Rust source, with each
 # variant pre-prefixed (HEGEL_STATUS_VALID etc.), so cbindgen's automatic

--- a/hegel-c/examples/pool.c
+++ b/hegel-c/examples/pool.c
@@ -83,7 +83,7 @@ int main(void) {
         if (tc == NULL) break;
 
         struct live_set live = { .count = 0 };
-        int64_t pool;
+        hegel_pool_t *pool;
         if (hegel_new_pool(ctx, tc, &pool) != HEGEL_OK) {
             HEGEL_CHECK(hegel_mark_complete, ctx, tc, HEGEL_STATUS_OVERRUN, NULL);
             HEGEL_CHECK(hegel_test_case_free, ctx, tc);
@@ -122,6 +122,10 @@ int main(void) {
             }
             if (live.count > max_pool) max_pool = live.count;
         }
+
+        /* The pool handle is caller-owned and freed independently of the
+         * test case. */
+        HEGEL_CHECK(hegel_pool_free, ctx, pool);
 
         if (bad) {
             HEGEL_CHECK(hegel_mark_complete, ctx, tc, HEGEL_STATUS_INTERESTING,

--- a/hegel-c/examples/spans_collections.c
+++ b/hegel-c/examples/spans_collections.c
@@ -27,8 +27,8 @@
 static int draw_bool_list(hegel_context_t *ctx, hegel_test_case_t *tc, uint64_t min_size, uint64_t max_size) {
     if (hegel_start_span(ctx, tc, HEGEL_LABEL_LIST) != HEGEL_OK) return -1;
 
-    int64_t cid;
-    if (hegel_new_collection(ctx, tc, min_size, max_size, &cid) != HEGEL_OK) {
+    hegel_collection_t *collection;
+    if (hegel_new_collection(ctx, tc, min_size, max_size, &collection) != HEGEL_OK) {
         hegel_stop_span(ctx, tc, false);
         return -1;
     }
@@ -36,20 +36,23 @@ static int draw_bool_list(hegel_context_t *ctx, hegel_test_case_t *tc, uint64_t 
     int n = 0;
     while (true) {
         bool more;
-        hegel_result_t rc = hegel_collection_more(ctx, tc, cid, &more);
+        hegel_result_t rc = hegel_collection_more(ctx, tc, collection, &more);
         if (rc != HEGEL_OK) {
+            hegel_collection_free(ctx, collection);
             hegel_stop_span(ctx, tc, false);
             return -1;
         }
         if (!more) break;
 
         if (hegel_start_span(ctx, tc, HEGEL_LABEL_LIST_ELEMENT) != HEGEL_OK) {
+            hegel_collection_free(ctx, collection);
             hegel_stop_span(ctx, tc, false);
             return -1;
         }
         bool value;
         rc = hegel_generate_boolean(ctx, tc, 0.5, false, false, &value);
         if (rc != HEGEL_OK) {
+            hegel_collection_free(ctx, collection);
             hegel_stop_span(ctx, tc, false);
             hegel_stop_span(ctx, tc, false);
             return -1;
@@ -58,6 +61,9 @@ static int draw_bool_list(hegel_context_t *ctx, hegel_test_case_t *tc, uint64_t 
         n++;
     }
 
+    /* The collection handle is caller-owned and freed independently of the
+     * test case. */
+    hegel_collection_free(ctx, collection);
     hegel_stop_span(ctx, tc, false);
     return n;
 }

--- a/hegel-c/examples/state_machine.c
+++ b/hegel-c/examples/state_machine.c
@@ -54,7 +54,7 @@ int main(void) {
         HEGEL_CHECK(hegel_next_test_case, ctx, run, &tc);
         if (tc == NULL) break;
 
-        int64_t machine;
+        hegel_state_machine_t *machine;
         if (hegel_new_state_machine(ctx, tc, RULES, NUM_RULES,
                                     INVARIANTS, NUM_INVARIANTS,
                                     &machine) != HEGEL_OK) {
@@ -83,6 +83,10 @@ int main(void) {
             /* Invariant: the counter never goes negative. */
             if (counter < 0) { bad = true; break; }
         }
+
+        /* The state-machine handle is caller-owned and freed independently
+         * of the test case. */
+        HEGEL_CHECK(hegel_state_machine_free, ctx, machine);
 
         if (bad) {
             HEGEL_CHECK(hegel_mark_complete, ctx, tc, HEGEL_STATUS_INTERESTING,

--- a/hegel-c/include/hegel.h
+++ b/hegel-c/include/hegel.h
@@ -1119,8 +1119,9 @@ hegel_result_t hegel_new_collection(hegel_context_t *ctx,
  `false` into `*out_more` and returns `HEGEL_OK`. Call in a loop until
  `*out_more` is `false`, drawing the next element each time.
 
- Returns `HEGEL_E_INVALID_HANDLE` for a NULL `tc` or `collection`,
- `HEGEL_E_INVALID_ARG` for a NULL `out_more`, and
+ Returns `HEGEL_E_STOP_TEST` when the engine's choice budget is exhausted
+ for this test case, `HEGEL_E_INVALID_HANDLE` for a NULL `tc` or
+ `collection`, `HEGEL_E_INVALID_ARG` for a NULL `out_more`, and
  `HEGEL_E_CONCURRENT_USE` when another thread is mid-operation on either
  the test-case handle or the collection.
  */
@@ -1136,9 +1137,10 @@ hegel_result_t hegel_collection_more(hegel_context_t *ctx,
  rejection reason (NULL is allowed); it is validated but currently
  unused, reserved for future rejection diagnostics.
 
- Returns `HEGEL_E_INVALID_HANDLE` for a NULL `tc` or `collection`, and
- `HEGEL_E_CONCURRENT_USE` when another thread is mid-operation on either
- the test-case handle or the collection.
+ Returns `HEGEL_E_STOP_TEST` when the engine's choice budget is exhausted
+ for this test case, `HEGEL_E_INVALID_HANDLE` for a NULL `tc` or
+ `collection`, and `HEGEL_E_CONCURRENT_USE` when another thread is
+ mid-operation on either the test-case handle or the collection.
  */
 hegel_result_t hegel_collection_reject(hegel_context_t *ctx,
                                        hegel_test_case_t *tc,
@@ -1177,9 +1179,10 @@ hegel_result_t hegel_new_pool(hegel_context_t *ctx, hegel_test_case_t *tc, hegel
 
  On success writes the new variable's id into `*out_variable_id` and
  returns `HEGEL_OK`. `pool` must be a handle from `hegel_new_pool` on a
- handle of this test case's family. Returns `HEGEL_E_INVALID_HANDLE` for
- a NULL `tc` or `pool`, and `HEGEL_E_INVALID_ARG` for a NULL
- `out_variable_id`.
+ handle of this test case's family. Returns `HEGEL_E_STOP_TEST` when the
+ engine's choice budget is exhausted for this test case,
+ `HEGEL_E_INVALID_HANDLE` for a NULL `tc` or `pool`, and
+ `HEGEL_E_INVALID_ARG` for a NULL `out_variable_id`.
  */
 hegel_result_t hegel_pool_add(hegel_context_t *ctx,
                               hegel_test_case_t *tc,
@@ -1199,7 +1202,8 @@ hegel_result_t hegel_pool_add(hegel_context_t *ctx,
  failed assumption: it may recover and continue the test case (as
  stateful testing does when a rule's assumption fails, by skipping the
  action), or give up on the case and mark it INVALID. Returns
- `HEGEL_E_INVALID_HANDLE` for a NULL `tc` or `pool`, and
+ `HEGEL_E_STOP_TEST` when the engine's choice budget is exhausted for
+ this test case, `HEGEL_E_INVALID_HANDLE` for a NULL `tc` or `pool`, and
  `HEGEL_E_INVALID_ARG` for a NULL `out_variable_id`.
  */
 hegel_result_t hegel_pool_generate(hegel_context_t *ctx,

--- a/hegel-c/include/hegel.h
+++ b/hegel-c/include/hegel.h
@@ -34,6 +34,9 @@
  *     hegel_run_result           ->  hegel_run_result_free
  *     hegel_run_result_failure   ->  hegel_failure_free
  *     hegel_string_generator_*   ->  hegel_string_generator_free
+ *     hegel_new_collection       ->  hegel_collection_free
+ *     hegel_new_pool             ->  hegel_pool_free
+ *     hegel_new_state_machine    ->  hegel_state_machine_free
  *     hegel_generate_bytes       ->  hegel_generate_bytes_result_free
  *     hegel_generate_string      ->  hegel_generate_string_result_free
  *
@@ -465,6 +468,24 @@ typedef enum {
 } hegel_status_t;
 
 /*
+ Opaque handle to an engine-managed variable-length collection.
+
+ Created by `hegel_new_collection` on a test case; driven by
+ `hegel_collection_more` / `hegel_collection_reject` through any handle of
+ the *same* test-case family (the root or any clone) — the continue/stop
+ decisions are drawn from whichever handle makes the call. A collection
+ must not be used from two threads at once: the operations take an
+ internal non-blocking lock and return `HEGEL_E_CONCURRENT_USE` on
+ contention.
+
+ The handle is independent of the test case and run it was created under:
+ free it with `hegel_collection_free` exactly once, at any point — before
+ or after the test case or run is freed, in any order relative to other
+ frees.
+ */
+typedef struct hegel_collection_t hegel_collection_t;
+
+/*
  Opaque error-reporting context.
 
  libhegel records the diagnostic for a failed call on a context the caller
@@ -502,6 +523,25 @@ typedef struct hegel_context_t hegel_context_t;
  the diagnostic and re-raise the test's own failure.
  */
 typedef struct hegel_failure_t hegel_failure_t;
+
+/*
+ Opaque handle to an engine-managed *variable pool* for stateful testing.
+
+ Created by `hegel_new_pool` on a test case; driven by `hegel_pool_add` /
+ `hegel_pool_generate` through any handle of the *same* test-case family
+ (the root or any clone) — the draw comes from whichever handle makes the
+ call. Unlike a collection, a pool may legitimately be shared between
+ clone handles driven from parallel threads: it holds an internal lock,
+ so concurrent operations serialize instead of erroring. (Which variable
+ a concurrent draw picks then depends on scheduling order, with the usual
+ replay caveat for racy tests.)
+
+ The handle is independent of the test case and run it was created under:
+ free it with `hegel_pool_free` exactly once, at any point — before or
+ after the test case or run is freed, in any order relative to other
+ frees.
+ */
+typedef struct hegel_pool_t hegel_pool_t;
 
 /*
  In-flight property-test run.
@@ -551,6 +591,25 @@ typedef struct hegel_run_result_t hegel_run_result_t;
  with any other use of the same handle.
  */
 typedef struct hegel_settings_t hegel_settings_t;
+
+/*
+ Opaque handle to an engine-owned *state machine* for stateful
+ (rule-based) testing.
+
+ Created by `hegel_new_state_machine` on a test case; driven by
+ `hegel_state_machine_next_rule` through any handle of the *same*
+ test-case family (the root or any clone) — each rule choice is drawn
+ from whichever handle makes the call. The machine holds an internal
+ lock, so concurrent use from two clone handles serializes instead of
+ erroring. (Which rule a concurrent draw picks then depends on scheduling
+ order, with the usual replay caveat for racy tests.)
+
+ The handle is independent of the test case and run it was created under:
+ free it with `hegel_state_machine_free` exactly once, at any point —
+ before or after the test case or run is freed, in any order relative to
+ other frees.
+ */
+typedef struct hegel_state_machine_t hegel_state_machine_t;
 
 /*
  Opaque specification of a string draw — the alphabet-and-shape half of
@@ -991,9 +1050,11 @@ hegel_result_t hegel_test_case_free(hegel_context_t *ctx, hegel_test_case_t *tc)
  produces are deterministic under replay and shrink correctly. (Whereas
  using a *single* handle from two threads returns
  `HEGEL_E_CONCURRENT_USE`.) Collections, variable pools, and state
- machines remain shared across the family — ids from one handle work on
- any other — but *concurrent* use of one such object from two streams
- makes the affected values scheduling-dependent.
+ machines remain usable across the family — a handle created through one
+ test-case handle works with any other — but *concurrent* use of one such
+ object from two streams makes the affected values scheduling-dependent
+ (and a *collection* used from two threads at once reports
+ `HEGEL_E_CONCURRENT_USE`; see `hegel_collection_t`).
 
  Cloning is a stream operation: it occupies one choice position on the
  source handle's stream, takes the source handle's lock like a draw
@@ -1038,25 +1099,34 @@ hegel_result_t hegel_stop_span(hegel_context_t *ctx, hegel_test_case_t *tc, bool
  a time by calling `hegel_collection_more` in a loop. Pass
  `max_size = UINT64_MAX` for no upper bound.
 
- On success writes the new collection's id into `*out_collection_id`
- and returns `HEGEL_OK`. The id is opaque; pass it to subsequent
- `hegel_collection_more` / `hegel_collection_reject` calls.
+ On success writes a caller-owned handle into `*out_collection` (release
+ with `hegel_collection_free`) and returns `HEGEL_OK`. Pass the handle to
+ subsequent `hegel_collection_more` / `hegel_collection_reject` calls with
+ any handle of the same test-case family. Returns `HEGEL_E_STOP_TEST` when
+ the engine's choice budget is already exhausted for this test case, and
+ `HEGEL_E_INVALID_ARG` for a NULL `out_collection` or
+ `min_size > max_size`.
  */
 hegel_result_t hegel_new_collection(hegel_context_t *ctx,
                                     hegel_test_case_t *tc,
                                     uint64_t min_size,
                                     uint64_t max_size,
-                                    int64_t *out_collection_id);
+                                    hegel_collection_t **out_collection);
 
 /*
- Ask whether the engine wants another element in this collection.
- On success writes `true` or `false` into `*out_more` and returns
- `HEGEL_OK`. Call in a loop until `*out_more` is `false`, drawing
- the next element each time.
+ Ask whether the engine wants another element in this collection,
+ drawing the decision from `tc`'s stream. On success writes `true` or
+ `false` into `*out_more` and returns `HEGEL_OK`. Call in a loop until
+ `*out_more` is `false`, drawing the next element each time.
+
+ Returns `HEGEL_E_INVALID_HANDLE` for a NULL `tc` or `collection`,
+ `HEGEL_E_INVALID_ARG` for a NULL `out_more`, and
+ `HEGEL_E_CONCURRENT_USE` when another thread is mid-operation on either
+ the test-case handle or the collection.
  */
 hegel_result_t hegel_collection_more(hegel_context_t *ctx,
                                      hegel_test_case_t *tc,
-                                     int64_t collection_id,
+                                     hegel_collection_t *collection,
                                      bool *out_more);
 
 /*
@@ -1065,11 +1135,23 @@ hegel_result_t hegel_collection_more(hegel_context_t *ctx,
  should try a different one. `why` is an optional human-readable
  rejection reason (NULL is allowed); it is validated but currently
  unused, reserved for future rejection diagnostics.
+
+ Returns `HEGEL_E_INVALID_HANDLE` for a NULL `tc` or `collection`, and
+ `HEGEL_E_CONCURRENT_USE` when another thread is mid-operation on either
+ the test-case handle or the collection.
  */
 hegel_result_t hegel_collection_reject(hegel_context_t *ctx,
                                        hegel_test_case_t *tc,
-                                       int64_t collection_id,
+                                       hegel_collection_t *collection,
                                        const char *why);
+
+/*
+ Release a collection handle from `hegel_new_collection`. Safe to call
+ with NULL (a no-op that returns `HEGEL_OK`), and safe at any point in any
+ order relative to freeing the test case or the run. Each handle must be
+ freed exactly once; freeing the same handle twice is undefined behaviour.
+ */
+hegel_result_t hegel_collection_free(hegel_context_t *ctx, hegel_collection_t *collection);
 
 /*
  Create a new engine-managed *variable pool* for stateful testing.
@@ -1080,23 +1162,28 @@ hegel_result_t hegel_collection_reject(hegel_context_t *ctx,
  its own mapping from variable id to the actual value it generated
  (mirroring how `Pool<T>` holds a `HashMap<i64, T>`).
 
- On success writes the new pool's id into `*out_pool_id` and returns
- `HEGEL_OK`. The id is opaque; pass it to subsequent `hegel_pool_add`
- / `hegel_pool_generate` calls on the *same* test case.
+ On success writes a caller-owned handle into `*out_pool` (release with
+ `hegel_pool_free`) and returns `HEGEL_OK`. Pass the handle to subsequent
+ `hegel_pool_add` / `hegel_pool_generate` calls with any handle of the
+ same test-case family. Returns `HEGEL_E_STOP_TEST` when the engine's
+ choice budget is already exhausted for this test case, and
+ `HEGEL_E_INVALID_ARG` for a NULL `out_pool`.
  */
-hegel_result_t hegel_new_pool(hegel_context_t *ctx, hegel_test_case_t *tc, int64_t *out_pool_id);
+hegel_result_t hegel_new_pool(hegel_context_t *ctx, hegel_test_case_t *tc, hegel_pool_t **out_pool);
 
 /*
  Register a new variable in the pool. The engine assigns it a fresh
  id, which the caller associates with the value it just generated.
 
  On success writes the new variable's id into `*out_variable_id` and
- returns `HEGEL_OK`. `pool_id` must be an id returned by
- `hegel_new_pool` on this test case.
+ returns `HEGEL_OK`. `pool` must be a handle from `hegel_new_pool` on a
+ handle of this test case's family. Returns `HEGEL_E_INVALID_HANDLE` for
+ a NULL `tc` or `pool`, and `HEGEL_E_INVALID_ARG` for a NULL
+ `out_variable_id`.
  */
 hegel_result_t hegel_pool_add(hegel_context_t *ctx,
                               hegel_test_case_t *tc,
-                              int64_t pool_id,
+                              hegel_pool_t *pool,
                               int64_t *out_variable_id);
 
 /*
@@ -1104,20 +1191,30 @@ hegel_result_t hegel_pool_add(hegel_context_t *ctx,
  shrink) which previously-added variable to reuse. When
  `consume = true` the drawn variable is removed from the pool (model a
  destructive action); when `false` it stays available for future
- draws.
+ draws. The choice is drawn from `tc`'s stream.
 
  On success writes the chosen variable id into `*out_variable_id` and
  returns `HEGEL_OK`. Returns `HEGEL_E_ASSUME` if the pool currently
  has no active variables — the caller should treat that like any other
  failed assumption: it may recover and continue the test case (as
  stateful testing does when a rule's assumption fails, by skipping the
- action), or give up on the case and mark it INVALID.
+ action), or give up on the case and mark it INVALID. Returns
+ `HEGEL_E_INVALID_HANDLE` for a NULL `tc` or `pool`, and
+ `HEGEL_E_INVALID_ARG` for a NULL `out_variable_id`.
  */
 hegel_result_t hegel_pool_generate(hegel_context_t *ctx,
                                    hegel_test_case_t *tc,
-                                   int64_t pool_id,
+                                   hegel_pool_t *pool,
                                    bool consume,
                                    int64_t *out_variable_id);
+
+/*
+ Release a pool handle from `hegel_new_pool`. Safe to call with NULL (a
+ no-op that returns `HEGEL_OK`), and safe at any point in any order
+ relative to freeing the test case or the run. Each handle must be freed
+ exactly once; freeing the same handle twice is undefined behaviour.
+ */
+hegel_result_t hegel_pool_free(hegel_context_t *ctx, hegel_pool_t *pool);
 
 /*
  Register a *state machine* for engine-owned stateful (rule-based)
@@ -1130,11 +1227,13 @@ hegel_result_t hegel_pool_generate(hegel_context_t *ctx,
  applies it, until that call signals that no more steps should
  follow.
 
- On success writes the new machine's id into `*out_state_machine_id`
- and returns `HEGEL_OK`. The id is opaque; pass it to subsequent
- `hegel_state_machine_next_rule` calls on the *same* test case.
- Returns `HEGEL_E_INVALID_ARG` if `num_rules` is zero, or on null /
- non-UTF-8 names.
+ On success writes a caller-owned handle into `*out_state_machine`
+ (release with `hegel_state_machine_free`) and returns `HEGEL_OK`. Pass
+ the handle to subsequent `hegel_state_machine_next_rule` calls with any
+ handle of the same test-case family. Returns `HEGEL_E_STOP_TEST` when
+ the engine's choice budget is already exhausted for this test case, and
+ `HEGEL_E_INVALID_ARG` if `num_rules` is zero, on null / non-UTF-8 names,
+ or for a NULL `out_state_machine`.
  */
 hegel_result_t hegel_new_state_machine(hegel_context_t *ctx,
                                        hegel_test_case_t *tc,
@@ -1142,7 +1241,7 @@ hegel_result_t hegel_new_state_machine(hegel_context_t *ctx,
                                        size_t num_rules,
                                        const char *const *invariant_names,
                                        size_t num_invariants,
-                                       int64_t *out_state_machine_id);
+                                       hegel_state_machine_t **out_state_machine);
 
 /*
  Draw the index of the next rule to run, in `[0, num_rules)`, letting
@@ -1152,16 +1251,25 @@ hegel_result_t hegel_new_state_machine(hegel_context_t *ctx,
  of the test case, with restrictions that shrink away in minimal
  counterexamples.
 
- `state_machine_id` must be an id returned by
- `hegel_new_state_machine` on this test case. Returns
- `HEGEL_E_STOP_TEST` when the engine's choice budget is exhausted
- (the caller should abort the body and call `hegel_mark_complete`
- with `HEGEL_STATUS_OVERRUN`).
+ `state_machine` must be a handle from `hegel_new_state_machine` on a
+ handle of this test case's family. Returns `HEGEL_E_STOP_TEST` when the
+ engine's choice budget is exhausted (the caller should abort the body
+ and call `hegel_mark_complete` with `HEGEL_STATUS_OVERRUN`), and
+ `HEGEL_E_INVALID_HANDLE` for a NULL `tc` or `state_machine`.
  */
 hegel_result_t hegel_state_machine_next_rule(hegel_context_t *ctx,
                                              hegel_test_case_t *tc,
-                                             int64_t state_machine_id,
+                                             hegel_state_machine_t *state_machine,
                                              int64_t *out_rule_index);
+
+/*
+ Release a state-machine handle from `hegel_new_state_machine`. Safe to
+ call with NULL (a no-op that returns `HEGEL_OK`), and safe at any point
+ in any order relative to freeing the test case or the run. Each handle
+ must be freed exactly once; freeing the same handle twice is undefined
+ behaviour.
+ */
+hegel_result_t hegel_state_machine_free(hegel_context_t *ctx, hegel_state_machine_t *state_machine);
 
 /*
  Draw a single boolean that is `true` with probability `p`. `p`

--- a/hegel-c/src/backend.rs
+++ b/hegel-c/src/backend.rs
@@ -1,6 +1,7 @@
 use core::net::{Ipv4Addr, Ipv6Addr};
 
 use crate::native::bignum::BigInt;
+use crate::native::core::{ManyState, NativeStateMachine, NativeVariables};
 use crate::native::draws::special::{Date, DateTime, Time};
 use crate::native::draws::{FloatSpec, StringSpec};
 
@@ -112,33 +113,44 @@ pub trait DataSource: Send + Sync {
     /// family-wide.
     fn clone_stream(&self) -> Result<Box<dyn DataSource + Send + Sync>, DataSourceError>;
 
-    /// Create a new collection. Returns an opaque handle.
-    fn new_collection(&self, min_size: u64, max_size: Option<u64>) -> Result<i64, DataSourceError>;
+    /// Create the sizing state for a new engine-managed collection. The
+    /// caller owns the returned [`ManyState`] and passes it back to
+    /// [`Self::collection_more`] / [`Self::collection_reject`]; any stream
+    /// of the same family may drive it.
+    fn new_collection(
+        &self,
+        min_size: u64,
+        max_size: Option<u64>,
+    ) -> Result<ManyState, DataSourceError>;
 
-    /// Ask whether the collection should produce another element.
-    fn collection_more(&self, collection_id: i64) -> Result<bool, DataSourceError>;
+    /// Ask whether the collection should produce another element, drawing
+    /// the continue/stop decision from this stream.
+    fn collection_more(&self, state: &mut ManyState) -> Result<bool, DataSourceError>;
 
     /// Reject the last element drawn from a collection.
     fn collection_reject(
         &self,
-        collection_id: i64,
+        state: &mut ManyState,
         why: Option<&str>,
     ) -> Result<(), DataSourceError>;
 
     /// Register a state machine with the given rule and invariant names for
-    /// engine-owned (swarm) rule selection. Returns an opaque state-machine
-    /// id. Errors with `InvalidArgument` if `rule_names` is empty.
+    /// engine-owned (swarm) rule selection. The caller owns the returned
+    /// [`NativeStateMachine`] and passes it back to
+    /// [`Self::state_machine_next_rule`]; any stream of the same family may
+    /// drive it. Errors with `InvalidArgument` if `rule_names` is empty.
     fn new_state_machine(
         &self,
         rule_names: Vec<String>,
         invariant_names: Vec<String>,
-    ) -> Result<i64, DataSourceError>;
+    ) -> Result<NativeStateMachine, DataSourceError>;
 
     /// Draw the index of the next rule to run, in `[0, num_rules)`, or
-    /// `None` once the test case has run enough steps.
+    /// `None` once the test case has run enough steps. The rule choice is
+    /// drawn from this stream.
     fn state_machine_next_rule(
         &self,
-        state_machine_id: i64,
+        machine: &mut NativeStateMachine,
     ) -> Result<Option<i64>, DataSourceError>;
 
     /// Draw a boolean that is `true` with probability `p`.
@@ -148,15 +160,21 @@ pub trait DataSource: Send + Sync {
     /// consumed.
     fn generate_boolean(&self, p: f64, forced: Option<bool>) -> Result<bool, DataSourceError>;
 
-    /// Create a new variable pool. Returns an opaque pool id.
-    fn new_pool(&self) -> Result<i64, DataSourceError>;
+    /// Create a new variable pool. The caller owns the returned
+    /// [`NativeVariables`] and passes it back to [`Self::pool_add`] /
+    /// [`Self::pool_generate`]; any stream of the same family may drive it.
+    fn new_pool(&self) -> Result<NativeVariables, DataSourceError>;
 
     /// Register a new variable in the pool. Returns the variable id.
-    fn pool_add(&self, pool_id: i64) -> Result<i64, DataSourceError>;
+    fn pool_add(&self, pool: &mut NativeVariables) -> Result<i64, DataSourceError>;
 
-    /// Draw a variable id from the pool.
-    /// If `consume` is true, the variable is removed from the pool.
-    fn pool_generate(&self, pool_id: i64, consume: bool) -> Result<i64, DataSourceError>;
+    /// Draw a variable id from the pool, with the choice drawn from this
+    /// stream. If `consume` is true, the variable is removed from the pool.
+    fn pool_generate(
+        &self,
+        pool: &mut NativeVariables,
+        consume: bool,
+    ) -> Result<i64, DataSourceError>;
 
     /// Record a targeting observation for the current test case.
     ///

--- a/hegel-c/src/lib.rs
+++ b/hegel-c/src/lib.rs
@@ -1899,8 +1899,9 @@ pub unsafe extern "C" fn hegel_new_collection(
 /// `false` into `*out_more` and returns `HEGEL_OK`. Call in a loop until
 /// `*out_more` is `false`, drawing the next element each time.
 ///
-/// Returns `HEGEL_E_INVALID_HANDLE` for a NULL `tc` or `collection`,
-/// `HEGEL_E_INVALID_ARG` for a NULL `out_more`, and
+/// Returns `HEGEL_E_STOP_TEST` when the engine's choice budget is exhausted
+/// for this test case, `HEGEL_E_INVALID_HANDLE` for a NULL `tc` or
+/// `collection`, `HEGEL_E_INVALID_ARG` for a NULL `out_more`, and
 /// `HEGEL_E_CONCURRENT_USE` when another thread is mid-operation on either
 /// the test-case handle or the collection.
 #[unsafe(no_mangle)]
@@ -1942,9 +1943,10 @@ pub unsafe extern "C" fn hegel_collection_more(
 /// rejection reason (NULL is allowed); it is validated but currently
 /// unused, reserved for future rejection diagnostics.
 ///
-/// Returns `HEGEL_E_INVALID_HANDLE` for a NULL `tc` or `collection`, and
-/// `HEGEL_E_CONCURRENT_USE` when another thread is mid-operation on either
-/// the test-case handle or the collection.
+/// Returns `HEGEL_E_STOP_TEST` when the engine's choice budget is exhausted
+/// for this test case, `HEGEL_E_INVALID_HANDLE` for a NULL `tc` or
+/// `collection`, and `HEGEL_E_CONCURRENT_USE` when another thread is
+/// mid-operation on either the test-case handle or the collection.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hegel_collection_reject(
     ctx: *mut HegelContext,
@@ -2083,9 +2085,10 @@ pub unsafe extern "C" fn hegel_new_pool(
 ///
 /// On success writes the new variable's id into `*out_variable_id` and
 /// returns `HEGEL_OK`. `pool` must be a handle from `hegel_new_pool` on a
-/// handle of this test case's family. Returns `HEGEL_E_INVALID_HANDLE` for
-/// a NULL `tc` or `pool`, and `HEGEL_E_INVALID_ARG` for a NULL
-/// `out_variable_id`.
+/// handle of this test case's family. Returns `HEGEL_E_STOP_TEST` when the
+/// engine's choice budget is exhausted for this test case,
+/// `HEGEL_E_INVALID_HANDLE` for a NULL `tc` or `pool`, and
+/// `HEGEL_E_INVALID_ARG` for a NULL `out_variable_id`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hegel_pool_add(
     ctx: *mut HegelContext,
@@ -2128,7 +2131,8 @@ pub unsafe extern "C" fn hegel_pool_add(
 /// failed assumption: it may recover and continue the test case (as
 /// stateful testing does when a rule's assumption fails, by skipping the
 /// action), or give up on the case and mark it INVALID. Returns
-/// `HEGEL_E_INVALID_HANDLE` for a NULL `tc` or `pool`, and
+/// `HEGEL_E_STOP_TEST` when the engine's choice budget is exhausted for
+/// this test case, `HEGEL_E_INVALID_HANDLE` for a NULL `tc` or `pool`, and
 /// `HEGEL_E_INVALID_ARG` for a NULL `out_variable_id`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hegel_pool_generate(

--- a/hegel-c/src/lib.rs
+++ b/hegel-c/src/lib.rs
@@ -1557,9 +1557,11 @@ pub unsafe extern "C" fn hegel_test_case_free(
 /// produces are deterministic under replay and shrink correctly. (Whereas
 /// using a *single* handle from two threads returns
 /// `HEGEL_E_CONCURRENT_USE`.) Collections, variable pools, and state
-/// machines remain shared across the family — ids from one handle work on
-/// any other — but *concurrent* use of one such object from two streams
-/// makes the affected values scheduling-dependent.
+/// machines remain usable across the family — a handle created through one
+/// test-case handle works with any other — but *concurrent* use of one such
+/// object from two streams makes the affected values scheduling-dependent
+/// (and a *collection* used from two threads at once reports
+/// `HEGEL_E_CONCURRENT_USE`; see `hegel_collection_t`).
 ///
 /// Cloning is a stream operation: it occupies one choice position on the
 /// source handle's stream, takes the source handle's lock like a draw
@@ -1778,31 +1780,90 @@ pub unsafe extern "C" fn hegel_stop_span(
     }
 }
 
+/// Opaque handle to an engine-managed variable-length collection.
+///
+/// Created by `hegel_new_collection` on a test case; driven by
+/// `hegel_collection_more` / `hegel_collection_reject` through any handle of
+/// the *same* test-case family (the root or any clone) — the continue/stop
+/// decisions are drawn from whichever handle makes the call. A collection
+/// must not be used from two threads at once: the operations take an
+/// internal non-blocking lock and return `HEGEL_E_CONCURRENT_USE` on
+/// contention.
+///
+/// The handle is independent of the test case and run it was created under:
+/// free it with `hegel_collection_free` exactly once, at any point — before
+/// or after the test case or run is freed, in any order relative to other
+/// frees.
+pub struct HegelCollection {
+    state: Mutex<crate::native::core::ManyState>,
+}
+
+/// Resolve a collection handle, recording a diagnostic and returning
+/// `HEGEL_E_INVALID_HANDLE` on a null pointer.
+unsafe fn collection_ref<'a>(
+    ctx: *mut HegelContext,
+    fn_name: &str,
+    collection: *const HegelCollection,
+) -> Result<&'a HegelCollection, hegel_result_t> {
+    match unsafe { collection.as_ref() } {
+        Some(c) => Ok(c),
+        None => {
+            set_last_error(ctx, &format!("{fn_name}: collection handle is null"));
+            Err(HEGEL_E_INVALID_HANDLE)
+        }
+    }
+}
+
+/// Lock a collection's sizing state for one operation. A collection may be
+/// driven by at most one thread at a time, so contention is reported as
+/// `HEGEL_E_CONCURRENT_USE` rather than waited out.
+fn collection_lock<'a>(
+    ctx: *mut HegelContext,
+    fn_name: &str,
+    collection: &'a HegelCollection,
+) -> Result<parking_lot::MutexGuard<'a, crate::native::core::ManyState>, hegel_result_t> {
+    match collection.state.try_lock() {
+        Some(guard) => Ok(guard),
+        None => {
+            set_last_error(
+                ctx,
+                &format!("{fn_name}: collection handle is in use on another thread"),
+            );
+            Err(HEGEL_E_CONCURRENT_USE)
+        }
+    }
+}
+
 /// Start an engine-managed variable-length collection. The engine
 /// chooses how many elements to produce; the caller pulls them one at
 /// a time by calling `hegel_collection_more` in a loop. Pass
 /// `max_size = UINT64_MAX` for no upper bound.
 ///
-/// On success writes the new collection's id into `*out_collection_id`
-/// and returns `HEGEL_OK`. The id is opaque; pass it to subsequent
-/// `hegel_collection_more` / `hegel_collection_reject` calls.
+/// On success writes a caller-owned handle into `*out_collection` (release
+/// with `hegel_collection_free`) and returns `HEGEL_OK`. Pass the handle to
+/// subsequent `hegel_collection_more` / `hegel_collection_reject` calls with
+/// any handle of the same test-case family. Returns `HEGEL_E_STOP_TEST` when
+/// the engine's choice budget is already exhausted for this test case, and
+/// `HEGEL_E_INVALID_ARG` for a NULL `out_collection` or
+/// `min_size > max_size`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hegel_new_collection(
     ctx: *mut HegelContext,
     tc: *mut HegelTestCase,
     min_size: u64,
     max_size: u64,
-    out_collection_id: *mut i64,
+    out_collection: *mut *mut HegelCollection,
 ) -> hegel_result_t {
     clear_last_error(ctx);
     let (tc, _guard) = match unsafe { tc_guard(ctx, "hegel_new_collection", tc) } {
         Ok(t) => t,
         Err(rc) => return rc,
     };
-    if out_collection_id.is_null() {
+    if out_collection.is_null() {
         set_last_error(ctx, "hegel_new_collection: out parameter is null");
         return HEGEL_E_INVALID_ARG;
     }
+    unsafe { *out_collection = ptr::null_mut() };
     let max = if max_size == u64::MAX {
         None
     } else {
@@ -1821,23 +1882,32 @@ pub unsafe extern "C" fn hegel_new_collection(
         }
     }
     match tc.stream.new_collection(min_size, max) {
-        Ok(id) => {
-            unsafe { *out_collection_id = id };
+        Ok(state) => {
+            unsafe {
+                *out_collection = into_raw_send_sync(HegelCollection {
+                    state: Mutex::new(state),
+                });
+            }
             HEGEL_OK
         }
         Err(e) => translate_ds_error(ctx, e),
     }
 }
 
-/// Ask whether the engine wants another element in this collection.
-/// On success writes `true` or `false` into `*out_more` and returns
-/// `HEGEL_OK`. Call in a loop until `*out_more` is `false`, drawing
-/// the next element each time.
+/// Ask whether the engine wants another element in this collection,
+/// drawing the decision from `tc`'s stream. On success writes `true` or
+/// `false` into `*out_more` and returns `HEGEL_OK`. Call in a loop until
+/// `*out_more` is `false`, drawing the next element each time.
+///
+/// Returns `HEGEL_E_INVALID_HANDLE` for a NULL `tc` or `collection`,
+/// `HEGEL_E_INVALID_ARG` for a NULL `out_more`, and
+/// `HEGEL_E_CONCURRENT_USE` when another thread is mid-operation on either
+/// the test-case handle or the collection.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hegel_collection_more(
     ctx: *mut HegelContext,
     tc: *mut HegelTestCase,
-    collection_id: i64,
+    collection: *mut HegelCollection,
     out_more: *mut bool,
 ) -> hegel_result_t {
     clear_last_error(ctx);
@@ -1845,11 +1915,19 @@ pub unsafe extern "C" fn hegel_collection_more(
         Ok(t) => t,
         Err(rc) => return rc,
     };
+    let collection = match unsafe { collection_ref(ctx, "hegel_collection_more", collection) } {
+        Ok(c) => c,
+        Err(rc) => return rc,
+    };
     if out_more.is_null() {
         set_last_error(ctx, "hegel_collection_more: out parameter is null");
         return HEGEL_E_INVALID_ARG;
     }
-    match tc.stream.collection_more(collection_id) {
+    let mut state = match collection_lock(ctx, "hegel_collection_more", collection) {
+        Ok(state) => state,
+        Err(rc) => return rc,
+    };
+    match tc.stream.collection_more(&mut state) {
         Ok(m) => {
             unsafe { *out_more = m };
             HEGEL_OK
@@ -1863,16 +1941,24 @@ pub unsafe extern "C" fn hegel_collection_more(
 /// should try a different one. `why` is an optional human-readable
 /// rejection reason (NULL is allowed); it is validated but currently
 /// unused, reserved for future rejection diagnostics.
+///
+/// Returns `HEGEL_E_INVALID_HANDLE` for a NULL `tc` or `collection`, and
+/// `HEGEL_E_CONCURRENT_USE` when another thread is mid-operation on either
+/// the test-case handle or the collection.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hegel_collection_reject(
     ctx: *mut HegelContext,
     tc: *mut HegelTestCase,
-    collection_id: i64,
+    collection: *mut HegelCollection,
     why: *const c_char,
 ) -> hegel_result_t {
     clear_last_error(ctx);
     let (tc, _guard) = match unsafe { tc_guard(ctx, "hegel_collection_reject", tc) } {
         Ok(t) => t,
+        Err(rc) => return rc,
+    };
+    let collection = match unsafe { collection_ref(ctx, "hegel_collection_reject", collection) } {
+        Ok(c) => c,
         Err(rc) => return rc,
     };
     let why_str = if why.is_null() {
@@ -1886,9 +1972,66 @@ pub unsafe extern "C" fn hegel_collection_reject(
             }
         }
     };
-    match tc.stream.collection_reject(collection_id, why_str) {
+    let mut state = match collection_lock(ctx, "hegel_collection_reject", collection) {
+        Ok(state) => state,
+        Err(rc) => return rc,
+    };
+    match tc.stream.collection_reject(&mut state, why_str) {
         Ok(()) => HEGEL_OK,
         Err(e) => translate_ds_error(ctx, e),
+    }
+}
+
+/// Release a collection handle from `hegel_new_collection`. Safe to call
+/// with NULL (a no-op that returns `HEGEL_OK`), and safe at any point in any
+/// order relative to freeing the test case or the run. Each handle must be
+/// freed exactly once; freeing the same handle twice is undefined behaviour.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn hegel_collection_free(
+    ctx: *mut HegelContext,
+    collection: *mut HegelCollection,
+) -> hegel_result_t {
+    clear_last_error(ctx);
+    if !collection.is_null() {
+        // SAFETY: `collection` came from `hegel_new_collection`'s
+        // Box::into_raw and is freed exactly once here.
+        drop(unsafe { Box::from_raw(collection) });
+    }
+    HEGEL_OK
+}
+
+/// Opaque handle to an engine-managed *variable pool* for stateful testing.
+///
+/// Created by `hegel_new_pool` on a test case; driven by `hegel_pool_add` /
+/// `hegel_pool_generate` through any handle of the *same* test-case family
+/// (the root or any clone) — the draw comes from whichever handle makes the
+/// call. Unlike a collection, a pool may legitimately be shared between
+/// clone handles driven from parallel threads: it holds an internal lock,
+/// so concurrent operations serialize instead of erroring. (Which variable
+/// a concurrent draw picks then depends on scheduling order, with the usual
+/// replay caveat for racy tests.)
+///
+/// The handle is independent of the test case and run it was created under:
+/// free it with `hegel_pool_free` exactly once, at any point — before or
+/// after the test case or run is freed, in any order relative to other
+/// frees.
+pub struct HegelPool {
+    variables: Mutex<crate::native::core::NativeVariables>,
+}
+
+/// Resolve a pool handle, recording a diagnostic and returning
+/// `HEGEL_E_INVALID_HANDLE` on a null pointer.
+unsafe fn pool_ref<'a>(
+    ctx: *mut HegelContext,
+    fn_name: &str,
+    pool: *const HegelPool,
+) -> Result<&'a HegelPool, hegel_result_t> {
+    match unsafe { pool.as_ref() } {
+        Some(p) => Ok(p),
+        None => {
+            set_last_error(ctx, &format!("{fn_name}: pool handle is null"));
+            Err(HEGEL_E_INVALID_HANDLE)
+        }
     }
 }
 
@@ -1900,27 +2043,35 @@ pub unsafe extern "C" fn hegel_collection_reject(
 /// its own mapping from variable id to the actual value it generated
 /// (mirroring how `Pool<T>` holds a `HashMap<i64, T>`).
 ///
-/// On success writes the new pool's id into `*out_pool_id` and returns
-/// `HEGEL_OK`. The id is opaque; pass it to subsequent `hegel_pool_add`
-/// / `hegel_pool_generate` calls on the *same* test case.
+/// On success writes a caller-owned handle into `*out_pool` (release with
+/// `hegel_pool_free`) and returns `HEGEL_OK`. Pass the handle to subsequent
+/// `hegel_pool_add` / `hegel_pool_generate` calls with any handle of the
+/// same test-case family. Returns `HEGEL_E_STOP_TEST` when the engine's
+/// choice budget is already exhausted for this test case, and
+/// `HEGEL_E_INVALID_ARG` for a NULL `out_pool`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hegel_new_pool(
     ctx: *mut HegelContext,
     tc: *mut HegelTestCase,
-    out_pool_id: *mut i64,
+    out_pool: *mut *mut HegelPool,
 ) -> hegel_result_t {
     clear_last_error(ctx);
     let (tc, _guard) = match unsafe { tc_guard(ctx, "hegel_new_pool", tc) } {
         Ok(t) => t,
         Err(rc) => return rc,
     };
-    if out_pool_id.is_null() {
+    if out_pool.is_null() {
         set_last_error(ctx, "hegel_new_pool: out parameter is null");
         return HEGEL_E_INVALID_ARG;
     }
+    unsafe { *out_pool = ptr::null_mut() };
     match tc.stream.new_pool() {
-        Ok(id) => {
-            unsafe { *out_pool_id = id };
+        Ok(variables) => {
+            unsafe {
+                *out_pool = into_raw_send_sync(HegelPool {
+                    variables: Mutex::new(variables),
+                });
+            }
             HEGEL_OK
         }
         Err(e) => translate_ds_error(ctx, e),
@@ -1931,13 +2082,15 @@ pub unsafe extern "C" fn hegel_new_pool(
 /// id, which the caller associates with the value it just generated.
 ///
 /// On success writes the new variable's id into `*out_variable_id` and
-/// returns `HEGEL_OK`. `pool_id` must be an id returned by
-/// `hegel_new_pool` on this test case.
+/// returns `HEGEL_OK`. `pool` must be a handle from `hegel_new_pool` on a
+/// handle of this test case's family. Returns `HEGEL_E_INVALID_HANDLE` for
+/// a NULL `tc` or `pool`, and `HEGEL_E_INVALID_ARG` for a NULL
+/// `out_variable_id`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hegel_pool_add(
     ctx: *mut HegelContext,
     tc: *mut HegelTestCase,
-    pool_id: i64,
+    pool: *mut HegelPool,
     out_variable_id: *mut i64,
 ) -> hegel_result_t {
     clear_last_error(ctx);
@@ -1945,11 +2098,16 @@ pub unsafe extern "C" fn hegel_pool_add(
         Ok(t) => t,
         Err(rc) => return rc,
     };
+    let pool = match unsafe { pool_ref(ctx, "hegel_pool_add", pool) } {
+        Ok(p) => p,
+        Err(rc) => return rc,
+    };
     if out_variable_id.is_null() {
         set_last_error(ctx, "hegel_pool_add: out parameter is null");
         return HEGEL_E_INVALID_ARG;
     }
-    match tc.stream.pool_add(pool_id) {
+    let mut variables = pool.variables.lock();
+    match tc.stream.pool_add(&mut variables) {
         Ok(id) => {
             unsafe { *out_variable_id = id };
             HEGEL_OK
@@ -1962,19 +2120,21 @@ pub unsafe extern "C" fn hegel_pool_add(
 /// shrink) which previously-added variable to reuse. When
 /// `consume = true` the drawn variable is removed from the pool (model a
 /// destructive action); when `false` it stays available for future
-/// draws.
+/// draws. The choice is drawn from `tc`'s stream.
 ///
 /// On success writes the chosen variable id into `*out_variable_id` and
 /// returns `HEGEL_OK`. Returns `HEGEL_E_ASSUME` if the pool currently
 /// has no active variables — the caller should treat that like any other
 /// failed assumption: it may recover and continue the test case (as
 /// stateful testing does when a rule's assumption fails, by skipping the
-/// action), or give up on the case and mark it INVALID.
+/// action), or give up on the case and mark it INVALID. Returns
+/// `HEGEL_E_INVALID_HANDLE` for a NULL `tc` or `pool`, and
+/// `HEGEL_E_INVALID_ARG` for a NULL `out_variable_id`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hegel_pool_generate(
     ctx: *mut HegelContext,
     tc: *mut HegelTestCase,
-    pool_id: i64,
+    pool: *mut HegelPool,
     consume: bool,
     out_variable_id: *mut i64,
 ) -> hegel_result_t {
@@ -1983,17 +2143,40 @@ pub unsafe extern "C" fn hegel_pool_generate(
         Ok(t) => t,
         Err(rc) => return rc,
     };
+    let pool = match unsafe { pool_ref(ctx, "hegel_pool_generate", pool) } {
+        Ok(p) => p,
+        Err(rc) => return rc,
+    };
     if out_variable_id.is_null() {
         set_last_error(ctx, "hegel_pool_generate: out parameter is null");
         return HEGEL_E_INVALID_ARG;
     }
-    match tc.stream.pool_generate(pool_id, consume) {
+    let mut variables = pool.variables.lock();
+    match tc.stream.pool_generate(&mut variables, consume) {
         Ok(id) => {
             unsafe { *out_variable_id = id };
             HEGEL_OK
         }
         Err(e) => translate_ds_error(ctx, e),
     }
+}
+
+/// Release a pool handle from `hegel_new_pool`. Safe to call with NULL (a
+/// no-op that returns `HEGEL_OK`), and safe at any point in any order
+/// relative to freeing the test case or the run. Each handle must be freed
+/// exactly once; freeing the same handle twice is undefined behaviour.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn hegel_pool_free(
+    ctx: *mut HegelContext,
+    pool: *mut HegelPool,
+) -> hegel_result_t {
+    clear_last_error(ctx);
+    if !pool.is_null() {
+        // SAFETY: `pool` came from `hegel_new_pool`'s Box::into_raw and is
+        // freed exactly once here.
+        drop(unsafe { Box::from_raw(pool) });
+    }
+    HEGEL_OK
 }
 
 /// Convert a C array of `len` NUL-terminated strings into owned Rust
@@ -2033,6 +2216,41 @@ unsafe fn names_from_c_array(
     Ok(out)
 }
 
+/// Opaque handle to an engine-owned *state machine* for stateful
+/// (rule-based) testing.
+///
+/// Created by `hegel_new_state_machine` on a test case; driven by
+/// `hegel_state_machine_next_rule` through any handle of the *same*
+/// test-case family (the root or any clone) — each rule choice is drawn
+/// from whichever handle makes the call. The machine holds an internal
+/// lock, so concurrent use from two clone handles serializes instead of
+/// erroring. (Which rule a concurrent draw picks then depends on scheduling
+/// order, with the usual replay caveat for racy tests.)
+///
+/// The handle is independent of the test case and run it was created under:
+/// free it with `hegel_state_machine_free` exactly once, at any point —
+/// before or after the test case or run is freed, in any order relative to
+/// other frees.
+pub struct HegelStateMachine {
+    machine: Mutex<crate::native::core::NativeStateMachine>,
+}
+
+/// Resolve a state-machine handle, recording a diagnostic and returning
+/// `HEGEL_E_INVALID_HANDLE` on a null pointer.
+unsafe fn state_machine_ref<'a>(
+    ctx: *mut HegelContext,
+    fn_name: &str,
+    state_machine: *const HegelStateMachine,
+) -> Result<&'a HegelStateMachine, hegel_result_t> {
+    match unsafe { state_machine.as_ref() } {
+        Some(m) => Ok(m),
+        None => {
+            set_last_error(ctx, &format!("{fn_name}: state machine handle is null"));
+            Err(HEGEL_E_INVALID_HANDLE)
+        }
+    }
+}
+
 /// Register a *state machine* for engine-owned stateful (rule-based)
 /// testing: `num_rules` rules and `num_invariants` invariants, each
 /// identified by a NUL-terminated UTF-8 name. The engine owns rule
@@ -2043,11 +2261,13 @@ unsafe fn names_from_c_array(
 /// applies it, until that call signals that no more steps should
 /// follow.
 ///
-/// On success writes the new machine's id into `*out_state_machine_id`
-/// and returns `HEGEL_OK`. The id is opaque; pass it to subsequent
-/// `hegel_state_machine_next_rule` calls on the *same* test case.
-/// Returns `HEGEL_E_INVALID_ARG` if `num_rules` is zero, or on null /
-/// non-UTF-8 names.
+/// On success writes a caller-owned handle into `*out_state_machine`
+/// (release with `hegel_state_machine_free`) and returns `HEGEL_OK`. Pass
+/// the handle to subsequent `hegel_state_machine_next_rule` calls with any
+/// handle of the same test-case family. Returns `HEGEL_E_STOP_TEST` when
+/// the engine's choice budget is already exhausted for this test case, and
+/// `HEGEL_E_INVALID_ARG` if `num_rules` is zero, on null / non-UTF-8 names,
+/// or for a NULL `out_state_machine`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hegel_new_state_machine(
     ctx: *mut HegelContext,
@@ -2056,17 +2276,18 @@ pub unsafe extern "C" fn hegel_new_state_machine(
     num_rules: usize,
     invariant_names: *const *const c_char,
     num_invariants: usize,
-    out_state_machine_id: *mut i64,
+    out_state_machine: *mut *mut HegelStateMachine,
 ) -> hegel_result_t {
     clear_last_error(ctx);
     let (tc, _guard) = match unsafe { tc_guard(ctx, "hegel_new_state_machine", tc) } {
         Ok(t) => t,
         Err(rc) => return rc,
     };
-    if out_state_machine_id.is_null() {
+    if out_state_machine.is_null() {
         set_last_error(ctx, "hegel_new_state_machine: out parameter is null");
         return HEGEL_E_INVALID_ARG;
     }
+    unsafe { *out_state_machine = ptr::null_mut() };
     let rules = match unsafe {
         names_from_c_array(
             ctx,
@@ -2092,8 +2313,12 @@ pub unsafe extern "C" fn hegel_new_state_machine(
         Err(rc) => return rc,
     };
     match tc.stream.new_state_machine(rules, invariants) {
-        Ok(id) => {
-            unsafe { *out_state_machine_id = id };
+        Ok(machine) => {
+            unsafe {
+                *out_state_machine = into_raw_send_sync(HegelStateMachine {
+                    machine: Mutex::new(machine),
+                });
+            }
             HEGEL_OK
         }
         Err(e) => translate_ds_error(ctx, e),
@@ -2112,16 +2337,16 @@ pub const HEGEL_STATE_MACHINE_DONE: i64 = -1;
 /// of the test case, with restrictions that shrink away in minimal
 /// counterexamples.
 ///
-/// `state_machine_id` must be an id returned by
-/// `hegel_new_state_machine` on this test case. Returns
-/// `HEGEL_E_STOP_TEST` when the engine's choice budget is exhausted
-/// (the caller should abort the body and call `hegel_mark_complete`
-/// with `HEGEL_STATUS_OVERRUN`).
+/// `state_machine` must be a handle from `hegel_new_state_machine` on a
+/// handle of this test case's family. Returns `HEGEL_E_STOP_TEST` when the
+/// engine's choice budget is exhausted (the caller should abort the body
+/// and call `hegel_mark_complete` with `HEGEL_STATUS_OVERRUN`), and
+/// `HEGEL_E_INVALID_HANDLE` for a NULL `tc` or `state_machine`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hegel_state_machine_next_rule(
     ctx: *mut HegelContext,
     tc: *mut HegelTestCase,
-    state_machine_id: i64,
+    state_machine: *mut HegelStateMachine,
     out_rule_index: *mut i64,
 ) -> hegel_result_t {
     clear_last_error(ctx);
@@ -2129,11 +2354,17 @@ pub unsafe extern "C" fn hegel_state_machine_next_rule(
         Ok(t) => t,
         Err(rc) => return rc,
     };
+    let state_machine =
+        match unsafe { state_machine_ref(ctx, "hegel_state_machine_next_rule", state_machine) } {
+            Ok(m) => m,
+            Err(rc) => return rc,
+        };
     if out_rule_index.is_null() {
         set_last_error(ctx, "hegel_state_machine_next_rule: out parameter is null");
         return HEGEL_E_INVALID_ARG;
     }
-    match tc.stream.state_machine_next_rule(state_machine_id) {
+    let mut machine = state_machine.machine.lock();
+    match tc.stream.state_machine_next_rule(&mut machine) {
         Ok(Some(index)) => {
             unsafe { *out_rule_index = index };
             HEGEL_OK
@@ -2144,6 +2375,25 @@ pub unsafe extern "C" fn hegel_state_machine_next_rule(
         }
         Err(e) => translate_ds_error(ctx, e),
     }
+}
+
+/// Release a state-machine handle from `hegel_new_state_machine`. Safe to
+/// call with NULL (a no-op that returns `HEGEL_OK`), and safe at any point
+/// in any order relative to freeing the test case or the run. Each handle
+/// must be freed exactly once; freeing the same handle twice is undefined
+/// behaviour.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn hegel_state_machine_free(
+    ctx: *mut HegelContext,
+    state_machine: *mut HegelStateMachine,
+) -> hegel_result_t {
+    clear_last_error(ctx);
+    if !state_machine.is_null() {
+        // SAFETY: `state_machine` came from `hegel_new_state_machine`'s
+        // Box::into_raw and is freed exactly once here.
+        drop(unsafe { Box::from_raw(state_machine) });
+    }
+    HEGEL_OK
 }
 
 /// Draw a single boolean that is `true` with probability `p`. `p`

--- a/hegel-c/src/native/core/state.rs
+++ b/hegel-c/src/native/core/state.rs
@@ -1,6 +1,6 @@
 use crate::native::{HashMap, HashSet};
 use std::fmt::Debug;
-use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU8, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering};
 use std::sync::{Arc, LazyLock, Mutex};
 
 use rand::{Rng, RngExt};
@@ -14,7 +14,6 @@ use super::choices::{
     StringChoice,
 };
 use super::float_index::index_to_float;
-use super::state_machine::NativeStateMachine;
 use super::{BOUNDARY_PROBABILITY, BUFFER_SIZE};
 use crate::control::{hegel_internal_assert, hegel_internal_debug_assert};
 use crate::native::bignum::{BigInt, BigUint, ToPrimitive, Zero};
@@ -942,10 +941,9 @@ const STATUS_UNSET: u8 = u8::MAX;
 /// A family concludes exactly once: the first stream to conclude wins, and
 /// every other stream's subsequent draws fail fast with the family's
 /// verdict. The draw budget and `tc.target()` observations are likewise
-/// family-wide. Collections, variable pools, and state machines are shared
-/// across streams so ids remain valid on any clone; they are shared mutable
-/// state, so when several clones use one concurrently the interleaving (and
-/// therefore replay of the affected values) is scheduling-dependent.
+/// family-wide. Collections, variable pools, and state machines live in
+/// caller-owned handles rather than here; any stream of the family can
+/// drive one, drawing from its own choice sequence.
 pub struct FamilyCore {
     /// The family's write-once conclusion, with the interesting origin for
     /// an `Interesting` verdict.
@@ -962,15 +960,6 @@ pub struct FamilyCore {
     /// `tc.target()` observations, keyed by label. Family-wide so the
     /// once-per-test-case label uniqueness holds across clones.
     pub(crate) target_observations: Mutex<HashMap<String, f64>>,
-    /// Variable-length collection state, keyed by collection id.
-    pub(crate) collections: Mutex<HashMap<i64, ManyState>>,
-    next_collection_id: AtomicI64,
-    /// Variable pools for stateful testing, indexed by pool id.
-    pub(crate) variable_pools: Mutex<Vec<NativeVariables>>,
-    /// State machines, indexed by machine id. Each machine sits behind its
-    /// own lock so two clones drawing rules concurrently serialize on the
-    /// machine while drawing from their own streams.
-    pub(crate) state_machines: Mutex<Vec<Arc<Mutex<NativeStateMachine>>>>,
     /// When set, state machines draw no step cap and never report their
     /// rule sequence as done. Set for single-test-case runs, which explore
     /// one unbounded test case instead of many capped ones.
@@ -985,10 +974,6 @@ impl FamilyCore {
             total_draws: AtomicUsize::new(0),
             budget: AtomicUsize::new(budget),
             target_observations: Mutex::new(HashMap::default()),
-            collections: Mutex::new(HashMap::default()),
-            next_collection_id: AtomicI64::new(0),
-            variable_pools: Mutex::new(Vec::new()),
-            state_machines: Mutex::new(Vec::new()),
             state_machine_steps_unbounded: AtomicBool::new(false),
         }
     }
@@ -1044,11 +1029,6 @@ impl FamilyCore {
 
     fn set_budget(&self, budget: usize) {
         self.budget.store(budget, Ordering::Relaxed);
-    }
-
-    /// Allocate the next collection id.
-    pub(crate) fn next_collection_id(&self) -> i64 {
-        self.next_collection_id.fetch_add(1, Ordering::Relaxed)
     }
 }
 
@@ -1437,17 +1417,6 @@ impl NativeTestCase {
     /// The family's concluded status, or `None` while still running.
     pub fn status(&self) -> Option<Status> {
         self.family.status()
-    }
-
-    /// Allocate a new collection ID and store the given state.
-    pub fn new_collection(&mut self, state: ManyState) -> i64 {
-        let id = self.family.next_collection_id();
-        self.family
-            .collections
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .insert(id, state);
-        id
     }
 
     /// Draw a random integer in `[min_value, max_value]`.

--- a/hegel-c/src/native/data_source.rs
+++ b/hegel-c/src/native/data_source.rs
@@ -251,7 +251,7 @@ impl DataSource for NativeDataSource {
         min_size: u64,
         max_size: Option<u64>,
     ) -> Result<ManyState, DataSourceError> {
-        self.with_ntc(|_ntc| {
+        self.with_ntc(|_| {
             let min_size = usize::try_from(min_size).unwrap_or(usize::MAX);
             let max_size = max_size.map(|n| usize::try_from(n).unwrap_or(usize::MAX));
             Ok(ManyState::new(min_size, max_size))
@@ -280,7 +280,7 @@ impl DataSource for NativeDataSource {
                 "cannot run a state machine with no rules".to_string(),
             ));
         }
-        self.with_ntc(|_ntc| Ok(NativeStateMachine::new(rule_names, invariant_names)))
+        self.with_ntc(|_| Ok(NativeStateMachine::new(rule_names, invariant_names)))
     }
 
     fn state_machine_next_rule(
@@ -295,11 +295,11 @@ impl DataSource for NativeDataSource {
     }
 
     fn new_pool(&self) -> Result<NativeVariables, DataSourceError> {
-        self.with_ntc(|_ntc| Ok(NativeVariables::new()))
+        self.with_ntc(|_| Ok(NativeVariables::new()))
     }
 
     fn pool_add(&self, pool: &mut NativeVariables) -> Result<i64, DataSourceError> {
-        self.with_ntc(|_ntc| Ok(pool.next()))
+        self.with_ntc(|_| Ok(pool.next()))
     }
 
     fn pool_generate(

--- a/hegel-c/src/native/data_source.rs
+++ b/hegel-c/src/native/data_source.rs
@@ -5,8 +5,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use crate::backend::{DataSource, DataSourceError, Failure, TestCaseResult};
 use crate::native::bignum::{BigInt, ToPrimitive};
 use crate::native::core::{
-    ChoiceNode, EngineError, InterestingOrigin, ManyState, NativeTestCase, NativeTestCaseHandle,
-    Span, SpanEvent, Status,
+    ChoiceNode, EngineError, InterestingOrigin, ManyState, NativeStateMachine, NativeTestCase,
+    NativeTestCaseHandle, NativeVariables, Span, SpanEvent, Status,
 };
 use crate::native::draws;
 
@@ -163,25 +163,6 @@ impl NativeDataSource {
     }
 }
 
-/// Build the `InvalidArgument` error for a caller-supplied opaque id (a
-/// collection / pool / state-machine handle) that libhegel never issued.
-/// Returned rather than panicked so the C ABI stays panic-free on bad input
-/// (libhegel must remain correct under `panic = "abort"`; an invalid argument
-/// is not a bug).
-fn unknown_id_error(kind: &str, id: i64) -> EngineError {
-    EngineError::InvalidArgument(format!("unknown {kind} id: {id}"))
-}
-
-/// Validate a caller-supplied opaque id against the length of the `Vec` it
-/// indexes, returning its `usize` index or [`unknown_id_error`]. Rejects both
-/// negative ids and ids past the end.
-fn checked_id(kind: &str, id: i64, len: usize) -> Result<usize, EngineError> {
-    usize::try_from(id)
-        .ok()
-        .filter(|&idx| idx < len)
-        .ok_or_else(|| unknown_id_error(kind, id))
-}
-
 impl DataSource for NativeDataSource {
     fn generate_integer(
         &self,
@@ -265,122 +246,69 @@ impl DataSource for NativeDataSource {
         })
     }
 
-    fn new_collection(&self, min_size: u64, max_size: Option<u64>) -> Result<i64, DataSourceError> {
-        self.with_ntc(|ntc| {
+    fn new_collection(
+        &self,
+        min_size: u64,
+        max_size: Option<u64>,
+    ) -> Result<ManyState, DataSourceError> {
+        self.with_ntc(|_ntc| {
             let min_size = usize::try_from(min_size).unwrap_or(usize::MAX);
             let max_size = max_size.map(|n| usize::try_from(n).unwrap_or(usize::MAX));
-            let state = ManyState::new(min_size, max_size);
-            Ok(ntc.new_collection(state))
+            Ok(ManyState::new(min_size, max_size))
         })
     }
 
-    fn collection_more(&self, collection_id: i64) -> Result<bool, DataSourceError> {
-        self.with_ntc(|ntc| {
-            let family = Arc::clone(ntc.family());
-            let mut collections = family.collections.lock().unwrap_or_else(|e| e.into_inner());
-            let state = collections
-                .get_mut(&collection_id)
-                .ok_or_else(|| unknown_id_error("collection", collection_id))?;
-            draws::many_more(ntc, state)
-        })
+    fn collection_more(&self, state: &mut ManyState) -> Result<bool, DataSourceError> {
+        self.with_ntc(|ntc| draws::many_more(ntc, state))
     }
 
     fn collection_reject(
         &self,
-        collection_id: i64,
+        state: &mut ManyState,
         _why: Option<&str>,
     ) -> Result<(), DataSourceError> {
-        self.with_ntc(|ntc| {
-            let family = Arc::clone(ntc.family());
-            let mut collections = family.collections.lock().unwrap_or_else(|e| e.into_inner());
-            let state = collections
-                .get_mut(&collection_id)
-                .ok_or_else(|| unknown_id_error("collection", collection_id))?;
-            draws::many_reject(ntc, state)
-        })
+        self.with_ntc(|ntc| draws::many_reject(ntc, state))
     }
 
     fn new_state_machine(
         &self,
         rule_names: Vec<String>,
         invariant_names: Vec<String>,
-    ) -> Result<i64, DataSourceError> {
+    ) -> Result<NativeStateMachine, DataSourceError> {
         if rule_names.is_empty() {
             return Err(DataSourceError::InvalidArgument(
                 "cannot run a state machine with no rules".to_string(),
             ));
         }
-        self.with_ntc(|ntc| {
-            let mut machines = ntc
-                .family()
-                .state_machines
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
-            let id = machines.len() as i64;
-            machines.push(Arc::new(std::sync::Mutex::new(
-                crate::native::core::NativeStateMachine::new(rule_names, invariant_names),
-            )));
-            Ok(id)
-        })
+        self.with_ntc(|_ntc| Ok(NativeStateMachine::new(rule_names, invariant_names)))
     }
 
     fn state_machine_next_rule(
         &self,
-        state_machine_id: i64,
+        machine: &mut NativeStateMachine,
     ) -> Result<Option<i64>, DataSourceError> {
-        self.with_ntc(|ntc| {
-            let machine = {
-                let machines = ntc
-                    .family()
-                    .state_machines
-                    .lock()
-                    .unwrap_or_else(|e| e.into_inner());
-                let idx = checked_id("state machine", state_machine_id, machines.len())?;
-                Arc::clone(&machines[idx])
-            };
-            let mut machine = machine.lock().unwrap_or_else(|e| e.into_inner());
-            machine.next_rule(ntc)
-        })
+        self.with_ntc(|ntc| machine.next_rule(ntc))
     }
 
     fn generate_boolean(&self, p: f64, forced: Option<bool>) -> Result<bool, DataSourceError> {
         self.with_ntc(|ntc| draws::generate_boolean(ntc, p, forced))
     }
 
-    fn new_pool(&self) -> Result<i64, DataSourceError> {
-        self.with_ntc(|ntc| {
-            let mut pools = ntc
-                .family()
-                .variable_pools
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
-            let pool_id = pools.len() as i64;
-            pools.push(crate::native::core::NativeVariables::new());
-            Ok(pool_id)
-        })
+    fn new_pool(&self) -> Result<NativeVariables, DataSourceError> {
+        self.with_ntc(|_ntc| Ok(NativeVariables::new()))
     }
 
-    fn pool_add(&self, pool_id: i64) -> Result<i64, DataSourceError> {
-        self.with_ntc(|ntc| {
-            let mut pools = ntc
-                .family()
-                .variable_pools
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
-            let idx = checked_id("variable pool", pool_id, pools.len())?;
-            Ok(pools[idx].next())
-        })
+    fn pool_add(&self, pool: &mut NativeVariables) -> Result<i64, DataSourceError> {
+        self.with_ntc(|_ntc| Ok(pool.next()))
     }
 
-    fn pool_generate(&self, pool_id: i64, consume: bool) -> Result<i64, DataSourceError> {
+    fn pool_generate(
+        &self,
+        pool: &mut NativeVariables,
+        consume: bool,
+    ) -> Result<i64, DataSourceError> {
         self.with_ntc(|ntc| {
-            let family = Arc::clone(ntc.family());
-            let mut pools = family
-                .variable_pools
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
-            let pool_idx = checked_id("variable pool", pool_id, pools.len())?;
-            let active = pools[pool_idx].active();
+            let active = pool.active();
             if active.is_empty() {
                 return Err(EngineError::AssumeViolation);
             }
@@ -391,7 +319,7 @@ impl DataSource for NativeDataSource {
                 .unwrap() as usize;
             let variable_id = active[n - 1 - k];
             if consume {
-                pools[pool_idx].consume(variable_id);
+                pool.consume(variable_id);
             }
             Ok(variable_id)
         })

--- a/hegel-c/tests/c_abi_inprocess.rs
+++ b/hegel-c/tests/c_abi_inprocess.rs
@@ -13,20 +13,22 @@ mod common;
 use common::{last_error, make_settings, next_case, ok, start, start_with_output};
 use hegel_c::hegel_result_t::*;
 use hegel_c::{
-    HEGEL_STATE_MACHINE_DONE, HegelContext, HegelFailure, HegelRun, HegelRunResult, HegelTestCase,
-    hegel_backend_t, hegel_collection_more, hegel_collection_reject, hegel_context_free,
-    hegel_context_last_error, hegel_context_new, hegel_failure_free, hegel_failure_origin,
-    hegel_failure_reproduction_blob, hegel_generate_boolean, hegel_generate_integer, hegel_label_t,
-    hegel_mark_complete, hegel_mode_t, hegel_new_collection, hegel_new_pool,
-    hegel_new_state_machine, hegel_next_test_case, hegel_pool_add, hegel_pool_generate,
-    hegel_run_free, hegel_run_result, hegel_run_result_error, hegel_run_result_failure,
+    HEGEL_STATE_MACHINE_DONE, HegelCollection, HegelContext, HegelFailure, HegelPool, HegelRun,
+    HegelRunResult, HegelStateMachine, HegelTestCase, hegel_backend_t, hegel_collection_free,
+    hegel_collection_more, hegel_collection_reject, hegel_context_free, hegel_context_last_error,
+    hegel_context_new, hegel_failure_free, hegel_failure_origin, hegel_failure_reproduction_blob,
+    hegel_generate_boolean, hegel_generate_integer, hegel_label_t, hegel_mark_complete,
+    hegel_mode_t, hegel_new_collection, hegel_new_pool, hegel_new_state_machine,
+    hegel_next_test_case, hegel_pool_add, hegel_pool_free, hegel_pool_generate, hegel_run_free,
+    hegel_run_result, hegel_run_result_error, hegel_run_result_failure,
     hegel_run_result_failure_count, hegel_run_result_free, hegel_run_result_status,
     hegel_run_start, hegel_run_status_t, hegel_settings_free, hegel_settings_new,
     hegel_settings_set_backend, hegel_settings_set_database, hegel_settings_set_database_key,
     hegel_settings_set_mode, hegel_settings_set_phases,
     hegel_settings_set_report_multiple_failures, hegel_settings_set_suppress_health_check,
-    hegel_start_span, hegel_state_machine_next_rule, hegel_status_t, hegel_stop_span, hegel_target,
-    hegel_test_case_clone, hegel_test_case_free, hegel_test_case_from_blob, hegel_version,
+    hegel_start_span, hegel_state_machine_free, hegel_state_machine_next_rule, hegel_status_t,
+    hegel_stop_span, hegel_target, hegel_test_case_clone, hegel_test_case_free,
+    hegel_test_case_from_blob, hegel_version,
 };
 use std::ffi::{CString, c_void};
 use std::os::raw::c_char;
@@ -240,25 +242,33 @@ fn null_handles_are_rejected_without_crashing() {
         assert_eq!(hegel_start_span(ctx, tc, 1), HEGEL_E_INVALID_HANDLE);
         assert_eq!(hegel_stop_span(ctx, tc, false), HEGEL_E_INVALID_HANDLE);
         let mut id = 0i64;
+        let mut collection: *mut HegelCollection = ptr::null_mut();
         assert_eq!(
-            hegel_new_collection(ctx, tc, 0, u64::MAX, &mut id),
+            hegel_new_collection(ctx, tc, 0, u64::MAX, &mut collection),
             HEGEL_E_INVALID_HANDLE
         );
         let mut more = false;
         assert_eq!(
-            hegel_collection_more(ctx, tc, 0, &mut more),
+            hegel_collection_more(ctx, tc, ptr::null_mut(), &mut more),
             HEGEL_E_INVALID_HANDLE
         );
         assert_eq!(
-            hegel_collection_reject(ctx, tc, 0, ptr::null()),
+            hegel_collection_reject(ctx, tc, ptr::null_mut(), ptr::null()),
             HEGEL_E_INVALID_HANDLE
         );
-        assert_eq!(hegel_new_pool(ctx, tc, &mut id), HEGEL_E_INVALID_HANDLE);
-        assert_eq!(hegel_pool_add(ctx, tc, 0, &mut id), HEGEL_E_INVALID_HANDLE);
+        let mut pool: *mut HegelPool = ptr::null_mut();
+        assert_eq!(hegel_new_pool(ctx, tc, &mut pool), HEGEL_E_INVALID_HANDLE);
         assert_eq!(
-            hegel_pool_generate(ctx, tc, 0, false, &mut id),
+            hegel_pool_add(ctx, tc, ptr::null_mut(), &mut id),
             HEGEL_E_INVALID_HANDLE
         );
+        assert_eq!(
+            hegel_pool_generate(ctx, tc, ptr::null_mut(), false, &mut id),
+            HEGEL_E_INVALID_HANDLE
+        );
+        assert_eq!(hegel_collection_free(ctx, ptr::null_mut()), HEGEL_OK);
+        assert_eq!(hegel_pool_free(ctx, ptr::null_mut()), HEGEL_OK);
+        assert_eq!(hegel_state_machine_free(ctx, ptr::null_mut()), HEGEL_OK);
         assert_eq!(
             hegel_target(ctx, tc, 0.0, c"x".as_ptr()),
             HEGEL_E_INVALID_HANDLE
@@ -694,15 +704,16 @@ fn live_test_case_argument_validation() {
         );
         assert!(last_error(ctx).contains("min_value"));
 
-        let mut id = 0i64;
+        let mut collection: *mut HegelCollection = ptr::null_mut();
         assert_eq!(
             hegel_new_collection(ctx, tc, 0, u64::MAX, ptr::null_mut()),
             HEGEL_E_INVALID_ARG
         );
         assert_eq!(
-            hegel_new_collection(ctx, tc, 5, 3, &mut id),
+            hegel_new_collection(ctx, tc, 5, 3, &mut collection),
             HEGEL_E_INVALID_ARG
         );
+        assert!(collection.is_null());
         assert!(last_error(ctx).contains("min_size <= max_size"));
         assert!(last_error(ctx).contains("[5, 3]"));
         assert_eq!(
@@ -710,23 +721,53 @@ fn live_test_case_argument_validation() {
             HEGEL_E_INVALID_ARG
         );
 
-        assert_eq!(hegel_new_collection(ctx, tc, 0, 3, &mut id), HEGEL_OK);
+        let mut null_more = false;
         assert_eq!(
-            hegel_collection_more(ctx, tc, id, ptr::null_mut()),
+            hegel_collection_more(ctx, tc, ptr::null_mut(), &mut null_more),
+            HEGEL_E_INVALID_HANDLE
+        );
+        assert!(last_error(ctx).contains("collection handle is null"));
+        assert_eq!(
+            hegel_collection_reject(ctx, tc, ptr::null_mut(), ptr::null()),
+            HEGEL_E_INVALID_HANDLE
+        );
+        let mut var_id = 0i64;
+        assert_eq!(
+            hegel_pool_add(ctx, tc, ptr::null_mut(), &mut var_id),
+            HEGEL_E_INVALID_HANDLE
+        );
+        assert!(last_error(ctx).contains("pool handle is null"));
+        assert_eq!(
+            hegel_pool_generate(ctx, tc, ptr::null_mut(), false, &mut var_id),
+            HEGEL_E_INVALID_HANDLE
+        );
+
+        assert_eq!(
+            hegel_new_collection(ctx, tc, 0, 3, &mut collection),
+            HEGEL_OK
+        );
+        assert!(!collection.is_null());
+        assert_eq!(
+            hegel_collection_more(ctx, tc, collection, ptr::null_mut()),
             HEGEL_E_INVALID_ARG
         );
         assert_eq!(
-            hegel_collection_reject(ctx, tc, id, bad_utf8.as_ptr()),
+            hegel_collection_reject(ctx, tc, collection, bad_utf8.as_ptr()),
             HEGEL_E_INVALID_ARG
         );
         let mut more = false;
-        if hegel_collection_more(ctx, tc, id, &mut more) == HEGEL_OK && more {
+        if hegel_collection_more(ctx, tc, collection, &mut more) == HEGEL_OK && more {
             let _ = hegel_generate_integer(ctx, tc, 0, 100, &mut value);
-            assert_eq!(hegel_collection_reject(ctx, tc, id, ptr::null()), HEGEL_OK);
+            assert_eq!(
+                hegel_collection_reject(ctx, tc, collection, ptr::null()),
+                HEGEL_OK
+            );
         }
+        assert_eq!(hegel_collection_free(ctx, collection), HEGEL_OK);
 
-        let mut pool = 0i64;
+        let mut pool: *mut HegelPool = ptr::null_mut();
         assert_eq!(hegel_new_pool(ctx, tc, &mut pool), HEGEL_OK);
+        assert!(!pool.is_null());
         assert_eq!(
             hegel_pool_add(ctx, tc, pool, ptr::null_mut()),
             HEGEL_E_INVALID_ARG
@@ -735,6 +776,11 @@ fn live_test_case_argument_validation() {
             hegel_pool_generate(ctx, tc, pool, false, ptr::null_mut()),
             HEGEL_E_INVALID_ARG
         );
+        assert_eq!(
+            hegel_pool_generate(ctx, tc, pool, false, &mut var_id),
+            HEGEL_E_ASSUME
+        );
+        assert_eq!(hegel_pool_free(ctx, pool), HEGEL_OK);
 
         assert_eq!(hegel_target(ctx, tc, 0.0, ptr::null()), HEGEL_E_INVALID_ARG);
         assert!(last_error(ctx).contains("label is null"));
@@ -971,6 +1017,23 @@ fn primitives_after_overrun_all_report_stop_test() {
         let tc = next_case(ctx, run);
         assert!(!tc.is_null());
 
+        let mut collection: *mut HegelCollection = ptr::null_mut();
+        ok(hegel_new_collection(ctx, tc, 0, 3, &mut collection));
+        let mut pool: *mut HegelPool = ptr::null_mut();
+        ok(hegel_new_pool(ctx, tc, &mut pool));
+        let rule = CString::new("only").unwrap();
+        let rules = [rule.as_ptr()];
+        let mut machine: *mut HegelStateMachine = ptr::null_mut();
+        ok(hegel_new_state_machine(
+            ctx,
+            tc,
+            rules.as_ptr(),
+            1,
+            ptr::null(),
+            0,
+            &mut machine,
+        ));
+
         let mut value = 0i64;
         let mut overran = false;
         for _ in 0..1_000_000 {
@@ -987,16 +1050,53 @@ fn primitives_after_overrun_all_report_stop_test() {
         );
         assert_eq!(hegel_stop_span(ctx, tc, false), HEGEL_E_STOP_TEST);
         let mut id = 0i64;
+        let mut post_overrun: *mut HegelCollection = ptr::null_mut();
         assert_eq!(
-            hegel_new_collection(ctx, tc, 0, 3, &mut id),
+            hegel_new_collection(ctx, tc, 0, 3, &mut post_overrun),
+            HEGEL_E_STOP_TEST
+        );
+        assert!(post_overrun.is_null());
+        let mut more = false;
+        assert_eq!(
+            hegel_collection_more(ctx, tc, collection, &mut more),
             HEGEL_E_STOP_TEST
         );
         assert_eq!(
-            hegel_collection_reject(ctx, tc, 0, ptr::null()),
+            hegel_collection_reject(ctx, tc, collection, ptr::null()),
             HEGEL_E_STOP_TEST
         );
-        assert_eq!(hegel_new_pool(ctx, tc, &mut id), HEGEL_E_STOP_TEST);
-        assert_eq!(hegel_pool_add(ctx, tc, 0, &mut id), HEGEL_E_STOP_TEST);
+        let mut post_overrun_pool: *mut HegelPool = ptr::null_mut();
+        assert_eq!(
+            hegel_new_pool(ctx, tc, &mut post_overrun_pool),
+            HEGEL_E_STOP_TEST
+        );
+        assert!(post_overrun_pool.is_null());
+        assert_eq!(hegel_pool_add(ctx, tc, pool, &mut id), HEGEL_E_STOP_TEST);
+        assert_eq!(
+            hegel_pool_generate(ctx, tc, pool, false, &mut id),
+            HEGEL_E_STOP_TEST
+        );
+        let mut post_overrun_machine: *mut HegelStateMachine = ptr::null_mut();
+        assert_eq!(
+            hegel_new_state_machine(
+                ctx,
+                tc,
+                rules.as_ptr(),
+                1,
+                ptr::null(),
+                0,
+                &mut post_overrun_machine
+            ),
+            HEGEL_E_STOP_TEST
+        );
+        assert!(post_overrun_machine.is_null());
+        assert_eq!(
+            hegel_state_machine_next_rule(ctx, tc, machine, &mut id),
+            HEGEL_E_STOP_TEST
+        );
+        ok(hegel_collection_free(ctx, collection));
+        ok(hegel_pool_free(ctx, pool));
+        ok(hegel_state_machine_free(ctx, machine));
 
         ok(hegel_mark_complete(
             ctx,
@@ -1040,13 +1140,22 @@ fn state_machine_and_primitive_boolean_paths() {
         let null_tc: *mut HegelTestCase = ptr::null_mut();
         let rule_a = CString::new("a").unwrap();
         let rules: [*const c_char; 1] = [rule_a.as_ptr()];
+        let mut machine: *mut HegelStateMachine = ptr::null_mut();
         let mut out_id = 0i64;
         assert_eq!(
-            hegel_new_state_machine(ctx, null_tc, rules.as_ptr(), 1, ptr::null(), 0, &mut out_id),
+            hegel_new_state_machine(
+                ctx,
+                null_tc,
+                rules.as_ptr(),
+                1,
+                ptr::null(),
+                0,
+                &mut machine
+            ),
             HEGEL_E_INVALID_HANDLE
         );
         assert_eq!(
-            hegel_state_machine_next_rule(ctx, null_tc, 0, &mut out_id),
+            hegel_state_machine_next_rule(ctx, null_tc, ptr::null_mut(), &mut out_id),
             HEGEL_E_INVALID_HANDLE
         );
         let mut bv = false;
@@ -1068,47 +1177,70 @@ fn state_machine_and_primitive_boolean_paths() {
             HEGEL_E_INVALID_ARG
         );
         assert_eq!(
-            hegel_new_state_machine(ctx, tc, ptr::null(), 1, ptr::null(), 0, &mut out_id),
+            hegel_new_state_machine(ctx, tc, ptr::null(), 1, ptr::null(), 0, &mut machine),
             HEGEL_E_INVALID_ARG
         );
+        assert!(machine.is_null());
         assert!(last_error(ctx).contains("rule_names pointer is null"));
         let null_entry: [*const c_char; 1] = [ptr::null()];
         assert_eq!(
-            hegel_new_state_machine(ctx, tc, null_entry.as_ptr(), 1, ptr::null(), 0, &mut out_id),
+            hegel_new_state_machine(
+                ctx,
+                tc,
+                null_entry.as_ptr(),
+                1,
+                ptr::null(),
+                0,
+                &mut machine
+            ),
             HEGEL_E_INVALID_ARG
         );
         assert!(last_error(ctx).contains("rule_names[0] is null"));
         let bad_entry: [*const c_char; 1] = [bad_utf8.as_ptr()];
         assert_eq!(
-            hegel_new_state_machine(ctx, tc, bad_entry.as_ptr(), 1, ptr::null(), 0, &mut out_id),
+            hegel_new_state_machine(ctx, tc, bad_entry.as_ptr(), 1, ptr::null(), 0, &mut machine),
             HEGEL_E_INVALID_ARG
         );
         assert!(last_error(ctx).contains("not valid UTF-8"));
         let bad_inv: [*const c_char; 1] = [ptr::null()];
         assert_eq!(
-            hegel_new_state_machine(ctx, tc, rules.as_ptr(), 1, bad_inv.as_ptr(), 1, &mut out_id),
+            hegel_new_state_machine(
+                ctx,
+                tc,
+                rules.as_ptr(),
+                1,
+                bad_inv.as_ptr(),
+                1,
+                &mut machine
+            ),
             HEGEL_E_INVALID_ARG
         );
         assert!(last_error(ctx).contains("invariant_names[0] is null"));
 
         assert_eq!(
-            hegel_new_state_machine(ctx, tc, rules.as_ptr(), 1, ptr::null(), 0, &mut out_id),
+            hegel_new_state_machine(ctx, tc, rules.as_ptr(), 1, ptr::null(), 0, &mut machine),
             HEGEL_OK
         );
+        assert!(!machine.is_null());
         assert_eq!(
-            hegel_state_machine_next_rule(ctx, tc, out_id, ptr::null_mut()),
+            hegel_state_machine_next_rule(ctx, tc, machine, ptr::null_mut()),
             HEGEL_E_INVALID_ARG
         );
+        assert_eq!(
+            hegel_state_machine_next_rule(ctx, tc, ptr::null_mut(), &mut out_id),
+            HEGEL_E_INVALID_HANDLE
+        );
+        assert!(last_error(ctx).contains("state machine handle is null"));
         let mut rule_idx = -1i64;
         assert_eq!(
-            hegel_state_machine_next_rule(ctx, tc, out_id, &mut rule_idx),
+            hegel_state_machine_next_rule(ctx, tc, machine, &mut rule_idx),
             HEGEL_OK
         );
         assert_eq!(rule_idx, 0, "a single-rule machine always selects rule 0");
         let mut steps = 1;
         loop {
             assert_eq!(
-                hegel_state_machine_next_rule(ctx, tc, out_id, &mut rule_idx),
+                hegel_state_machine_next_rule(ctx, tc, machine, &mut rule_idx),
                 HEGEL_OK
             );
             if rule_idx == HEGEL_STATE_MACHINE_DONE {
@@ -1118,6 +1250,7 @@ fn state_machine_and_primitive_boolean_paths() {
             steps += 1;
             assert!(steps <= 50, "the engine's step cap never exceeds 50");
         }
+        assert_eq!(hegel_state_machine_free(ctx, machine), HEGEL_OK);
 
         assert_eq!(
             hegel_generate_boolean(ctx, tc, 0.5, false, false, &mut bv),
@@ -1659,4 +1792,200 @@ fn from_blob_replay_trace_goes_to_the_output_callback() {
     }
     let lines = lines.into_inner().unwrap();
     assert_eq!(lines, ["replaying failure blob: choices = 2"]);
+}
+
+/// Collection, pool, and state-machine handles are independent of the test
+/// case and run they were created under: they outlive `hegel_test_case_free`
+/// and `hegel_run_free`, and the frees themselves are safe in any order —
+/// here the run and settings go first and the object handles are released
+/// last, in an order unrelated to creation order.
+#[test]
+fn object_handles_are_freed_safely_after_the_run() {
+    let ctx = hegel_context_new();
+    unsafe {
+        let s = make_settings(ctx);
+        let empty = CString::new("").unwrap();
+        ok(hegel_settings_set_database(ctx, s, empty.as_ptr()));
+        ok(hegel_c::hegel_settings_set_test_cases(ctx, s, 1));
+        ok(hegel_c::hegel_settings_set_seed(ctx, s, 1, true));
+        let run = start(ctx, s);
+        let tc = next_case(ctx, run);
+        assert!(!tc.is_null());
+
+        let mut collection: *mut HegelCollection = ptr::null_mut();
+        ok(hegel_new_collection(ctx, tc, 0, 3, &mut collection));
+        let mut pool: *mut HegelPool = ptr::null_mut();
+        ok(hegel_new_pool(ctx, tc, &mut pool));
+        let mut var_id = 0i64;
+        ok(hegel_pool_add(ctx, tc, pool, &mut var_id));
+        let rule = CString::new("only").unwrap();
+        let rules = [rule.as_ptr()];
+        let mut machine: *mut HegelStateMachine = ptr::null_mut();
+        ok(hegel_new_state_machine(
+            ctx,
+            tc,
+            rules.as_ptr(),
+            1,
+            ptr::null(),
+            0,
+            &mut machine,
+        ));
+
+        ok(hegel_mark_complete(
+            ctx,
+            tc,
+            hegel_status_t::HEGEL_STATUS_VALID as u32,
+            ptr::null(),
+        ));
+        ok(hegel_test_case_free(ctx, tc));
+        ok(hegel_run_free(ctx, run));
+        ok(hegel_settings_free(ctx, s));
+
+        ok(hegel_state_machine_free(ctx, machine));
+        ok(hegel_collection_free(ctx, collection));
+        ok(hegel_pool_free(ctx, pool));
+        ok(hegel_context_free(ctx));
+    }
+}
+
+/// A collection created through the root test-case handle is driven through
+/// a clone handle: the continue/stop decisions draw from the clone's stream
+/// and the collection still respects its size bounds.
+#[test]
+fn collection_created_on_the_root_is_driven_via_a_clone() {
+    let ctx = hegel_context_new();
+    unsafe {
+        let s = make_settings(ctx);
+        let empty = CString::new("").unwrap();
+        ok(hegel_settings_set_database(ctx, s, empty.as_ptr()));
+        ok(hegel_c::hegel_settings_set_test_cases(ctx, s, 1));
+        ok(hegel_c::hegel_settings_set_seed(ctx, s, 7, true));
+        let run = start(ctx, s);
+        let tc = next_case(ctx, run);
+        assert!(!tc.is_null());
+
+        let mut collection: *mut HegelCollection = ptr::null_mut();
+        ok(hegel_new_collection(ctx, tc, 1, 4, &mut collection));
+
+        let mut clone: *mut HegelTestCase = ptr::null_mut();
+        ok(hegel_test_case_clone(ctx, tc, &mut clone));
+        assert!(!clone.is_null());
+
+        let mut n = 0u64;
+        loop {
+            let mut more = false;
+            ok(hegel_collection_more(ctx, clone, collection, &mut more));
+            if !more {
+                break;
+            }
+            let mut value = false;
+            ok(hegel_generate_boolean(
+                ctx, clone, 0.5, false, false, &mut value,
+            ));
+            n += 1;
+        }
+        assert!((1..=4).contains(&n), "collection produced {n} elements");
+
+        ok(hegel_collection_free(ctx, collection));
+        ok(hegel_test_case_free(ctx, clone));
+        ok(hegel_mark_complete(
+            ctx,
+            tc,
+            hegel_status_t::HEGEL_STATUS_VALID as u32,
+            ptr::null(),
+        ));
+        ok(hegel_test_case_free(ctx, tc));
+        ok(hegel_run_free(ctx, run));
+        ok(hegel_settings_free(ctx, s));
+        ok(hegel_context_free(ctx));
+    }
+}
+
+/// A raw pointer wrapper so test threads can share libhegel handles; sound
+/// here because pools serialize internally and each thread drives its own
+/// test-case clone.
+struct SendPtr<T>(*mut T);
+impl<T> Copy for SendPtr<T> {}
+impl<T> Clone for SendPtr<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+unsafe impl<T> Send for SendPtr<T> {}
+unsafe impl<T> Sync for SendPtr<T> {}
+
+/// One pool shared between two clone handles driven from parallel threads:
+/// the pool's internal lock serializes concurrent `hegel_pool_add` /
+/// `hegel_pool_generate` calls, every drawn id is one that was added, and
+/// consumed ids are handed out exactly once.
+#[test]
+fn pool_is_shared_across_two_clone_threads() {
+    let ctx = hegel_context_new();
+    unsafe {
+        let s = make_settings(ctx);
+        let empty = CString::new("").unwrap();
+        ok(hegel_settings_set_database(ctx, s, empty.as_ptr()));
+        ok(hegel_c::hegel_settings_set_test_cases(ctx, s, 1));
+        ok(hegel_c::hegel_settings_set_seed(ctx, s, 11, true));
+        let run = start(ctx, s);
+        let tc = next_case(ctx, run);
+        assert!(!tc.is_null());
+
+        let mut pool: *mut HegelPool = ptr::null_mut();
+        ok(hegel_new_pool(ctx, tc, &mut pool));
+
+        let mut clone_a: *mut HegelTestCase = ptr::null_mut();
+        ok(hegel_test_case_clone(ctx, tc, &mut clone_a));
+        let mut clone_b: *mut HegelTestCase = ptr::null_mut();
+        ok(hegel_test_case_clone(ctx, tc, &mut clone_b));
+
+        let pool = SendPtr(pool);
+        let consumed = Mutex::new(Vec::<i64>::new());
+        std::thread::scope(|scope| {
+            for clone in [SendPtr(clone_a), SendPtr(clone_b)] {
+                let consumed = &consumed;
+                scope.spawn(move || {
+                    let clone = clone;
+                    let pool = pool;
+                    let worker_ctx = hegel_context_new();
+                    let mut added = Vec::new();
+                    for _ in 0..8 {
+                        let mut var_id = 0i64;
+                        ok(hegel_pool_add(worker_ctx, clone.0, pool.0, &mut var_id));
+                        added.push(var_id);
+                    }
+                    for _ in 0..4 {
+                        let mut drawn = 0i64;
+                        ok(hegel_pool_generate(
+                            worker_ctx, clone.0, pool.0, true, &mut drawn,
+                        ));
+                        assert!(drawn >= 1, "drew an id that was never added: {drawn}");
+                        consumed.lock().unwrap().push(drawn);
+                    }
+                    ok(hegel_context_free(worker_ctx));
+                });
+            }
+        });
+        let mut consumed = consumed.into_inner().unwrap();
+        let n = consumed.len();
+        consumed.sort_unstable();
+        consumed.dedup();
+        assert_eq!(n, 8, "each consuming draw returns one variable");
+        assert_eq!(consumed.len(), 8, "no consumed variable is drawn twice");
+        assert!(consumed.iter().all(|id| (1..=16).contains(id)));
+
+        ok(hegel_test_case_free(ctx, clone_a));
+        ok(hegel_test_case_free(ctx, clone_b));
+        ok(hegel_mark_complete(
+            ctx,
+            tc,
+            hegel_status_t::HEGEL_STATUS_VALID as u32,
+            ptr::null(),
+        ));
+        ok(hegel_test_case_free(ctx, tc));
+        ok(hegel_run_free(ctx, run));
+        ok(hegel_settings_free(ctx, s));
+        ok(hegel_pool_free(ctx, pool.0));
+        ok(hegel_context_free(ctx));
+    }
 }

--- a/hegel-c/tests/embedded/lib_tests.rs
+++ b/hegel-c/tests/embedded/lib_tests.rs
@@ -144,6 +144,51 @@ fn completion_is_reported_before_concurrent_use() {
     }
 }
 
+/// A collection used from two threads at once reports
+/// `HEGEL_E_CONCURRENT_USE`. As in
+/// [`concurrent_use_of_one_handle_is_rejected`], "another thread is
+/// mid-operation" is stood in for by holding the collection's own state lock
+/// on this thread — the two test-case handles are distinct clones, so the
+/// contention observed is the collection's, not the test case's.
+#[test]
+fn concurrent_use_of_one_collection_is_rejected() {
+    unsafe {
+        let (ctx, s, run, tc) = start_run_and_first_case();
+
+        let mut collection: *mut HegelCollection = ptr::null_mut();
+        ok(hegel_new_collection(ctx, tc, 0, 3, &mut collection));
+        let mut clone: *mut HegelTestCase = ptr::null_mut();
+        ok(hegel_test_case_clone(ctx, tc, &mut clone));
+
+        let held = (&*collection).state.try_lock().unwrap();
+        let mut more = false;
+        assert_eq!(
+            hegel_collection_more(ctx, clone, collection, &mut more),
+            HEGEL_E_CONCURRENT_USE
+        );
+        assert_eq!(
+            hegel_collection_reject(ctx, clone, collection, ptr::null()),
+            HEGEL_E_CONCURRENT_USE
+        );
+        drop(held);
+
+        loop {
+            ok(hegel_collection_more(ctx, clone, collection, &mut more));
+            if !more {
+                break;
+            }
+            let mut value = false;
+            ok(hegel_generate_boolean(
+                ctx, clone, 0.5, false, false, &mut value,
+            ));
+        }
+
+        ok(hegel_collection_free(ctx, collection));
+        ok(hegel_test_case_free(ctx, clone));
+        finish(ctx, s, run, tc);
+    }
+}
+
 #[test]
 fn size_arg_is_lossless_within_usize_and_saturates_beyond() {
     assert_eq!(size_arg(0), 0);

--- a/hegel-c/tests/embedded/native/data_source_tests.rs
+++ b/hegel-c/tests/embedded/native/data_source_tests.rs
@@ -47,83 +47,71 @@ fn start_and_stop_span_return_ok() {
 }
 
 #[test]
-fn new_collection_returns_sequential_id() {
+fn new_collection_returns_state_with_requested_bounds() {
     let (ds, _handle) = random_source();
-    let id_a = ds.new_collection(0, None).unwrap();
-    let id_b = ds.new_collection(1, Some(3)).unwrap();
-    assert_eq!(id_a, 0);
-    assert_eq!(id_b, 1);
+    let unbounded = ds.new_collection(0, None).unwrap();
+    assert_eq!(unbounded.min_size, 0);
+    assert!(unbounded.max_size.is_infinite());
+    let bounded = ds.new_collection(1, Some(3)).unwrap();
+    assert_eq!(bounded.min_size, 1);
+    assert_eq!(bounded.max_size, 3.0);
 }
 
 #[test]
 fn collection_more_and_reject_round_trip() {
     let (ds, _handle) = random_source();
-    let id = ds.new_collection(2, Some(4)).unwrap();
-    assert!(ds.collection_more(id).unwrap());
-    ds.collection_reject(id, None).unwrap();
-    assert!(ds.collection_more(id).unwrap());
-    ds.collection_reject(id, Some("nope")).unwrap();
+    let mut state = ds.new_collection(2, Some(4)).unwrap();
+    assert!(ds.collection_more(&mut state).unwrap());
+    ds.collection_reject(&mut state, None).unwrap();
+    assert!(ds.collection_more(&mut state).unwrap());
+    ds.collection_reject(&mut state, Some("nope")).unwrap();
 }
 
 #[test]
 fn new_pool_pool_add_and_pool_generate_non_consuming() {
     let (ds, _handle) = random_source();
-    let pool = ds.new_pool().unwrap();
-    let v1 = ds.pool_add(pool).unwrap();
-    let v2 = ds.pool_add(pool).unwrap();
+    let mut pool = ds.new_pool().unwrap();
+    let v1 = ds.pool_add(&mut pool).unwrap();
+    let v2 = ds.pool_add(&mut pool).unwrap();
     assert_eq!(v1, 1);
     assert_eq!(v2, 2);
-    let drawn = ds.pool_generate(pool, false).unwrap();
+    let drawn = ds.pool_generate(&mut pool, false).unwrap();
     assert!(drawn == v1 || drawn == v2);
-    assert_eq!(ds.pool_generate(pool, true).ok().map(|_| ()), Some(()));
+    assert_eq!(ds.pool_generate(&mut pool, true).ok().map(|_| ()), Some(()));
 }
 
 #[test]
 fn pool_generate_on_empty_pool_returns_assume() {
     let (ds, _handle) = random_source();
-    let pool = ds.new_pool().unwrap();
+    let mut pool = ds.new_pool().unwrap();
     assert!(matches!(
-        ds.pool_generate(pool, false),
+        ds.pool_generate(&mut pool, false),
         Err(DataSourceError::Assume)
     ));
 }
 
 #[test]
-fn new_state_machine_returns_sequential_ids() {
-    let (ds, _handle) = random_source();
-    assert_eq!(
-        ds.new_state_machine(vec!["push".into(), "pop".into()], vec!["sorted".into()])
-            .unwrap(),
-        0
-    );
-    assert_eq!(
-        ds.new_state_machine(vec!["clear".into()], vec![]).unwrap(),
-        1
-    );
-}
-
-#[test]
 fn new_state_machine_with_no_rules_is_invalid_argument_without_aborting() {
     let (ds, _handle) = random_source();
-    let err = ds.new_state_machine(vec![], vec![]).unwrap_err();
+    let err = match ds.new_state_machine(vec![], vec![]) {
+        Err(e) => e,
+        Ok(_) => panic!("expected an InvalidArgument error"),
+    };
     assert!(matches!(err, DataSourceError::InvalidArgument(_)));
     assert!(err.to_string().contains("no rules"));
     assert!(!ds.test_aborted());
-    assert_eq!(
-        ds.new_state_machine(vec!["push".into()], vec![]).unwrap(),
-        0
-    );
+    ds.new_state_machine(vec!["push".into()], vec![]).unwrap();
 }
 
 #[test]
 fn state_machine_next_rule_returns_in_range_indices() {
     let (ds, _handle) = random_source();
-    let id = ds
+    let mut machine = ds
         .new_state_machine(vec!["a".into(), "b".into(), "c".into()], vec![])
         .unwrap();
-    assert!(ds.state_machine_next_rule(id).unwrap().unwrap() < 3);
+    assert!(ds.state_machine_next_rule(&mut machine).unwrap().unwrap() < 3);
     for _ in 0..20 {
-        match ds.state_machine_next_rule(id).unwrap() {
+        match ds.state_machine_next_rule(&mut machine).unwrap() {
             Some(index) => assert!(index < 3),
             None => break,
         }
@@ -133,14 +121,12 @@ fn state_machine_next_rule_returns_in_range_indices() {
 #[test]
 fn state_machine_next_rule_on_exhausted_source_stops_test() {
     let (ds, _handle) = exhausted_source();
-    let id = ds
-        .new_state_machine(vec!["a".into(), "b".into()], vec![])
-        .unwrap();
+    let mut machine = NativeStateMachine::new(vec!["a".into(), "b".into()], vec![]);
     assert!(matches!(
-        ds.state_machine_next_rule(id),
+        ds.state_machine_next_rule(&mut machine),
         Err(DataSourceError::StopTest)
     ));
-    assert!(ds.state_machine_next_rule(id).is_err());
+    assert!(ds.state_machine_next_rule(&mut machine).is_err());
     assert!(ds.new_state_machine(vec!["a".into()], vec![]).is_err());
 }
 
@@ -214,44 +200,14 @@ fn generate_stoptest_sets_aborted_and_short_circuits() {
     assert!(ds.start_span(0).is_err());
     assert!(ds.stop_span(false).is_err());
     assert!(ds.new_collection(0, None).is_err());
-    assert!(ds.collection_more(0).is_err());
-    assert!(ds.collection_reject(0, None).is_err());
+    let mut state = ManyState::new(0, None);
+    assert!(ds.collection_more(&mut state).is_err());
+    assert!(ds.collection_reject(&mut state, None).is_err());
     assert!(ds.generate_boolean(0.5, None).is_err());
     assert!(ds.new_pool().is_err());
-    assert!(ds.pool_add(0).is_err());
-    assert!(ds.pool_generate(0, false).is_err());
-}
-
-#[test]
-fn unknown_handle_ids_map_to_invalid_argument_without_panicking() {
-    let (ds, _handle) = random_source();
-
-    let more = ds.collection_more(999).unwrap_err();
-    assert!(
-        matches!(&more, DataSourceError::InvalidArgument(m) if m.contains("unknown collection id")),
-        "{more:?}"
-    );
-    let reject = ds.collection_reject(999, None).unwrap_err();
-    assert!(
-        matches!(&reject, DataSourceError::InvalidArgument(m) if m.contains("unknown collection id")),
-        "{reject:?}"
-    );
-
-    let pool_negative = ds.pool_add(-1).unwrap_err();
-    assert!(
-        matches!(&pool_negative, DataSourceError::InvalidArgument(m) if m.contains("unknown variable pool id")),
-        "{pool_negative:?}"
-    );
-    let pool_past_end = ds.pool_generate(0, false).unwrap_err();
-    assert!(
-        matches!(&pool_past_end, DataSourceError::InvalidArgument(m) if m.contains("unknown variable pool id")),
-        "{pool_past_end:?}"
-    );
-    let sm_past_end = ds.state_machine_next_rule(0).unwrap_err();
-    assert!(
-        matches!(&sm_past_end, DataSourceError::InvalidArgument(m) if m.contains("unknown state machine id")),
-        "{sm_past_end:?}"
-    );
+    let mut pool = NativeVariables::new();
+    assert!(ds.pool_add(&mut pool).is_err());
+    assert!(ds.pool_generate(&mut pool, false).is_err());
 }
 
 #[test]
@@ -333,13 +289,13 @@ fn clone_stream_draws_independently_and_reassembles() {
 #[test]
 fn pools_are_shared_across_cloned_streams() {
     let (ds, _handle) = random_source();
-    let pool = ds.new_pool().unwrap();
-    let v1 = ds.pool_add(pool).unwrap();
+    let mut pool = ds.new_pool().unwrap();
+    let v1 = ds.pool_add(&mut pool).unwrap();
     let child = ds.clone_stream().unwrap();
-    let got = child.pool_generate(pool, true).unwrap();
+    let got = child.pool_generate(&mut pool, true).unwrap();
     assert_eq!(got, v1);
     assert!(matches!(
-        ds.pool_generate(pool, false),
+        ds.pool_generate(&mut pool, false),
         Err(DataSourceError::Assume)
     ));
 }
@@ -347,21 +303,27 @@ fn pools_are_shared_across_cloned_streams() {
 #[test]
 fn collections_are_shared_across_cloned_streams() {
     let (ds, _handle) = random_source();
-    let collection = ds.new_collection(1, Some(1)).unwrap();
+    let mut collection = ds.new_collection(1, Some(1)).unwrap();
     let child = ds.clone_stream().unwrap();
-    assert!(child.collection_more(collection).unwrap());
-    assert!(!child.collection_more(collection).unwrap());
+    assert!(child.collection_more(&mut collection).unwrap());
+    assert!(!child.collection_more(&mut collection).unwrap());
 }
 
 #[test]
 fn state_machines_are_shared_across_cloned_streams() {
     let (ds, _handle) = random_source();
-    let machine = ds
+    let mut machine = ds
         .new_state_machine(vec!["a".into(), "b".into(), "c".into()], vec![])
         .unwrap();
     let child = ds.clone_stream().unwrap();
-    assert!(child.state_machine_next_rule(machine).unwrap().unwrap() < 3);
-    if let Some(index) = ds.state_machine_next_rule(machine).unwrap() {
+    assert!(
+        child
+            .state_machine_next_rule(&mut machine)
+            .unwrap()
+            .unwrap()
+            < 3
+    );
+    if let Some(index) = ds.state_machine_next_rule(&mut machine).unwrap() {
         assert!(index < 3);
     }
 }

--- a/hegel-c/tests/embedded/native/test_runner_tests.rs
+++ b/hegel-c/tests/embedded/native/test_runner_tests.rs
@@ -506,13 +506,13 @@ fn slow_shrink_warning_mentions_shrinking() {
 #[test]
 fn run_main_stops_shrinking_when_budget_is_exhausted() {
     let body = |ds: &dyn DataSource| -> TestCaseResult {
-        let cid = match ds.new_collection(0, None) {
+        let mut collection = match ds.new_collection(0, None) {
             Ok(c) => c,
             Err(_) => return TestCaseResult::Overrun,
         };
         let mut len = 0usize;
         loop {
-            match ds.collection_more(cid) {
+            match ds.collection_more(&mut collection) {
                 Ok(true) => {}
                 Ok(false) => break,
                 Err(_) => return TestCaseResult::Overrun,

--- a/hegel-c/tests/smoke.rs
+++ b/hegel-c/tests/smoke.rs
@@ -116,9 +116,10 @@ type FnFailureFree = unsafe extern "C" fn(*mut u8, *mut u8) -> c_int;
 type FnRunFree = unsafe extern "C" fn(*mut u8, *mut u8) -> c_int;
 type FnGenerateInteger = unsafe extern "C" fn(*mut u8, *mut u8, i64, i64, *mut i64) -> c_int;
 type FnMarkComplete = unsafe extern "C" fn(*mut u8, *mut u8, CStatus, *const c_char) -> c_int;
-type FnNewPool = unsafe extern "C" fn(*mut u8, *mut u8, *mut i64) -> c_int;
-type FnPoolAdd = unsafe extern "C" fn(*mut u8, *mut u8, i64, *mut i64) -> c_int;
-type FnPoolGenerate = unsafe extern "C" fn(*mut u8, *mut u8, i64, bool, *mut i64) -> c_int;
+type FnNewPool = unsafe extern "C" fn(*mut u8, *mut u8, *mut *mut u8) -> c_int;
+type FnPoolAdd = unsafe extern "C" fn(*mut u8, *mut u8, *mut u8, *mut i64) -> c_int;
+type FnPoolGenerate = unsafe extern "C" fn(*mut u8, *mut u8, *mut u8, bool, *mut i64) -> c_int;
+type FnPoolFree = unsafe extern "C" fn(*mut u8, *mut u8) -> c_int;
 type FnNewStateMachine = unsafe extern "C" fn(
     *mut u8,
     *mut u8,
@@ -126,9 +127,10 @@ type FnNewStateMachine = unsafe extern "C" fn(
     usize,
     *const *const c_char,
     usize,
-    *mut i64,
+    *mut *mut u8,
 ) -> c_int;
-type FnStateMachineNextRule = unsafe extern "C" fn(*mut u8, *mut u8, i64, *mut i64) -> c_int;
+type FnStateMachineNextRule = unsafe extern "C" fn(*mut u8, *mut u8, *mut u8, *mut i64) -> c_int;
+type FnStateMachineFree = unsafe extern "C" fn(*mut u8, *mut u8) -> c_int;
 type FnPrimitiveBoolean =
     unsafe extern "C" fn(*mut u8, *mut u8, f64, bool, bool, *mut bool) -> c_int;
 type FnStringGeneratorText = unsafe extern "C" fn(
@@ -149,7 +151,9 @@ type FnStringGeneratorText = unsafe extern "C" fn(
     *mut *mut u8,
 ) -> c_int;
 type FnTarget = unsafe extern "C" fn(*mut u8, *mut u8, f64, *const c_char) -> c_int;
-type FnCollectionMore = unsafe extern "C" fn(*mut u8, *mut u8, i64, *mut bool) -> c_int;
+type FnNewCollection = unsafe extern "C" fn(*mut u8, *mut u8, u64, u64, *mut *mut u8) -> c_int;
+type FnCollectionMore = unsafe extern "C" fn(*mut u8, *mut u8, *mut u8, *mut bool) -> c_int;
+type FnCollectionFree = unsafe extern "C" fn(*mut u8, *mut u8) -> c_int;
 type FnRunResultStatus = unsafe extern "C" fn(*mut u8, *const u8, *mut CRunStatus) -> c_int;
 type FnRunResultError = unsafe extern "C" fn(*mut u8, *const u8, *mut *const c_char) -> c_int;
 type FnRunResultFailureCount = unsafe extern "C" fn(*mut u8, *const u8, *mut usize) -> c_int;
@@ -187,12 +191,16 @@ struct Api<'a> {
     new_pool: Symbol<'a, FnNewPool>,
     pool_add: Symbol<'a, FnPoolAdd>,
     pool_generate: Symbol<'a, FnPoolGenerate>,
+    pool_free: Symbol<'a, FnPoolFree>,
     new_state_machine: Symbol<'a, FnNewStateMachine>,
     state_machine_next_rule: Symbol<'a, FnStateMachineNextRule>,
+    state_machine_free: Symbol<'a, FnStateMachineFree>,
     primitive_boolean: Symbol<'a, FnPrimitiveBoolean>,
     string_generator_text: Symbol<'a, FnStringGeneratorText>,
     target: Symbol<'a, FnTarget>,
+    new_collection: Symbol<'a, FnNewCollection>,
     collection_more: Symbol<'a, FnCollectionMore>,
+    collection_free: Symbol<'a, FnCollectionFree>,
     run_result_status: Symbol<'a, FnRunResultStatus>,
     run_result_error: Symbol<'a, FnRunResultError>,
     run_result_failure_count: Symbol<'a, FnRunResultFailureCount>,
@@ -228,12 +236,16 @@ unsafe fn bind(lib: &Library) -> Api<'_> {
             new_pool: lib.get(b"hegel_new_pool\0").unwrap(),
             pool_add: lib.get(b"hegel_pool_add\0").unwrap(),
             pool_generate: lib.get(b"hegel_pool_generate\0").unwrap(),
+            pool_free: lib.get(b"hegel_pool_free\0").unwrap(),
             new_state_machine: lib.get(b"hegel_new_state_machine\0").unwrap(),
             state_machine_next_rule: lib.get(b"hegel_state_machine_next_rule\0").unwrap(),
+            state_machine_free: lib.get(b"hegel_state_machine_free\0").unwrap(),
             primitive_boolean: lib.get(b"hegel_generate_boolean\0").unwrap(),
             string_generator_text: lib.get(b"hegel_string_generator_text\0").unwrap(),
             target: lib.get(b"hegel_target\0").unwrap(),
+            new_collection: lib.get(b"hegel_new_collection\0").unwrap(),
             collection_more: lib.get(b"hegel_collection_more\0").unwrap(),
+            collection_free: lib.get(b"hegel_collection_free\0").unwrap(),
             run_result_status: lib.get(b"hegel_run_result_status\0").unwrap(),
             run_result_error: lib.get(b"hegel_run_result_error\0").unwrap(),
             run_result_failure_count: lib.get(b"hegel_run_result_failure_count\0").unwrap(),
@@ -615,19 +627,38 @@ fn caller_usage_errors_return_error_not_abort() {
 
         let mut more = false;
         assert_eq!(
-            (a.collection_more)(ctx, tc, 9999, &mut more),
-            HEGEL_E_INVALID_ARG
+            (a.collection_more)(ctx, tc, ptr::null_mut(), &mut more),
+            HEGEL_E_INVALID_HANDLE
         );
         let mut var_id = 0i64;
         assert_eq!(
-            (a.pool_add)(ctx, tc, 9999, &mut var_id),
-            HEGEL_E_INVALID_ARG
+            (a.pool_add)(ctx, tc, ptr::null_mut(), &mut var_id),
+            HEGEL_E_INVALID_HANDLE
         );
         let mut rule_idx = 0i64;
         assert_eq!(
-            (a.state_machine_next_rule)(ctx, tc, 9999, &mut rule_idx),
+            (a.state_machine_next_rule)(ctx, tc, ptr::null_mut(), &mut rule_idx),
+            HEGEL_E_INVALID_HANDLE
+        );
+        assert_eq!((a.collection_free)(ctx, ptr::null_mut()), HEGEL_OK);
+        assert_eq!((a.pool_free)(ctx, ptr::null_mut()), HEGEL_OK);
+        assert_eq!((a.state_machine_free)(ctx, ptr::null_mut()), HEGEL_OK);
+
+        let mut collection: *mut u8 = ptr::null_mut();
+        assert_eq!(
+            (a.new_collection)(ctx, tc, 5, 3, &mut collection),
             HEGEL_E_INVALID_ARG
         );
+        assert!(collection.is_null());
+        assert_eq!((a.new_collection)(ctx, tc, 0, 3, &mut collection), HEGEL_OK);
+        assert!(!collection.is_null());
+        while (a.collection_more)(ctx, tc, collection, &mut more) == HEGEL_OK && more {
+            let mut b = false;
+            if (a.primitive_boolean)(ctx, tc, 0.5, false, false, &mut b) != HEGEL_OK {
+                break;
+            }
+        }
+        assert_eq!((a.collection_free)(ctx, collection), HEGEL_OK);
 
         a.complete_and_free(ctx, tc, CStatus::Valid, ptr::null());
         a.run_free(ctx, run);
@@ -908,22 +939,24 @@ fn libhegel_pool_primitives_draw_added_variables() {
                 break;
             }
 
-            let mut pool_id: i64 = -1;
-            let rc = (a.new_pool)(ctx, tc, &mut pool_id);
+            let mut pool: *mut u8 = ptr::null_mut();
+            let rc = (a.new_pool)(ctx, tc, &mut pool);
             assert_eq!(rc, HEGEL_OK, "new_pool failed: rc={}", rc);
+            assert!(!pool.is_null());
 
             let mut added = Vec::new();
             for _ in 0..3 {
                 let mut var_id: i64 = -1;
-                let rc = (a.pool_add)(ctx, tc, pool_id, &mut var_id);
+                let rc = (a.pool_add)(ctx, tc, pool, &mut var_id);
                 assert_eq!(rc, HEGEL_OK, "pool_add failed: rc={}", rc);
                 added.push(var_id);
             }
             assert_eq!(added, vec![1, 2, 3]);
 
             let mut drawn: i64 = -1;
-            let rc = (a.pool_generate)(ctx, tc, pool_id, false, &mut drawn);
+            let rc = (a.pool_generate)(ctx, tc, pool, false, &mut drawn);
             if rc == HEGEL_E_STOP_TEST {
+                assert_eq!((a.pool_free)(ctx, pool), HEGEL_OK);
                 a.complete_and_free(ctx, tc, CStatus::Overrun, ptr::null());
                 continue;
             }
@@ -934,7 +967,7 @@ fn libhegel_pool_primitives_draw_added_variables() {
             let mut consumed = 0;
             for _ in 0..3 {
                 let mut v: i64 = -1;
-                let rc = (a.pool_generate)(ctx, tc, pool_id, true, &mut v);
+                let rc = (a.pool_generate)(ctx, tc, pool, true, &mut v);
                 if rc == HEGEL_E_STOP_TEST {
                     break;
                 }
@@ -944,7 +977,7 @@ fn libhegel_pool_primitives_draw_added_variables() {
             }
             if consumed == 3 {
                 let mut v: i64 = -1;
-                let rc = (a.pool_generate)(ctx, tc, pool_id, true, &mut v);
+                let rc = (a.pool_generate)(ctx, tc, pool, true, &mut v);
                 assert_eq!(
                     rc, HEGEL_E_ASSUME,
                     "expected HEGEL_E_ASSUME on empty pool, got rc={}",
@@ -953,6 +986,7 @@ fn libhegel_pool_primitives_draw_added_variables() {
                 saw_empty_reject = true;
             }
 
+            assert_eq!((a.pool_free)(ctx, pool), HEGEL_OK);
             a.complete_and_free(ctx, tc, CStatus::Valid, ptr::null());
         }
 
@@ -1012,7 +1046,7 @@ fn libhegel_state_machine_selects_registered_rules_with_swarm() {
                 break;
             }
 
-            let mut machine_id: i64 = -1;
+            let mut machine: *mut u8 = ptr::null_mut();
             let rc = (a.new_state_machine)(
                 ctx,
                 tc,
@@ -1020,13 +1054,14 @@ fn libhegel_state_machine_selects_registered_rules_with_swarm() {
                 0,
                 invariant_ptrs.as_ptr(),
                 invariant_ptrs.len(),
-                &mut machine_id,
+                &mut machine,
             );
             assert_eq!(
                 rc, HEGEL_E_INVALID_ARG,
                 "expected HEGEL_E_INVALID_ARG, got rc={}",
                 rc
             );
+            assert!(machine.is_null());
 
             let rc = (a.new_state_machine)(
                 ctx,
@@ -1035,17 +1070,17 @@ fn libhegel_state_machine_selects_registered_rules_with_swarm() {
                 rule_ptrs.len(),
                 invariant_ptrs.as_ptr(),
                 invariant_ptrs.len(),
-                &mut machine_id,
+                &mut machine,
             );
             assert_eq!(rc, HEGEL_OK, "new_state_machine failed: rc={}", rc);
-            assert_eq!(machine_id, 0);
+            assert!(!machine.is_null());
 
             let mut overran = false;
             let mut current_run = 0usize;
             let mut previous: Option<i64> = None;
             for _ in 0..25 {
                 let mut index: i64 = i64::MAX;
-                let rc = (a.state_machine_next_rule)(ctx, tc, machine_id, &mut index);
+                let rc = (a.state_machine_next_rule)(ctx, tc, machine, &mut index);
                 if rc == HEGEL_E_STOP_TEST {
                     overran = true;
                     break;
@@ -1065,6 +1100,7 @@ fn libhegel_state_machine_selects_registered_rules_with_swarm() {
                 longest_single_rule_run = longest_single_rule_run.max(current_run);
             }
 
+            assert_eq!((a.state_machine_free)(ctx, machine), HEGEL_OK);
             if overran {
                 a.complete_and_free(ctx, tc, CStatus::Overrun, ptr::null());
             } else {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -631,57 +631,71 @@ impl CTestCase {
         &self,
         min_size: u64,
         max_size: Option<u64>,
-    ) -> Result<i64, hegel_result_t> {
-        let mut id: i64 = 0;
+    ) -> Result<CollectionHandle, hegel_result_t> {
+        let mut raw: *mut hegel_c::HegelCollection = ptr::null_mut();
         let rc = with_context(|ctx| unsafe {
             hegel_c::hegel_new_collection(
                 ctx,
                 self.raw,
                 min_size,
                 max_size.unwrap_or(u64::MAX),
-                &mut id,
+                &mut raw,
             )
         });
-        rc_to_value(rc, id)
+        if rc != hegel_result_t::HEGEL_OK {
+            return Err(rc);
+        }
+        Ok(CollectionHandle { raw })
     }
 
-    pub(crate) fn collection_more(&self, collection_id: i64) -> Result<bool, hegel_result_t> {
+    pub(crate) fn collection_more(
+        &self,
+        collection: &CollectionHandle,
+    ) -> Result<bool, hegel_result_t> {
         let mut more = false;
         let rc = with_context(|ctx| unsafe {
-            hegel_c::hegel_collection_more(ctx, self.raw, collection_id, &mut more)
+            hegel_c::hegel_collection_more(ctx, self.raw, collection.raw, &mut more)
         });
         rc_to_value(rc, more)
     }
 
     pub(crate) fn collection_reject(
         &self,
-        collection_id: i64,
+        collection: &CollectionHandle,
         why: Option<&str>,
     ) -> Result<(), hegel_result_t> {
         let c_why = why.map(cstring_lossy);
         let why_ptr = c_why.as_ref().map_or(ptr::null(), |c| c.as_ptr());
         rc_to_unit(with_context(|ctx| unsafe {
-            hegel_c::hegel_collection_reject(ctx, self.raw, collection_id, why_ptr)
+            hegel_c::hegel_collection_reject(ctx, self.raw, collection.raw, why_ptr)
         }))
     }
 
-    pub(crate) fn new_pool(&self) -> Result<i64, hegel_result_t> {
-        let mut id: i64 = 0;
-        let rc = with_context(|ctx| unsafe { hegel_c::hegel_new_pool(ctx, self.raw, &mut id) });
-        rc_to_value(rc, id)
+    pub(crate) fn new_pool(&self) -> Result<PoolHandle, hegel_result_t> {
+        let mut raw: *mut hegel_c::HegelPool = ptr::null_mut();
+        let rc = with_context(|ctx| unsafe { hegel_c::hegel_new_pool(ctx, self.raw, &mut raw) });
+        if rc != hegel_result_t::HEGEL_OK {
+            return Err(rc);
+        }
+        Ok(PoolHandle { raw })
     }
 
-    pub(crate) fn pool_add(&self, pool_id: i64) -> Result<i64, hegel_result_t> {
-        let mut id: i64 = 0;
-        let rc =
-            with_context(|ctx| unsafe { hegel_c::hegel_pool_add(ctx, self.raw, pool_id, &mut id) });
-        rc_to_value(rc, id)
-    }
-
-    pub(crate) fn pool_generate(&self, pool_id: i64, consume: bool) -> Result<i64, hegel_result_t> {
+    pub(crate) fn pool_add(&self, pool: &PoolHandle) -> Result<i64, hegel_result_t> {
         let mut id: i64 = 0;
         let rc = with_context(|ctx| unsafe {
-            hegel_c::hegel_pool_generate(ctx, self.raw, pool_id, consume, &mut id)
+            hegel_c::hegel_pool_add(ctx, self.raw, pool.raw, &mut id)
+        });
+        rc_to_value(rc, id)
+    }
+
+    pub(crate) fn pool_generate(
+        &self,
+        pool: &PoolHandle,
+        consume: bool,
+    ) -> Result<i64, hegel_result_t> {
+        let mut id: i64 = 0;
+        let rc = with_context(|ctx| unsafe {
+            hegel_c::hegel_pool_generate(ctx, self.raw, pool.raw, consume, &mut id)
         });
         rc_to_value(rc, id)
     }
@@ -690,14 +704,14 @@ impl CTestCase {
         &self,
         rule_names: &[&str],
         invariant_names: &[&str],
-    ) -> Result<i64, hegel_result_t> {
+    ) -> Result<StateMachineHandle, hegel_result_t> {
         let rule_cstrings: Vec<CString> = rule_names.iter().map(|s| cstring_lossy(s)).collect();
         let invariant_cstrings: Vec<CString> =
             invariant_names.iter().map(|s| cstring_lossy(s)).collect();
         let rule_ptrs: Vec<*const c_char> = rule_cstrings.iter().map(|c| c.as_ptr()).collect();
         let invariant_ptrs: Vec<*const c_char> =
             invariant_cstrings.iter().map(|c| c.as_ptr()).collect();
-        let mut id: i64 = 0;
+        let mut raw: *mut hegel_c::HegelStateMachine = ptr::null_mut();
         let rc = with_context(|ctx| unsafe {
             hegel_c::hegel_new_state_machine(
                 ctx,
@@ -706,21 +720,24 @@ impl CTestCase {
                 rule_ptrs.len(),
                 invariant_ptrs.as_ptr(),
                 invariant_ptrs.len(),
-                &mut id,
+                &mut raw,
             )
         });
-        rc_to_value(rc, id)
+        if rc != hegel_result_t::HEGEL_OK {
+            return Err(rc);
+        }
+        Ok(StateMachineHandle { raw })
     }
 
     /// Ask the engine for the next rule to run; `None` once the engine has
     /// run enough steps (`HEGEL_STATE_MACHINE_DONE`).
     pub(crate) fn state_machine_next_rule(
         &self,
-        state_machine_id: i64,
+        state_machine: &StateMachineHandle,
     ) -> Result<Option<i64>, hegel_result_t> {
         let mut out: i64 = 0;
         let rc = with_context(|ctx| unsafe {
-            hegel_c::hegel_state_machine_next_rule(ctx, self.raw, state_machine_id, &mut out)
+            hegel_c::hegel_state_machine_next_rule(ctx, self.raw, state_machine.raw, &mut out)
         });
         let index = if out == hegel_c::HEGEL_STATE_MACHINE_DONE {
             None
@@ -758,6 +775,82 @@ impl Drop for CTestCase {
         // frontend created (from_blob, next_test_case, or clone_handle) and is
         // freed exactly once here, dropping its reference to the test case.
         free_on_drop(|ctx| unsafe { hegel_c::hegel_test_case_free(ctx, self.raw) });
+    }
+}
+
+/// An owned libhegel collection handle (`hegel_collection_t`), freed on drop.
+///
+/// Built by [`CTestCase::new_collection`] and driven through
+/// [`CTestCase::collection_more`] / [`CTestCase::collection_reject`] with any
+/// handle of the same test-case family. The handle is independent of the test
+/// case and run it was created under, so dropping it is safe in any order.
+pub(crate) struct CollectionHandle {
+    raw: *mut hegel_c::HegelCollection,
+}
+
+// SAFETY: libhegel guards the collection's state with its own lock (rejecting
+// concurrent use with `HEGEL_E_CONCURRENT_USE`), so moving or sharing the
+// handle across threads is sound.
+unsafe impl Send for CollectionHandle {}
+unsafe impl Sync for CollectionHandle {}
+
+impl Drop for CollectionHandle {
+    fn drop(&mut self) {
+        // SAFETY: `raw` came from hegel_new_collection (or is null after a
+        // failed creation, which the free accepts) and is freed exactly once.
+        free_on_drop(|ctx| unsafe { hegel_c::hegel_collection_free(ctx, self.raw) });
+    }
+}
+
+/// An owned libhegel variable-pool handle (`hegel_pool_t`), freed on drop.
+///
+/// Built by [`CTestCase::new_pool`] and driven through
+/// [`CTestCase::pool_add`] / [`CTestCase::pool_generate`] with any handle of
+/// the same test-case family. The pool serializes concurrent use internally,
+/// so it may be shared between clone handles on parallel threads; it is
+/// independent of the test case and run it was created under, so dropping it
+/// is safe in any order.
+pub(crate) struct PoolHandle {
+    raw: *mut hegel_c::HegelPool,
+}
+
+// SAFETY: libhegel guards the pool's state with its own lock (serializing
+// concurrent operations), so moving or sharing the handle across threads is
+// sound.
+unsafe impl Send for PoolHandle {}
+unsafe impl Sync for PoolHandle {}
+
+impl Drop for PoolHandle {
+    fn drop(&mut self) {
+        // SAFETY: `raw` came from hegel_new_pool (or is null after a failed
+        // creation, which the free accepts) and is freed exactly once.
+        free_on_drop(|ctx| unsafe { hegel_c::hegel_pool_free(ctx, self.raw) });
+    }
+}
+
+/// An owned libhegel state-machine handle (`hegel_state_machine_t`), freed on
+/// drop.
+///
+/// Built by [`CTestCase::new_state_machine`] and driven through
+/// [`CTestCase::state_machine_next_rule`] with any handle of the same
+/// test-case family. The machine serializes concurrent use internally; it is
+/// independent of the test case and run it was created under, so dropping it
+/// is safe in any order.
+pub(crate) struct StateMachineHandle {
+    raw: *mut hegel_c::HegelStateMachine,
+}
+
+// SAFETY: libhegel guards the machine's state with its own lock (serializing
+// concurrent operations), so moving or sharing the handle across threads is
+// sound.
+unsafe impl Send for StateMachineHandle {}
+unsafe impl Sync for StateMachineHandle {}
+
+impl Drop for StateMachineHandle {
+    fn drop(&mut self) {
+        // SAFETY: `raw` came from hegel_new_state_machine (or is null after a
+        // failed creation, which the free accepts) and is freed exactly once.
+        free_on_drop(|ctx| unsafe { hegel_c::hegel_state_machine_free(ctx, self.raw) });
     }
 }
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -796,8 +796,8 @@ unsafe impl Sync for CollectionHandle {}
 
 impl Drop for CollectionHandle {
     fn drop(&mut self) {
-        // SAFETY: `raw` came from hegel_new_collection (or is null after a
-        // failed creation, which the free accepts) and is freed exactly once.
+        // SAFETY: `raw` came from a successful hegel_new_collection call and
+        // is freed exactly once here.
         free_on_drop(|ctx| unsafe { hegel_c::hegel_collection_free(ctx, self.raw) });
     }
 }
@@ -822,8 +822,8 @@ unsafe impl Sync for PoolHandle {}
 
 impl Drop for PoolHandle {
     fn drop(&mut self) {
-        // SAFETY: `raw` came from hegel_new_pool (or is null after a failed
-        // creation, which the free accepts) and is freed exactly once.
+        // SAFETY: `raw` came from a successful hegel_new_pool call and is
+        // freed exactly once here.
         free_on_drop(|ctx| unsafe { hegel_c::hegel_pool_free(ctx, self.raw) });
     }
 }
@@ -848,8 +848,8 @@ unsafe impl Sync for StateMachineHandle {}
 
 impl Drop for StateMachineHandle {
     fn drop(&mut self) {
-        // SAFETY: `raw` came from hegel_new_state_machine (or is null after a
-        // failed creation, which the free accepts) and is freed exactly once.
+        // SAFETY: `raw` came from a successful hegel_new_state_machine call
+        // and is freed exactly once here.
         free_on_drop(|ctx| unsafe { hegel_c::hegel_state_machine_free(ctx, self.raw) });
     }
 }

--- a/src/stateful.rs
+++ b/src/stateful.rs
@@ -107,14 +107,14 @@ impl<M> Rule<M> {
 /// value is recorded in the failing-test replay and the choice shrinks like any
 /// other draw.
 pub struct Pool<T> {
-    pool_id: i64,
+    pool: crate::ffi::PoolHandle,
     tc: TestCase,
     values: HashMap<i64, T>,
 }
 
-/// Ask the engine for a variable id from `pool_id`, consuming it if `consume`.
-fn pool_generate(tc: &TestCase, pool_id: i64, consume: bool) -> i64 {
-    match tc.with_ctc(|ctc| ctc.pool_generate(pool_id, consume)) {
+/// Ask the engine for a variable id from `pool`, consuming it if `consume`.
+fn pool_generate(tc: &TestCase, pool: &crate::ffi::PoolHandle, consume: bool) -> i64 {
+    match tc.with_ctc(|ctc| ctc.pool_generate(pool, consume)) {
         Ok(id) => id,
         Err(rc) => raise_for_rc(rc),
     }
@@ -133,7 +133,7 @@ impl<T> Pool<T> {
 
     /// Add a value to the pool.
     pub fn add(&mut self, v: T) {
-        let variable_id: i64 = match self.tc.with_ctc(|ctc| ctc.pool_add(self.pool_id)) {
+        let variable_id: i64 = match self.tc.with_ctc(|ctc| ctc.pool_add(&self.pool)) {
             Ok(id) => id,
             Err(rc) => raise_for_rc(rc), // nocov
         };
@@ -150,7 +150,7 @@ impl<T> Pool<T> {
     /// `assume(false)`) when the pool is empty.
     pub fn values_reusable(&self) -> ValuesReusable<'_, T> {
         ValuesReusable {
-            pool_id: self.pool_id,
+            pool: &self.pool,
             values: &self.values,
         }
     }
@@ -162,7 +162,7 @@ impl<T> Pool<T> {
     /// current test case (as if by `assume(false)`) when the pool is empty.
     pub fn values_consumed(&mut self) -> ValuesConsumed<'_, T> {
         ValuesConsumed {
-            pool_id: self.pool_id,
+            pool: &self.pool,
             values: RefCell::new(&mut self.values),
         }
     }
@@ -173,14 +173,14 @@ impl<T> Pool<T> {
 /// Returned by [`Pool::values_reusable`]. Borrows the pool, so the references it
 /// produces stay valid for as long as the generator is alive.
 pub struct ValuesReusable<'a, T> {
-    pool_id: i64,
+    pool: &'a crate::ffi::PoolHandle,
     values: &'a HashMap<i64, T>,
 }
 
 impl<'a, T> Generator<&'a T> for ValuesReusable<'a, T> {
     fn do_draw(&self, tc: &TestCase) -> &'a T {
         tc.assume(!self.values.is_empty());
-        let variable_id = pool_generate(tc, self.pool_id, false);
+        let variable_id = pool_generate(tc, self.pool, false);
         self.values.get(&variable_id).unwrap()
     }
 }
@@ -192,26 +192,26 @@ impl<'a, T> Generator<&'a T> for ValuesReusable<'a, T> {
 /// [`RefCell`] is what lets it remove a value during a draw, which only has
 /// shared access to the generator.
 pub struct ValuesConsumed<'a, T> {
-    pool_id: i64,
+    pool: &'a crate::ffi::PoolHandle,
     values: RefCell<&'a mut HashMap<i64, T>>,
 }
 
 impl<T> Generator<T> for ValuesConsumed<'_, T> {
     fn do_draw(&self, tc: &TestCase) -> T {
         tc.assume(!self.values.borrow().is_empty());
-        let variable_id = pool_generate(tc, self.pool_id, true);
+        let variable_id = pool_generate(tc, self.pool, true);
         self.values.borrow_mut().remove(&variable_id).unwrap()
     }
 }
 
 /// Create a new value pool for stateful tests.
 pub fn pool<T>(tc: &TestCase) -> Pool<T> {
-    let pool_id = match tc.with_ctc(|ctc| ctc.new_pool()) {
-        Ok(id) => id,
+    let pool = match tc.with_ctc(|ctc| ctc.new_pool()) {
+        Ok(handle) => handle,
         Err(rc) => raise_for_rc(rc), // nocov
     };
     Pool {
-        pool_id,
+        pool,
         tc: tc.clone(),
         values: HashMap::new(),
     }
@@ -242,8 +242,8 @@ pub fn run<M: StateMachine>(mut m: M, tc: TestCase) {
     let rule_names: Vec<&str> = rules.iter().map(|r| r.name.as_str()).collect();
     let invariants = m.invariants();
     let invariant_names: Vec<&str> = invariants.iter().map(|r| r.name.as_str()).collect();
-    let machine_id = match tc.with_ctc(|ctc| ctc.new_state_machine(&rule_names, &invariant_names)) {
-        Ok(id) => id,
+    let machine = match tc.with_ctc(|ctc| ctc.new_state_machine(&rule_names, &invariant_names)) {
+        Ok(handle) => handle,
         Err(rc) => raise_for_rc(rc),
     };
 
@@ -255,7 +255,7 @@ pub fn run<M: StateMachine>(mut m: M, tc: TestCase) {
     let mut steps_attempted: i64 = 0;
 
     while is_single || steps_attempted < 1000 {
-        let rule_index = match tc.with_ctc(|ctc| ctc.state_machine_next_rule(machine_id)) {
+        let rule_index = match tc.with_ctc(|ctc| ctc.state_machine_next_rule(&machine)) {
             Ok(Some(i)) => i,
             Ok(None) => break,
             Err(rc) => raise_for_rc(rc),

--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -191,9 +191,9 @@ pub(crate) struct TestCaseLocalData {
 /// run, and such failures may not reproduce or shrink well.
 ///
 /// Variable pools and engine-managed collections are shared across clones
-/// (an id from one clone works on any other). Using one such object from
-/// two threads *at the same time* makes the affected draws depend on
-/// scheduling order, which brings back the same replay caveat.
+/// (one created through any clone works on any other). Using one such
+/// object from two threads *at the same time* makes the affected draws
+/// depend on scheduling order, which brings back the same replay caveat.
 ///
 /// ## Panics inside spawned threads
 ///
@@ -881,7 +881,7 @@ pub struct Collection<'a> {
     tc: &'a TestCase,
     min_size: usize,
     max_size: Option<usize>,
-    handle: Option<i64>,
+    handle: Option<crate::ffi::CollectionHandle>,
     finished: bool,
 }
 
@@ -897,18 +897,18 @@ impl<'a> Collection<'a> {
         }
     }
 
-    fn ensure_initialized(&mut self) -> i64 {
+    fn ensure_initialized(&mut self) -> &crate::ffi::CollectionHandle {
         if self.handle.is_none() {
             let result = self.tc.with_ctc(|ctc| {
                 ctc.new_collection(self.min_size as u64, self.max_size.map(|m| m as u64))
             });
-            let id = match result {
-                Ok(id) => id,
+            let handle = match result {
+                Ok(handle) => handle,
                 Err(rc) => raise_for_rc(rc), // nocov
             };
-            self.handle = Some(id);
+            self.handle = Some(handle);
         }
-        self.handle.unwrap()
+        self.handle.as_ref().unwrap()
     }
 
     /// Ask the backend whether to produce another element.
@@ -916,7 +916,8 @@ impl<'a> Collection<'a> {
         if self.finished {
             return false;
         }
-        let handle = self.ensure_initialized();
+        self.ensure_initialized();
+        let handle = self.handle.as_ref().unwrap();
         let result = match self.tc.with_ctc(|ctc| ctc.collection_more(handle)) {
             Ok(b) => b,
             Err(rc) => {
@@ -935,7 +936,8 @@ impl<'a> Collection<'a> {
         if self.finished {
             return;
         }
-        let handle = self.ensure_initialized();
+        self.ensure_initialized();
+        let handle = self.handle.as_ref().unwrap();
         let _ = self.tc.with_ctc(|ctc| ctc.collection_reject(handle, why));
     }
 }

--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -897,7 +897,7 @@ impl<'a> Collection<'a> {
         }
     }
 
-    fn ensure_initialized(&mut self) -> &crate::ffi::CollectionHandle {
+    fn ensure_initialized(&mut self) {
         if self.handle.is_none() {
             let result = self.tc.with_ctc(|ctc| {
                 ctc.new_collection(self.min_size as u64, self.max_size.map(|m| m as u64))
@@ -908,7 +908,6 @@ impl<'a> Collection<'a> {
             };
             self.handle = Some(handle);
         }
-        self.handle.as_ref().unwrap()
     }
 
     /// Ask the backend whether to produce another element.

--- a/tests/embedded/ffi_tests.rs
+++ b/tests/embedded/ffi_tests.rs
@@ -56,20 +56,20 @@ fn ffi_drives_a_passing_run_exercising_every_primitive() {
 
         tc.start_span(hegel_c::hegel_label_t::HEGEL_LABEL_LIST as u64)
             .unwrap();
-        let cid = tc.new_collection(0, Some(3)).unwrap();
+        let collection = tc.new_collection(0, Some(3)).unwrap();
         loop {
-            if !tc.collection_more(cid)? {
+            if !tc.collection_more(&collection)? {
                 break;
             }
             if tc.generate_integer(0, 100)? == 0 {
-                tc.collection_reject(cid, Some("zero")).unwrap();
+                tc.collection_reject(&collection, Some("zero")).unwrap();
             }
         }
         tc.stop_span(false).unwrap();
 
         let pool = tc.new_pool().unwrap();
-        let added = tc.pool_add(pool).unwrap();
-        let drawn = tc.pool_generate(pool, false)?;
+        let added = tc.pool_add(&pool).unwrap();
+        let drawn = tc.pool_generate(&pool, false)?;
         assert_eq!(drawn, added, "non-consuming draw returns the added id");
 
         tc.target(0.0, "score").unwrap();
@@ -117,6 +117,30 @@ fn ffi_drives_a_passing_run_exercising_every_primitive() {
     assert!(result.status() == hegel_c::hegel_run_status_t::HEGEL_RUN_STATUS_PASSED);
     assert_eq!(result.failure_count(), 0);
     assert!(result.error().is_none());
+}
+
+/// The collection / pool / state-machine constructors surface libhegel's
+/// error code instead of a handle: on a completed test case each returns
+/// `HEGEL_E_ALREADY_COMPLETE`.
+#[test]
+fn ffi_object_constructors_error_on_a_completed_case() {
+    const ALREADY_COMPLETE: hegel_c::hegel_result_t =
+        hegel_c::hegel_result_t::HEGEL_E_ALREADY_COMPLETE;
+    let settings = test_settings(2);
+    let sh = SettingsHandle::build(&settings, None);
+    let run = RunHandle::start(&sh, None).unwrap();
+    while let Some(tc) = run.next_test_case() {
+        tc.mark_complete(VALID, None).unwrap();
+        assert!(matches!(
+            tc.new_collection(0, Some(3)),
+            Err(ALREADY_COMPLETE)
+        ));
+        assert!(matches!(tc.new_pool(), Err(ALREADY_COMPLETE)));
+        assert!(matches!(
+            tc.new_state_machine(&["only"], &[]),
+            Err(ALREADY_COMPLETE)
+        ));
+    }
 }
 
 #[test]


### PR DESCRIPTION
<details><summary>AI-generated implementation notes</summary>

## What

Replaces the `int64_t` ids for collections, variable pools, and state machines with opaque caller-owned handles across the C ABI (breaking change): `hegel_new_collection` / `hegel_new_pool` / `hegel_new_state_machine` now write `hegel_collection_t*` / `hegel_pool_t*` / `hegel_state_machine_t*` through their out-parameters, the per-object operations take that handle alongside the test-case handle, and each handle is released exactly once with a new matching free function (`hegel_collection_free` / `hegel_pool_free` / `hegel_state_machine_free`). The header `hegel-c/include/hegel.h` is regenerated, the C examples and the Rust frontend (`src/ffi.rs` gains owned `CollectionHandle` / `PoolHandle` / `StateMachineHandle` wrappers) are ported, and `hegel-c/RELEASE.md` documents the break with a before/after snippet.

## Why

The id-based API kept per-family object tables inside engine state, which is exactly the kind of shared mutable registry the no_std/dlclose work needs to eliminate. Each handle now owns its object state directly behind a `parking_lot::Mutex` (`HegelCollection{Mutex<ManyState>}`, `HegelPool{Mutex<NativeVariables>}`, `HegelStateMachine{Mutex<NativeStateMachine>}`); no references back into engine state are needed because all draws come from the calling test case's stream, so frees are safe in any order, including after `hegel_run_free`. Locking: collection ops `try_lock` and report `HEGEL_E_CONCURRENT_USE` on contention; pool and state-machine ops take a blocking lock so clone handles on parallel threads can share them. Lock order is always tc.local -> object -> stream, cycle-free; this also removes a latent family-wide lock previously held across element draws. Creation calls still flow through the data source so budget-exhausted cases keep returning `HEGEL_E_STOP_TEST`.

## Review findings and how they were resolved

Three reviewers examined the diff; all findings were low severity, none must-fix.

- **`Collection::ensure_initialized` dead return value** (`src/test_case.rs`) — fixed: signature changed to return `()`; both callers already re-fetched the handle themselves (the re-fetch is required because holding the returned `&CollectionHandle` would keep `self` mutably borrowed across the subsequent `self.tc.with_ctc` call).
- **`|_ntc|` closure parameters** (`hegel-c/src/native/data_source.rs` lines 254, 283, 298, 302) — fixed: changed to `|_|` per the repo convention against underscore-renaming unused bindings.
- **Inaccurate SAFETY comments on the three new `Drop` impls** (`src/ffi.rs`) — fixed: verified the constructors return `Err(rc)` before ever constructing a handle, so the "null after a failed creation" parenthetical described an unreachable state; the comments now state only what is true (pointer from a successful creation, freed exactly once).
- **Missing `HEGEL_E_STOP_TEST` in error-code listings** (`hegel-c/src/lib.rs` rustdoc for `hegel_collection_more`, `hegel_collection_reject`, `hegel_pool_add`, `hegel_pool_generate`) — fixed: verified these ops do return `HEGEL_E_STOP_TEST` after overrun (asserted by `primitives_after_overrun_all_report_stop_test`); docs updated and the header regenerated with `just c-header`.
- **`RELEASE_TYPE: minor` vs the stage brief's "major"** (`hegel-c/RELEASE.md`) — refuted / no change: the repo changelog skill is explicit that `major` is not used while zerover and breaking changes are `minor`; hegel-c is 0.30.x, so `minor` is correct and the stage brief's "major" was the error.
- **Two-thread collection test stands in for the second thread by holding the internal state lock** (`hegel-c/tests/embedded/lib_tests.rs`) — no change: this mirrors the documented precedent of `concurrent_use_of_one_handle_is_rejected` and is deterministic where a real racing thread would be flaky; reviewers agreed it is acceptable.
- **dlclose SIGSEGV / static-example "Text file busy" flakes** — environmental observations, no change needed; see verification below for this run's status.

## Verification

All run on this branch after the fixes above:

- `just lint` — exit 0.
- `cargo test --workspace` — exit 0, all `test result:` summaries 0 failed.
- `cargo test --all-features` — exit 0, all summaries 0 failed.
- `just c-test` — exit 0: hegel-c unit/integration suites all green, all C examples (shared and static) built and ran successfully. The known dlclose-sensitive smoke test `libhegel_replays_persisted_failure_with_same_database_key` passed (no segfault) in this run; it is known to SIGSEGV intermittently at dlclose on this platform (aarch64/glibc) — that is the root-cause bug this series fixes in stages 4/5. The previously observed static-example "Text file busy" flake did not reproduce.

## Open questions for David

- `just miri` fails on aarch64 with "unsupported operation: inline assembly is not supported" in libm 0.2.16's `fsqrt` (via `LogStudentTDistribution::new`). This is inherited from stage 1's libm routing — verified reproducible on unmodified `no-std-1-mechanical-ports` — and needs a stage-1 fix (e.g. a `cfg(miri)` soft-float fallback), not a fix here.
- No coverage exceptions: no `// nocov` added and no ratchet numbers changed.
- No root `RELEASE.md`: the hegeltest-visible surface is unchanged (the autogenerated dependency-bump entry suffices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>
