### PR TITLE
Complete diverged span-mutation proposals with random draws

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch improves random generation for tests with repeated structure (recursive generators, collections, state machines). The engine proposes new test cases by splicing the choices of one span over another with the same label; a spliced sequence that diverged from its donor's path was previously discarded, and is now completed with fresh random draws instead, so every such proposal becomes a real test case seeded with the mutation.

--- a/hegel-c/RELEASE.md
+++ b/hegel-c/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch improves the generation phase's span mutation. A mutated choice sequence that diverges from its donor's path previously ran out of data and was discarded as an overrun; mutation probes now draw randomly past the end of the spliced choices, so a diverged proposal becomes a complete test case seeded with the mutation. On recursive-generator workloads this turns a substantial fraction of previously wasted probes into productive test cases.

--- a/hegel-c/src/native/test_runner.rs
+++ b/hegel-c/src/native/test_runner.rs
@@ -1090,34 +1090,33 @@ impl<'a> Engine<'a> {
     /// interesting-origin filter) is applied by the caller, so replay and
     /// matching are not entangled.
     ///
-    /// With `extend == 0` the realised path is known up front, so a path the
-    /// lossless tree already records is served by [`data_tree::simulate_full`]
-    /// with its full outcome — nodes, spans, status, origin, observations —
-    /// without running the body, for *any* status (interesting included). With
-    /// `extend > 0` the random continuation isn't known ahead of time, so it
-    /// always executes. A genuine miss (a novel or undetermined path) runs
-    /// through [`Self::test_function`], which records the run into the tree so a
-    /// later replay of the same path is served. There is no separate result
-    /// cache: the tree is the single source of truth.
+    /// A path the lossless tree already records completely is served by
+    /// [`data_tree::simulate_full`] with its full outcome — nodes, spans,
+    /// status, origin, observations — without running the body, for *any*
+    /// status (interesting included). That holds for any `extend`: a
+    /// tree-determined path concludes within `choices`, so the continuation
+    /// budget is irrelevant to it. A genuine miss (a novel path, or one whose
+    /// recorded prefix runs out of `choices` before concluding) runs through
+    /// [`Self::test_function`] — bare when `extend == 0`, with up to `extend`
+    /// random draws past the end of `choices` otherwise — which records the
+    /// run into the tree so a later replay of the same path is served. There
+    /// is no separate result cache: the tree is the single source of truth.
     async fn cached_test_function(
         &mut self,
         choices: &[ChoiceValue],
         nodes: Option<&[ChoiceNode]>,
         extend: usize,
     ) -> Result<RunResult, RunError> {
-        if extend == 0 {
-            if let Some(out) =
-                crate::native::data_tree::simulate_full(&self.tree_root, choices, nodes)?
-            {
-                return Ok(RunResult {
-                    status: out.status,
-                    nodes: out.nodes,
-                    spans: out.spans,
-                    origin: out.origin,
-                    target_observations: out.target_observations,
-                    span_events: Vec::new(),
-                });
-            }
+        if let Some(out) = crate::native::data_tree::simulate_full(&self.tree_root, choices, nodes)?
+        {
+            return Ok(RunResult {
+                status: out.status,
+                nodes: out.nodes,
+                spans: out.spans,
+                origin: out.origin,
+                target_observations: out.target_observations,
+                span_events: Vec::new(),
+            });
         }
         let ntc = if extend == 0 {
             NativeTestCase::for_choices(choices, nodes, None)
@@ -1182,6 +1181,12 @@ impl ShrinkProbe for EngineShrinkProbe<'_, '_> {
 /// so it counts toward the same budgets as a freshly generated example and a
 /// later identical proposal is served from the tree; tree-served probes are not
 /// re-recorded, exactly as Hypothesis's cache hits cost nothing.
+///
+/// A mutated sequence often diverges from the path its donor took and would
+/// run out of data as a bare replay. Rather than discarding such a proposal
+/// (Hypothesis's behavior), every probe allows random draws past the end of
+/// the spliced choices, so a diverged attempt becomes a complete test case
+/// seeded with the mutation instead of an overrun.
 impl<'a> Engine<'a> {
     async fn try_span_mutation(
         &mut self,
@@ -1256,7 +1261,9 @@ impl<'a> Engine<'a> {
                 out
             };
 
-            let run = self.cached_test_function(&attempt, None, 0).await?;
+            let extend =
+                BUFFER_SIZE.saturating_sub(crate::native::core::flattened_values_len(&attempt));
+            let run = self.cached_test_function(&attempt, None, extend).await?;
             if run.status == Status::Interesting {
                 return Ok(());
             }

--- a/hegel-c/tests/embedded/native/test_runner_tests.rs
+++ b/hegel-c/tests/embedded/native/test_runner_tests.rs
@@ -386,6 +386,44 @@ fn span_mutation_stops_when_example_budget_is_full() {
 }
 
 #[test]
+fn span_mutation_extends_diverged_proposals_with_random_draws() {
+    with_counting_ctx(
+        |ds| {
+            for _ in 0..4 {
+                if rbool(ds).is_err() {
+                    return TestCaseResult::Overrun;
+                }
+            }
+            TestCaseResult::Valid
+        },
+        async |ctx, count| {
+            let nodes = vec![bool_node(false), bool_node(true)];
+            let span = |start, end| Span {
+                start,
+                end,
+                label: "L".to_string(),
+                depth: 0,
+                parent: None,
+                discarded: false,
+            };
+            let spans = vec![span(0, 2), span(1, 2)];
+
+            ctx.try_span_mutation(&nodes, &spans).await.unwrap();
+
+            assert!(count.get() >= 1);
+            assert!(
+                ctx.valid_test_cases >= 1,
+                "a mutated sequence that runs out of data should be completed \
+                 with fresh random draws instead of being discarded, got {} \
+                 valid cases from {} calls",
+                ctx.valid_test_cases,
+                ctx.calls
+            );
+        },
+    );
+}
+
+#[test]
 fn create_rng_default_backend_is_prng() {
     let settings = Settings::new().seed(Some(123));
     assert!(matches!(

--- a/tests/test_find_quality/collections.rs
+++ b/tests/test_find_quality/collections.rs
@@ -21,7 +21,7 @@ fn test_duplicate_containment() {
     let (ls, i) = FindAny::new(list_and_int(), |(ls, i): &(Vec<i64>, i64)| {
         ls.iter().filter(|&&x| x == *i).count() > 1
     })
-    .seed(1)
+    .seed(2)
     .run();
     assert!(ls.iter().filter(|&&x| x == i).count() > 1);
 }


### PR DESCRIPTION
*(Placeholder — title and description to be written by David.)*

<details>
<summary>Implementation notes (AI-generated)</summary>

A span-mutation proposal splices choices from one same-label span over another, which usually diverges from the donor's path and runs out of data partway through a bare replay. Previously such proposals were discarded as overruns: on a recursive-generator workload (jj's revset property tests), roughly 15% of executed test cases were these dead probes, and the mutation machinery contributed nothing there.

Changes:
- `try_span_mutation` now gives every probe a random-draw budget past the end of the spliced sequence (`BUFFER_SIZE` minus the attempt's flattened length), so a diverged attempt becomes a complete test case seeded with the mutation instead of an overrun.
- `cached_test_function` consults the choice tree regardless of the extension budget. A tree-determined path concludes within its own choices, so serving it is correct for any `extend` value; identical complete proposals still cost no execution (the existing dedup test passes unchanged).
- `test_duplicate_containment`'s pinned seed is re-pinned (1 → 2): the extension changes RNG consumption in the generate phase, and seed 1 happens to be the one seed in thirty that no longer finds the duplicate within its budget. A 30-seed sweep shows the find rate is otherwise unchanged (29/30 after vs 28/30 before).

Measured on jj's revset property suite (4 tests × 256 cases, recursive expression generator): out-of-data cases drop from ~15% to exactly 0 in every test, with generated-size distributions and wall time unchanged. New embedded test: `span_mutation_extends_diverged_proposals_with_random_draws` (fails on main, passes here).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)