### PR TITLE
Fix novel-prefix generation flipping rare booleans at 50/50

### DIFF
--- a/hegel-c/RELEASE.md
+++ b/hegel-c/RELEASE.md
@@ -1,0 +1,8 @@
+RELEASE_TYPE: patch
+
+This patch fixes the engine's novel-prefix exploration treating every
+recorded boolean draw as a fair coin, regardless of the probability it was
+actually drawn with. Stateful tests were most affected: the per-step stop
+decision is a very rare draw, but exploration flipped it about half the
+time, so roughly half of all generated stateful test cases were truncated
+well before their step target.

--- a/hegel-c/RELEASE.md
+++ b/hegel-c/RELEASE.md
@@ -1,8 +1,5 @@
 RELEASE_TYPE: patch
 
-This patch fixes the engine's novel-prefix exploration treating every
-recorded boolean draw as a fair coin, regardless of the probability it was
-actually drawn with. Stateful tests were most affected: the per-step stop
-decision is a very rare draw, but exploration flipped it about half the
-time, so roughly half of all generated stateful test cases were truncated
-well before their step target.
+This patch fixes a bias in data generation where some choices were made with the wrong probability.
+The most visible effect should be the stateful tests should run a full set of steps more often.
+Collection sizes may also be affected.

--- a/hegel-c/src/native/core/choices.rs
+++ b/hegel-c/src/native/core/choices.rs
@@ -115,9 +115,20 @@ impl IntegerChoice {
     }
 }
 
-/// A boolean choice. Simplest value is `false`.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct BooleanChoice;
+/// A boolean choice drawn with probability `p` of `true`. Simplest value is
+/// `false`.
+#[derive(Clone, Debug)]
+pub struct BooleanChoice {
+    pub p: f64,
+}
+
+impl PartialEq for BooleanChoice {
+    fn eq(&self, other: &Self) -> bool {
+        self.p.to_bits() == other.p.to_bits()
+    }
+}
+
+impl Eq for BooleanChoice {}
 
 impl BooleanChoice {
     pub fn simplest(&self) -> bool {
@@ -1214,7 +1225,9 @@ impl ChoiceKind {
             (ChoiceKind::Integer(ic), ChoiceValue::Integer(v)) if ic.validate(v) => {
                 Some(ChoiceData::Integer(Arc::clone(ic), v.clone()))
             }
-            (ChoiceKind::Boolean(_), ChoiceValue::Boolean(v)) => Some(ChoiceData::Boolean(*v)),
+            (ChoiceKind::Boolean(bc), ChoiceValue::Boolean(v)) => {
+                Some(ChoiceData::Boolean(bc.clone(), *v))
+            }
             (ChoiceKind::Float(fc), ChoiceValue::Float(v)) if fc.validate(*v) => {
                 Some(ChoiceData::Float(fc.clone(), *v))
             }
@@ -1282,9 +1295,13 @@ impl ChoiceKind {
             ChoiceKind::Integer(ic) => Some(ChoiceValue::Integer(
                 crate::native::core::state::biased_integer_sample(ic, rng)?,
             )),
-            ChoiceKind::Boolean(_) => Some(ChoiceValue::Boolean(
-                crate::native::core::state::weighted_boolean_sample(0.5, rng),
-            )),
+            ChoiceKind::Boolean(bc) => Some(ChoiceValue::Boolean(if bc.p <= 0.0 {
+                false
+            } else if bc.p >= 1.0 {
+                true
+            } else {
+                crate::native::core::state::weighted_boolean_sample_precise(bc.p, rng)
+            })),
             ChoiceKind::Float(fc) => Some(ChoiceValue::Float(
                 crate::native::core::state::biased_float_sample(fc, rng)?,
             )),
@@ -1353,7 +1370,7 @@ impl ChoiceKind {
 #[derive(Clone, Debug)]
 pub enum ChoiceData {
     Integer(Arc<IntegerChoice>, BigInt),
-    Boolean(bool),
+    Boolean(BooleanChoice, bool),
     Float(FloatChoice, f64),
     Bytes(BytesChoice, Vec<u8>),
     String(StringChoice, Vec<u32>),
@@ -1364,7 +1381,7 @@ impl PartialEq for ChoiceData {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (ChoiceData::Integer(ac, av), ChoiceData::Integer(bc, bv)) => ac == bc && av == bv,
-            (ChoiceData::Boolean(a), ChoiceData::Boolean(b)) => a == b,
+            (ChoiceData::Boolean(ac, av), ChoiceData::Boolean(bc, bv)) => ac == bc && av == bv,
             (ChoiceData::Float(ac, av), ChoiceData::Float(bc, bv)) => {
                 ac == bc && av.to_bits() == bv.to_bits()
             }
@@ -1387,7 +1404,7 @@ impl ChoiceData {
     pub fn kind(&self) -> ChoiceKind {
         match self {
             ChoiceData::Integer(ic, _) => ChoiceKind::Integer(Arc::clone(ic)),
-            ChoiceData::Boolean(_) => ChoiceKind::Boolean(BooleanChoice),
+            ChoiceData::Boolean(bc, _) => ChoiceKind::Boolean(bc.clone()),
             ChoiceData::Float(fc, _) => ChoiceKind::Float(fc.clone()),
             ChoiceData::Bytes(bc, _) => ChoiceKind::Bytes(bc.clone()),
             ChoiceData::String(sc, _) => ChoiceKind::String(sc.clone()),
@@ -1401,7 +1418,7 @@ impl ChoiceData {
     pub fn value(&self) -> ChoiceValue {
         match self {
             ChoiceData::Integer(_, v) => ChoiceValue::Integer(v.clone()),
-            ChoiceData::Boolean(v) => ChoiceValue::Boolean(*v),
+            ChoiceData::Boolean(_, v) => ChoiceValue::Boolean(*v),
             ChoiceData::Float(_, v) => ChoiceValue::Float(*v),
             ChoiceData::Bytes(_, v) => ChoiceValue::Bytes(v.clone()),
             ChoiceData::String(_, v) => ChoiceValue::String(v.clone()),
@@ -1415,7 +1432,7 @@ impl ChoiceData {
     pub fn value_ref(&self) -> ChoiceValueRef<'_> {
         match self {
             ChoiceData::Integer(_, v) => ChoiceValueRef::Integer(v),
-            ChoiceData::Boolean(v) => ChoiceValueRef::Boolean(*v),
+            ChoiceData::Boolean(_, v) => ChoiceValueRef::Boolean(*v),
             ChoiceData::Float(_, v) => ChoiceValueRef::Float(*v),
             ChoiceData::Bytes(_, v) => ChoiceValueRef::Bytes(v),
             ChoiceData::String(_, v) => ChoiceValueRef::String(v),
@@ -1435,7 +1452,7 @@ impl ChoiceData {
     pub fn is_simplest(&self) -> Result<bool, InternalError> {
         Ok(match self {
             ChoiceData::Integer(ic, v) => *v == ic.simplest(),
-            ChoiceData::Boolean(v) => !v,
+            ChoiceData::Boolean(_, v) => !v,
             ChoiceData::Float(fc, v) => v.to_bits() == fc.simplest()?.to_bits(),
             ChoiceData::Bytes(bc, v) => *v == bc.simplest(),
             ChoiceData::String(sc, v) => *v == sc.simplest()?,
@@ -1447,7 +1464,7 @@ impl ChoiceData {
     pub fn with_simplest(&self) -> Result<ChoiceData, InternalError> {
         Ok(match self {
             ChoiceData::Integer(ic, _) => ChoiceData::Integer(Arc::clone(ic), ic.simplest()),
-            ChoiceData::Boolean(_) => ChoiceData::Boolean(false),
+            ChoiceData::Boolean(bc, _) => ChoiceData::Boolean(bc.clone(), false),
             ChoiceData::Float(fc, _) => ChoiceData::Float(fc.clone(), fc.simplest()?),
             ChoiceData::Bytes(bc, _) => ChoiceData::Bytes(bc.clone(), bc.simplest()),
             ChoiceData::String(sc, _) => ChoiceData::String(sc.clone(), sc.simplest()?),
@@ -1473,7 +1490,7 @@ impl ChoiceData {
     pub fn to_index(&self) -> Result<Option<crate::native::bignum::BigUint>, InternalError> {
         Ok(match self {
             ChoiceData::Integer(ic, v) => Some(ic.to_index(v)),
-            ChoiceData::Boolean(v) => Some(BooleanChoice.to_index(*v)),
+            ChoiceData::Boolean(bc, v) => Some(bc.to_index(*v)),
             ChoiceData::Float(fc, v) => Some(fc.to_index(*v)?),
             ChoiceData::Bytes(bc, v) => Some(bc.to_index(v)),
             ChoiceData::String(sc, v) => Some(sc.to_index(v)),
@@ -1592,8 +1609,8 @@ impl ChoiceNode {
     }
 
     /// A boolean node.
-    pub fn boolean(value: bool, was_forced: bool) -> Self {
-        Self::new(ChoiceData::Boolean(value), was_forced)
+    pub fn boolean(constraint: BooleanChoice, value: bool, was_forced: bool) -> Self {
+        Self::new(ChoiceData::Boolean(constraint, value), was_forced)
     }
 
     /// A float node.
@@ -1768,7 +1785,9 @@ impl ChoiceNode {
                 let (mag, neg) = ic.sort_key(v);
                 NodeSortKeyRef::Scalar(mag, neg)
             }
-            ChoiceData::Boolean(v) => NodeSortKeyRef::Scalar(BigUint::from(u32::from(*v)), false),
+            ChoiceData::Boolean(_, v) => {
+                NodeSortKeyRef::Scalar(BigUint::from(u32::from(*v)), false)
+            }
             ChoiceData::Float(fc, v) => {
                 let (mag, neg) = fc.sort_key(*v);
                 NodeSortKeyRef::Scalar(BigUint::from(mag), neg)

--- a/hegel-c/src/native/core/state.rs
+++ b/hegel-c/src/native/core/state.rs
@@ -1674,7 +1674,7 @@ impl NativeTestCase {
         forced: Option<bool>,
         sample: impl Fn(f64, &mut EngineRng) -> bool,
     ) -> Result<bool, EngineError> {
-        let kind = BooleanChoice;
+        let kind = BooleanChoice { p };
 
         let forced_value = forced.or(if p <= 0.0 {
             Some(false)
@@ -1699,7 +1699,7 @@ impl NativeTestCase {
             )?
         };
 
-        self.nodes.push(ChoiceNode::boolean(v, was_forced));
+        self.nodes.push(ChoiceNode::boolean(kind, v, was_forced));
 
         if let Some(ref mut obs) = self.observer {
             obs.draw_boolean(v, was_forced);

--- a/hegel-c/src/native/data_tree.rs
+++ b/hegel-c/src/native/data_tree.rs
@@ -61,7 +61,7 @@ impl From<&ChoiceData> for ChoiceValueKey {
     fn from(d: &ChoiceData) -> Self {
         match d {
             ChoiceData::Integer(_, n) => ChoiceValueKey::Integer(n.clone()),
-            ChoiceData::Boolean(b) => ChoiceValueKey::Boolean(*b),
+            ChoiceData::Boolean(_, b) => ChoiceValueKey::Boolean(*b),
             ChoiceData::Float(_, f) => ChoiceValueKey::Float(f.to_bits()),
             ChoiceData::Bytes(_, b) => ChoiceValueKey::Bytes(b.clone()),
             ChoiceData::String(_, s) => ChoiceValueKey::String(s.clone()),

--- a/hegel-c/src/native/shrinker/deletion.rs
+++ b/hegel-c/src/native/shrinker/deletion.rs
@@ -33,7 +33,9 @@ impl<'a> Shrinker<'a> {
                         ChoiceData::Integer(ic, v) if *v != ic.simplest() => ic
                             .value_from_bigint(&(v.clone() - 1))
                             .map(|nv| ChoiceData::Integer(alloc::sync::Arc::clone(ic), nv)),
-                        ChoiceData::Boolean(true) => Some(ChoiceData::Boolean(false)),
+                        ChoiceData::Boolean(bc, true) => {
+                            Some(ChoiceData::Boolean(bc.clone(), false))
+                        }
                         _ => None,
                     };
                     if let Some(new_data) = decremented {

--- a/hegel-c/src/native/shrinker/sequence.rs
+++ b/hegel-c/src/native/shrinker/sequence.rs
@@ -27,7 +27,7 @@ impl<'a> Shrinker<'a> {
     }
 
     pub(super) async fn sort_values_booleans(&mut self) -> ShrinkResult<()> {
-        self.try_sort_group(|d| matches!(d, ChoiceData::Boolean(_)))
+        self.try_sort_group(|d| matches!(d, ChoiceData::Boolean(..)))
             .await
     }
 

--- a/hegel-c/src/native/targeting.rs
+++ b/hegel-c/src/native/targeting.rs
@@ -304,7 +304,7 @@ pub(crate) fn is_climbable(data: &ChoiceData) -> bool {
         data,
         ChoiceData::Integer(..)
             | ChoiceData::Float(..)
-            | ChoiceData::Boolean(_)
+            | ChoiceData::Boolean(..)
             | ChoiceData::Bytes(..)
     )
 }
@@ -327,7 +327,7 @@ pub(crate) fn step_choice(node: &ChoiceNode, delta: i128) -> Option<ChoiceValue>
             }
             Some(ChoiceValue::Float(new))
         }
-        ChoiceData::Boolean(b) => {
+        ChoiceData::Boolean(_, b) => {
             if delta.saturating_abs() > 1 {
                 return None;
             }

--- a/hegel-c/tests/embedded/native/choices_tests.rs
+++ b/hegel-c/tests/embedded/native/choices_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::native::core::choices::BooleanChoice;
 use alloc::string::ToString;
 
 #[test]
@@ -139,7 +140,7 @@ fn integer_full_i128_range_is_two_pow_128() {
 
 #[test]
 fn max_children_saturating_boolean() {
-    let kind = ChoiceKind::Boolean(BooleanChoice);
+    let kind = ChoiceKind::Boolean(BooleanChoice { p: 0.5 });
     assert_eq!(kind.max_children_saturating(1), 1);
     assert_eq!(kind.max_children_saturating(10), 2);
 }
@@ -344,7 +345,7 @@ fn integer_choice_index_round_trip_shrink_towards_clamped_outside_range() {
 #[test]
 fn boolean_is_always_two() {
     assert_eq!(
-        ChoiceKind::Boolean(BooleanChoice).max_children(),
+        ChoiceKind::Boolean(BooleanChoice { p: 0.5 }).max_children(),
         Some(bu(2))
     );
 }
@@ -915,8 +916,10 @@ fn choice_kind_unit_dispatches_to_each_sub_kind() {
     );
 
     assert_eq!(
-        ChoiceKind::Boolean(BooleanChoice).unit().unwrap(),
-        ChoiceValue::Boolean(BooleanChoice.unit())
+        ChoiceKind::Boolean(BooleanChoice { p: 0.5 })
+            .unit()
+            .unwrap(),
+        ChoiceValue::Boolean(BooleanChoice { p: 0.5 }.unit())
     );
 
     let fch = fc(0.0, 10.0, false, false);
@@ -1046,28 +1049,51 @@ fn string_to_index_via_dispatch() {
     assert_eq!(data.to_index().unwrap(), Some(bu(0)));
 }
 
-/// An unbiased boolean drawn via `random_value` must spend exactly one byte of
-/// entropy (it routes through `weighted_boolean_sample(0.5, …)`), not a whole
-/// `u32`. The urandom backend feeds every byte from the fuzzer, so a one-bit
-/// decision must cost one byte. Regression for a bare `rng.random::<bool>()`.
+/// A boolean drawn via `random_value` must sample from the kind's recorded
+/// `p`; a hardcoded 0.5 used to flip every recorded boolean half the time.
 #[test]
-fn random_value_boolean_consumes_exactly_one_byte() {
+fn random_value_boolean_respects_p() {
     use crate::native::rng::EngineRng;
-    use rand::Rng;
 
-    let kind = ChoiceKind::Boolean(BooleanChoice);
-    let mut a = EngineRng::seeded(2024);
-    let mut b = EngineRng::seeded(2024);
+    let rare = ChoiceKind::Boolean(BooleanChoice { p: 0.01 });
+    let mut rng = EngineRng::seeded(2024);
+    let mut trues = 0;
+    for _ in 0..1000 {
+        if rare.random_value(&mut rng).unwrap().unwrap() == ChoiceValue::Boolean(true) {
+            trues += 1;
+        }
+    }
+    assert!(trues < 50, "p = 0.01 produced {trues}/1000 trues");
 
-    let value = kind.random_value(&mut a).unwrap().unwrap();
-    let ChoiceValue::Boolean(got) = value else {
-        panic!("expected a boolean choice value");
-    };
+    let common = ChoiceKind::Boolean(BooleanChoice { p: 0.99 });
+    let mut trues = 0;
+    for _ in 0..1000 {
+        if common.random_value(&mut rng).unwrap().unwrap() == ChoiceValue::Boolean(true) {
+            trues += 1;
+        }
+    }
+    assert!(trues > 950, "p = 0.99 produced only {trues}/1000 trues");
+}
 
-    let mut byte = [0u8; 1];
-    b.fill_bytes(&mut byte);
-    assert_eq!(got, u32::from(byte[0]) >= 128);
-    assert_eq!(a.next_u64(), b.next_u64());
+/// `p <= 0` and `p >= 1` must resolve deterministically rather than reach
+/// the precise sampler, which panics outside `(0, 1)`.
+#[test]
+fn random_value_boolean_degenerate_p_is_deterministic() {
+    use crate::native::rng::EngineRng;
+
+    let mut rng = EngineRng::seeded(1);
+    let never = ChoiceKind::Boolean(BooleanChoice { p: 0.0 });
+    let always = ChoiceKind::Boolean(BooleanChoice { p: 1.0 });
+    for _ in 0..20 {
+        assert_eq!(
+            never.random_value(&mut rng).unwrap().unwrap(),
+            ChoiceValue::Boolean(false)
+        );
+        assert_eq!(
+            always.random_value(&mut rng).unwrap().unwrap(),
+            ChoiceValue::Boolean(true)
+        );
+    }
 }
 
 #[test]
@@ -1120,7 +1146,7 @@ fn string_choice_simplest_on_empty_alphabet_is_an_internal_error() {
 }
 
 fn boolean_node(value: bool) -> ChoiceNode {
-    ChoiceNode::boolean(value, false)
+    ChoiceNode::boolean(BooleanChoice { p: 0.5 }, value, false)
 }
 
 fn clone_node(children: Vec<ChoiceNode>) -> ChoiceNode {
@@ -1396,7 +1422,10 @@ fn clone_kind_random_value_is_none() {
 fn choice_data_equality_compares_constraint_and_value() {
     let pairs = [
         (integer_node(0, 10, 3).data, integer_node(0, 10, 4).data),
-        (ChoiceData::Boolean(false), ChoiceData::Boolean(true)),
+        (
+            ChoiceData::Boolean(BooleanChoice { p: 0.5 }, false),
+            ChoiceData::Boolean(BooleanChoice { p: 0.5 }, true),
+        ),
         (
             ChoiceNode::float(fc(0.0, 1.0, false, false), 0.25, false).data,
             ChoiceNode::float(fc(0.0, 1.0, false, false), 0.5, false).data,

--- a/hegel-c/tests/embedded/native/data_tree_tests.rs
+++ b/hegel-c/tests/embedded/native/data_tree_tests.rs
@@ -22,11 +22,11 @@ fn int_node(min: i128, max: i128, value: i128) -> ChoiceNode {
 }
 
 fn bool_node(value: bool) -> ChoiceNode {
-    ChoiceNode::boolean(value, false)
+    ChoiceNode::boolean(BooleanChoice { p: 0.5 }, value, false)
 }
 
 fn forced_bool_node(value: bool) -> ChoiceNode {
-    ChoiceNode::boolean(value, true)
+    ChoiceNode::boolean(BooleanChoice { p: 0.5 }, value, true)
 }
 
 #[test]
@@ -127,6 +127,38 @@ fn generate_novel_prefix_terminates_when_subtree_exhausted() {
     assert!(prefix.is_empty());
 }
 
+/// The novel-prefix walk must sample boolean proposals from the recorded
+/// draw's `p`, not a fair coin: while the common branch is unexhausted, a
+/// rare branch like the `p = 2^-16` stateful stop signal must stay rare.
+#[test]
+fn novel_prefix_respects_boolean_probability() {
+    let mut root = DataTreeNode::default();
+    for x in 0..100 {
+        record_tree(
+            &mut root,
+            &[
+                ChoiceNode::boolean(BooleanChoice { p: 1.0 / 65536.0 }, false, false),
+                int_node(0, 1_000_000, x),
+            ],
+            Status::Valid,
+            &[],
+        );
+    }
+    let mut rng = EngineRng::seeded(0);
+    let mut rare_first = 0;
+    for _ in 0..200 {
+        let prefix = generate_novel_prefix(&root, &mut rng).unwrap();
+        if prefix.first() == Some(&ChoiceValue::Boolean(true)) {
+            rare_first += 1;
+        }
+    }
+    assert!(
+        rare_first <= 5,
+        "the p = 2^-16 branch was proposed {rare_first}/200 times; the \
+         novel-prefix walk should sample from the recorded p, not 50/50"
+    );
+}
+
 #[test]
 fn simulate_unseen_on_empty_tree() {
     let root = DataTreeNode::default();
@@ -197,7 +229,7 @@ fn simulate_returns_interesting_conclusion() {
 
 #[test]
 fn simulate_follows_forced_value_ignoring_prefix() {
-    let forced_true = ChoiceNode::boolean(true, true);
+    let forced_true = ChoiceNode::boolean(BooleanChoice { p: 0.5 }, true, true);
     let mut root = DataTreeNode::default();
     record_tree(&mut root, &[forced_true], Status::Valid, &[]);
 
@@ -330,7 +362,10 @@ fn record_and_simulate_roundtrip_with_clone_nodes() {
     };
     let realized = record.realized_nodes().unwrap();
     assert_eq!(realized.len(), 2);
-    assert_eq!(realized[0].kind(), ChoiceKind::Boolean(BooleanChoice));
+    assert_eq!(
+        realized[0].kind(),
+        ChoiceKind::Boolean(BooleanChoice { p: 0.5 })
+    );
     assert_eq!(realized[1].value(), ChoiceValue::Integer(BigInt::from(2)));
 
     let values_only: Vec<ChoiceValue> = vec![

--- a/hegel-c/tests/embedded/native/database_tests.rs
+++ b/hegel-c/tests/embedded/native/database_tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::native::bignum::BigInt;
 use crate::native::core::ChoiceValue;
+use crate::native::core::choices::BooleanChoice;
 use alloc::string::ToString;
 use alloc::vec;
 use tempfile::TempDir;
@@ -464,7 +465,7 @@ fn serialize_roundtrips_clone_values() {
 fn serialize_clone_drops_realized_info_but_preserves_equality() {
     use crate::native::core::{ChoiceNode, CloneRecord, Span, SpanEvent};
     let realized = ChoiceValue::Clone(std::sync::Arc::new(CloneRecord::from_run(
-        vec![ChoiceNode::boolean(true, false)],
+        vec![ChoiceNode::boolean(BooleanChoice { p: 0.5 }, true, false)],
         vec![Span {
             start: 0,
             end: 1,

--- a/hegel-c/tests/embedded/native/shrinker_cache_tests.rs
+++ b/hegel-c/tests/embedded/native/shrinker_cache_tests.rs
@@ -13,6 +13,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use crate::exchange::drive_no_yield;
+use crate::native::core::choices::BooleanChoice;
 use crate::native::core::choices::IntegerChoice;
 use crate::native::core::{ChoiceNode, ChoiceValue, Spans};
 use crate::native::shrinker::search::FindInteger;
@@ -31,7 +32,7 @@ fn int_node(value: i128) -> ChoiceNode {
 }
 
 fn bool_node(value: bool) -> ChoiceNode {
-    ChoiceNode::boolean(value, false)
+    ChoiceNode::boolean(BooleanChoice { p: 0.5 }, value, false)
 }
 
 #[test]

--- a/hegel-c/tests/embedded/native/shrinker_clones_tests.rs
+++ b/hegel-c/tests/embedded/native/shrinker_clones_tests.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use crate::exchange::drive_no_yield;
 use crate::native::bignum::BigInt;
+use crate::native::core::choices::BooleanChoice;
 use crate::native::core::choices::IntegerChoice;
 use crate::native::core::{ChoiceNode, ChoiceValue, RealizedStream, Spans};
 use crate::native::shrinker::{ShrinkRun, Shrinker};
@@ -22,7 +23,7 @@ fn int_node(value: i128) -> ChoiceNode {
 }
 
 fn bool_node(value: bool) -> ChoiceNode {
-    ChoiceNode::boolean(value, false)
+    ChoiceNode::boolean(BooleanChoice { p: 0.5 }, value, false)
 }
 
 fn clone_node(children: Vec<ChoiceNode>) -> ChoiceNode {

--- a/hegel-c/tests/embedded/native/shrinker_defensive_branch_tests.rs
+++ b/hegel-c/tests/embedded/native/shrinker_defensive_branch_tests.rs
@@ -8,6 +8,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use crate::exchange::drive_no_yield;
+use crate::native::core::choices::BooleanChoice;
 use crate::native::core::choices::IntegerChoice;
 use crate::native::core::{ChoiceNode, ChoiceValue, Spans};
 use crate::native::shrinker::{ShrinkRun, Shrinker};
@@ -124,7 +125,7 @@ fn lower_integers_together_skips_kind_punning() {
             ShrinkRun::Full(nodes) => {
                 let mut out: Vec<ChoiceNode> = nodes.to_vec();
                 if out.len() >= 2 {
-                    out[1] = ChoiceNode::boolean(true, false);
+                    out[1] = ChoiceNode::boolean(BooleanChoice { p: 0.5 }, true, false);
                 }
                 (true, out, Spans::new())
             }
@@ -142,7 +143,7 @@ fn lower_integers_together_survives_accepted_same_length_kind_pun() {
         Box::new(|run: ShrinkRun<'_>| match run {
             ShrinkRun::Full(nodes) => {
                 let mut out: Vec<ChoiceNode> = nodes.to_vec();
-                out[0] = ChoiceNode::boolean(false, false);
+                out[0] = ChoiceNode::boolean(BooleanChoice { p: 0.5 }, false, false);
                 (true, out, Spans::new())
             }
             ShrinkRun::Probe { .. } => (false, Vec::new(), Spans::new()),
@@ -227,7 +228,7 @@ fn try_shortening_via_increment_skips_a_node_punned_mid_candidates() {
         Box::new(|run: ShrinkRun<'_>| match run {
             ShrinkRun::Full(nodes) => {
                 let mut out: Vec<ChoiceNode> = nodes.to_vec();
-                out[0] = ChoiceNode::boolean(false, false);
+                out[0] = ChoiceNode::boolean(BooleanChoice { p: 0.5 }, false, false);
                 (true, out, Spans::new())
             }
             ShrinkRun::Probe { .. } => (false, Vec::new(), Spans::new()),
@@ -238,6 +239,6 @@ fn try_shortening_via_increment_skips_a_node_punned_mid_candidates() {
     drive_no_yield(shrinker.try_shortening_via_increment()).unwrap();
     assert!(matches!(
         shrinker.current_nodes[0].data,
-        ChoiceData::Boolean(false)
+        ChoiceData::Boolean(_, false)
     ));
 }

--- a/hegel-c/tests/embedded/native/shrinker_forced_node_tests.rs
+++ b/hegel-c/tests/embedded/native/shrinker_forced_node_tests.rs
@@ -4,6 +4,7 @@
 
 use crate::exchange::drive_no_yield;
 use crate::native::bignum::BigInt;
+use crate::native::core::choices::BooleanChoice;
 use crate::native::core::choices::{BytesChoice, FloatChoice, IntegerChoice};
 use crate::native::core::{ChoiceNode, ChoiceValue, Spans};
 use crate::native::shrinker::{ShrinkRun, Shrinker};
@@ -38,7 +39,7 @@ fn float_node(value: f64, was_forced: bool) -> ChoiceNode {
 }
 
 fn bool_node(value: bool, was_forced: bool) -> ChoiceNode {
-    ChoiceNode::boolean(value, was_forced)
+    ChoiceNode::boolean(BooleanChoice { p: 0.5 }, value, was_forced)
 }
 
 fn bytes_node(value: Vec<u8>, was_forced: bool) -> ChoiceNode {

--- a/hegel-c/tests/embedded/native/shrinker_lower_common_node_offset_tests.rs
+++ b/hegel-c/tests/embedded/native/shrinker_lower_common_node_offset_tests.rs
@@ -2,6 +2,7 @@
 
 use crate::exchange::drive_no_yield;
 use crate::native::bignum::BigInt;
+use crate::native::core::choices::BooleanChoice;
 use crate::native::core::choices::IntegerChoice;
 use crate::native::core::{ChoiceNode, ChoiceValue, Spans};
 use crate::native::shrinker::{ShrinkRun, Shrinker};
@@ -113,7 +114,7 @@ fn lower_common_node_offset_handles_negative_shrink_target() {
 #[test]
 fn lower_common_node_offset_skips_non_integer_nodes() {
     use crate::native::core::choices::FloatChoice;
-    let bool_node = ChoiceNode::boolean(true, false);
+    let bool_node = ChoiceNode::boolean(BooleanChoice { p: 0.5 }, true, false);
     let float_node = ChoiceNode::float(
         FloatChoice {
             min_value: f64::NEG_INFINITY,
@@ -136,7 +137,7 @@ fn lower_common_node_offset_skips_non_integer_nodes() {
     );
     drive_no_yield(shrinker.consider(&[
         int_node(3, 0),
-        ChoiceNode::boolean(false, false),
+        ChoiceNode::boolean(BooleanChoice { p: 0.5 }, false, false),
         ChoiceNode::float(
             FloatChoice {
                 min_value: f64::NEG_INFINITY,

--- a/hegel-c/tests/embedded/native/shrinker_minimize_duplicated_choices_tests.rs
+++ b/hegel-c/tests/embedded/native/shrinker_minimize_duplicated_choices_tests.rs
@@ -3,6 +3,7 @@
 
 use crate::exchange::drive_no_yield;
 use crate::native::bignum::BigInt;
+use crate::native::core::choices::BooleanChoice;
 use crate::native::core::choices::{BytesChoice, FloatChoice, IntegerChoice, StringChoice};
 use crate::native::core::{ChoiceNode, ChoiceValue, Spans};
 use crate::native::intervalsets::IntervalSet;
@@ -12,7 +13,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 fn bool_node(value: bool) -> ChoiceNode {
-    ChoiceNode::boolean(value, false)
+    ChoiceNode::boolean(BooleanChoice { p: 0.5 }, value, false)
 }
 
 fn float_node(value: f64) -> ChoiceNode {

--- a/hegel-c/tests/embedded/native/shrinker_node_program_tests.rs
+++ b/hegel-c/tests/embedded/native/shrinker_node_program_tests.rs
@@ -2,6 +2,7 @@
 
 use crate::exchange::drive_no_yield;
 use crate::native::bignum::BigInt;
+use crate::native::core::choices::BooleanChoice;
 use crate::native::core::choices::IntegerChoice;
 use crate::native::core::{ChoiceNode, ChoiceValue, Spans};
 use crate::native::shrinker::{ShrinkRun, Shrinker};
@@ -231,9 +232,9 @@ fn initial_node_count() -> usize {
 #[test]
 fn node_program_adaptively_deletes_long_false_run() {
     let mut initial: Vec<ChoiceNode> = (0..1000)
-        .map(|_| ChoiceNode::boolean(false, false))
+        .map(|_| ChoiceNode::boolean(BooleanChoice { p: 0.5 }, false, false))
         .collect();
-    initial.push(ChoiceNode::boolean(true, false));
+    initial.push(ChoiceNode::boolean(BooleanChoice { p: 0.5 }, true, false));
     let mut shrinker = Shrinker::with_probe(
         Box::new(|run: ShrinkRun<'_>| match run {
             ShrinkRun::Full(nodes) => {

--- a/hegel-c/tests/embedded/native/shrinker_remove_discarded_tests.rs
+++ b/hegel-c/tests/embedded/native/shrinker_remove_discarded_tests.rs
@@ -8,6 +8,7 @@ use alloc::vec::Vec;
 use std::sync::{Arc, Mutex};
 
 use crate::exchange::drive_no_yield;
+use crate::native::core::choices::BooleanChoice;
 use crate::native::core::choices::IntegerChoice;
 use crate::native::core::{ChoiceNode, ChoiceValue, Span, Spans};
 use crate::native::shrinker::{ShrinkProbe, ShrinkRun, Shrinker};
@@ -25,7 +26,7 @@ fn int_node(value: i128) -> ChoiceNode {
 }
 
 fn bool_node(value: bool) -> ChoiceNode {
-    ChoiceNode::boolean(value, false)
+    ChoiceNode::boolean(BooleanChoice { p: 0.5 }, value, false)
 }
 
 fn span(start: usize, end: usize, discarded: bool) -> Span {

--- a/hegel-c/tests/embedded/native/shrinker_sequence_tests.rs
+++ b/hegel-c/tests/embedded/native/shrinker_sequence_tests.rs
@@ -2,6 +2,7 @@
 
 use crate::exchange::drive_no_yield;
 use crate::native::bignum::BigInt;
+use crate::native::core::choices::BooleanChoice;
 use crate::native::core::choices::IntegerChoice;
 use crate::native::core::{ChoiceNode, ChoiceValue, Spans};
 use crate::native::shrinker::{ShrinkRun, Shrinker};
@@ -22,7 +23,7 @@ fn int_node(value: i128) -> ChoiceNode {
 }
 
 fn bool_node(value: bool) -> ChoiceNode {
-    ChoiceNode::boolean(value, false)
+    ChoiceNode::boolean(BooleanChoice { p: 0.5 }, value, false)
 }
 
 fn int_values(shrinker: &Shrinker) -> Vec<i128> {

--- a/hegel-c/tests/embedded/native/shrinker_spans_tests.rs
+++ b/hegel-c/tests/embedded/native/shrinker_spans_tests.rs
@@ -11,6 +11,7 @@
 
 use crate::exchange::drive_no_yield;
 use crate::native::bignum::BigInt;
+use crate::native::core::choices::BooleanChoice;
 use crate::native::core::choices::IntegerChoice;
 use crate::native::core::{ChoiceNode, ChoiceValue, Span, Spans};
 use crate::native::shrinker::{ShrinkRun, Shrinker};
@@ -32,7 +33,7 @@ fn int_node(value: i128) -> ChoiceNode {
 }
 
 fn bool_node(value: bool) -> ChoiceNode {
-    ChoiceNode::boolean(value, false)
+    ChoiceNode::boolean(BooleanChoice { p: 0.5 }, value, false)
 }
 
 fn span(start: usize, end: usize, label: &str) -> Span {

--- a/hegel-c/tests/embedded/native/shrinker_string_passes_tests.rs
+++ b/hegel-c/tests/embedded/native/shrinker_string_passes_tests.rs
@@ -3,6 +3,7 @@
 
 use crate::exchange::drive_no_yield;
 use crate::native::bignum::BigInt;
+use crate::native::core::choices::BooleanChoice;
 use crate::native::core::choices::StringChoice;
 use crate::native::core::{ChoiceKind, ChoiceNode, ChoiceValue, Spans};
 use crate::native::intervalsets::IntervalSet;
@@ -146,7 +147,7 @@ fn normalize_unicode_chars_handles_string_truncated_by_closure() {
 
 #[test]
 fn normalize_unicode_chars_does_nothing_on_non_string() {
-    let initial = vec![ChoiceNode::boolean(true, false)];
+    let initial = vec![ChoiceNode::boolean(BooleanChoice { p: 0.5 }, true, false)];
     let mut shrinker = Shrinker::with_probe(
         Box::new(|run: ShrinkRun<'_>| match run {
             ShrinkRun::Full(nodes) => (true, nodes.to_vec(), Spans::new()),

--- a/hegel-c/tests/embedded/native/state_tests.rs
+++ b/hegel-c/tests/embedded/native/state_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::native::core::choices::BooleanChoice;
 use crate::native::rng::EngineRng;
 
 #[test]
@@ -26,9 +27,9 @@ fn spans_get_mut_returns_none_out_of_bounds() {
 #[test]
 fn spans_trivial_handles_simplest_forced_and_oob() {
     use crate::native::core::choices::ChoiceNode;
-    let simplest = ChoiceNode::boolean(false, false);
-    let interesting = ChoiceNode::boolean(true, false);
-    let forced_interesting = ChoiceNode::boolean(true, true);
+    let simplest = ChoiceNode::boolean(BooleanChoice { p: 0.5 }, false, false);
+    let interesting = ChoiceNode::boolean(BooleanChoice { p: 0.5 }, true, false);
+    let forced_interesting = ChoiceNode::boolean(BooleanChoice { p: 0.5 }, true, true);
 
     let mut spans = Spans::new();
     spans.push(Span {
@@ -617,7 +618,7 @@ fn template_concrete_prefix_then_template() {
 #[test]
 fn template_concrete_prefix_with_punning_then_template() {
     let prefix = vec![ChoiceValue::Boolean(true)];
-    let prefix_nodes = vec![ChoiceNode::boolean(true, false)];
+    let prefix_nodes = vec![ChoiceNode::boolean(BooleanChoice { p: 0.5 }, true, false)];
     let mut tc = NativeTestCase::for_choices_and_template(
         &prefix,
         Some(&prefix_nodes),

--- a/hegel-c/tests/embedded/native/targeting_tests.rs
+++ b/hegel-c/tests/embedded/native/targeting_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::native::bignum::{BigInt, ToPrimitive};
+use crate::native::core::choices::BooleanChoice;
 use crate::native::core::choices::IntegerChoice;
 use crate::native::core::{BytesChoice, FloatChoice};
 use alloc::string::ToString;
@@ -105,7 +106,7 @@ fn schedule_for_small_max_examples_never_fires_in_range() {
 fn is_climbable_accepts_integer_float_boolean_bytes() {
     let int_node = integer_node(0, 0, 10);
     let float_node = float_node(0.0);
-    let bool_node = ChoiceNode::boolean(true, false);
+    let bool_node = ChoiceNode::boolean(BooleanChoice { p: 0.5 }, true, false);
     let bytes_node = bytes_node(vec![0], 0, 8);
     for node in [&int_node, &float_node, &bool_node, &bytes_node] {
         assert!(is_climbable(&node.data), "expected climbable: {node:?}");
@@ -156,7 +157,7 @@ fn step_choice_float_adds_delta_as_f64() {
 
 #[test]
 fn step_choice_boolean_only_steps_by_one() {
-    let node = ChoiceNode::boolean(false, false);
+    let node = ChoiceNode::boolean(BooleanChoice { p: 0.5 }, false, false);
     assert_eq!(step_choice(&node, 1), Some(ChoiceValue::Boolean(true)));
     assert_eq!(step_choice(&node, -1), Some(ChoiceValue::Boolean(false)));
     assert_eq!(step_choice(&node, 0), Some(ChoiceValue::Boolean(false)));

--- a/hegel-c/tests/embedded/native/test_runner_tests.rs
+++ b/hegel-c/tests/embedded/native/test_runner_tests.rs
@@ -10,6 +10,7 @@
 //! match the equivalent `gs::booleans()` / `gs::integers()` draws.
 
 use super::*;
+use crate::native::core::choices::BooleanChoice;
 use alloc::vec;
 
 use crate::backend::{DataSource, Failure, TestCaseResult};
@@ -153,7 +154,7 @@ fn run_main_sync(
 }
 
 fn bool_node(value: bool) -> ChoiceNode {
-    ChoiceNode::boolean(value, false)
+    ChoiceNode::boolean(BooleanChoice { p: 0.5 }, value, false)
 }
 
 #[test]


### PR DESCRIPTION
The data tree dropped a boolean draw's probability, so novel-prefix proposals re-drew recorded booleans as a fair coin; this records `p` on `BooleanChoice` and samples proposals from it, matching Hypothesis.

<details>
<summary>Details (AI-generated)</summary>

`BooleanChoice` was a unit struct, so `ChoiceKind::random_value` proposed boolean values with a hardcoded `weighted_boolean_sample(0.5, …)` — flipping even the `p = 2^-16` stateful stop signal about half the time whenever the novel-prefix walk descended a recorded case. Result: ~half of generated stateful test cases were truncated early, and the step-count assertions in `test_stateful.rs` only passed thanks to their `derandomize(true)` seed (they fail for ~45% of random seeds on main).

The fix threads `p` through `ChoiceData::Boolean`/`ChoiceNode::boolean` (bit-pattern equality, following `FloatChoice`) and samples proposals from it via the precise sampler; `p <= 0` / `p >= 1` resolve without consulting the RNG. Replay and shrinking read recorded values and are unaffected.

Verification: the new regression test fails at 99/200 rare-branch proposals with the fair coin restored and passes at 0/200 with the fix; the stateful full-step rate rises from mean 0.497 to 0.654 and the step-count assertions pass for 20/20 sampled random seeds. `just check` and `just check-coverage` pass.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)