### PR TITLE
#[composite] macro improvements

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,3 +4,4 @@ This patch brings various minor improvements to the `#[composite]` macro.
 
 - Adds support for passing parameters by reference without an explicit lifetime, if the lifetime is not used in the return type.
 - Stops the items_after_statements clippy lint from firing if constants/ functions are defined in the function body.
+- Tries to output generator even if errors are found as to not raise errors elsewhere

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch brings various minor improvements to the `#[composite]` macro.
+
+- Adds support for passing parameters by reference without an explicit lifetime, if the lifetime is not used in the return type.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,3 +3,4 @@ RELEASE_TYPE: patch
 This patch brings various minor improvements to the `#[composite]` macro.
 
 - Adds support for passing parameters by reference without an explicit lifetime, if the lifetime is not used in the return type.
+- Stops the items_after_statements clippy lint from firing if constants/ functions are defined in the function body.

--- a/hegel-macros/src/composite.rs
+++ b/hegel-macros/src/composite.rs
@@ -138,13 +138,11 @@ pub fn expand_composite(f: ItemFn) -> TokenStream {
     };
 
     let label_source = f.block.to_token_stream().to_string();
-    let mut body_block = *f.block;
-    body_block.stmts.insert(
-        0,
-        parse_quote! {
-            ::hegel::__assert_is_test_case::< #tc_inner_type >();
-        },
-    );
+    let inner_block = f.block;
+    let body_block: syn::Block = parse_quote! {{
+        ::hegel::__assert_is_test_case::< #tc_inner_type >();
+        #inner_block
+    }};
 
     let attributes = &f.attrs;
     let visibility = &f.vis;

--- a/hegel-macros/src/composite.rs
+++ b/hegel-macros/src/composite.rs
@@ -1,5 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::{ToTokens, format_ident, quote};
+use syn::spanned::Spanned;
 use syn::{FnArg, ItemFn, Pat, ReturnType, Type, parse_quote};
 
 use crate::utils::snake_to_pascal;
@@ -20,71 +21,91 @@ impl syn::visit_mut::VisitMut for ElidedLifetimeRewriter {
 }
 
 pub fn expand_composite(f: ItemFn) -> TokenStream {
+    let mut errors: Vec<syn::Error> = Vec::new();
+
     let input_parameters: Vec<FnArg> = f.sig.inputs.iter().cloned().collect();
 
-    let Some((FnArg::Typed(tc_arg), passthrough)) = input_parameters.split_first() else {
-        return syn::Error::new_spanned(
-            &f.sig,
-            "A #[composite] generator must define a first parameter of type &TestCase. When \
-            drawing from a #[composite] generator with tc.draw(my_composite_gen), the test \
-            case will be automatically passed to my_composite_gen as the first argument.",
-        )
-        .to_compile_error();
+    let (tc_arg, passthrough) = match input_parameters.split_first() {
+        Some((FnArg::Typed(tc_arg), passthrough)) => (Some(tc_arg), passthrough),
+        _ => {
+            errors.push(syn::Error::new_spanned(
+                &f.sig,
+                "A #[composite] generator must define a first parameter of type &TestCase. When \
+                    drawing from a #[composite] generator with tc.draw(my_composite_gen), the test \
+                    case will be automatically passed to my_composite_gen as the first argument.",
+            ));
+            (None, [].as_slice())
+        }
     };
 
-    let tc_inner_type = match tc_arg.ty.as_ref() {
-        Type::Reference(reference) if reference.mutability.is_none() => reference.elem.clone(),
-        Type::Reference(reference) => {
-            return syn::Error::new_spanned(
+    let (tc_inner_type, tc_type_is_valid) = match tc_arg.map(|arg| arg.ty.as_ref()) {
+        Some(Type::Reference(reference)) if reference.mutability.is_none() => {
+            (reference.elem.as_ref().clone(), true)
+        }
+        Some(Type::Reference(reference)) => {
+            errors.push(syn::Error::new_spanned(
                 reference,
                 "A #[composite] generator borrows its TestCase through a shared reference: \
                 change `&mut TestCase` to `&TestCase`. All TestCase methods take `&self`.",
-            )
-            .to_compile_error();
+            ));
+            (parse_quote! { ::hegel::TestCase }, false)
         }
-        _ => {
-            return syn::Error::new_spanned(
-                &tc_arg.ty,
+        Some(arg) => {
+            errors.push(syn::Error::new_spanned(
+                arg,
                 "#[composite] generators receive the test case by reference: change \
                 `tc: TestCase` to `tc: &TestCase`. (Earlier versions took the TestCase by \
                 value; the body of the generator rarely needs any other change.)",
-            )
-            .to_compile_error();
+            ));
+            (parse_quote! { ::hegel::TestCase }, false)
         }
+        None => (parse_quote! { ::hegel::TestCase }, false),
     };
 
-    let ReturnType::Type(_, return_type) = &f.sig.output else {
-        return syn::Error::new_spanned(
+    let tc_arg: FnArg = match tc_arg {
+        Some(arg) if tc_type_is_valid => FnArg::Typed(arg.clone()),
+        Some(arg) => {
+            let pattern = arg.pat.as_ref();
+            parse_quote! { #pattern: &::hegel::TestCase }
+        }
+        None => parse_quote! { __hegel_tc: &::hegel::TestCase },
+    };
+
+    let return_type = if let ReturnType::Type(_, ty) = f.sig.output {
+        ty
+    } else {
+        errors.push(syn::Error::new_spanned(
             &f.sig,
             "#[composite] generators must explicitly declare a return type.",
-        )
-        .to_compile_error();
+        ));
+        parse_quote! { () }
     };
 
     let mut field_idents = Vec::new();
     let mut field_types = Vec::new();
-    for arg in passthrough {
-        let ident = match arg {
-            FnArg::Typed(typed) => match typed.pat.as_ref() {
-                Pat::Ident(pat) if pat.by_ref.is_none() && pat.subpat.is_none() => {
-                    field_types.push(typed.ty.as_ref().clone());
-                    pat.ident.clone()
-                }
-                _ => {
-                    return syn::Error::new_spanned(
-                        &typed.pat,
-                        "parameters of a #[composite] generator (after the TestCase) must be \
-                        plain identifiers, so they can be stored on the generated generator \
-                        struct.",
-                    )
-                    .to_compile_error();
-                }
-            },
-            FnArg::Receiver(_) => {
-                unreachable!("syn only parses a receiver as the first parameter")
-            }
+    let mut body_parameters: Vec<FnArg> = Vec::new();
+    for (index, arg) in passthrough.iter().enumerate() {
+        let FnArg::Typed(typed) = arg else {
+            unreachable!("syn only parses a receiver as the first parameter")
         };
-        field_idents.push(ident);
+        field_types.push(typed.ty.as_ref().clone());
+        match typed.pat.as_ref() {
+            Pat::Ident(pat) if pat.by_ref.is_none() && pat.subpat.is_none() => {
+                field_idents.push(pat.ident.clone());
+                body_parameters.push(arg.clone());
+            }
+            pattern => {
+                errors.push(syn::Error::new_spanned(
+                    pattern,
+                    "parameters of a #[composite] generator (after the TestCase) must be plain \
+                    identifiers, so they can be stored on the generated generator struct.",
+                ));
+                let ident = format_ident!("__hegel_arg{index}", span = pattern.span());
+                let ty = typed.ty.as_ref();
+                body_parameters.push(parse_quote! { #ident: #ty });
+                field_idents.push(ident);
+            }
+        }
     }
 
     let fn_name = &f.sig.ident;
@@ -93,7 +114,6 @@ pub fn expand_composite(f: ItemFn) -> TokenStream {
     let struct_doc = format!("Generator returned by [`{fn_name}()`].");
 
     let mut generics = f.sig.generics.clone();
-    let mut body_parameters: Vec<FnArg> = passthrough.to_vec();
     {
         let mut rewriter = ElidedLifetimeRewriter {
             lifetime: syn::Lifetime::new("'__hegel_composite", fn_name.span()),
@@ -146,8 +166,11 @@ pub fn expand_composite(f: ItemFn) -> TokenStream {
 
     let attributes = &f.attrs;
     let visibility = &f.vis;
+    let errors = errors.into_iter().map(|e| e.to_compile_error());
 
     quote! {
+        #(#errors)*
+
         #[doc = #struct_doc]
         #visibility struct #struct_name #generics #where_clause {
             #(#field_idents: #field_types,)*

--- a/hegel-macros/src/composite.rs
+++ b/hegel-macros/src/composite.rs
@@ -4,6 +4,21 @@ use syn::{FnArg, ItemFn, Pat, ReturnType, Type, parse_quote};
 
 use crate::utils::snake_to_pascal;
 
+/// Replaces any elided lifetimes with the given lifetime
+struct ElidedLifetimeRewriter {
+    lifetime: syn::Lifetime,
+    used: bool,
+}
+impl syn::visit_mut::VisitMut for ElidedLifetimeRewriter {
+    fn visit_type_reference_mut(&mut self, node: &mut syn::TypeReference) {
+        if node.lifetime.is_none() {
+            node.lifetime = Some(self.lifetime.clone());
+            self.used = true;
+        }
+        syn::visit_mut::visit_type_reference_mut(self, node);
+    }
+}
+
 pub fn expand_composite(f: ItemFn) -> TokenStream {
     let input_parameters: Vec<FnArg> = f.sig.inputs.iter().cloned().collect();
 
@@ -52,7 +67,7 @@ pub fn expand_composite(f: ItemFn) -> TokenStream {
         let ident = match arg {
             FnArg::Typed(typed) => match typed.pat.as_ref() {
                 Pat::Ident(pat) if pat.by_ref.is_none() && pat.subpat.is_none() => {
-                    field_types.push(typed.ty.as_ref());
+                    field_types.push(typed.ty.as_ref().clone());
                     pat.ident.clone()
                 }
                 _ => {
@@ -77,7 +92,25 @@ pub fn expand_composite(f: ItemFn) -> TokenStream {
     let struct_name = format_ident!("{pascal_name}CompositeGenerator", span = fn_name.span());
     let struct_doc = format!("Generator returned by [`{fn_name}()`].");
 
-    let generics = &f.sig.generics;
+    let mut generics = f.sig.generics.clone();
+    let mut body_parameters: Vec<FnArg> = passthrough.to_vec();
+    {
+        let mut rewriter = ElidedLifetimeRewriter {
+            lifetime: syn::Lifetime::new("'__hegel_composite", fn_name.span()),
+            used: false,
+        };
+        for ty in &mut field_types {
+            syn::visit_mut::VisitMut::visit_type_mut(&mut rewriter, ty);
+        }
+        for arg in &mut body_parameters {
+            syn::visit_mut::VisitMut::visit_fn_arg_mut(&mut rewriter, arg);
+        }
+        if rewriter.used {
+            let lifetime = rewriter.lifetime;
+            generics.params.insert(0, parse_quote! { #lifetime });
+        }
+    }
+
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let lifetimes: Vec<_> = generics.lifetimes().map(|l| &l.lifetime).collect();
     let type_params: Vec<_> = generics.type_params().map(|t| &t.ident).collect();
@@ -132,7 +165,7 @@ pub fn expand_composite(f: ItemFn) -> TokenStream {
         }
 
         impl #impl_generics #struct_name #ty_generics #where_clause {
-            fn __hegel_body(#tc_arg, #(#passthrough),*) -> #return_type #body_block
+            fn __hegel_body(#tc_arg, #(#body_parameters),*) -> #return_type #body_block
         }
 
         impl #impl_generics ::core::clone::Clone for #struct_name #ty_generics #generator_where {

--- a/tests/test_composite.rs
+++ b/tests/test_composite.rs
@@ -233,3 +233,82 @@ mod composite_kwonlyargs {
         check_can_generate_examples(gs::vecs(kwonlyargs_composites("test")));
     }
 }
+
+mod composite_borrowed_data {
+    //! Composite generators can take borrowed parameters. A `&T` parameter may
+    //! leave its lifetime elided, and the macro supplies one for the generated
+    //! generator struct. If the lifetime is used in the result it must be specified.
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct Object {
+        name: String,
+        x: u8,
+        y: u8,
+    }
+
+    #[hegel::composite]
+    fn object_from_borrowed_name(tc: &TestCase, name: &str) -> Object {
+        let x = tc.draw(gs::integers().max_value(3));
+        let y = tc.draw(gs::integers().max_value(3));
+
+        Object {
+            name: name.to_owned(),
+            x,
+            y,
+        }
+    }
+
+    #[hegel::test]
+    fn test_elided_borrow_can_be_copied_into_generated_value(tc: TestCase) {
+        let object = tc.draw(object_from_borrowed_name("hello"));
+        assert_eq!(object.name, "hello");
+        assert!(object.x <= 3 && object.y <= 3);
+    }
+
+    #[derive(Debug)]
+    struct Config {
+        min: u8,
+        max: u8,
+    }
+
+    #[hegel::composite]
+    fn int_bounded_by_borrowed_config(tc: &TestCase, config: &Config) -> u8 {
+        tc.draw(gs::integers().min_value(config.min).max_value(config.max))
+    }
+
+    #[hegel::test]
+    fn test_elided_borrow_can_configure_draws(tc: TestCase) {
+        let config = Config { min: 5, max: 10 };
+        let x = tc.draw(int_bounded_by_borrowed_config(&config));
+        assert!((5..=10).contains(&x));
+    }
+
+    #[derive(Debug)]
+    struct BorrowedObject<'a> {
+        name: &'a str,
+        x: u8,
+    }
+
+    #[hegel::composite]
+    fn borrowed_object_from_name<'a>(
+        tc: &TestCase,
+        name: &'a str,
+        config: &Config,
+    ) -> BorrowedObject<'a> {
+        BorrowedObject {
+            name,
+            x: tc.draw(gs::integers().min_value(config.min).max_value(config.max)),
+        }
+    }
+
+    #[hegel::test]
+    fn test_explicit_lifetime_borrow_is_stored_in_generated_value(tc: TestCase) {
+        let config = Config { min: 5, max: 10 };
+        let object = tc.draw(borrowed_object_from_name("hello", &config));
+
+        assert_eq!(object.name, "hello");
+        assert!((5..=10).contains(&object.x));
+    }
+}

--- a/tests/test_composite.rs
+++ b/tests/test_composite.rs
@@ -312,3 +312,17 @@ mod composite_borrowed_data {
         assert!((5..=10).contains(&object.x));
     }
 }
+
+#[deny(clippy::items_after_statements)]
+#[allow(unused)]
+mod item_after_statement_lint {
+    use super::*;
+
+    #[hegel::composite]
+    fn link_metric(tc: &TestCase) -> u32 {
+        const MAX_METRIC: u32 = 1000;
+
+        let x = tc.draw(gs::integers().max_value(MAX_METRIC));
+        x + 1
+    }
+}


### PR DESCRIPTION
This PR fixes some minor papercuts introduced by the changes to the #[composite] macro in #397.

---

    #[composite] Better support for borrowed parameters

    Previously, functions using the #[composite] macro and references worked
    similarly to regular functions, and lifetimes could be elided in the same
    places.

    With the changes to store the parameters in a struct, if we pass a parameter
    by reference in we have to name the lifetime even if it is not used in the
    output. This makes functions with the composite macro act slightly differently
    to "normal" functions.

    If any parameters are passed as a reference without a lifetime, the macro
    now rewrites to add a hidden lifetime so it can be stored without the user having
    to specify a lifetime. Return types are left unchanged, and if they have elided
    lifetimes, the user will get the same warning as regular functions that the compiler
    can't tell if the lifetime should be from the test case or their parameter.

---

    #[composite] Stop items_after_statements warning

    If you define a constant, or function in a function using the
    `#[hegel::composite]` macro, you currently get a warning from
    the clippy `items_after_statements` lint.

    This is due to hegel injecting `::hegel::__assert_is_test_case::<::hegel::TestCase>();`
    as the first item in the function.

    Update to insert the whole body block after a block containing the
    injected item, rather than inserting the function in the user's
    block.
    
---

    #[composite] Output a generator even if there is an error

    Previously, if an error was found during the composite macro
    expansion (e.g. not having the test case as reference), only
    an error would have been returned.

    If the generator was used anywhere, it would spread many
    compiler warnings up the chain.

    Update so the macro tries to return the generator (and the errors)
    if an error is found, so anything which depends on it does not
    bring up an error.

    This also allows the macro to return multiple errors if necessary
    (e.g. both missing return type and wrong test case argument).