### PR TITLE
Add HEGEL_TEST_CASES and HEGEL_DATABASE environment variable overrides

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch adds two environment variables that override settings at runtime, so a whole test suite's behavior can be adjusted without editing source:
+
+- `HEGEL_TEST_CASES` overrides the number of test cases each test runs, taking precedence over values configured in source (including explicit `test_cases` settings). For example, `HEGEL_TEST_CASES=10000 cargo test` runs a deep exploration of every property test.
+- `HEGEL_DATABASE` overrides the failure database location: `HEGEL_DATABASE=disabled` turns the database off (the same keyword the `--database` CLI flag uses), and any other non-empty value relocates the database to that path.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,6 +173,16 @@
 //! }
 //! ```
 //!
+//! To override the number of test cases at runtime — for the whole suite,
+//! without editing source — set the `HEGEL_TEST_CASES` environment variable:
+//!
+//! ```bash
+//! HEGEL_TEST_CASES=10000 cargo test
+//! ```
+//!
+//! When set and non-empty, it takes precedence over any value configured in
+//! source, including explicit `test_cases` attributes.
+//!
 //! ## Threading
 //!
 //! [`TestCase`] is `Send` but not `Sync`: you can clone it and move the clone

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -189,6 +189,12 @@ impl Settings {
     }
 
     /// Set the number of test cases to run (default: 100).
+    ///
+    /// The `HEGEL_TEST_CASES` environment variable, when set and non-empty,
+    /// overrides this value at runtime — including a value set explicitly
+    /// here or via `#[hegel::test(test_cases = ...)]`. This makes it easy to
+    /// scale a whole test suite up (a nightly deep run) or down (a quick
+    /// smoke pass) without editing source.
     pub fn test_cases(mut self, n: u64) -> Self {
         self.test_cases = n;
         self
@@ -285,6 +291,25 @@ impl Settings {
         self.phases.contains(&phase)
     }
 
+    /// Apply environment-variable overrides to these settings. Called once
+    /// per run, after all builder configuration, so the environment wins
+    /// over values set in source.
+    pub(crate) fn with_env_overrides(self) -> Self {
+        self.with_env_overrides_from(env_var)
+    }
+
+    fn with_env_overrides_from(mut self, env: impl Fn(&str) -> Option<String>) -> Self {
+        if let Some(value) = env("HEGEL_TEST_CASES") {
+            if !value.is_empty() {
+                match value.parse::<u64>() {
+                    Ok(n) if n > 0 => self.test_cases = n,
+                    _ => panic!("HEGEL_TEST_CASES must be a positive integer, got {value:?}"),
+                }
+            }
+        }
+        self
+    }
+
     /// Control whether multi-bug runs report every distinct failing example
     /// or collapse to just the first one.
     ///
@@ -322,8 +347,12 @@ where
     Hegel::new(test_fn).run();
 }
 
+fn env_var(key: &str) -> Option<String> {
+    std::env::var_os(key).map(|value| value.to_string_lossy().into_owned())
+}
+
 fn is_in_ci() -> bool {
-    is_in_ci_from(|key| std::env::var_os(key).map(|value| value.to_string_lossy().into_owned()))
+    is_in_ci_from(env_var)
 }
 
 fn is_in_ci_from(env: impl Fn(&str) -> Option<String>) -> bool {
@@ -413,10 +442,11 @@ where
     ///
     /// Panics if any test case fails.
     pub fn run(self) {
+        let settings = self.settings.with_env_overrides();
         if let Some(blob) = self.reproduce_failure {
             crate::run_lifecycle::drive_blob_replay(
                 self.test_fn,
-                &self.settings,
+                &settings,
                 self.database_key.as_deref(),
                 &blob,
                 self.test_location.as_ref(),
@@ -426,7 +456,7 @@ where
 
         crate::run_lifecycle::drive(
             self.test_fn,
-            &self.settings,
+            &settings,
             self.database_key.as_deref(),
             self.test_location.as_ref(),
         );

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -228,6 +228,11 @@ impl Settings {
     }
 
     /// Set the database path for storing failing examples, or `None` to disable.
+    ///
+    /// The `HEGEL_DATABASE` environment variable, when set and non-empty,
+    /// overrides this value at runtime: the literal value `disabled` turns
+    /// the database off (matching the `--database` CLI flag's keyword), and
+    /// any other value is used as the database path.
     pub fn database(mut self, database: Option<String>) -> Self {
         self.database = match database {
             None => Database::Disabled,
@@ -305,6 +310,15 @@ impl Settings {
                     Ok(n) if n > 0 => self.test_cases = n,
                     _ => panic!("HEGEL_TEST_CASES must be a positive integer, got {value:?}"),
                 }
+            }
+        }
+        if let Some(value) = env("HEGEL_DATABASE") {
+            if !value.is_empty() {
+                self.database = if value == "disabled" {
+                    Database::Disabled
+                } else {
+                    Database::Path(value)
+                };
             }
         }
         self

--- a/tests/embedded/runner_tests.rs
+++ b/tests/embedded/runner_tests.rs
@@ -98,6 +98,33 @@ fn test_env_override_test_cases_zero_is_a_usage_error() {
 }
 
 #[test]
+fn test_env_override_database_disabled_keyword() {
+    use crate::runner::Database;
+    let s = Settings::new()
+        .database(Some("custom".to_string()))
+        .with_env_overrides_from(|key| (key == "HEGEL_DATABASE").then(|| "disabled".to_string()));
+    assert_eq!(s.database, Database::Disabled);
+}
+
+#[test]
+fn test_env_override_database_path() {
+    use crate::runner::Database;
+    let s = Settings::new()
+        .database(None)
+        .with_env_overrides_from(|key| (key == "HEGEL_DATABASE").then(|| "my-db".to_string()));
+    assert_eq!(s.database, Database::Path("my-db".to_string()));
+}
+
+#[test]
+fn test_env_override_database_empty_is_ignored() {
+    use crate::runner::Database;
+    let s = Settings::new()
+        .database(Some("custom".to_string()))
+        .with_env_overrides_from(|key| (key == "HEGEL_DATABASE").then(String::new));
+    assert_eq!(s.database, Database::Path("custom".to_string()));
+}
+
+#[test]
 fn test_is_in_ci_from_detects_presence_and_value_variables() {
     assert!(!is_in_ci_from(|_| None));
     assert!(is_in_ci_from(|key| (key == "CI").then(String::new)));

--- a/tests/embedded/runner_tests.rs
+++ b/tests/embedded/runner_tests.rs
@@ -60,6 +60,44 @@ fn test_settings_has_phase() {
 }
 
 #[test]
+fn test_env_override_replaces_test_cases() {
+    let s = Settings::new()
+        .test_cases(5)
+        .with_env_overrides_from(|key| (key == "HEGEL_TEST_CASES").then(|| "17".to_string()));
+    assert_eq!(s.test_cases, 17);
+}
+
+#[test]
+fn test_env_override_test_cases_absent_is_ignored() {
+    let s = Settings::new()
+        .test_cases(5)
+        .with_env_overrides_from(|_| None);
+    assert_eq!(s.test_cases, 5);
+}
+
+#[test]
+fn test_env_override_test_cases_empty_is_ignored() {
+    let s = Settings::new()
+        .test_cases(5)
+        .with_env_overrides_from(|key| (key == "HEGEL_TEST_CASES").then(String::new));
+    assert_eq!(s.test_cases, 5);
+}
+
+#[test]
+#[should_panic(expected = "HEGEL_TEST_CASES must be a positive integer, got \"lots\"")]
+fn test_env_override_test_cases_non_numeric_is_a_usage_error() {
+    Settings::new()
+        .with_env_overrides_from(|key| (key == "HEGEL_TEST_CASES").then(|| "lots".to_string()));
+}
+
+#[test]
+#[should_panic(expected = "HEGEL_TEST_CASES must be a positive integer, got \"0\"")]
+fn test_env_override_test_cases_zero_is_a_usage_error() {
+    Settings::new()
+        .with_env_overrides_from(|key| (key == "HEGEL_TEST_CASES").then(|| "0".to_string()));
+}
+
+#[test]
 fn test_is_in_ci_from_detects_presence_and_value_variables() {
     assert!(!is_in_ci_from(|_| None));
     assert!(is_in_ci_from(|key| (key == "CI").then(String::new)));

--- a/tests/test_settings.rs
+++ b/tests/test_settings.rs
@@ -1,5 +1,6 @@
 mod common;
 
+use common::exec::self_test;
 use hegel::generators as gs;
 
 #[test]
@@ -45,6 +46,29 @@ fn test_settings_verbosity() {
     .run();
 
     assert_eq!(count, 10);
+}
+
+/// Fixture for `test_hegel_test_cases_env_overrides_settings`, run via
+/// self-exec with `HEGEL_TEST_CASES=7`: the environment variable must win
+/// over the explicit `test_cases(100)` in the settings.
+#[test]
+#[ignore = "fixture: run via exec::self_test"]
+fn env_test_cases_fixture() {
+    let mut count = 0;
+    hegel::Hegel::new(|tc| {
+        tc.draw(gs::integers::<i32>());
+        count += 1;
+    })
+    .settings(hegel::Settings::new().test_cases(100).database(None))
+    .run();
+    assert_eq!(count, 7);
+}
+
+#[test]
+fn test_hegel_test_cases_env_overrides_settings() {
+    self_test("env_test_cases_fixture")
+        .env("HEGEL_TEST_CASES", "7")
+        .run();
 }
 
 #[test]

--- a/tests/test_settings.rs
+++ b/tests/test_settings.rs
@@ -71,6 +71,53 @@ fn test_hegel_test_cases_env_overrides_settings() {
         .run();
 }
 
+fn run_failing_test_with_default_database(key: &str) {
+    let result = std::panic::catch_unwind(|| {
+        hegel::Hegel::new(|tc: hegel::TestCase| {
+            tc.draw(gs::integers::<i32>());
+            panic!("stored failure");
+        })
+        .__database_key(key.to_string())
+        .settings(hegel::Settings::new().test_cases(1))
+        .run();
+    });
+    assert!(result.is_err());
+}
+
+/// Fixture for `test_hegel_database_env_relocates_database`, run via
+/// self-exec with `HEGEL_DATABASE=env-relocated-db`: the failing example
+/// must be stored under that directory instead of the default `.hegel/`.
+#[test]
+#[ignore = "fixture: run via exec::self_test"]
+fn env_database_path_fixture() {
+    run_failing_test_with_default_database("env_database_path_fixture");
+    assert!(std::path::Path::new("env-relocated-db").is_dir());
+}
+
+#[test]
+fn test_hegel_database_env_relocates_database() {
+    self_test("env_database_path_fixture")
+        .env("HEGEL_DATABASE", "env-relocated-db")
+        .run();
+}
+
+/// Fixture for `test_hegel_database_env_disables_database`, run via
+/// self-exec with `HEGEL_DATABASE=disabled`: no default `.hegel/` database
+/// may be created even though the settings leave the database unset.
+#[test]
+#[ignore = "fixture: run via exec::self_test"]
+fn env_database_disabled_fixture() {
+    run_failing_test_with_default_database("env_database_disabled_fixture");
+    assert!(!std::path::Path::new(".hegel").exists());
+}
+
+#[test]
+fn test_hegel_database_env_disables_database() {
+    self_test("env_database_disabled_fixture")
+        .env("HEGEL_DATABASE", "disabled")
+        .run();
+}
+
 #[test]
 fn test_settings_verbosity_debug() {
     let mut count = 0;


### PR DESCRIPTION
This adds some environment variables for overriding behaviour of hegel tests. They're mostly useful during experimentation with newly written tests and the like, which turns out to be particularly useful for getting LLMs to write tests.

<details>
<summary>Implementation notes (AI-generated)</summary>

Adds runtime environment-variable overrides, applied once per run in `Hegel::run` after all builder configuration, so the environment wins over values set in source:

- `HEGEL_TEST_CASES`: overrides the number of test cases, including values set explicitly via the builder or `#[hegel::test(test_cases = ...)]`. Scales a whole suite up (nightly deep run) or down (smoke pass) without editing source. Non-numeric or zero values are a usage error; empty/unset is ignored.
- `HEGEL_DATABASE`: overrides the failure-database location. The literal value `disabled` turns the database off (the same keyword the `--database` CLI flag uses); any other non-empty value is used as the database path. Useful for CI and for experiments needing independent trials.

Mechanics: a `Settings::with_env_overrides_from(env)` helper takes an injected environment accessor (same pattern as `is_in_ci_from`), unit-tested in the embedded runner tests; the thin `std::env` wiring is covered end-to-end by self-exec fixture tests (`exec::self_test` with controlled environments) verifying a run of 100 configured cases executes exactly 7 under `HEGEL_TEST_CASES=7`, that a failing run stores under the env-relocated directory, and that `HEGEL_DATABASE=disabled` prevents the default `.hegel/` from being created.

Rustdoc on `Settings::test_cases`, `Settings::database`, and the crate-level getting-started section documents both variables.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)