### PR TITLE
Make one_of! build arity-specific unboxed generators

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -27,4 +27,12 @@ compile error pointing at the vec-based `one_of()`, which remains the way
 to choose among a runtime-sized (or very large) collection of boxed
 generators. `one_of()` itself now accepts any iterable of generators of
 one type — `OneOfGenerator` is generic over the stored generator type,
-defaulting to `BoxedGenerator`, so existing uses keep compiling unchanged.
+defaulting to `BoxedGenerator`, so most existing uses keep compiling
+unchanged. The exception is calls that spelled out the type arguments:
+`one_of` gained a type parameter, so e.g. `one_of::<i64, _>(gens)` must
+drop the turbofish (plain `one_of(gens)` infers everything).
+
+For parity, the arity-specific tuple generator types (`Tuple0Generator`
+through `Tuple12Generator`) are now exported as well, so `tuples!` results
+can be named the same way, and `tuples!` reports the same clear compile
+error as `one_of!` when given more than 12 generators.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,30 @@
+RELEASE_TYPE: minor
+
+This release changes `one_of!` to expand to arity-specific generator types
+(`OneOf1Generator` through `OneOf12Generator`, mirroring the `tuples!`
+design) instead of boxing every alternative into a `OneOfGenerator`. The
+component generators keep their concrete types, so the macro's result is a
+nameable type that can be stored in a struct field or returned from a
+function, and building it no longer allocates per alternative. The drawn
+choice sequence (a ONE_OF span around one index draw) is unchanged, so
+saved failures replay identically.
+
+Two things can break. Code that annotated the macro's result as
+`OneOfGenerator` must now name the arity-specific type (or box the
+alternatives explicitly and call `one_of()`):
+
+```rust
+// before
+let g: gs::OneOfGenerator<i64> = hegel::one_of!(gs::integers(), gs::just(7));
+
+// after
+let g: gs::OneOf2Generator<gs::IntegerGenerator<i64>, gs::JustGenerator<i64>, i64> =
+    hegel::one_of!(gs::integers(), gs::just(7));
+```
+
+And `one_of!` now supports at most 12 alternatives; a longer list is a
+compile error pointing at the vec-based `one_of()`, which remains the way
+to choose among a runtime-sized (or very large) collection of boxed
+generators. `one_of()` itself now accepts any iterable of generators of
+one type — `OneOfGenerator` is generic over the stored generator type,
+defaulting to `BoxedGenerator`, so existing uses keep compiling unchanged.

--- a/src/generators/combinators.rs
+++ b/src/generators/combinators.rs
@@ -42,12 +42,19 @@ where
     SampledFromGenerator { elements }
 }
 
-/// Generator that chooses from multiple generators. Created by [`one_of()`] or [`one_of!`](crate::one_of).
-pub struct OneOfGenerator<'a, T> {
-    generators: Vec<BoxedGenerator<'a, T>>,
+/// Generator that chooses from a runtime collection of boxed generators.
+/// Created by [`one_of()`]; the [`one_of!`](crate::one_of) macro instead
+/// builds an arity-specific generator that keeps its components unboxed.
+///
+/// Generic over the stored generator type `B`, defaulting to
+/// [`BoxedGenerator`](super::BoxedGenerator) — the type-erased form a
+/// runtime-sized collection of alternatives needs.
+pub struct OneOfGenerator<'a, T, B = BoxedGenerator<'a, T>> {
+    generators: Vec<B>,
+    _phantom: PhantomData<fn(&'a ()) -> T>,
 }
 
-impl<T> Generator<T> for OneOfGenerator<'_, T> {
+impl<'a, T, B: Generator<T>> Generator<T> for OneOfGenerator<'a, T, B> {
     fn do_draw(&self, tc: &TestCase) -> T {
         tc.start_span(labels::ONE_OF);
         let index = integers::<usize>()
@@ -70,24 +77,31 @@ impl<T> Generator<T> for OneOfGenerator<'_, T> {
 
 /// Choose from multiple generators of the same type.
 ///
-/// Accepts any iterable of boxed generators (e.g. `Vec<BoxedGenerator<T>>`
-/// or an iterator chain). For a more convenient syntax, use the `one_of!`
-/// macro instead.
-pub fn one_of<'a, T, I>(generators: I) -> OneOfGenerator<'a, T>
+/// Accepts any iterable of generators of one type — typically
+/// `Vec<BoxedGenerator<T>>`. For a more convenient syntax, use the
+/// `one_of!` macro instead.
+pub fn one_of<'a, T, B, I>(generators: I) -> OneOfGenerator<'a, T, B>
 where
-    I: IntoIterator<Item = BoxedGenerator<'a, T>>,
+    B: Generator<T>,
+    I: IntoIterator<Item = B>,
 {
-    let generators: Vec<BoxedGenerator<'a, T>> = generators.into_iter().collect();
+    let generators: Vec<B> = generators.into_iter().collect();
     if generators.is_empty() {
         invalid_argument!("one_of requires at least one generator");
     }
-    OneOfGenerator { generators }
+    OneOfGenerator {
+        generators,
+        _phantom: PhantomData,
+    }
 }
 
-/// Choose from multiple generators of the same type.
+/// Choose from 1–12 generators of the same type.
 ///
-/// This macro automatically boxes each generator, providing a more ergonomic
-/// syntax than calling [`one_of`] directly.
+/// The component generators keep their concrete types (no boxing), so the
+/// result is a nameable, arity-specific generator type mirroring
+/// [`tuples!`](crate::tuples). For more than 12 alternatives, or a number
+/// not known at compile time, box the generators and call [`one_of`]
+/// directly.
 ///
 /// # Example
 ///
@@ -104,12 +118,263 @@ where
 /// ```
 #[macro_export]
 macro_rules! one_of {
-    ($($generator:expr),+ $(,)?) => {
-        $crate::generators::one_of(vec![
-            $($crate::generators::Generator::boxed($generator)),+
-        ])
+    ($g1:expr $(,)?) => {
+        $crate::generators::one_of1($g1)
+    };
+    ($g1:expr, $g2:expr $(,)?) => {
+        $crate::generators::one_of2($g1, $g2)
+    };
+    ($g1:expr, $g2:expr, $g3:expr $(,)?) => {
+        $crate::generators::one_of3($g1, $g2, $g3)
+    };
+    ($g1:expr, $g2:expr, $g3:expr, $g4:expr $(,)?) => {
+        $crate::generators::one_of4($g1, $g2, $g3, $g4)
+    };
+    ($g1:expr, $g2:expr, $g3:expr, $g4:expr, $g5:expr $(,)?) => {
+        $crate::generators::one_of5($g1, $g2, $g3, $g4, $g5)
+    };
+    ($g1:expr, $g2:expr, $g3:expr, $g4:expr, $g5:expr, $g6:expr $(,)?) => {
+        $crate::generators::one_of6($g1, $g2, $g3, $g4, $g5, $g6)
+    };
+    ($g1:expr, $g2:expr, $g3:expr, $g4:expr, $g5:expr, $g6:expr, $g7:expr $(,)?) => {
+        $crate::generators::one_of7($g1, $g2, $g3, $g4, $g5, $g6, $g7)
+    };
+    ($g1:expr, $g2:expr, $g3:expr, $g4:expr, $g5:expr, $g6:expr, $g7:expr, $g8:expr $(,)?) => {
+        $crate::generators::one_of8($g1, $g2, $g3, $g4, $g5, $g6, $g7, $g8)
+    };
+    ($g1:expr, $g2:expr, $g3:expr, $g4:expr, $g5:expr, $g6:expr, $g7:expr, $g8:expr, $g9:expr $(,)?) => {
+        $crate::generators::one_of9($g1, $g2, $g3, $g4, $g5, $g6, $g7, $g8, $g9)
+    };
+    ($g1:expr, $g2:expr, $g3:expr, $g4:expr, $g5:expr, $g6:expr, $g7:expr, $g8:expr, $g9:expr, $g10:expr $(,)?) => {
+        $crate::generators::one_of10($g1, $g2, $g3, $g4, $g5, $g6, $g7, $g8, $g9, $g10)
+    };
+    ($g1:expr, $g2:expr, $g3:expr, $g4:expr, $g5:expr, $g6:expr, $g7:expr, $g8:expr, $g9:expr, $g10:expr, $g11:expr $(,)?) => {
+        $crate::generators::one_of11($g1, $g2, $g3, $g4, $g5, $g6, $g7, $g8, $g9, $g10, $g11)
+    };
+    ($g1:expr, $g2:expr, $g3:expr, $g4:expr, $g5:expr, $g6:expr, $g7:expr, $g8:expr, $g9:expr, $g10:expr, $g11:expr, $g12:expr $(,)?) => {
+        $crate::generators::one_of12(
+            $g1, $g2, $g3, $g4, $g5, $g6, $g7, $g8, $g9, $g10, $g11, $g12,
+        )
+    };
+    ($g1:expr, $g2:expr, $g3:expr, $g4:expr, $g5:expr, $g6:expr, $g7:expr, $g8:expr, $g9:expr, $g10:expr, $g11:expr, $g12:expr, $($rest:expr),+ $(,)?) => {
+        compile_error!(
+            "one_of! supports at most 12 generators; for more, box them and call \
+             hegel::generators::one_of directly (e.g. \
+             one_of(vec![g1.boxed(), g2.boxed(), ...]))"
+        )
     };
 }
+
+/// Generator choosing from a single alternative. Created by
+/// [`one_of!`](crate::one_of); the 2–12 alternative forms are the
+/// macro-generated `OneOf2Generator` … `OneOf12Generator`.
+pub struct OneOf1Generator<G1, T> {
+    gen1: G1,
+    _phantom: PhantomData<fn(T)>,
+}
+
+impl<T, G1> Generator<T> for OneOf1Generator<G1, T>
+where
+    G1: Generator<T>,
+{
+    fn do_draw(&self, tc: &TestCase) -> T {
+        tc.start_span(labels::ONE_OF);
+        integers::<usize>().min_value(0).max_value(0).do_draw(tc);
+        let result = self.gen1.do_draw(tc);
+        tc.stop_span(false);
+        result
+    }
+
+    fn enumerate_values(&self) -> Option<Vec<T>> {
+        self.gen1.enumerate_values()
+    }
+}
+
+#[doc(hidden)]
+pub fn one_of1<T, G1: Generator<T>>(gen1: G1) -> OneOf1Generator<G1, T> {
+    OneOf1Generator {
+        gen1,
+        _phantom: PhantomData,
+    }
+}
+
+macro_rules! impl_one_of {
+    ($name:ident, $fn_name:ident, $max:expr,
+     $(($idx:tt, $field:ident, $G:ident)),+ ; ($last_field:ident, $last_G:ident)) => {
+        pub struct $name<$($G,)+ $last_G, T> {
+            $($field: $G,)+
+            $last_field: $last_G,
+            _phantom: PhantomData<fn(T)>,
+        }
+
+        impl<T, $($G,)+ $last_G> Generator<T> for $name<$($G,)+ $last_G, T>
+        where
+            $($G: Generator<T>,)+
+            $last_G: Generator<T>,
+        {
+            fn do_draw(&self, tc: &TestCase) -> T {
+                tc.start_span(labels::ONE_OF);
+                let index = integers::<usize>()
+                    .min_value(0)
+                    .max_value($max)
+                    .do_draw(tc);
+                let result = match index {
+                    $($idx => self.$field.do_draw(tc),)+
+                    _ => self.$last_field.do_draw(tc),
+                };
+                tc.stop_span(false);
+                result
+            }
+
+            fn enumerate_values(&self) -> Option<Vec<T>> {
+                let mut all = Vec::new();
+                $(all.extend(self.$field.enumerate_values()?);)+
+                all.extend(self.$last_field.enumerate_values()?);
+                Some(all)
+            }
+        }
+
+
+        #[doc(hidden)]
+        #[allow(clippy::too_many_arguments)]
+        pub fn $fn_name<T, $($G: Generator<T>,)+ $last_G: Generator<T>>(
+            $($field: $G,)+ $last_field: $last_G,
+        ) -> $name<$($G,)+ $last_G, T> {
+            $name {
+                $($field,)+
+                $last_field,
+                _phantom: PhantomData,
+            }
+        }
+    };
+}
+
+impl_one_of!(OneOf2Generator, one_of2, 1, (0, gen1, G1); (gen2, G2));
+impl_one_of!(
+    OneOf3Generator,
+    one_of3,
+    2,
+    (0, gen1, G1),
+    (1, gen2, G2);
+    (gen3, G3)
+);
+impl_one_of!(
+    OneOf4Generator,
+    one_of4,
+    3,
+    (0, gen1, G1),
+    (1, gen2, G2),
+    (2, gen3, G3);
+    (gen4, G4)
+);
+impl_one_of!(
+    OneOf5Generator,
+    one_of5,
+    4,
+    (0, gen1, G1),
+    (1, gen2, G2),
+    (2, gen3, G3),
+    (3, gen4, G4);
+    (gen5, G5)
+);
+impl_one_of!(
+    OneOf6Generator,
+    one_of6,
+    5,
+    (0, gen1, G1),
+    (1, gen2, G2),
+    (2, gen3, G3),
+    (3, gen4, G4),
+    (4, gen5, G5);
+    (gen6, G6)
+);
+impl_one_of!(
+    OneOf7Generator,
+    one_of7,
+    6,
+    (0, gen1, G1),
+    (1, gen2, G2),
+    (2, gen3, G3),
+    (3, gen4, G4),
+    (4, gen5, G5),
+    (5, gen6, G6);
+    (gen7, G7)
+);
+impl_one_of!(
+    OneOf8Generator,
+    one_of8,
+    7,
+    (0, gen1, G1),
+    (1, gen2, G2),
+    (2, gen3, G3),
+    (3, gen4, G4),
+    (4, gen5, G5),
+    (5, gen6, G6),
+    (6, gen7, G7);
+    (gen8, G8)
+);
+impl_one_of!(
+    OneOf9Generator,
+    one_of9,
+    8,
+    (0, gen1, G1),
+    (1, gen2, G2),
+    (2, gen3, G3),
+    (3, gen4, G4),
+    (4, gen5, G5),
+    (5, gen6, G6),
+    (6, gen7, G7),
+    (7, gen8, G8);
+    (gen9, G9)
+);
+impl_one_of!(
+    OneOf10Generator,
+    one_of10,
+    9,
+    (0, gen1, G1),
+    (1, gen2, G2),
+    (2, gen3, G3),
+    (3, gen4, G4),
+    (4, gen5, G5),
+    (5, gen6, G6),
+    (6, gen7, G7),
+    (7, gen8, G8),
+    (8, gen9, G9);
+    (gen10, G10)
+);
+impl_one_of!(
+    OneOf11Generator,
+    one_of11,
+    10,
+    (0, gen1, G1),
+    (1, gen2, G2),
+    (2, gen3, G3),
+    (3, gen4, G4),
+    (4, gen5, G5),
+    (5, gen6, G6),
+    (6, gen7, G7),
+    (7, gen8, G8),
+    (8, gen9, G9),
+    (9, gen10, G10);
+    (gen11, G11)
+);
+impl_one_of!(
+    OneOf12Generator,
+    one_of12,
+    11,
+    (0, gen1, G1),
+    (1, gen2, G2),
+    (2, gen3, G3),
+    (3, gen4, G4),
+    (4, gen5, G5),
+    (5, gen6, G6),
+    (6, gen7, G7),
+    (7, gen8, G8),
+    (8, gen9, G9),
+    (9, gen10, G10),
+    (10, gen11, G11);
+    (gen12, G12)
+);
 
 /// Generator that produces `Some(value)` or `None`. Created by [`optional()`].
 pub struct OptionalGenerator<G, T> {

--- a/src/generators/combinators.rs
+++ b/src/generators/combinators.rs
@@ -51,19 +51,25 @@ where
 /// runtime-sized collection of alternatives needs.
 pub struct OneOfGenerator<'a, T, B = BoxedGenerator<'a, T>> {
     generators: Vec<B>,
-    _phantom: PhantomData<fn(&'a ()) -> T>,
+    _phantom: PhantomData<&'a fn() -> T>,
+}
+
+fn draw_one_of<T>(tc: &TestCase, max_index: usize, pick: impl FnOnce(usize) -> T) -> T {
+    tc.start_span(labels::ONE_OF);
+    let index = integers::<usize>()
+        .min_value(0)
+        .max_value(max_index)
+        .do_draw(tc);
+    let result = pick(index);
+    tc.stop_span(false);
+    result
 }
 
 impl<'a, T, B: Generator<T>> Generator<T> for OneOfGenerator<'a, T, B> {
     fn do_draw(&self, tc: &TestCase) -> T {
-        tc.start_span(labels::ONE_OF);
-        let index = integers::<usize>()
-            .min_value(0)
-            .max_value(self.generators.len() - 1)
-            .do_draw(tc);
-        let result = self.generators[index].do_draw(tc);
-        tc.stop_span(false);
-        result
+        draw_one_of(tc, self.generators.len() - 1, |index| {
+            self.generators[index].do_draw(tc)
+        })
     }
 
     fn enumerate_values(&self) -> Option<Vec<T>> {
@@ -99,9 +105,10 @@ where
 ///
 /// The component generators keep their concrete types (no boxing), so the
 /// result is a nameable, arity-specific generator type mirroring
-/// [`tuples!`](crate::tuples). For more than 12 alternatives, or a number
-/// not known at compile time, box the generators and call [`one_of`]
-/// directly.
+/// [`tuples!`](crate::tuples): [`OneOf1Generator`](crate::generators::OneOf1Generator)
+/// through [`OneOf12Generator`](crate::generators::OneOf12Generator). For
+/// more than 12 alternatives, or a number not known at compile time, box
+/// the generators and call [`one_of`] directly.
 ///
 /// # Example
 ///
@@ -156,92 +163,55 @@ macro_rules! one_of {
             $g1, $g2, $g3, $g4, $g5, $g6, $g7, $g8, $g9, $g10, $g11, $g12,
         )
     };
-    ($g1:expr, $g2:expr, $g3:expr, $g4:expr, $g5:expr, $g6:expr, $g7:expr, $g8:expr, $g9:expr, $g10:expr, $g11:expr, $g12:expr, $($rest:expr),+ $(,)?) => {
+    ($g1:expr, $g2:expr, $g3:expr, $g4:expr, $g5:expr, $g6:expr, $g7:expr, $g8:expr, $g9:expr, $g10:expr, $g11:expr, $g12:expr, $($rest:tt)+) => {
         compile_error!(
             "one_of! supports at most 12 generators; for more, box them and call \
-             hegel::generators::one_of directly (e.g. \
-             one_of(vec![g1.boxed(), g2.boxed(), ...]))"
+             hegel::generators::one_of directly, e.g. \
+             one_of(vec![g1.boxed(), g2.boxed(), ...]) with the \
+             hegel::generators::Generator trait in scope for .boxed()"
         )
     };
 }
 
-/// Generator choosing from a single alternative. Created by
-/// [`one_of!`](crate::one_of); the 2–12 alternative forms are the
-/// macro-generated `OneOf2Generator` … `OneOf12Generator`.
-pub struct OneOf1Generator<G1, T> {
-    gen1: G1,
-    _phantom: PhantomData<fn(T)>,
-}
-
-impl<T, G1> Generator<T> for OneOf1Generator<G1, T>
-where
-    G1: Generator<T>,
-{
-    fn do_draw(&self, tc: &TestCase) -> T {
-        tc.start_span(labels::ONE_OF);
-        integers::<usize>().min_value(0).max_value(0).do_draw(tc);
-        let result = self.gen1.do_draw(tc);
-        tc.stop_span(false);
-        result
-    }
-
-    fn enumerate_values(&self) -> Option<Vec<T>> {
-        self.gen1.enumerate_values()
-    }
-}
-
-#[doc(hidden)]
-pub fn one_of1<T, G1: Generator<T>>(gen1: G1) -> OneOf1Generator<G1, T> {
-    OneOf1Generator {
-        gen1,
-        _phantom: PhantomData,
-    }
-}
-
 macro_rules! impl_one_of {
-    ($name:ident, $fn_name:ident, $max:expr,
-     $(($idx:tt, $field:ident, $G:ident)),+ ; ($last_field:ident, $last_G:ident)) => {
-        pub struct $name<$($G,)+ $last_G, T> {
-            $($field: $G,)+
+    ($name:ident, $fn_name:ident, $arity:literal,
+     $(($idx:tt, $field:ident, $G:ident)),* ; ($last_field:ident, $last_G:ident)) => {
+        #[doc = concat!(
+            "The ", $arity, "-alternative generator created by [`one_of!`](crate::one_of)."
+        )]
+        pub struct $name<$($G,)* $last_G, T> {
+            $($field: $G,)*
             $last_field: $last_G,
             _phantom: PhantomData<fn(T)>,
         }
 
-        impl<T, $($G,)+ $last_G> Generator<T> for $name<$($G,)+ $last_G, T>
+        impl<T, $($G,)* $last_G> Generator<T> for $name<$($G,)* $last_G, T>
         where
-            $($G: Generator<T>,)+
+            $($G: Generator<T>,)*
             $last_G: Generator<T>,
         {
             fn do_draw(&self, tc: &TestCase) -> T {
-                tc.start_span(labels::ONE_OF);
-                let index = integers::<usize>()
-                    .min_value(0)
-                    .max_value($max)
-                    .do_draw(tc);
-                let result = match index {
-                    $($idx => self.$field.do_draw(tc),)+
+                draw_one_of(tc, $arity - 1, |index| match index {
+                    $($idx => self.$field.do_draw(tc),)*
                     _ => self.$last_field.do_draw(tc),
-                };
-                tc.stop_span(false);
-                result
+                })
             }
 
             fn enumerate_values(&self) -> Option<Vec<T>> {
                 let mut all = Vec::new();
-                $(all.extend(self.$field.enumerate_values()?);)+
+                $(all.extend(self.$field.enumerate_values()?);)*
                 all.extend(self.$last_field.enumerate_values()?);
                 Some(all)
             }
         }
 
-
         #[doc(hidden)]
         #[allow(clippy::too_many_arguments)]
-        pub fn $fn_name<T, $($G: Generator<T>,)+ $last_G: Generator<T>>(
-            $($field: $G,)+ $last_field: $last_G,
-        ) -> $name<$($G,)+ $last_G, T> {
+        pub fn $fn_name<T, $($G: Generator<T>,)* $last_G: Generator<T>>(
+            $($field: $G,)* $last_field: $last_G,
+        ) -> $name<$($G,)* $last_G, T> {
             $name {
-                $($field,)+
+                $($field,)*
                 $last_field,
                 _phantom: PhantomData,
             }
@@ -249,11 +219,12 @@ macro_rules! impl_one_of {
     };
 }
 
-impl_one_of!(OneOf2Generator, one_of2, 1, (0, gen1, G1); (gen2, G2));
+impl_one_of!(OneOf1Generator, one_of1, 1, ; (gen1, G1));
+impl_one_of!(OneOf2Generator, one_of2, 2, (0, gen1, G1); (gen2, G2));
 impl_one_of!(
     OneOf3Generator,
     one_of3,
-    2,
+    3,
     (0, gen1, G1),
     (1, gen2, G2);
     (gen3, G3)
@@ -261,7 +232,7 @@ impl_one_of!(
 impl_one_of!(
     OneOf4Generator,
     one_of4,
-    3,
+    4,
     (0, gen1, G1),
     (1, gen2, G2),
     (2, gen3, G3);
@@ -270,7 +241,7 @@ impl_one_of!(
 impl_one_of!(
     OneOf5Generator,
     one_of5,
-    4,
+    5,
     (0, gen1, G1),
     (1, gen2, G2),
     (2, gen3, G3),
@@ -280,7 +251,7 @@ impl_one_of!(
 impl_one_of!(
     OneOf6Generator,
     one_of6,
-    5,
+    6,
     (0, gen1, G1),
     (1, gen2, G2),
     (2, gen3, G3),
@@ -291,7 +262,7 @@ impl_one_of!(
 impl_one_of!(
     OneOf7Generator,
     one_of7,
-    6,
+    7,
     (0, gen1, G1),
     (1, gen2, G2),
     (2, gen3, G3),
@@ -303,7 +274,7 @@ impl_one_of!(
 impl_one_of!(
     OneOf8Generator,
     one_of8,
-    7,
+    8,
     (0, gen1, G1),
     (1, gen2, G2),
     (2, gen3, G3),
@@ -316,7 +287,7 @@ impl_one_of!(
 impl_one_of!(
     OneOf9Generator,
     one_of9,
-    8,
+    9,
     (0, gen1, G1),
     (1, gen2, G2),
     (2, gen3, G3),
@@ -330,7 +301,7 @@ impl_one_of!(
 impl_one_of!(
     OneOf10Generator,
     one_of10,
-    9,
+    10,
     (0, gen1, G1),
     (1, gen2, G2),
     (2, gen3, G3),
@@ -345,7 +316,7 @@ impl_one_of!(
 impl_one_of!(
     OneOf11Generator,
     one_of11,
-    10,
+    11,
     (0, gen1, G1),
     (1, gen2, G2),
     (2, gen3, G3),
@@ -361,7 +332,7 @@ impl_one_of!(
 impl_one_of!(
     OneOf12Generator,
     one_of12,
-    11,
+    12,
     (0, gen1, G1),
     (1, gen2, G2),
     (2, gen3, G3),

--- a/src/generators/mod.rs
+++ b/src/generators/mod.rs
@@ -55,6 +55,11 @@ pub use strings::{
     from_regex, ip_addresses, text, time_strings, urls, uuids,
 };
 pub use time::{DurationGenerator, durations};
+pub use tuples::{
+    Tuple0Generator, Tuple1Generator, Tuple2Generator, Tuple3Generator, Tuple4Generator,
+    Tuple5Generator, Tuple6Generator, Tuple7Generator, Tuple8Generator, Tuple9Generator,
+    Tuple10Generator, Tuple11Generator, Tuple12Generator,
+};
 #[doc(hidden)]
 pub use tuples::{
     tuples0, tuples1, tuples2, tuples3, tuples4, tuples5, tuples6, tuples7, tuples8, tuples9,

--- a/src/generators/mod.rs
+++ b/src/generators/mod.rs
@@ -29,7 +29,15 @@ pub use collections::{
     vecs,
 };
 pub use combinators::{
-    OneOfGenerator, OptionalGenerator, SampledFromGenerator, one_of, optional, sampled_from,
+    OneOf1Generator, OneOf2Generator, OneOf3Generator, OneOf4Generator, OneOf5Generator,
+    OneOf6Generator, OneOf7Generator, OneOf8Generator, OneOf9Generator, OneOf10Generator,
+    OneOf11Generator, OneOf12Generator, OneOfGenerator, OptionalGenerator, SampledFromGenerator,
+    one_of, optional, sampled_from,
+};
+#[doc(hidden)]
+pub use combinators::{
+    one_of1, one_of2, one_of3, one_of4, one_of5, one_of6, one_of7, one_of8, one_of9, one_of10,
+    one_of11, one_of12,
 };
 pub use compose::ComposedGenerator;
 #[doc(hidden)]

--- a/src/generators/tuples.rs
+++ b/src/generators/tuples.rs
@@ -3,6 +3,10 @@ use std::marker::PhantomData;
 
 /// Creates a tuple generator from 0–12 component generators.
 ///
+/// The component generators keep their concrete types, so the result is a
+/// nameable, arity-specific generator type: [`Tuple0Generator`](crate::generators::Tuple0Generator)
+/// through [`Tuple12Generator`](crate::generators::Tuple12Generator).
+///
 /// # Examples
 ///
 /// ```no_run
@@ -64,10 +68,19 @@ macro_rules! tuples {
             $g1, $g2, $g3, $g4, $g5, $g6, $g7, $g8, $g9, $g10, $g11, $g12,
         )
     };
+    ($g1:expr, $g2:expr, $g3:expr, $g4:expr, $g5:expr, $g6:expr, $g7:expr, $g8:expr, $g9:expr, $g10:expr, $g11:expr, $g12:expr, $($rest:tt)+) => {
+        compile_error!(
+            "tuples! supports at most 12 generators; for wider shapes, nest \
+             tuples! calls or write a composite generator"
+        )
+    };
 }
 
 macro_rules! impl_tuple {
-    ($name:ident, $fn_name:ident, $(($idx:tt, $field:ident, $G:ident, $T:ident)),+) => {
+    ($name:ident, $fn_name:ident, $arity:literal, $(($idx:tt, $field:ident, $G:ident, $T:ident)),+) => {
+        #[doc = concat!(
+            "The ", $arity, "-element tuple generator created by [`tuples!`](crate::tuples)."
+        )]
         pub struct $name<$($G,)+ $($T,)+> {
             $($field: $G,)+
             _phantom: PhantomData<fn($($T,)+)>,
@@ -127,16 +140,18 @@ impl DefaultGenerator for () {
     }
 }
 
-impl_tuple!(Tuple1Generator, tuples1, (0, gen1, G1, T1));
+impl_tuple!(Tuple1Generator, tuples1, 1, (0, gen1, G1, T1));
 impl_tuple!(
     Tuple2Generator,
     tuples2,
+    2,
     (0, gen1, G1, T1),
     (1, gen2, G2, T2)
 );
 impl_tuple!(
     Tuple3Generator,
     tuples3,
+    3,
     (0, gen1, G1, T1),
     (1, gen2, G2, T2),
     (2, gen3, G3, T3)
@@ -144,6 +159,7 @@ impl_tuple!(
 impl_tuple!(
     Tuple4Generator,
     tuples4,
+    4,
     (0, gen1, G1, T1),
     (1, gen2, G2, T2),
     (2, gen3, G3, T3),
@@ -152,6 +168,7 @@ impl_tuple!(
 impl_tuple!(
     Tuple5Generator,
     tuples5,
+    5,
     (0, gen1, G1, T1),
     (1, gen2, G2, T2),
     (2, gen3, G3, T3),
@@ -161,6 +178,7 @@ impl_tuple!(
 impl_tuple!(
     Tuple6Generator,
     tuples6,
+    6,
     (0, gen1, G1, T1),
     (1, gen2, G2, T2),
     (2, gen3, G3, T3),
@@ -171,6 +189,7 @@ impl_tuple!(
 impl_tuple!(
     Tuple7Generator,
     tuples7,
+    7,
     (0, gen1, G1, T1),
     (1, gen2, G2, T2),
     (2, gen3, G3, T3),
@@ -182,6 +201,7 @@ impl_tuple!(
 impl_tuple!(
     Tuple8Generator,
     tuples8,
+    8,
     (0, gen1, G1, T1),
     (1, gen2, G2, T2),
     (2, gen3, G3, T3),
@@ -194,6 +214,7 @@ impl_tuple!(
 impl_tuple!(
     Tuple9Generator,
     tuples9,
+    9,
     (0, gen1, G1, T1),
     (1, gen2, G2, T2),
     (2, gen3, G3, T3),
@@ -207,6 +228,7 @@ impl_tuple!(
 impl_tuple!(
     Tuple10Generator,
     tuples10,
+    10,
     (0, gen1, G1, T1),
     (1, gen2, G2, T2),
     (2, gen3, G3, T3),
@@ -221,6 +243,7 @@ impl_tuple!(
 impl_tuple!(
     Tuple11Generator,
     tuples11,
+    11,
     (0, gen1, G1, T1),
     (1, gen2, G2, T2),
     (2, gen3, G3, T3),
@@ -236,6 +259,7 @@ impl_tuple!(
 impl_tuple!(
     Tuple12Generator,
     tuples12,
+    12,
     (0, gen1, G1, T1),
     (1, gen2, G2, T2),
     (2, gen3, G3, T3),

--- a/tests/test_combinators.rs
+++ b/tests/test_combinators.rs
@@ -28,6 +28,15 @@ fn test_one_of_enumerates_when_all_children_do() {
 
     let g = hegel::one_of!(gs::sampled_from(vec![1_i64, 2]), gs::integers::<i64>());
     assert!(g.enumerate_values().is_none());
+
+    let g = hegel::one_of!(gs::sampled_from(vec![1_i64, 2]));
+    assert_eq!(g.enumerate_values(), Some(vec![1, 2]));
+
+    let g = gs::one_of(vec![
+        gs::sampled_from(vec![1_i64, 2]).boxed(),
+        gs::sampled_from(vec![3_i64, 4]).boxed(),
+    ]);
+    assert_eq!(g.enumerate_values(), Some(vec![1, 2, 3, 4]));
 }
 
 #[test]
@@ -100,6 +109,44 @@ fn test_one_of_with_different_types_via_map(tc: TestCase) {
 fn test_one_of_many(tc: TestCase) {
     let value = tc.draw(gs::one_of((0..10).map(|i| gs::just(i).boxed())));
     assert!((0..10).contains(&value));
+}
+
+#[derive(Clone, PartialEq)]
+struct Opaque(i32);
+
+#[hegel::test]
+fn test_one_of_with_non_debug_components_draws_silently(tc: TestCase) {
+    let value = tc.draw_silent(hegel::one_of!(
+        gs::just(Opaque(1)),
+        gs::integers::<i32>().min_value(2).max_value(5).map(Opaque),
+    ));
+    assert!(value == Opaque(1) || (2..=5).contains(&value.0));
+}
+
+#[hegel::test]
+fn test_one_of_single_component(tc: TestCase) {
+    assert_eq!(tc.draw(hegel::one_of!(gs::just(42))), 42);
+    assert_eq!(tc.draw(hegel::one_of!(gs::just(43),)), 43);
+    assert_eq!(tc.draw_silent(hegel::one_of!(gs::just(44))), 44);
+}
+
+#[hegel::test]
+fn test_one_of_twelve_components(tc: TestCase) {
+    let value = tc.draw(hegel::one_of!(
+        gs::just(0),
+        gs::just(1),
+        gs::just(2),
+        gs::just(3),
+        gs::just(4),
+        gs::just(5),
+        gs::just(6),
+        gs::just(7),
+        gs::just(8),
+        gs::just(9),
+        gs::just(10),
+        gs::just(11),
+    ));
+    assert!((0..12).contains(&value));
 }
 
 #[hegel::test]
@@ -395,7 +442,7 @@ mod one_of {
     fn test_one_of_empty() {
         expect_panic(
             || {
-                gs::one_of::<i64, _>(vec![]);
+                gs::one_of(Vec::<gs::BoxedGenerator<i64>>::new());
             },
             "one_of requires at least one generator",
         );
@@ -1055,6 +1102,28 @@ mod nocover_given_reuse {
 
         Hegel::new(|tc| {
             let _z: String = tc.draw(&g);
+        })
+        .settings(Settings::new().database(None))
+        .run();
+    }
+}
+
+mod one_of_named_types {
+    use hegel::generators::{self as gs, OneOf2Generator};
+    use hegel::{Hegel, Settings};
+
+    struct Holder {
+        generator:
+            OneOf2Generator<gs::IntegerGenerator<i64>, gs::SampledFromGenerator<'static, i64>, i64>,
+    }
+
+    #[test]
+    fn test_one_of_result_types_are_nameable() {
+        let holder = Holder {
+            generator: hegel::one_of!(gs::integers::<i64>(), gs::sampled_from(vec![1_i64, 2])),
+        };
+        Hegel::new(move |tc| {
+            let _: i64 = tc.draw(&holder.generator);
         })
         .settings(Settings::new().database(None))
         .run();

--- a/tests/test_combinators.rs
+++ b/tests/test_combinators.rs
@@ -1129,3 +1129,152 @@ mod one_of_named_types {
         .run();
     }
 }
+
+fn _one_of_generator_is_covariant_in_its_lifetime<'a>(
+    g: gs::OneOfGenerator<'static, i64>,
+) -> gs::OneOfGenerator<'a, i64> {
+    g
+}
+
+mod one_of_arity_dispatch {
+    use hegel::generators::{self as gs, Generator};
+    use hegel::{Hegel, Settings, TestCase};
+    use std::collections::HashSet;
+    use std::sync::{Arc, Mutex};
+
+    fn assert_every_alternative_reachable<G>(arity: i32, generator: G)
+    where
+        G: Generator<i32> + Send + Sync + 'static,
+    {
+        let seen: Arc<Mutex<HashSet<i32>>> = Arc::new(Mutex::new(HashSet::new()));
+        let track = Arc::clone(&seen);
+        Hegel::new(move |tc: TestCase| {
+            track.lock().unwrap().insert(tc.draw(&generator));
+        })
+        .settings(Settings::new().database(None).test_cases(500))
+        .run();
+        assert_eq!(*seen.lock().unwrap(), (0..arity).collect::<HashSet<i32>>());
+    }
+
+    #[test]
+    fn test_one_of_every_arity_reaches_every_alternative() {
+        assert_every_alternative_reachable(1, hegel::one_of!(gs::just(0)));
+        assert_every_alternative_reachable(2, hegel::one_of!(gs::just(0), gs::just(1)));
+        assert_every_alternative_reachable(
+            3,
+            hegel::one_of!(gs::just(0), gs::just(1), gs::just(2)),
+        );
+        assert_every_alternative_reachable(
+            4,
+            hegel::one_of!(gs::just(0), gs::just(1), gs::just(2), gs::just(3)),
+        );
+        assert_every_alternative_reachable(
+            5,
+            hegel::one_of!(
+                gs::just(0),
+                gs::just(1),
+                gs::just(2),
+                gs::just(3),
+                gs::just(4)
+            ),
+        );
+        assert_every_alternative_reachable(
+            6,
+            hegel::one_of!(
+                gs::just(0),
+                gs::just(1),
+                gs::just(2),
+                gs::just(3),
+                gs::just(4),
+                gs::just(5)
+            ),
+        );
+        assert_every_alternative_reachable(
+            7,
+            hegel::one_of!(
+                gs::just(0),
+                gs::just(1),
+                gs::just(2),
+                gs::just(3),
+                gs::just(4),
+                gs::just(5),
+                gs::just(6)
+            ),
+        );
+        assert_every_alternative_reachable(
+            8,
+            hegel::one_of!(
+                gs::just(0),
+                gs::just(1),
+                gs::just(2),
+                gs::just(3),
+                gs::just(4),
+                gs::just(5),
+                gs::just(6),
+                gs::just(7)
+            ),
+        );
+        assert_every_alternative_reachable(
+            9,
+            hegel::one_of!(
+                gs::just(0),
+                gs::just(1),
+                gs::just(2),
+                gs::just(3),
+                gs::just(4),
+                gs::just(5),
+                gs::just(6),
+                gs::just(7),
+                gs::just(8)
+            ),
+        );
+        assert_every_alternative_reachable(
+            10,
+            hegel::one_of!(
+                gs::just(0),
+                gs::just(1),
+                gs::just(2),
+                gs::just(3),
+                gs::just(4),
+                gs::just(5),
+                gs::just(6),
+                gs::just(7),
+                gs::just(8),
+                gs::just(9)
+            ),
+        );
+        assert_every_alternative_reachable(
+            11,
+            hegel::one_of!(
+                gs::just(0),
+                gs::just(1),
+                gs::just(2),
+                gs::just(3),
+                gs::just(4),
+                gs::just(5),
+                gs::just(6),
+                gs::just(7),
+                gs::just(8),
+                gs::just(9),
+                gs::just(10)
+            ),
+        );
+        assert_every_alternative_reachable(
+            12,
+            hegel::one_of!(
+                gs::just(0),
+                gs::just(1),
+                gs::just(2),
+                gs::just(3),
+                gs::just(4),
+                gs::just(5),
+                gs::just(6),
+                gs::just(7),
+                gs::just(8),
+                gs::just(9),
+                gs::just(10),
+                gs::just(11)
+            ),
+        );
+    }
+}

--- a/tests/ui/one_of_too_many_generators.rs
+++ b/tests/ui/one_of_too_many_generators.rs
@@ -1,0 +1,32 @@
+// `one_of!` supports up to 12 component generators; a thirteenth must
+// produce a clear error pointing at the vec-based `one_of` function.
+//
+// (The `_used` binding keeps the `gs` import live — the compile_error!
+// discards the macro arguments before they can use it — and doubles as
+// filler keeping every line rustc renders in the diagnostic at a two-digit
+// line number: toolchains disagree on how single-digit line numbers are
+// aligned in a multi-digit gutter, and this golden must match both the
+// MSRV and current compilers.)
+
+use hegel::generators as gs;
+
+fn _check(tc: &hegel::TestCase) {
+    let _used = gs::just(0);
+    let _ = tc.draw(hegel::one_of!(
+        gs::just(0),
+        gs::just(1),
+        gs::just(2),
+        gs::just(3),
+        gs::just(4),
+        gs::just(5),
+        gs::just(6),
+        gs::just(7),
+        gs::just(8),
+        gs::just(9),
+        gs::just(10),
+        gs::just(11),
+        gs::just(12),
+    ));
+}
+
+fn main() {}

--- a/tests/ui/one_of_too_many_generators.stderr
+++ b/tests/ui/one_of_too_many_generators.stderr
@@ -1,8 +1,8 @@
-error: one_of! supports at most 12 generators; for more, box them and call hegel::generators::one_of directly (e.g. one_of(vec![g1.boxed(), g2.boxed(), ...]))
-  --> tests/ui/one_of_too_many_generators.rs:15:21
+error: one_of! supports at most 12 generators; for more, box them and call hegel::generators::one_of directly, e.g. one_of(vec![g1.boxed(), g2.boxed(), ...]) with the hegel::generators::Generator trait in scope for .boxed()
+  --> tests/ui/one_of_too_many_generators.rs:15:13
    |
-15 |       let _ = tc.draw(hegel::one_of!(
-   |  _____________________^
+15 |       tc.draw(hegel::one_of!(
+   |  _____________^
 16 | |         gs::just(0),
 17 | |         gs::just(1),
 18 | |         gs::just(2),

--- a/tests/ui/one_of_too_many_generators.stderr
+++ b/tests/ui/one_of_too_many_generators.stderr
@@ -1,0 +1,14 @@
+error: one_of! supports at most 12 generators; for more, box them and call hegel::generators::one_of directly (e.g. one_of(vec![g1.boxed(), g2.boxed(), ...]))
+  --> tests/ui/one_of_too_many_generators.rs:15:21
+   |
+15 |       let _ = tc.draw(hegel::one_of!(
+   |  _____________________^
+16 | |         gs::just(0),
+17 | |         gs::just(1),
+18 | |         gs::just(2),
+...  |
+28 | |         gs::just(12),
+29 | |     ));
+   | |_____^
+   |
+   = note: this error originates in the macro `hegel::one_of` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/tuples_too_many_generators.rs
+++ b/tests/ui/tuples_too_many_generators.rs
@@ -1,5 +1,6 @@
-// `one_of!` supports up to 12 component generators; a thirteenth must
-// produce a clear error pointing at the vec-based `one_of` function.
+// `tuples!` supports up to 12 component generators; a thirteenth must
+// produce a clear error suggesting nesting instead of rustc's opaque
+// "no rules expected this token".
 //
 // (The `_used` binding keeps the `gs` import live — the compile_error!
 // discards the macro arguments before they can use it — and doubles as
@@ -12,7 +13,7 @@ use hegel::generators as gs;
 
 fn _check(tc: &hegel::TestCase) {
     let _used = gs::just(0);
-    tc.draw(hegel::one_of!(
+    tc.draw(hegel::tuples!(
         gs::just(0),
         gs::just(1),
         gs::just(2),

--- a/tests/ui/tuples_too_many_generators.stderr
+++ b/tests/ui/tuples_too_many_generators.stderr
@@ -1,0 +1,14 @@
+error: tuples! supports at most 12 generators; for wider shapes, nest tuples! calls or write a composite generator
+  --> tests/ui/tuples_too_many_generators.rs:16:13
+   |
+16 |       tc.draw(hegel::tuples!(
+   |  _____________^
+17 | |         gs::just(0),
+18 | |         gs::just(1),
+19 | |         gs::just(2),
+...  |
+29 | |         gs::just(12),
+30 | |     ));
+   | |_____^
+   |
+   = note: this error originates in the macro `hegel::tuples` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
one_of! previously created a single heterogenous OneOfGenerator by boxing its arguments. It now expands to arity-specific generators (OneOf1Generator through OneOf12Generator, mirroring the tuples! design) that keep their components' concrete types. This removes the requirement that components in one_of be boxable (which forces them to be Sync) and lays some groundwork for later features.