### PR TITLE
Parallel test-case execution (Settings::threads)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,12 @@
+RELEASE_TYPE: patch
+
+This patch adds parallel test-case execution. The new `Settings::threads(n)` setting (default 1, overridable at runtime with the `HEGEL_THREADS` environment variable) runs test-case bodies on `n` worker threads during the generation phase; shrinking, database replay, and the failure report stay sequential, so every discovered failure still shrinks to a minimal counterexample and replays exactly via its reproduce blob and the failure database. Tests written with `#[hegel::test]` and `#[hegel::main]` support this out of the box:
+
+```rust
+#[hegel::test(threads = 4)]
+fn my_test(tc: hegel::TestCase) { ... }
+```
+
+With `threads` above 1 the search itself is not schedule-reproducible, even with a fixed seed: which test case is generated next depends on the order completions arrive. `#[hegel::standalone_function]` does not yet support `threads` above 1 and fails with a usage error if it is requested.
+
+Code calling the `Hegel` builder directly reaches parallel execution through the new `Hegel::new_concurrent` / `Hegel::run_concurrent` entry points, which require the test function to be `Fn(TestCase) + Sync`; `Hegel::new` / `Hegel::run` are unchanged and single-threaded.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,3 +10,5 @@ fn my_test(tc: hegel::TestCase) { ... }
 With `threads` above 1 the search itself is not schedule-reproducible, even with a fixed seed: which test case is generated next depends on the order completions arrive. `#[hegel::standalone_function]` does not yet support `threads` above 1 and fails with a usage error if it is requested.
 
 Code calling the `Hegel` builder directly reaches parallel execution through the new `Hegel::new_concurrent` / `Hegel::run_concurrent` entry points, which require the test function to be `Fn(TestCase) + Sync`; `Hegel::new` / `Hegel::run` are unchanged and single-threaded.
+
+The TooSlow health check now measures the generation phase's wall-clock time rather than summed per-test-case time, so it also accounts for time between test cases; single-threaded runs near the threshold may trip it marginally sooner.

--- a/hegel-c/RELEASE.md
+++ b/hegel-c/RELEASE.md
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch adds support for keeping several test cases open at once. The new `hegel_settings_set_max_open_test_cases` setting (default 1, which preserves the strict-alternation contract exactly) lets a caller take up to that many cases from `hegel_next_test_case` before marking them complete, so their bodies can run concurrently; the new `HEGEL_E_PENDING` result code reports that no case is available until one of the open ones completes. `hegel_mark_complete` may be called from any thread on any open handle, `hegel_run_free` now completes every open case, and concurrent misuse of a run handle reports `HEGEL_E_CONCURRENT_USE` instead of being undefined behavior. See the threading section of the header preamble and the new `open_window.c` example.
+
+The TooSlow health check now measures generation-phase wall-clock time rather than summed per-case time, which would overcount when test cases overlap.

--- a/hegel-c/cbindgen.toml
+++ b/hegel-c/cbindgen.toml
@@ -88,9 +88,17 @@ header = """
  *   threads is a data race.
  * - A settings handle may be shared across threads once configured, but
  *   each setter call requires exclusive access.
- * - A run handle must only be used from one thread at a time. Calling
- *   hegel_next_test_case, hegel_run_result, or hegel_run_free concurrently
- *   on the same run is undefined behavior.
+ * - A run handle must only be used from one thread at a time: pump
+ *   hegel_next_test_case, hegel_run_result, and hegel_run_free from a
+ *   single thread. Misuse is detected — a concurrent call on the same run
+ *   returns HEGEL_E_CONCURRENT_USE instead of racing.
+ * - hegel_mark_complete may be called from any thread on any open test-case
+ *   handle; completion is family-wide and first-caller-wins. With
+ *   hegel_settings_set_max_open_test_cases above 1, one thread pumps
+ *   hegel_next_test_case and hands the open cases to any threads it likes,
+ *   each of which reports its case's outcome from wherever it ran;
+ *   hegel_next_test_case returns HEGEL_E_PENDING while it waits for one of
+ *   them.
  * - A test-case handle may be driven by at most one thread at a time.
  *   Concurrent operations on it return HEGEL_E_CONCURRENT_USE. To generate
  *   from several threads, hegel_test_case_clone the handle and give each

--- a/hegel-c/examples/open_window.c
+++ b/hegel-c/examples/open_window.c
@@ -1,0 +1,145 @@
+/*
+ * open_window.c — demo: several test cases open at once via
+ * hegel_settings_set_max_open_test_cases.
+ *
+ * A single thread pumps hegel_next_test_case with a window of 3: it pulls
+ * cases until HEGEL_E_PENDING (or the window is full), runs each body as it
+ * is pulled, and marks the pooled cases complete newest-first — the
+ * out-of-order completion a thread pool would produce, minus the threads.
+ * Property: every integer in [0, 1000] is < 900. The run must fail with
+ * that one origin, and the pending state must have been observed.
+ *
+ * Build (same incantation as echo.c):
+ *   cc -o open_window open_window.c -I../include -L../../target/release \
+ *      -lhegel -Wl,-rpath,$PWD/../../target/release
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "hegel.h"
+#include "hegel_check.h"
+
+#define ORIGIN "n >= 900"
+#define WINDOW 3
+
+struct open_case {
+    hegel_test_case_t *tc;
+    hegel_status_t status;
+    const char *origin;
+};
+
+int main(void) {
+    hegel_context_t *ctx = hegel_context_new();
+
+    hegel_settings_t *s;
+    HEGEL_CHECK(hegel_settings_new, ctx, &s);
+    HEGEL_CHECK(hegel_settings_set_test_cases, ctx, s, 200);
+    HEGEL_CHECK(hegel_settings_set_database, ctx, s, "");
+    HEGEL_CHECK(hegel_settings_set_seed, ctx, s, 0xc0ffee, true);
+    HEGEL_CHECK(hegel_settings_set_max_open_test_cases, ctx, s, WINDOW);
+
+    hegel_run_t *run;
+    HEGEL_CHECK(hegel_run_start, ctx, s, NULL, NULL, &run);
+
+    struct open_case open[WINDOW];
+    size_t n_open = 0;
+    bool saw_pending = false;
+    bool finished = false;
+
+    while (!finished) {
+        /* Fill the pool: pull cases until the engine reports PENDING, the
+         * window is full, or the run finishes. */
+        while (n_open < WINDOW) {
+            hegel_test_case_t *tc;
+            hegel_result_t rc = hegel_next_test_case(ctx, run, &tc);
+            if (rc == HEGEL_E_PENDING) {
+                saw_pending = true;
+                break;
+            }
+            if (rc != HEGEL_OK) {
+                fprintf(stderr, "hegel_next_test_case: rc=%d %s\n", (int)rc,
+                        hegel_context_last_error(ctx));
+                return 1;
+            }
+            if (tc == NULL) {
+                finished = true;
+                break;
+            }
+
+            /* Run the body now; report the outcome later, out of order. */
+            struct open_case c = {tc, HEGEL_STATUS_VALID, NULL};
+            int64_t n;
+            hegel_result_t draw = hegel_generate_integer(ctx, tc, 0, 1000, &n);
+            if (draw == HEGEL_E_STOP_TEST) {
+                c.status = HEGEL_STATUS_OVERRUN;
+            } else if (draw != HEGEL_OK) {
+                fprintf(stderr, "hegel_generate_integer: rc=%d %s\n",
+                        (int)draw, hegel_context_last_error(ctx));
+                return 1;
+            } else if (n >= 900) {
+                c.status = HEGEL_STATUS_INTERESTING;
+                c.origin = ORIGIN;
+            }
+            open[n_open++] = c;
+        }
+
+        /* Complete one pooled case, newest first. */
+        if (n_open > 0) {
+            struct open_case c = open[--n_open];
+            HEGEL_CHECK(hegel_mark_complete, ctx, c.tc, c.status, c.origin);
+            HEGEL_CHECK(hegel_test_case_free, ctx, c.tc);
+        }
+    }
+
+    /* The run can finish while cases that concluded during a draw are still
+     * held; report and free the leftovers. */
+    while (n_open > 0) {
+        struct open_case c = open[--n_open];
+        HEGEL_CHECK(hegel_mark_complete, ctx, c.tc, c.status, c.origin);
+        HEGEL_CHECK(hegel_test_case_free, ctx, c.tc);
+    }
+
+    if (!saw_pending) {
+        fprintf(stderr, "FAIL: never observed HEGEL_E_PENDING\n");
+        return 1;
+    }
+
+    hegel_run_result_t *result;
+    HEGEL_CHECK(hegel_run_result, ctx, run, &result);
+    hegel_run_status_t status;
+    HEGEL_CHECK(hegel_run_result_status, ctx, result, &status);
+    if (status != HEGEL_RUN_STATUS_FAILED) {
+        fprintf(stderr, "FAIL: expected a failing run, got status %d\n",
+                (int)status);
+        return 1;
+    }
+
+    size_t nf;
+    HEGEL_CHECK(hegel_run_result_failure_count, ctx, result, &nf);
+    if (nf != 1) {
+        fprintf(stderr, "FAIL: expected exactly one failure, got %zu\n", nf);
+        return 1;
+    }
+    hegel_failure_t *failure;
+    HEGEL_CHECK(hegel_run_result_failure, ctx, result, 0, &failure);
+    const char *origin;
+    HEGEL_CHECK(hegel_failure_origin, ctx, failure, &origin);
+    if (strcmp(origin, ORIGIN) != 0) {
+        fprintf(stderr, "FAIL: unexpected origin %s\n", origin);
+        return 1;
+    }
+
+    printf("open_window: window of %d, out-of-order completion, "
+           "failure reported: %s\n",
+           WINDOW, origin);
+
+    HEGEL_CHECK(hegel_failure_free, ctx, failure);
+    HEGEL_CHECK(hegel_run_result_free, ctx, result);
+    HEGEL_CHECK(hegel_run_free, ctx, run);
+    HEGEL_CHECK(hegel_settings_free, ctx, s);
+    HEGEL_CHECK(hegel_context_free, ctx);
+    return 0;
+}

--- a/hegel-c/include/hegel.h
+++ b/hegel-c/include/hegel.h
@@ -774,6 +774,22 @@ hegel_result_t hegel_settings_set_test_cases(hegel_context_t *ctx, hegel_setting
 
 /*
  Parameters:
+ `max_open`: Maximum number of test cases that may be open (taken via
+   `hegel_next_test_case` but not yet marked complete) at once. The
+   default is 1, which preserves the strict-alternation contract exactly.
+   Values above 1 let the caller run that many test-case bodies
+   concurrently during generation; `hegel_next_test_case` then returns
+   `HEGEL_E_PENDING` when the engine is waiting for one of the open cases
+   to be marked complete. `max_open` must be at least 1.
+
+ Returns `HEGEL_OK`, or `HEGEL_E_INVALID_ARG` for `max_open` of 0.
+ */
+hegel_result_t hegel_settings_set_max_open_test_cases(hegel_context_t *ctx,
+                                                      hegel_settings_t *s,
+                                                      uint64_t max_open);
+
+/*
+ Parameters:
  `n`: Target number of steps to run per stateful test case. Each stateful
    case runs at least one step and at most `n`. The default is 50. `n`
    must be at least 1.

--- a/hegel-c/include/hegel.h
+++ b/hegel-c/include/hegel.h
@@ -86,9 +86,17 @@
  *   threads is a data race.
  * - A settings handle may be shared across threads once configured, but
  *   each setter call requires exclusive access.
- * - A run handle must only be used from one thread at a time. Calling
- *   hegel_next_test_case, hegel_run_result, or hegel_run_free concurrently
- *   on the same run is undefined behavior.
+ * - A run handle must only be used from one thread at a time: pump
+ *   hegel_next_test_case, hegel_run_result, and hegel_run_free from a
+ *   single thread. Misuse is detected — a concurrent call on the same run
+ *   returns HEGEL_E_CONCURRENT_USE instead of racing.
+ * - hegel_mark_complete may be called from any thread on any open test-case
+ *   handle; completion is family-wide and first-caller-wins. With
+ *   hegel_settings_set_max_open_test_cases above 1, one thread pumps
+ *   hegel_next_test_case and hands the open cases to any threads it likes,
+ *   each of which reports its case's outcome from wherever it ran;
+ *   hegel_next_test_case returns HEGEL_E_PENDING while it waits for one of
+ *   them.
  * - A test-case handle may be driven by at most one thread at a time.
  *   Concurrent operations on it return HEGEL_E_CONCURRENT_USE. To generate
  *   from several threads, hegel_test_case_clone the handle and give each
@@ -163,6 +171,13 @@ typedef enum {
      the handle instead.
      */
     HEGEL_E_CONCURRENT_USE = -9,
+    /*
+     `hegel_next_test_case`: no test case is available yet — the engine is
+     waiting for one of the open test cases to be marked complete. Complete
+     one, then call `hegel_next_test_case` again. Only returned when
+     `max_open_test_cases` is greater than 1.
+     */
+    HEGEL_E_PENDING = -10,
 } hegel_result_t;
 
 /*
@@ -550,6 +565,11 @@ typedef struct hegel_pool_t hegel_pool_t;
  The run handle owns the suspended run loop as a future, and each
  `hegel_next_test_case` call resumes it on the calling thread until it
  returns the next test case or finishes.
+
+ All run state lives behind an internal non-blocking lock: the run
+ functions are meant to be called from one thread at a time (see the
+ header preamble), and a concurrent call observes
+ `HEGEL_E_CONCURRENT_USE` instead of a data race.
  */
 typedef struct hegel_run_t hegel_run_t;
 
@@ -927,7 +947,10 @@ hegel_result_t hegel_run_start(hegel_context_t *ctx,
  Returns `HEGEL_OK`, including at normal completion, where
  `*out_test_case` is NULL and you should call `hegel_run_result`.
  `HEGEL_E_NOT_COMPLETE` if the previous test case was not marked
- complete.
+ complete (with the default `max_open_test_cases` of 1).
+ `HEGEL_E_PENDING` if `max_open_test_cases` is above 1 and no case is
+ available until one of the open ones is marked complete.
+ `HEGEL_E_CONCURRENT_USE` if another thread is mid-call on this run.
 
  The handle is owned by the caller and must be released with
  `hegel_test_case_free`.
@@ -942,7 +965,8 @@ hegel_result_t hegel_next_test_case(hegel_context_t *ctx,
    result.
 
  Returns `HEGEL_OK`, or `HEGEL_E_NOT_COMPLETE` if the run hasn't finished
- yet.
+ yet, or `HEGEL_E_CONCURRENT_USE` if another thread is mid-call on this
+ run.
 
  Each call produces a copy, freed separately. It stays valid after
  `hegel_run_free`.
@@ -968,7 +992,7 @@ hegel_result_t hegel_run_result_free(hegel_context_t *ctx, hegel_run_result_t *r
 
  Returns `HEGEL_OK`.
 
- If the caller exited its loop early, any in-flight test case is marked
+ If the caller exited its loop early, every in-flight test case is marked
  complete and the rest of the exploration is dropped.
  */
 hegel_result_t hegel_run_free(hegel_context_t *ctx, hegel_run_t *run);

--- a/hegel-c/src/exchange.rs
+++ b/hegel-c/src/exchange.rs
@@ -9,15 +9,20 @@
 //! one poll per test case (`hegel_next_test_case`) or in a loop to
 //! completion (the test-only `drive`).
 //!
-//! The protocol is strict alternation. Polling the engine future either
-//! returns `Ready` (the run is finished) or `Pending`, in which case the
-//! engine has stored exactly one offered case in the exchange for the driver
-//! to [`take`](CaseExchange::take). The driver must finish that case —
-//! everything through `mark_complete` — before polling again: the next poll
-//! resumes the engine, which immediately reads the case's outcome off its
-//! handle.
+//! The protocol generalises strict alternation to a bounded queue. Polling
+//! the engine future either returns `Ready` (the run is finished) or
+//! `Pending`, in which case the engine has queued zero or more offered cases
+//! in the exchange for the driver to take (via
+//! [`try_take`](CaseExchange::try_take), or [`take`](CaseExchange::take)
+//! where the protocol guarantees one is queued). With a pipeline window of 1
+//! (the default) this is exactly the old strict alternation: each `Pending`
+//! carries exactly one queued case, and the driver must finish it —
+//! everything through `mark_complete` — before polling again. With a wider
+//! window the engine may queue several cases before suspending, and a poll
+//! may legitimately find some of them still open.
 
 use alloc::boxed::Box;
+use alloc::collections::VecDeque;
 use core::future::Future;
 use core::pin::Pin;
 use core::task::{Context, Poll};
@@ -29,26 +34,45 @@ use crate::sys::sync::Mutex;
 /// A data source handed across the exchange, one per test case.
 pub(crate) type BoxedDataSource = Box<dyn DataSource + Send + Sync>;
 
-/// One engine-to-driver handoff slot. See the module docs for the protocol.
+/// The engine-to-driver handoff queue. See the module docs for the protocol.
 pub(crate) struct CaseExchange {
-    slot: Mutex<Option<BoxedDataSource>>,
+    queue: Mutex<VecDeque<BoxedDataSource>>,
 }
 
 impl CaseExchange {
     pub(crate) fn new() -> Self {
         CaseExchange {
-            slot: Mutex::new(None),
+            queue: Mutex::new(VecDeque::new()),
         }
     }
 
-    /// Yield `ds` to the driver. The returned future stores `ds` in the
-    /// exchange and suspends; by the alternation protocol it resolves on the
-    /// next poll, which the driver performs only once the case is complete.
-    pub(crate) fn offer(&self, ds: BoxedDataSource) -> Offer<'_> {
-        Offer {
-            exchange: self,
-            ds: Some(ds),
-        }
+    /// Queue `ds` for the driver without suspending, so the engine can keep
+    /// several cases open at once. The driver picks it up from a later
+    /// [`try_take`](Self::take) / [`take`](Self::take).
+    pub(crate) fn offer_nowait(&self, ds: BoxedDataSource) {
+        self.queue.lock().push_back(ds);
+    }
+
+    /// Suspend the engine until the driver polls it again. Combined with
+    /// [`offer_nowait`](Self::offer_nowait) this is how the engine hands
+    /// control back to the driver; on its own it is how the engine waits for
+    /// open cases to conclude.
+    pub(crate) fn suspend(&self) -> Yield {
+        Yield { suspended: false }
+    }
+
+    /// Yield `ds` to the driver: queue it and suspend. With a pipeline
+    /// window of 1 this preserves strict alternation — the future resolves
+    /// on the next poll, which the driver performs only once the case is
+    /// complete.
+    pub(crate) async fn offer(&self, ds: BoxedDataSource) {
+        self.offer_nowait(ds);
+        self.suspend().await;
+    }
+
+    /// Take the oldest queued case, or `None` when the queue is empty.
+    pub(crate) fn try_take(&self) -> Option<BoxedDataSource> {
+        self.queue.lock().pop_front()
     }
 
     /// Take the case the engine just offered. `Err` if the engine suspended
@@ -56,7 +80,7 @@ impl CaseExchange {
     /// bug in the engine, surfaced by the driver as a run-level error
     /// instead of a panic.
     pub(crate) fn take(&self) -> Result<BoxedDataSource, InternalError> {
-        let taken = self.slot.lock().take();
+        let taken = self.try_take();
         Ok(hegel_internal_unwrap!(
             taken,
             "the engine suspended without offering a test case"
@@ -70,24 +94,22 @@ impl Default for CaseExchange {
     }
 }
 
-/// Future returned by [`CaseExchange::offer`]: stores the data source and
-/// returns `Pending` on the first poll, `Ready` on the next.
-pub(crate) struct Offer<'a> {
-    exchange: &'a CaseExchange,
-    ds: Option<BoxedDataSource>,
+/// Future returned by [`CaseExchange::suspend`]: `Pending` on the first
+/// poll, `Ready` on the next.
+pub(crate) struct Yield {
+    suspended: bool,
 }
 
-impl Future for Offer<'_> {
+impl Future for Yield {
     type Output = ();
 
     fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<()> {
         let this = self.get_mut();
-        match this.ds.take() {
-            Some(ds) => {
-                *this.exchange.slot.lock() = Some(ds);
-                Poll::Pending
-            }
-            None => Poll::Ready(()),
+        if this.suspended {
+            Poll::Ready(())
+        } else {
+            this.suspended = true;
+            Poll::Pending
         }
     }
 }

--- a/hegel-c/src/lib.rs
+++ b/hegel-c/src/lib.rs
@@ -824,6 +824,38 @@ pub unsafe extern "C" fn hegel_settings_set_test_cases(
 }
 
 /// Parameters:
+/// `max_open`: Maximum number of test cases that may be open (taken via
+///   `hegel_next_test_case` but not yet marked complete) at once. The
+///   default is 1, which preserves the strict-alternation contract exactly.
+///   Values above 1 let the caller run that many test-case bodies
+///   concurrently during generation; `hegel_next_test_case` then returns
+///   `HEGEL_E_PENDING` when the engine is waiting for one of the open cases
+///   to be marked complete. `max_open` must be at least 1.
+///
+/// Returns `HEGEL_OK`, or `HEGEL_E_INVALID_ARG` for `max_open` of 0.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn hegel_settings_set_max_open_test_cases(
+    ctx: *mut HegelContext,
+    s: *mut HegelSettings,
+    max_open: u64,
+) -> hegel_result_t {
+    clear_last_error(ctx);
+    let handle = match unsafe { settings_mut(ctx, s, "hegel_settings_set_max_open_test_cases") } {
+        Ok(h) => h,
+        Err(rc) => return rc,
+    };
+    if max_open < 1 {
+        set_last_error(
+            ctx,
+            "hegel_settings_set_max_open_test_cases: max_open must be at least 1, got 0",
+        );
+        return HEGEL_E_INVALID_ARG;
+    }
+    handle.inner = handle.inner.clone().max_open_test_cases(max_open);
+    HEGEL_OK
+}
+
+/// Parameters:
 /// `n`: Target number of steps to run per stateful test case. Each stateful
 ///   case runs at least one step and at most `n`. The default is 50. `n`
 ///   must be at least 1.

--- a/hegel-c/src/lib.rs
+++ b/hegel-c/src/lib.rs
@@ -121,6 +121,12 @@ pub enum hegel_result_t {
     /// A single test-case handle was used from two threads at once. Clone
     /// the handle instead.
     HEGEL_E_CONCURRENT_USE = -9,
+
+    /// `hegel_next_test_case`: no test case is available yet — the engine is
+    /// waiting for one of the open test cases to be marked complete. Complete
+    /// one, then call `hegel_next_test_case` again. Only returned when
+    /// `max_open_test_cases` is greater than 1.
+    HEGEL_E_PENDING = -10,
 }
 
 use hegel_result_t::*;
@@ -562,21 +568,37 @@ type EngineFuture = Pin<Box<dyn Future<Output = Result<TestRunResult, RunError>>
 /// The run handle owns the suspended run loop as a future, and each
 /// `hegel_next_test_case` call resumes it on the calling thread until it
 /// returns the next test case or finishes.
+///
+/// All run state lives behind an internal non-blocking lock: the run
+/// functions are meant to be called from one thread at a time (see the
+/// header preamble), and a concurrent call observes
+/// `HEGEL_E_CONCURRENT_USE` instead of a data race.
 pub struct HegelRun {
+    inner: Mutex<RunInner>,
+}
+
+/// The lock-guarded state of a [`HegelRun`].
+struct RunInner {
     /// The suspended engine. `None` once the run has produced its result.
     engine: Option<EngineFuture>,
     /// The exchange the engine offers each test case's data source through;
     /// the engine future holds the other reference.
     exchange: Arc<CaseExchange>,
-    // The run's own reference to the current test case's family.
+    // The run's own references to the open test cases' families, oldest
+    // first.
     //
-    // The handle returned to the caller from `hegel_next_test_case` is freed
-    // by the caller (via `hegel_test_case_free`); this is a *separate*
-    // reference the run holds so the data source stays alive while the run is
-    // reading it, and so the caller freeing its handle early does not drop the
-    // family. It is released (decrementing the family refcount) when the run
-    // advances to the next case or is freed.
-    current_family: Option<Arc<FamilyShared>>,
+    // The handles returned to the caller from `hegel_next_test_case` are
+    // freed by the caller (via `hegel_test_case_free`); these are *separate*
+    // references the run holds so each data source stays alive while the run
+    // is reading it, and so the caller freeing its handle early does not drop
+    // the family. Each is released (decrementing the family refcount) once
+    // `hegel_next_test_case` observes its completion, or when the run is
+    // freed.
+    in_flight: Vec<Arc<FamilyShared>>,
+    /// The run's `max_open_test_cases` setting: how many incomplete families
+    /// `hegel_next_test_case` allows before refusing (1, the strict
+    /// alternation contract) or reporting `HEGEL_E_PENDING` (above 1).
+    max_open: u64,
     result: Option<HegelRunResult>,
 }
 
@@ -1171,6 +1193,7 @@ pub unsafe extern "C" fn hegel_run_start(
         .clone()
         .output(output_from_callback(callback, user_data));
     let database_key = handle.database_key.clone();
+    let max_open = settings.max_open_test_cases;
 
     let exchange = Arc::new(CaseExchange::new());
     let engine_exchange = Arc::clone(&exchange);
@@ -1179,10 +1202,13 @@ pub unsafe extern "C" fn hegel_run_start(
     });
 
     let run = Box::into_raw(Box::new(HegelRun {
-        engine: Some(engine),
-        exchange,
-        current_family: None,
-        result: None,
+        inner: Mutex::new(RunInner {
+            engine: Some(engine),
+            exchange,
+            in_flight: Vec::new(),
+            max_open,
+            result: None,
+        }),
     }));
     unsafe { *out_run = run };
     HEGEL_OK
@@ -1195,7 +1221,10 @@ pub unsafe extern "C" fn hegel_run_start(
 /// Returns `HEGEL_OK`, including at normal completion, where
 /// `*out_test_case` is NULL and you should call `hegel_run_result`.
 /// `HEGEL_E_NOT_COMPLETE` if the previous test case was not marked
-/// complete.
+/// complete (with the default `max_open_test_cases` of 1).
+/// `HEGEL_E_PENDING` if `max_open_test_cases` is above 1 and no case is
+/// available until one of the open ones is marked complete.
+/// `HEGEL_E_CONCURRENT_USE` if another thread is mid-call on this run.
 ///
 /// The handle is owned by the caller and must be released with
 /// `hegel_test_case_free`.
@@ -1206,7 +1235,7 @@ pub unsafe extern "C" fn hegel_next_test_case(
     out_test_case: *mut *mut HegelTestCase,
 ) -> hegel_result_t {
     clear_last_error(ctx);
-    let Some(run) = (unsafe { run.as_mut() }) else {
+    let Some(run) = (unsafe { run.as_ref() }) else {
         set_last_error(ctx, "hegel_next_test_case: run pointer is null");
         return HEGEL_E_INVALID_HANDLE;
     };
@@ -1215,49 +1244,98 @@ pub unsafe extern "C" fn hegel_next_test_case(
         return HEGEL_E_INVALID_ARG;
     }
     unsafe { *out_test_case = ptr::null_mut() };
+    let mut inner = match run_lock(ctx, "hegel_next_test_case", run) {
+        Ok(guard) => guard,
+        Err(rc) => return rc,
+    };
+    let inner = &mut *inner;
 
-    if let Some(family) = run.current_family.take() {
-        if !family.completed.load(Ordering::Acquire) {
-            set_last_error(
-                ctx,
-                "hegel_next_test_case: previous test case was not marked complete \
-                 (call hegel_mark_complete before requesting the next case)",
-            );
-            run.current_family = Some(family);
-            return HEGEL_E_NOT_COMPLETE;
-        }
-        // The previous case is complete; dropping the run's reference here
-        // releases the data source unless the caller still holds a handle to
-        // it (in which case it lives until the caller frees that handle).
-        drop(family);
+    // Drop the run's reference to every family the caller has completed
+    // since the last call; each release frees the data source unless the
+    // caller still holds a handle to it (in which case it lives until the
+    // caller frees that handle).
+    inner
+        .in_flight
+        .retain(|family| !family.completed.load(Ordering::Acquire));
+
+    // A case the engine queued on an earlier poll can be handed out without
+    // resuming the engine.
+    if let Some(ds) = inner.exchange.try_take() {
+        unsafe { *out_test_case = hand_out_case(inner, ds) };
+        return HEGEL_OK;
     }
 
-    let Some(engine) = run.engine.as_mut() else {
+    if inner.max_open <= 1 && !inner.in_flight.is_empty() {
+        set_last_error(
+            ctx,
+            "hegel_next_test_case: previous test case was not marked complete \
+             (call hegel_mark_complete before requesting the next case)",
+        );
+        return HEGEL_E_NOT_COMPLETE;
+    }
+
+    let Some(engine) = inner.engine.as_mut() else {
         return HEGEL_OK;
     };
 
     match poll_engine(engine) {
-        Poll::Pending => match run.exchange.take() {
+        Poll::Pending => match inner.exchange.take() {
             Ok(ds) => {
-                let family = new_family(ds);
-                let case = handle_from_family(Arc::clone(&family));
-                run.current_family = Some(family);
-                unsafe { *out_test_case = case };
+                unsafe { *out_test_case = hand_out_case(inner, ds) };
                 HEGEL_OK
             }
+            Err(_) if !inner.in_flight.is_empty() => {
+                set_last_error(
+                    ctx,
+                    "hegel_next_test_case: no test case is available until one of \
+                     the open test cases is marked complete (call \
+                     hegel_mark_complete on one, then call hegel_next_test_case \
+                     again)",
+                );
+                HEGEL_E_PENDING
+            }
             Err(e) => {
-                run.result = Some(HegelRunResult::from_error(&e.to_string()));
-                run.engine = None;
+                inner.result = Some(HegelRunResult::from_error(&e.to_string()));
+                inner.engine = None;
                 HEGEL_OK
             }
         },
         Poll::Ready(r) => {
-            run.result = Some(match r {
+            inner.result = Some(match r {
                 Ok(r) => HegelRunResult::from(r),
                 Err(run_error) => HegelRunResult::from_error(&run_error.to_string()),
             });
-            run.engine = None;
+            inner.engine = None;
             HEGEL_OK
+        }
+    }
+}
+
+/// Wrap a queued data source as a caller-owned test-case handle, keeping the
+/// run's own reference to the family in `in_flight`.
+fn hand_out_case(
+    inner: &mut RunInner,
+    ds: Box<dyn DataSource + Send + Sync>,
+) -> *mut HegelTestCase {
+    let family = new_family(ds);
+    let case = handle_from_family(Arc::clone(&family));
+    inner.in_flight.push(family);
+    case
+}
+
+/// Acquire a run handle's internal lock without blocking, reporting a
+/// concurrent call on the same run as `HEGEL_E_CONCURRENT_USE` rather than
+/// racing it.
+fn run_lock<'a>(
+    ctx: *mut HegelContext,
+    func: &str,
+    run: &'a HegelRun,
+) -> Result<MutexGuard<'a, RunInner>, hegel_result_t> {
+    match run.inner.try_lock() {
+        Some(guard) => Ok(guard),
+        None => {
+            set_last_error(ctx, &format!("{func}: the run is in use by another thread"));
+            Err(HEGEL_E_CONCURRENT_USE)
         }
     }
 }
@@ -1276,7 +1354,8 @@ fn poll_engine(engine: &mut EngineFuture) -> Poll<Result<TestRunResult, RunError
 ///   result.
 ///
 /// Returns `HEGEL_OK`, or `HEGEL_E_NOT_COMPLETE` if the run hasn't finished
-/// yet.
+/// yet, or `HEGEL_E_CONCURRENT_USE` if another thread is mid-call on this
+/// run.
 ///
 /// Each call produces a copy, freed separately. It stays valid after
 /// `hegel_run_free`.
@@ -1296,7 +1375,11 @@ pub unsafe extern "C" fn hegel_run_result(
         return HEGEL_E_INVALID_ARG;
     }
     unsafe { *out_result = ptr::null_mut() };
-    match &run.result {
+    let inner = match run_lock(ctx, "hegel_run_result", run) {
+        Ok(guard) => guard,
+        Err(rc) => return rc,
+    };
+    match &inner.result {
         Some(r) => {
             unsafe { *out_result = into_raw_send_sync(r.clone()) };
             HEGEL_OK
@@ -1335,7 +1418,7 @@ pub unsafe extern "C" fn hegel_run_result_free(
 ///
 /// Returns `HEGEL_OK`.
 ///
-/// If the caller exited its loop early, any in-flight test case is marked
+/// If the caller exited its loop early, every in-flight test case is marked
 /// complete and the rest of the exploration is dropped.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hegel_run_free(
@@ -1348,14 +1431,17 @@ pub unsafe extern "C" fn hegel_run_free(
     }
     let run = unsafe { Box::from_raw(run) };
 
-    if let Some(family) = run.current_family.as_ref() {
-        // If the caller bailed out of its loop with this case still in flight,
-        // claim completion for the family so any handles the caller still
-        // holds observe a concluded case. Dropping the run's reference (as
-        // part of dropping the run below) releases the data source unless the
-        // caller still holds a handle to it, in which case it lives until the
-        // caller frees that handle.
-        family.complete(&TestCaseResult::Valid);
+    {
+        let inner = run.inner.lock();
+        for family in inner.in_flight.iter() {
+            // If the caller bailed out of its loop with cases still in
+            // flight, claim completion for each family so any handles the
+            // caller still holds observe a concluded case. Dropping the
+            // run's references (as part of dropping the run below) releases
+            // each data source unless the caller still holds a handle to it,
+            // in which case it lives until the caller frees that handle.
+            family.complete(&TestCaseResult::Valid);
+        }
     }
 
     // Dropping the run drops the suspended engine future, cancelling the rest

--- a/hegel-c/src/lib.rs
+++ b/hegel-c/src/lib.rs
@@ -495,18 +495,26 @@ struct FamilyShared {
     /// alive; the root handle also draws from this source, and completion
     /// (which is family-wide in the engine) is reported through it.
     ds: Arc<dyn DataSource + Send + Sync>,
-    /// Family-wide completion status. Set once via `compare_exchange` in
-    /// [`Self::complete`] so `ds.mark_complete` runs exactly once, no matter
-    /// which handle reports it. For a run-owned family this is also the gate
-    /// `hegel_next_test_case` checks before resuming the engine.
+    /// The family-wide completion *claim*. Taken once via `compare_exchange`
+    /// in [`Self::complete`] so `ds.mark_complete` runs exactly once, no
+    /// matter which handle reports it.
     completed: AtomicBool,
+    /// Whether the claimed completion's conclusion has been *written* to the
+    /// data source. This — not the claim — is what `hegel_next_test_case`
+    /// consults before dropping a family from the run's `in_flight`: between
+    /// the claim and the write (a completing thread preempted inside
+    /// `hegel_mark_complete`), the engine cannot see the conclusion yet, and
+    /// pruning on the claim alone would let the pump misreport the engine's
+    /// suspension as a run error instead of `HEGEL_E_PENDING`.
+    concluded: AtomicBool,
 }
 
 impl FamilyShared {
     /// Claim family-wide completion. First caller wins: it records `outcome`
-    /// on the data source; every later call — a racing clone, or the run
-    /// tearing down an in-flight case — is a no-op. This is the single home
-    /// of the exactly-once completion protocol.
+    /// on the data source, then publishes that the conclusion is visible;
+    /// every later call — a racing clone, or the run tearing down an
+    /// in-flight case — is a no-op. This is the single home of the
+    /// exactly-once completion protocol.
     fn complete(&self, outcome: &TestCaseResult) {
         if self
             .completed
@@ -514,6 +522,7 @@ impl FamilyShared {
             .is_ok()
         {
             self.ds.mark_complete(outcome);
+            self.concluded.store(true, Ordering::Release);
         }
     }
 }
@@ -1250,13 +1259,15 @@ pub unsafe extern "C" fn hegel_next_test_case(
     };
     let inner = &mut *inner;
 
-    // Drop the run's reference to every family the caller has completed
-    // since the last call; each release frees the data source unless the
-    // caller still holds a handle to it (in which case it lives until the
-    // caller frees that handle).
+    // Drop the run's reference to every family whose conclusion has been
+    // written since the last call; each release frees the data source unless
+    // the caller still holds a handle to it (in which case it lives until
+    // the caller frees that handle). This consults the conclusion, not the
+    // completion claim: a family claimed by a thread still inside
+    // `hegel_mark_complete` stays open until the engine can see its outcome.
     inner
         .in_flight
-        .retain(|family| !family.completed.load(Ordering::Acquire));
+        .retain(|family| !family.concluded.load(Ordering::Acquire));
 
     // A case the engine queued on an earlier poll can be handed out without
     // resuming the engine.
@@ -1589,6 +1600,7 @@ fn new_family(ds: Box<dyn DataSource + Send + Sync>) -> Arc<FamilyShared> {
     Arc::new(FamilyShared {
         ds: Arc::from(ds),
         completed: AtomicBool::new(false),
+        concluded: AtomicBool::new(false),
     })
 }
 

--- a/hegel-c/src/native/data_source.rs
+++ b/hegel-c/src/native/data_source.rs
@@ -77,6 +77,24 @@ impl NativeDataSource {
         handle.lock().family().target_observations.lock().clone()
     }
 
+    /// The test case's outcome if its family has concluded, or `None` while
+    /// it is still open. The non-erroring peek the engine's harvest loop
+    /// uses to spot finished cases among several in flight, where an
+    /// unconcluded family is an ordinary state rather than a contract
+    /// violation.
+    pub fn try_conclusion(handle: &NativeTestCaseHandle) -> Option<TestCaseResult> {
+        let (status, origin) = handle.lock().family().conclusion()?;
+        Some(match status {
+            Status::Valid => TestCaseResult::Valid,
+            Status::Invalid => TestCaseResult::Invalid,
+            Status::EarlyStop => TestCaseResult::Overrun,
+            Status::Interesting => TestCaseResult::Interesting(Failure {
+                origin: origin.map(|o| o.0).unwrap_or_default(),
+                reproduce_blob: None,
+            }),
+        })
+    }
+
     /// The test case's outcome, reconstructed from its family's write-once
     /// conclusion. Whoever concluded the family first — a draw that overran
     /// or hit a terminal assume, or the body via `mark_complete` — set the
@@ -89,23 +107,13 @@ impl NativeDataSource {
     /// unconcluded run, so its callers can't reach this), reported as a
     /// run-level [`RunError::UsageError`] rather than a panic.
     pub fn take_outcome(handle: &NativeTestCaseHandle) -> Result<TestCaseResult, RunError> {
-        let conclusion = handle.lock().family().conclusion();
-        let Some((status, origin)) = conclusion else {
-            return Err(RunError::UsageError(
+        Self::try_conclusion(handle).ok_or_else(|| {
+            RunError::UsageError(
                 "the test case was never marked complete: every test case the \
                  engine offers must be concluded with mark_complete before the \
                  run is resumed"
                     .to_string(),
-            ));
-        };
-        Ok(match status {
-            Status::Valid => TestCaseResult::Valid,
-            Status::Invalid => TestCaseResult::Invalid,
-            Status::EarlyStop => TestCaseResult::Overrun,
-            Status::Interesting => TestCaseResult::Interesting(Failure {
-                origin: origin.map(|o| o.0).unwrap_or_default(),
-                reproduce_blob: None,
-            }),
+            )
         })
     }
 

--- a/hegel-c/src/native/test_runner.rs
+++ b/hegel-c/src/native/test_runner.rs
@@ -24,6 +24,7 @@ use alloc::boxed::Box;
 use alloc::format;
 use alloc::string::String;
 use alloc::string::ToString;
+use alloc::sync::Arc;
 use alloc::vec::Vec;
 use hashbrown::hash_map::Entry;
 
@@ -32,8 +33,8 @@ use rand::RngExt;
 use crate::backend::{Failure, RunError, TestCaseResult};
 use crate::exchange::CaseExchange;
 use crate::native::core::{
-    BUFFER_SIZE, ChoiceNode, ChoiceValue, MAX_SHRINKING_SECONDS, NativeTestCase, Span, SpanEvent,
-    Spans, Status, sort_key,
+    BUFFER_SIZE, ChoiceNode, ChoiceValue, MAX_SHRINKING_SECONDS, NativeTestCase,
+    NativeTestCaseHandle, Span, SpanEvent, Spans, Status, sort_key,
 };
 use crate::native::data_source::NativeDataSource;
 use crate::native::data_tree::generate_novel_prefix;
@@ -282,6 +283,7 @@ impl<'a> Engine<'a> {
             log_phase("Generate", "Start");
         }
 
+        let generation_started = crate::sys::Instant::now();
         if settings.phases.contains(&Phase::Generate)
             && !self.test_is_trivial
             && self.within_invalid_budget(invalid_budget)
@@ -305,6 +307,7 @@ impl<'a> Engine<'a> {
             }
         }
 
+        let window = settings.max_open_test_cases.max(1);
         while settings.phases.contains(&Phase::Generate)
             && !found_in_reuse
             && !self.test_is_trivial
@@ -339,93 +342,102 @@ impl<'a> Engine<'a> {
                     break;
                 }
 
-                let case_rng = self.rng.spawn();
-                let tree_root = &self.tree_root;
-                let prefix = generate_novel_prefix(tree_root, &mut self.rng)?;
-                let ntc = if prefix.is_empty() {
-                    NativeTestCase::new_random(case_rng)
-                } else {
-                    NativeTestCase::for_probe(&prefix, case_rng, BUFFER_SIZE)
-                };
-                if verbosity == Verbosity::Verbose {
-                    output.line("Running test case");
+                while (self.in_flight.len() as u64) < window
+                    && self.valid_test_cases + (self.in_flight.len() as u64) < max_test_cases
+                {
+                    let case_rng = self.rng.spawn();
+                    let tree_root = &self.tree_root;
+                    let prefix = generate_novel_prefix(tree_root, &mut self.rng)?;
+                    let ntc = if prefix.is_empty() {
+                        NativeTestCase::new_random(case_rng)
+                    } else {
+                        NativeTestCase::for_probe(&prefix, case_rng, BUFFER_SIZE)
+                    };
+                    if verbosity == Verbosity::Verbose {
+                        output.line("Running test case");
+                    }
+                    self.spawn_case(ntc);
                 }
 
-                let (run, mismatch) = self.test_function(ntc).await?;
-                if let Some(msg) = mismatch {
-                    return Err(RunError::NonDeterministic(msg));
-                }
+                for (run, mismatch) in self.await_completions().await? {
+                    if let Some(msg) = mismatch {
+                        return Err(RunError::NonDeterministic(msg));
+                    }
 
-                if verbosity == Verbosity::Debug {
-                    output.line(&format!(
-                        "test case #{}: status = {:?}, choices = {}",
-                        self.calls,
-                        run.status,
-                        crate::native::core::flattened_len(&run.nodes)
-                    ));
-                }
+                    if verbosity == Verbosity::Debug {
+                        output.line(&format!(
+                            "test case #{}: status = {:?}, choices = {}",
+                            self.calls,
+                            run.status,
+                            crate::native::core::flattened_len(&run.nodes)
+                        ));
+                    }
 
-                if self.interesting.is_empty() {
-                    if run.status == Status::Invalid
-                        && self.invalid_test_cases >= FILTER_TOO_MUCH_THRESHOLD
-                        && self.valid_test_cases < HEALTH_CHECK_MAX_VALID
-                        && !settings
-                            .suppress_health_check
-                            .contains(&HealthCheck::FilterTooMuch)
-                    {
-                        return Err(RunError::HealthCheck(format!(
-                            "FailedHealthCheck: FilterTooMuch — it looks like this \
+                    if self.interesting.is_empty() {
+                        if run.status == Status::Invalid
+                            && self.invalid_test_cases >= FILTER_TOO_MUCH_THRESHOLD
+                            && self.valid_test_cases < HEALTH_CHECK_MAX_VALID
+                            && !settings
+                                .suppress_health_check
+                                .contains(&HealthCheck::FilterTooMuch)
+                        {
+                            return Err(RunError::HealthCheck(format!(
+                                "FailedHealthCheck: FilterTooMuch — it looks like this \
                          test is filtering out too many inputs. \
                          {} inputs were filtered out by assume() \
                          while only {} valid inputs were \
                          generated. If this is expected, suppress the check with \
                          suppress_health_check = [HealthCheck::FilterTooMuch].",
-                            self.invalid_test_cases, self.valid_test_cases
-                        )));
-                    }
-                    if let Some(msg) = too_large_check(
-                        self.valid_test_cases,
-                        self.overrun_test_cases,
-                        settings
-                            .suppress_health_check
-                            .contains(&HealthCheck::TestCasesTooLarge),
-                    ) {
-                        return Err(RunError::HealthCheck(msg));
+                                self.invalid_test_cases, self.valid_test_cases
+                            )));
+                        }
+                        if let Some(msg) = too_large_check(
+                            self.valid_test_cases,
+                            self.overrun_test_cases,
+                            settings
+                                .suppress_health_check
+                                .contains(&HealthCheck::TestCasesTooLarge),
+                        ) {
+                            return Err(RunError::HealthCheck(msg));
+                        }
+
+                        if let Some(msg) = too_slow_check(
+                            self.valid_test_cases,
+                            generation_started
+                                .map_or(core::time::Duration::ZERO, |start| start.elapsed()),
+                            too_slow_threshold,
+                            settings
+                                .suppress_health_check
+                                .contains(&HealthCheck::TooSlow),
+                        ) {
+                            return Err(RunError::HealthCheck(msg));
+                        }
                     }
 
-                    if let Some(msg) = too_slow_check(
-                        self.valid_test_cases,
-                        self.total_test_time,
-                        too_slow_threshold,
-                        settings
-                            .suppress_health_check
-                            .contains(&HealthCheck::TooSlow),
-                    ) {
-                        return Err(RunError::HealthCheck(msg));
+                    if target_enabled
+                        && self.interesting.is_empty()
+                        && !self.targeting.is_empty()
+                        && target_schedule.should_fire(self.valid_test_cases)
+                    {
+                        self.drain_in_flight().await?;
+                        let mut optimiser = crate::native::targeting::Optimiser {
+                            engine: &mut *self,
+                            max_valid: max_test_cases,
+                            max_calls: max_test_cases * 10,
+                        };
+                        optimiser.optimise_targets().await?;
                     }
-                }
 
-                if target_enabled
-                    && self.interesting.is_empty()
-                    && !self.targeting.is_empty()
-                    && target_schedule.should_fire(self.valid_test_cases)
-                {
-                    let mut optimiser = crate::native::targeting::Optimiser {
-                        engine: &mut *self,
-                        max_valid: max_test_cases,
-                        max_calls: max_test_cases * 10,
-                    };
-                    optimiser.optimise_targets().await?;
-                }
-
-                if run.status == Status::Valid
-                    && (self.valid_test_cases >= HEALTH_CHECK_MAX_VALID
-                        || !self.interesting.is_empty())
-                {
-                    self.try_span_mutation(&run.nodes, &run.spans).await?;
+                    if run.status == Status::Valid
+                        && (self.valid_test_cases >= HEALTH_CHECK_MAX_VALID
+                            || !self.interesting.is_empty())
+                    {
+                        self.try_span_mutation(&run.nodes, &run.spans).await?;
+                    }
                 }
             }
         }
+        self.drain_in_flight().await?;
 
         if self.tree_root.is_exhausted
             && self.valid_test_cases == 0
@@ -927,11 +939,19 @@ pub(crate) struct Engine<'a> {
     pub(crate) valid_test_cases: u64,
     pub(crate) invalid_test_cases: u64,
     pub(crate) overrun_test_cases: u64,
-    pub(crate) total_test_time: core::time::Duration,
     pub(crate) test_is_trivial: bool,
     pub(crate) first_bug_at: Option<u64>,
     pub(crate) last_bug_at: Option<u64>,
     pub(crate) first_bug_time: Option<crate::sys::Instant>,
+    /// Handles of cases offered to the driver whose conclusion
+    /// [`Self::harvest`] has not yet seen. Bounded by
+    /// `settings.max_open_test_cases` during generation; every logically
+    /// sequential path keeps it at one via [`Self::await_case`].
+    in_flight: Vec<NativeTestCaseHandle>,
+    /// Concluded, recorded cases not yet consumed by their awaiter — the
+    /// buffer between [`Self::harvest`] (which records every conclusion the
+    /// moment it is seen) and the callers that process specific results.
+    harvested: Vec<(NativeTestCaseHandle, RunResult, Option<String>)>,
 }
 
 impl<'a> Engine<'a> {
@@ -958,11 +978,12 @@ impl<'a> Engine<'a> {
             valid_test_cases: 0,
             invalid_test_cases: 0,
             overrun_test_cases: 0,
-            total_test_time: core::time::Duration::ZERO,
             test_is_trivial: false,
             first_bug_at: None,
             last_bug_at: None,
             first_bug_time: None,
+            in_flight: Vec::new(),
+            harvested: Vec::new(),
         })
     }
 
@@ -978,32 +999,163 @@ impl<'a> Engine<'a> {
     }
 
     /// Execute one test case and record everything about its outcome —
-    /// Hypothesis's `ConjectureRunner.test_function`. Returns the run plus
-    /// the choice-tree non-determinism diagnostic, if recording the run's
-    /// path contradicted an earlier run. `Err` means the driver violated
-    /// the run contract (see [`NativeDataSource::take_outcome`]).
+    /// Hypothesis's `ConjectureRunner.test_function`. Composed of
+    /// [`Self::spawn_case`] and [`Self::await_case`], so it is logically
+    /// sequential no matter how many other cases are in flight around it.
+    /// Returns the run plus the choice-tree non-determinism diagnostic, if
+    /// recording the run's path contradicted an earlier run. `Err` means the
+    /// driver violated the run contract (see
+    /// [`NativeDataSource::take_outcome`]).
     pub(crate) async fn test_function(
         &mut self,
         ntc: NativeTestCase,
     ) -> Result<(RunResult, Option<String>), RunError> {
+        let handle = self.spawn_case(ntc);
+        self.await_case(&handle).await
+    }
+
+    /// Offer one test case to the driver without waiting for its outcome,
+    /// tracking it as in flight until [`Self::harvest`] sees its conclusion.
+    fn spawn_case(&mut self, ntc: NativeTestCase) -> NativeTestCaseHandle {
         ntc.family()
             .set_stateful_step_count(self.settings.stateful_step_count);
-        let tc_start = crate::sys::Instant::now();
-        let run = self.execute(ntc).await?;
-        let elapsed = tc_start.map_or(core::time::Duration::ZERO, |start| start.elapsed());
-        let mismatch = self.record_run(&run, elapsed);
-        Ok((run, mismatch))
+        let (data_source, handle) = NativeDataSource::new(ntc);
+        self.exchange.offer_nowait(Box::new(data_source));
+        self.in_flight.push(Arc::clone(&handle));
+        handle
+    }
+
+    /// Move every concluded in-flight case into the harvested buffer,
+    /// recording each through [`Self::record_run`] the moment its conclusion
+    /// is seen. Recording is order-independent — the tree records path by
+    /// path, `interesting` keeps the shortlex minimum per origin, the
+    /// persister is per-origin monotone, targeting keeps maxima, and the
+    /// counters are sums — so which of several open cases concludes first
+    /// does not change what a run's results mean.
+    fn harvest(&mut self) {
+        let mut i = 0;
+        while i < self.in_flight.len() {
+            let Some(tc_result) = NativeDataSource::try_conclusion(&self.in_flight[i]) else {
+                i += 1;
+                continue;
+            };
+            let handle = self.in_flight.remove(i);
+            let nodes = NativeDataSource::take_nodes(&handle);
+            let spans = NativeDataSource::take_spans(&handle);
+            let span_events = NativeDataSource::take_span_events(&handle);
+            let target_observations = NativeDataSource::take_target_observations(&handle);
+            let (status, origin) = match tc_result {
+                TestCaseResult::Valid => (Status::Valid, None),
+                TestCaseResult::Invalid => (Status::Invalid, None),
+                TestCaseResult::Overrun => (Status::EarlyStop, None),
+                TestCaseResult::Interesting(f) => (Status::Interesting, Some(f.origin)),
+            };
+            let run = RunResult {
+                status,
+                nodes,
+                spans,
+                origin,
+                target_observations,
+                span_events,
+            };
+            let mismatch = self.record_run(&run);
+            self.harvested.push((handle, run, mismatch));
+        }
+    }
+
+    /// Remove `handle`'s harvested result, if it has one.
+    fn take_harvested(
+        &mut self,
+        handle: &NativeTestCaseHandle,
+    ) -> Option<(RunResult, Option<String>)> {
+        let idx = self
+            .harvested
+            .iter()
+            .position(|(h, _, _)| Arc::ptr_eq(h, handle))?;
+        let (_, run, mismatch) = self.harvested.remove(idx);
+        Some((run, mismatch))
+    }
+
+    /// Suspend until `handle`'s case concludes and return its recorded
+    /// result, harvesting every other case that concludes in the meantime.
+    /// Under strict alternation (`max_open_test_cases == 1`) a resume
+    /// without a conclusion is the driver violating the run contract,
+    /// surfaced exactly as [`NativeDataSource::take_outcome`] reports it;
+    /// with a wider window it is an ordinary poll and the engine just
+    /// suspends again.
+    async fn await_case(
+        &mut self,
+        handle: &NativeTestCaseHandle,
+    ) -> Result<(RunResult, Option<String>), RunError> {
+        let mut resumed = false;
+        loop {
+            self.harvest();
+            if let Some(found) = self.take_harvested(handle) {
+                return Ok(found);
+            }
+            if resumed && self.settings.max_open_test_cases <= 1 {
+                NativeDataSource::take_outcome(handle)?;
+            }
+            self.exchange.suspend().await;
+            resumed = true;
+        }
+    }
+
+    /// Wait until at least one in-flight case has concluded and return every
+    /// harvested result. Returns an empty vector only when nothing is in
+    /// flight. The strict-alternation contract violation is surfaced as in
+    /// [`Self::await_case`].
+    async fn await_completions(&mut self) -> Result<Vec<(RunResult, Option<String>)>, RunError> {
+        let mut resumed = false;
+        loop {
+            self.harvest();
+            if !self.harvested.is_empty() {
+                let runs = self
+                    .harvested
+                    .drain(..)
+                    .map(|(_, run, mismatch)| (run, mismatch))
+                    .collect();
+                return Ok(runs);
+            }
+            let Some(first) = self.in_flight.first() else {
+                return Ok(Vec::new());
+            };
+            if resumed && self.settings.max_open_test_cases <= 1 {
+                NativeDataSource::take_outcome(first)?;
+            }
+            self.exchange.suspend().await;
+            resumed = true;
+        }
+    }
+
+    /// Harvest until no case is in flight, surfacing any nondeterminism the
+    /// drained cases recorded. Called at phase boundaries — before targeting
+    /// fires and after the generation loop exits — so `interesting` and the
+    /// counters are final before the logically sequential phases read them.
+    async fn drain_in_flight(&mut self) -> Result<(), RunError> {
+        loop {
+            self.harvest();
+            for (_, _, mismatch) in self.harvested.drain(..) {
+                if let Some(msg) = mismatch {
+                    return Err(RunError::NonDeterministic(msg));
+                }
+            }
+            if self.in_flight.is_empty() {
+                return Ok(());
+            }
+            self.exchange.suspend().await;
+        }
     }
 
     /// Record one executed test case: the choice tree (losslessly — nodes,
-    /// span events, and the full conclusion), counters, test time, triviality,
+    /// span events, and the full conclusion), counters, triviality,
     /// the targeting observations, the per-origin interesting map (with its
     /// incremental database save), and the bug-window markers.
     ///
     /// Every execution feeds the tree, so a later replay of the same path is
     /// served by [`data_tree::simulate_full`] without re-running the body.
     ///
-    fn record_run(&mut self, run: &RunResult, elapsed: core::time::Duration) -> Option<String> {
+    fn record_run(&mut self, run: &RunResult) -> Option<String> {
         let mismatch = crate::native::data_tree::record_tree_full(
             &mut self.tree_root,
             &run.nodes,
@@ -1014,7 +1166,6 @@ impl<'a> Engine<'a> {
             &[],
         );
         self.calls += 1;
-        self.total_test_time += elapsed;
         if run.nodes.is_empty() && run.status >= Status::Invalid {
             self.test_is_trivial = true;
         }
@@ -1048,39 +1199,6 @@ impl<'a> Engine<'a> {
             self.valid_test_cases,
             budget,
         )
-    }
-
-    /// Execute one test case by offering it through the exchange, recording
-    /// the trie and returning a [`RunResult`] populated from the outcome
-    /// reported by the data source's `mark_complete` plus the
-    /// [`NativeTestCase`]'s realized choice nodes. Always a non-final
-    /// execution. `Err` means the driver violated the run contract by
-    /// resuming the engine without concluding the offered case (see
-    /// [`NativeDataSource::take_outcome`]).
-    async fn execute(&mut self, ntc: NativeTestCase) -> Result<RunResult, RunError> {
-        let (data_source, handle) = NativeDataSource::new(ntc);
-        self.exchange.offer(Box::new(data_source)).await;
-        let nodes = NativeDataSource::take_nodes(&handle);
-        let spans = NativeDataSource::take_spans(&handle);
-        let span_events = NativeDataSource::take_span_events(&handle);
-        let target_observations = NativeDataSource::take_target_observations(&handle);
-        let tc_result = NativeDataSource::take_outcome(&handle)?;
-
-        let (status, origin) = match tc_result {
-            TestCaseResult::Valid => (Status::Valid, None),
-            TestCaseResult::Invalid => (Status::Invalid, None),
-            TestCaseResult::Overrun => (Status::EarlyStop, None),
-            TestCaseResult::Interesting(f) => (Status::Interesting, Some(f.origin)),
-        };
-
-        Ok(RunResult {
-            status,
-            nodes,
-            spans,
-            origin,
-            target_observations,
-            span_events,
-        })
     }
 
     /// The single replay chokepoint — Hypothesis's `cached_test_function` —

--- a/hegel-c/src/settings.rs
+++ b/hegel-c/src/settings.rs
@@ -150,6 +150,7 @@ pub enum Verbosity {
 pub struct Settings {
     pub(crate) mode: Mode,
     pub(crate) test_cases: u64,
+    pub(crate) max_open_test_cases: u64,
     pub(crate) stateful_step_count: i64,
     pub(crate) verbosity: Verbosity,
     pub(crate) output: Output,
@@ -175,6 +176,7 @@ impl Settings {
         Self {
             mode: Mode::TestRun,
             test_cases: 100,
+            max_open_test_cases: 1,
             stateful_step_count: 50,
             verbosity: Verbosity::Normal,
             output: Output::stderr(),
@@ -230,6 +232,15 @@ impl Settings {
     /// Set the number of test cases to run (default: 100).
     pub fn test_cases(mut self, n: u64) -> Self {
         self.test_cases = n;
+        self
+    }
+
+    /// Set the maximum number of test cases the engine keeps open at once
+    /// (default: 1, which preserves strict alternation with the driver).
+    /// During generation the engine offers up to this many cases before
+    /// waiting for completions; all other phases stay sequential.
+    pub fn max_open_test_cases(mut self, n: u64) -> Self {
+        self.max_open_test_cases = n;
         self
     }
 

--- a/hegel-c/tests/c_abi_inprocess.rs
+++ b/hegel-c/tests/c_abi_inprocess.rs
@@ -2036,3 +2036,144 @@ fn pool_is_shared_across_two_clone_threads() {
         ok(hegel_context_free(ctx));
     }
 }
+
+/// Drive a whole run single-threadedly with `max_open_test_cases = 3`:
+/// pull open cases until `HEGEL_E_PENDING` (or the window is full), run each
+/// body as it is pulled, and mark them complete newest-first. Exercises the
+/// multi-case window over the public ABI — the pending state, out-of-order
+/// completion, and the run result at the end — with no threads involved.
+#[test]
+fn max_open_window_reverse_order_completion_reaches_the_verdict() {
+    let ctx = hegel_context_new();
+    unsafe {
+        let s = make_settings(ctx);
+        let empty = CString::new("").unwrap();
+        ok(hegel_settings_set_database(ctx, s, empty.as_ptr()));
+        ok(hegel_c::hegel_settings_set_seed(ctx, s, 0xfeed, true));
+        ok(hegel_c::hegel_settings_set_max_open_test_cases(ctx, s, 3));
+        let run = start(ctx, s);
+
+        let mut open: Vec<(*mut HegelTestCase, u32, *const c_char)> = Vec::new();
+        let origin = CString::new("n >= 900").unwrap();
+        let mut saw_pending = false;
+        'run: loop {
+            loop {
+                let mut tc: *mut HegelTestCase = ptr::null_mut();
+                let rc = hegel_next_test_case(ctx, run, &mut tc);
+                if rc == HEGEL_E_PENDING {
+                    saw_pending = true;
+                    assert!(
+                        !open.is_empty(),
+                        "PENDING must only be reported while cases are open"
+                    );
+                    assert!(last_error(ctx).contains("marked complete"));
+                    break;
+                }
+                ok(rc);
+                if tc.is_null() {
+                    // The run can finish while the caller still holds cases
+                    // that concluded during a draw (an overrun latches the
+                    // conclusion before mark_complete); report and free them.
+                    for (tc, status, case_origin) in open.drain(..) {
+                        ok(hegel_mark_complete(ctx, tc, status, case_origin));
+                        ok(hegel_test_case_free(ctx, tc));
+                    }
+                    break 'run;
+                }
+                assert!(open.len() < 3, "the engine must respect the window");
+                let mut n: i64 = 0;
+                let draw = hegel_generate_integer(ctx, tc, 0, 1000, &mut n);
+                let (status, case_origin) = if draw == HEGEL_E_STOP_TEST {
+                    (hegel_status_t::HEGEL_STATUS_OVERRUN as u32, ptr::null())
+                } else {
+                    ok(draw);
+                    if n >= 900 {
+                        (
+                            hegel_status_t::HEGEL_STATUS_INTERESTING as u32,
+                            origin.as_ptr(),
+                        )
+                    } else {
+                        (hegel_status_t::HEGEL_STATUS_VALID as u32, ptr::null())
+                    }
+                };
+                open.push((tc, status, case_origin));
+                if open.len() == 3 {
+                    break;
+                }
+            }
+            if let Some((tc, status, case_origin)) = open.pop() {
+                ok(hegel_mark_complete(ctx, tc, status, case_origin));
+                ok(hegel_test_case_free(ctx, tc));
+            }
+        }
+        assert!(saw_pending, "a window of 3 must hit the pending state");
+
+        let r = result(ctx, run);
+        assert!(matches!(
+            status_of(ctx, r),
+            hegel_run_status_t::HEGEL_RUN_STATUS_FAILED
+        ));
+        assert_eq!(failure_count_of(ctx, r), 1);
+        let f = failure_at(ctx, r, 0);
+        let reported = std::ffi::CStr::from_ptr(origin_of(ctx, f))
+            .to_str()
+            .unwrap();
+        assert_eq!(reported, "n >= 900");
+        ok(hegel_failure_free(ctx, f));
+        ok(hegel_run_result_free(ctx, r));
+        ok(hegel_run_free(ctx, run));
+        ok(hegel_settings_free(ctx, s));
+        ok(hegel_context_free(ctx));
+    }
+}
+
+/// `hegel_run_free` with several cases still open completes every one of
+/// them, so handles the caller still holds observe a concluded case.
+#[test]
+fn run_free_completes_every_open_case() {
+    let ctx = hegel_context_new();
+    unsafe {
+        let s = make_settings(ctx);
+        let empty = CString::new("").unwrap();
+        ok(hegel_settings_set_database(ctx, s, empty.as_ptr()));
+        ok(hegel_c::hegel_settings_set_seed(ctx, s, 7, true));
+        ok(hegel_c::hegel_settings_set_max_open_test_cases(ctx, s, 3));
+        let run = start(ctx, s);
+
+        // The run's first case is the sequential smallest-natural-example
+        // probe; the window opens once it completes. It must draw, or the
+        // drawless choice tree is exhausted and the run ends immediately.
+        let mut probe: *mut HegelTestCase = ptr::null_mut();
+        ok(hegel_next_test_case(ctx, run, &mut probe));
+        assert!(!probe.is_null());
+        let mut n: i64 = 0;
+        ok(hegel_generate_integer(ctx, probe, 0, 1000, &mut n));
+        ok(hegel_mark_complete(
+            ctx,
+            probe,
+            hegel_status_t::HEGEL_STATUS_VALID as u32,
+            ptr::null(),
+        ));
+        ok(hegel_test_case_free(ctx, probe));
+
+        let mut open: Vec<*mut HegelTestCase> = Vec::new();
+        for _ in 0..3 {
+            let mut tc: *mut HegelTestCase = ptr::null_mut();
+            ok(hegel_next_test_case(ctx, run, &mut tc));
+            assert!(!tc.is_null());
+            open.push(tc);
+        }
+        ok(hegel_run_free(ctx, run));
+
+        for tc in open {
+            let mut n: i64 = 0;
+            assert_eq!(
+                hegel_generate_integer(ctx, tc, 0, 10, &mut n),
+                HEGEL_E_ALREADY_COMPLETE
+            );
+            ok(hegel_test_case_free(ctx, tc));
+        }
+        ok(hegel_settings_free(ctx, s));
+        ok(hegel_context_free(ctx));
+    }
+}

--- a/hegel-c/tests/c_abi_inprocess.rs
+++ b/hegel-c/tests/c_abi_inprocess.rs
@@ -145,6 +145,10 @@ fn null_handles_are_rejected_without_crashing() {
             HEGEL_E_INVALID_HANDLE
         );
         assert_eq!(
+            hegel_c::hegel_settings_set_max_open_test_cases(ctx, ptr::null_mut(), 1),
+            HEGEL_E_INVALID_HANDLE
+        );
+        assert_eq!(
             hegel_c::hegel_settings_set_verbosity(
                 ctx,
                 ptr::null_mut(),
@@ -648,6 +652,12 @@ fn out_of_range_enum_values_are_invalid_arguments() {
             hegel_c::hegel_settings_set_stateful_step_count(ctx, s, -3),
             HEGEL_E_INVALID_ARG
         );
+        assert_eq!(
+            hegel_c::hegel_settings_set_max_open_test_cases(ctx, s, 0),
+            HEGEL_E_INVALID_ARG
+        );
+        assert!(last_error(ctx).contains("max_open must be at least 1"));
+        ok(hegel_c::hegel_settings_set_max_open_test_cases(ctx, s, 3));
 
         let empty = CString::new("").unwrap();
         ok(hegel_settings_set_database(ctx, s, empty.as_ptr()));

--- a/hegel-c/tests/embedded/exchange_tests.rs
+++ b/hegel-c/tests/embedded/exchange_tests.rs
@@ -50,6 +50,69 @@ fn offer_resumes_only_after_the_driver_polls_again() {
 }
 
 #[test]
+fn offer_nowait_queues_without_suspending() {
+    let exchange = CaseExchange::new();
+    exchange.offer_nowait(fresh_source());
+    exchange.offer_nowait(fresh_source());
+    assert!(exchange.try_take().is_some());
+    assert!(exchange.try_take().is_some());
+    assert!(exchange.try_take().is_none());
+}
+
+#[test]
+fn queued_cases_are_taken_in_offer_order() {
+    let exchange = CaseExchange::new();
+    let one_choice = NativeTestCase::for_choices(
+        &[crate::native::core::ChoiceValue::Boolean(true)],
+        None,
+        None,
+    );
+    let (first, _handle) = NativeDataSource::new(one_choice);
+    exchange.offer_nowait(Box::new(first));
+    exchange.offer_nowait(fresh_source());
+    assert!(
+        exchange
+            .try_take()
+            .unwrap()
+            .generate_boolean(0.5, None)
+            .is_ok()
+    );
+    assert!(
+        exchange
+            .try_take()
+            .unwrap()
+            .generate_boolean(0.5, None)
+            .is_err()
+    );
+}
+
+#[test]
+fn suspend_is_pending_once_then_ready() {
+    let exchange = CaseExchange::new();
+    let fut = exchange.suspend();
+    let mut fut = std::pin::pin!(fut);
+    let mut cx = std::task::Context::from_waker(std::task::Waker::noop());
+    assert!(fut.as_mut().poll(&mut cx).is_pending());
+    assert!(fut.as_mut().poll(&mut cx).is_ready());
+}
+
+#[test]
+fn offer_queues_several_cases_across_one_suspension() {
+    let exchange = CaseExchange::new();
+    let fut = async {
+        exchange.offer_nowait(fresh_source());
+        exchange.offer(fresh_source()).await;
+    };
+    let mut fut = std::pin::pin!(fut);
+    let mut cx = std::task::Context::from_waker(std::task::Waker::noop());
+    assert!(fut.as_mut().poll(&mut cx).is_pending());
+    assert!(exchange.try_take().is_some());
+    assert!(exchange.try_take().is_some());
+    assert!(exchange.try_take().is_none());
+    assert!(fut.as_mut().poll(&mut cx).is_ready());
+}
+
+#[test]
 fn take_errors_when_nothing_was_offered() {
     let err = CaseExchange::new().take().err().unwrap();
     let msg = err.to_string();

--- a/hegel-c/tests/embedded/lib_tests.rs
+++ b/hegel-c/tests/embedded/lib_tests.rs
@@ -360,3 +360,85 @@ fn concurrent_use_of_a_run_handle_is_rejected() {
         finish(ctx, s, run, tc);
     }
 }
+
+/// A worker preempted inside `hegel_mark_complete` — the family's completion
+/// claim has landed but the conclusion is not yet written to the data source
+/// — must not make the pump misreport the run. The prune in
+/// `hegel_next_test_case` may only drop a family once its conclusion is
+/// visible to the engine; until then the case counts as open, so the pump
+/// gets `HEGEL_E_PENDING`, not a false "internal error" run conclusion.
+#[test]
+fn half_completed_family_reports_pending_not_a_run_error() {
+    let ctx = hegel_context_new();
+    unsafe {
+        let mut s: *mut HegelSettings = ptr::null_mut();
+        assert_eq!(hegel_settings_new(ctx, &mut s), HEGEL_OK);
+        let empty = CString::new("").unwrap();
+        ok(hegel_settings_set_database(ctx, s, empty.as_ptr()));
+        ok(hegel_settings_set_seed(ctx, s, 1, true));
+        ok(hegel_settings_set_test_cases(ctx, s, 3));
+        ok(hegel_settings_set_max_open_test_cases(ctx, s, 2));
+        let mut run: *mut HegelRun = ptr::null_mut();
+        assert_eq!(
+            hegel_run_start(ctx, s, None, ptr::null_mut(), &mut run),
+            HEGEL_OK
+        );
+
+        let next = |out: &mut *mut HegelTestCase| -> hegel_result_t {
+            *out = ptr::null_mut();
+            hegel_next_test_case(ctx, run, out)
+        };
+        let draw = |tc: *mut HegelTestCase| {
+            let mut n: i64 = 0;
+            let rc = hegel_generate_integer(ctx, tc, 0, 1000, &mut n);
+            assert!(rc == HEGEL_OK || rc == HEGEL_E_STOP_TEST, "rc={rc:?}");
+        };
+        let complete_valid = |tc: *mut HegelTestCase| {
+            ok(hegel_mark_complete(
+                ctx,
+                tc,
+                hegel_status_t::HEGEL_STATUS_VALID as u32,
+                ptr::null(),
+            ));
+            ok(hegel_test_case_free(ctx, tc));
+        };
+
+        let mut probe: *mut HegelTestCase = ptr::null_mut();
+        assert_eq!(next(&mut probe), HEGEL_OK);
+        assert!(!probe.is_null());
+        draw(probe);
+        complete_valid(probe);
+
+        let mut a: *mut HegelTestCase = ptr::null_mut();
+        assert_eq!(next(&mut a), HEGEL_OK);
+        assert!(!a.is_null());
+        draw(a);
+        let mut b: *mut HegelTestCase = ptr::null_mut();
+        assert_eq!(next(&mut b), HEGEL_OK);
+        assert!(!b.is_null());
+        draw(b);
+
+        // Simulate the preemption: B's completion claim has landed, but the
+        // conclusion write has not happened yet.
+        let b_ref = &*b;
+        b_ref
+            .family
+            .completed
+            .store(true, std::sync::atomic::Ordering::Release);
+
+        complete_valid(a);
+
+        let mut tc: *mut HegelTestCase = ptr::null_mut();
+        assert_eq!(
+            next(&mut tc),
+            HEGEL_E_PENDING,
+            "B is still open: the pump must wait for it, not conclude the run"
+        );
+        assert!(tc.is_null());
+
+        ok(hegel_test_case_free(ctx, b));
+        ok(hegel_run_free(ctx, run));
+        ok(hegel_settings_free(ctx, s));
+        ok(hegel_context_free(ctx));
+    }
+}

--- a/hegel-c/tests/embedded/lib_tests.rs
+++ b/hegel-c/tests/embedded/lib_tests.rs
@@ -212,10 +212,13 @@ fn engine_suspending_without_an_offer_becomes_a_run_error() {
     let exchange = Arc::new(CaseExchange::new());
     let engine: EngineFuture = Box::pin(std::future::pending());
     let run = Box::into_raw(Box::new(HegelRun {
-        engine: Some(engine),
-        exchange,
-        current_family: None,
-        result: None,
+        inner: Mutex::new(RunInner {
+            engine: Some(engine),
+            exchange,
+            in_flight: Vec::new(),
+            max_open: 1,
+            result: None,
+        }),
     }));
 
     unsafe {
@@ -298,10 +301,13 @@ fn internal_run_error_surfaces_through_run_result_error() {
         ))
     });
     let run = Box::into_raw(Box::new(HegelRun {
-        engine: Some(engine),
-        exchange,
-        current_family: None,
-        result: None,
+        inner: Mutex::new(RunInner {
+            engine: Some(engine),
+            exchange,
+            in_flight: Vec::new(),
+            max_open: 1,
+            result: None,
+        }),
     }));
 
     unsafe {
@@ -326,5 +332,31 @@ fn internal_run_error_surfaces_through_run_result_error() {
         ok(hegel_run_result_free(ctx, result));
         ok(hegel_run_free(ctx, run));
         ok(hegel_context_free(ctx));
+    }
+}
+
+/// The run handle's internal lock turns a concurrent call on the same run
+/// into `HEGEL_E_CONCURRENT_USE` instead of a data race. As in
+/// [`concurrent_use_of_one_handle_is_rejected`], "another thread is
+/// mid-call" is stood in for by holding the run's own lock on this thread.
+#[test]
+fn concurrent_use_of_a_run_handle_is_rejected() {
+    unsafe {
+        let (ctx, s, run, tc) = start_run_and_first_case();
+
+        let held = (&*run).inner.try_lock().unwrap();
+        let mut next: *mut HegelTestCase = ptr::null_mut();
+        assert_eq!(
+            hegel_next_test_case(ctx, run, &mut next),
+            HEGEL_E_CONCURRENT_USE
+        );
+        let mut result: *mut HegelRunResult = ptr::null_mut();
+        assert_eq!(
+            hegel_run_result(ctx, run, &mut result),
+            HEGEL_E_CONCURRENT_USE
+        );
+        drop(held);
+
+        finish(ctx, s, run, tc);
     }
 }

--- a/hegel-c/tests/embedded/native/data_source_tests.rs
+++ b/hegel-c/tests/embedded/native/data_source_tests.rs
@@ -404,3 +404,52 @@ fn clone_stream_on_an_exhausted_source_stops_the_test() {
     let (ds, _handle) = exhausted_source();
     assert!(matches!(ds.clone_stream(), Err(DataSourceError::StopTest)));
 }
+
+#[test]
+fn try_conclusion_is_none_for_an_unconcluded_family() {
+    let (ds, handle) = random_source();
+    ds.generate_boolean(0.5, None).unwrap();
+    assert!(NativeDataSource::try_conclusion(&handle).is_none());
+}
+
+#[test]
+fn try_conclusion_reports_each_status() {
+    for reported in [
+        TestCaseResult::Valid,
+        TestCaseResult::Invalid,
+        TestCaseResult::Overrun,
+    ] {
+        let (ds, handle) = random_source();
+        ds.mark_complete(&reported);
+        let concluded = NativeDataSource::try_conclusion(&handle).unwrap();
+        assert_eq!(
+            core::mem::discriminant(&concluded),
+            core::mem::discriminant(&reported)
+        );
+    }
+}
+
+#[test]
+fn try_conclusion_reports_an_interesting_conclusion_with_its_origin() {
+    let (ds, handle) = random_source();
+    ds.mark_complete(&TestCaseResult::Interesting(Failure {
+        origin: "Panic at somewhere".to_string(),
+        reproduce_blob: None,
+    }));
+    let conclusion = NativeDataSource::try_conclusion(&handle).unwrap();
+    let TestCaseResult::Interesting(failure) = conclusion else {
+        panic!("expected an interesting conclusion, got {conclusion:?}");
+    };
+    assert_eq!(failure.origin, "Panic at somewhere");
+    assert!(failure.reproduce_blob.is_none());
+}
+
+#[test]
+fn try_conclusion_reports_a_draw_time_overrun() {
+    let (ds, handle) = exhausted_source();
+    assert!(ds.generate_boolean(0.5, None).is_err());
+    assert!(matches!(
+        NativeDataSource::try_conclusion(&handle),
+        Some(TestCaseResult::Overrun)
+    ));
+}

--- a/hegel-c/tests/embedded/native/test_runner_tests.rs
+++ b/hegel-c/tests/embedded/native/test_runner_tests.rs
@@ -250,8 +250,8 @@ fn overrun_during_draw_overrides_a_swallowed_valid_outcome() {
             TestCaseResult::Valid
         },
         async |ctx, _| {
-            let run = ctx
-                .execute(NativeTestCase::for_choices(&[], None, None))
+            let (run, _mismatch) = ctx
+                .test_function(NativeTestCase::for_choices(&[], None, None))
                 .await
                 .unwrap();
             assert_eq!(run.status, Status::EarlyStop);
@@ -1205,4 +1205,306 @@ fn run_main_shrinks_a_cloned_stream_failure_to_the_minimal_tree() {
         choices[1],
         ChoiceValue::Integer(crate::native::bignum::BigInt::from(0))
     );
+}
+
+/// Drive an engine future with up to `max_open_test_cases` cases open at
+/// once: on each suspension, pull every queued case into a local pool and
+/// run its body immediately, then mark exactly one pooled case complete —
+/// the one `pick` chooses — before polling again. Single-threaded and fully
+/// deterministic, this exercises every out-of-order completion path without
+/// spawning a thread.
+fn drive_out_of_order<F: core::future::Future>(
+    exchange: &CaseExchange,
+    fut: F,
+    mut run_case: impl FnMut(&dyn DataSource) -> TestCaseResult,
+    mut pick: impl FnMut(usize) -> usize,
+) -> F::Output {
+    let mut fut = core::pin::pin!(fut);
+    let mut cx = core::task::Context::from_waker(core::task::Waker::noop());
+    let mut pool: Vec<(crate::exchange::BoxedDataSource, TestCaseResult)> = Vec::new();
+    loop {
+        match fut.as_mut().poll(&mut cx) {
+            core::task::Poll::Ready(out) => return out,
+            core::task::Poll::Pending => {
+                while let Some(ds) = exchange.try_take() {
+                    let result = run_case(&*ds);
+                    pool.push((ds, result));
+                }
+                assert!(!pool.is_empty(), "engine suspended with nothing to run");
+                let idx = pick(pool.len());
+                let (ds, result) = pool.remove(idx);
+                ds.mark_complete(&result);
+            }
+        }
+    }
+}
+
+/// Run `run_main` under [`drive_out_of_order`] with a window of
+/// `max_open` and the given completion policy.
+fn run_main_out_of_order<F>(
+    settings: Settings,
+    mut body: F,
+    pick: impl FnMut(usize) -> usize,
+) -> Result<Vec<Failure>, crate::backend::RunError>
+where
+    F: FnMut(&dyn DataSource) -> TestCaseResult,
+{
+    let exchange = CaseExchange::new();
+    drive_out_of_order(
+        &exchange,
+        run_main(
+            &settings,
+            None,
+            &exchange,
+            Duration::from_secs(30),
+            Duration::from_secs(300),
+        ),
+        &mut body,
+        pick,
+    )
+}
+
+/// A body failing on values >= 100 whose sequential convergent minimum is
+/// the single choice `100`.
+fn threshold_body(ds: &dyn DataSource) -> TestCaseResult {
+    match rint(ds, 0, 1000) {
+        Ok(v) if v >= 100 => boom("too big"),
+        Ok(_) => TestCaseResult::Valid,
+        Err(()) => TestCaseResult::Overrun,
+    }
+}
+
+fn assert_shrunk_to_100(failures: &[Failure]) {
+    assert_eq!(failures.len(), 1, "{failures:?}");
+    assert!(failures[0].origin.contains("too big"), "{failures:?}");
+    let blob = failures[0].reproduce_blob.as_ref().unwrap();
+    let choices = crate::native::blob::decode_failure(blob).unwrap();
+    assert_eq!(choices.len(), 1);
+    assert_eq!(choices[0], ChoiceValue::Integer(BigInt::from(100)));
+}
+
+#[test]
+fn out_of_order_newest_first_completion_shrinks_to_the_sequential_minimum() {
+    let failures = run_main_out_of_order(
+        Settings::new()
+            .database(None)
+            .max_open_test_cases(3)
+            .verbosity(Verbosity::Quiet),
+        threshold_body,
+        |n| n - 1,
+    )
+    .unwrap();
+    assert_shrunk_to_100(&failures);
+}
+
+#[test]
+fn out_of_order_oldest_first_completion_shrinks_to_the_sequential_minimum() {
+    let failures = run_main_out_of_order(
+        Settings::new()
+            .database(None)
+            .max_open_test_cases(3)
+            .verbosity(Verbosity::Quiet),
+        threshold_body,
+        |_| 0,
+    )
+    .unwrap();
+    assert_shrunk_to_100(&failures);
+}
+
+#[test]
+fn out_of_order_seeded_random_completion_shrinks_to_the_sequential_minimum() {
+    let mut state: u64 = 0x2545F4914F6CDD1D;
+    let failures = run_main_out_of_order(
+        Settings::new()
+            .database(None)
+            .max_open_test_cases(4)
+            .verbosity(Verbosity::Quiet),
+        threshold_body,
+        move |n| {
+            state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+            ((state >> 33) as usize) % n
+        },
+    )
+    .unwrap();
+    assert_shrunk_to_100(&failures);
+}
+
+#[test]
+fn pipelined_passing_run_executes_exactly_the_example_budget() {
+    use std::cell::Cell;
+    let executed = Cell::new(0u64);
+    let failures = run_main_out_of_order(
+        Settings::new()
+            .database(None)
+            .test_cases(50)
+            .max_open_test_cases(3)
+            .verbosity(Verbosity::Quiet),
+        |ds| {
+            executed.set(executed.get() + 1);
+            match ru64(ds) {
+                Ok(_) => TestCaseResult::Valid,
+                Err(()) => TestCaseResult::Overrun,
+            }
+        },
+        |n| n - 1,
+    )
+    .unwrap();
+    assert!(failures.is_empty(), "{failures:?}");
+    assert_eq!(
+        executed.get(),
+        50,
+        "spawn gating must count in-flight cases against the budget"
+    );
+}
+
+#[test]
+fn pipelined_filter_too_much_fires_for_an_always_rejecting_body() {
+    let result = run_main_out_of_order(
+        Settings::new()
+            .database(None)
+            .max_open_test_cases(3)
+            .verbosity(Verbosity::Quiet),
+        |ds| match ru64(ds) {
+            Ok(_) => TestCaseResult::Invalid,
+            Err(()) => TestCaseResult::Overrun,
+        },
+        |n| n - 1,
+    );
+    match result {
+        Err(crate::backend::RunError::HealthCheck(msg)) => {
+            assert!(msg.contains("FilterTooMuch"), "{msg}");
+        }
+        other => panic!("expected RunError::HealthCheck, got {other:?}"),
+    }
+}
+
+#[test]
+fn pipelined_harvest_surfaces_nondeterminism() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    let flip = AtomicUsize::new(0);
+    let result = run_main_out_of_order(
+        Settings::new()
+            .database(None)
+            .max_open_test_cases(3)
+            .verbosity(Verbosity::Quiet),
+        |ds| {
+            let r = if flip.fetch_add(1, Ordering::SeqCst) % 2 == 0 {
+                rbool(ds).map(|_| ())
+            } else {
+                rint(ds, i64::MIN, i64::MAX).map(|_| ())
+            };
+            match r {
+                Ok(()) => TestCaseResult::Valid,
+                Err(()) => TestCaseResult::Overrun,
+            }
+        },
+        |n| n - 1,
+    );
+    match result {
+        Err(crate::backend::RunError::NonDeterministic(msg)) => {
+            assert!(
+                msg.to_lowercase().contains("non-deterministic"),
+                "got: {msg}"
+            );
+        }
+        other => panic!("expected RunError::NonDeterministic, got {other:?}"),
+    }
+}
+
+#[test]
+fn pipelined_targeting_drains_and_optimises() {
+    let failures = run_main_out_of_order(
+        Settings::new()
+            .database(None)
+            .test_cases(60)
+            .max_open_test_cases(3)
+            .verbosity(Verbosity::Quiet),
+        |ds| match rint(ds, 0, 1000) {
+            Ok(v) => {
+                ds.target_observation(v as f64, "score").unwrap();
+                TestCaseResult::Valid
+            }
+            Err(()) => TestCaseResult::Overrun,
+        },
+        |n| n - 1,
+    )
+    .unwrap();
+    assert!(failures.is_empty(), "{failures:?}");
+}
+
+/// The engine tolerates being resumed with cases open and nothing concluded
+/// when the window allows several open cases: it just suspends again, and
+/// the run still finishes once the driver resumes completing cases.
+#[test]
+fn resume_without_progress_is_benign_with_a_multi_case_window() {
+    let settings = Settings::new()
+        .database(None)
+        .test_cases(10)
+        .max_open_test_cases(3)
+        .verbosity(Verbosity::Quiet);
+    let exchange = CaseExchange::new();
+    let fut = run_main(
+        &settings,
+        None,
+        &exchange,
+        Duration::from_secs(30),
+        Duration::from_secs(300),
+    );
+    let mut fut = core::pin::pin!(fut);
+    let mut cx = core::task::Context::from_waker(core::task::Waker::noop());
+    let mut pool: Vec<(crate::exchange::BoxedDataSource, TestCaseResult)> = Vec::new();
+    let mut idle_polls = 0usize;
+    let failures = loop {
+        match fut.as_mut().poll(&mut cx) {
+            core::task::Poll::Ready(out) => break out.unwrap(),
+            core::task::Poll::Pending => {
+                while let Some(ds) = exchange.try_take() {
+                    let result = match ru64(&*ds) {
+                        Ok(_) => TestCaseResult::Valid,
+                        Err(()) => TestCaseResult::Overrun,
+                    };
+                    pool.push((ds, result));
+                }
+                if idle_polls < 5 {
+                    idle_polls += 1;
+                    continue;
+                }
+                let (ds, result) = pool.pop().unwrap();
+                ds.mark_complete(&result);
+            }
+        }
+    };
+    assert!(failures.is_empty(), "{failures:?}");
+    assert_eq!(idle_polls, 5, "the idle polls must actually have happened");
+}
+
+/// Under strict alternation (the default window of 1), resuming the engine
+/// without completing the offered case is still the driving-contract
+/// violation it always was.
+#[test]
+fn resuming_without_completion_at_window_one_is_a_usage_error() {
+    let settings = Settings::new().database(None).verbosity(Verbosity::Quiet);
+    let exchange = CaseExchange::new();
+    let fut = run_main(
+        &settings,
+        None,
+        &exchange,
+        Duration::from_secs(30),
+        Duration::from_secs(300),
+    );
+    let mut fut = core::pin::pin!(fut);
+    let mut cx = core::task::Context::from_waker(core::task::Waker::noop());
+    assert!(fut.as_mut().poll(&mut cx).is_pending());
+    let ds = exchange.take().unwrap();
+    let result = match fut.as_mut().poll(&mut cx) {
+        core::task::Poll::Ready(out) => out,
+        core::task::Poll::Pending => panic!("expected the run to end in a usage error"),
+    };
+    drop(ds);
+    match result {
+        Err(crate::backend::RunError::UsageError(msg)) => {
+            assert!(msg.contains("never marked complete"), "{msg}");
+        }
+        other => panic!("expected RunError::UsageError, got {other:?}"),
+    }
 }

--- a/hegel-c/tests/embedded/native/test_runner_tests.rs
+++ b/hegel-c/tests/embedded/native/test_runner_tests.rs
@@ -1508,3 +1508,95 @@ fn resuming_without_completion_at_window_one_is_a_usage_error() {
         other => panic!("expected RunError::UsageError, got {other:?}"),
     }
 }
+
+#[test]
+fn await_completions_with_nothing_in_flight_returns_empty() {
+    with_counting_ctx(
+        |_| TestCaseResult::Valid,
+        async |ctx, count| {
+            let runs = ctx.await_completions().await.unwrap();
+            assert!(runs.is_empty());
+            assert_eq!(count.get(), 0);
+        },
+    );
+}
+
+#[test]
+fn drain_in_flight_surfaces_nondeterminism() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    let calls = AtomicUsize::new(0);
+    with_counting_ctx(
+        |ds| {
+            let r = if calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                rbool(ds).map(|_| ())
+            } else {
+                rint(ds, 0, 100).map(|_| ())
+            };
+            match r {
+                Ok(()) => TestCaseResult::Valid,
+                Err(()) => TestCaseResult::Overrun,
+            }
+        },
+        async |ctx, _| {
+            let (run, mismatch) = ctx
+                .test_function(NativeTestCase::for_choices(
+                    &[ChoiceValue::Boolean(true)],
+                    None,
+                    None,
+                ))
+                .await
+                .unwrap();
+            assert_eq!(run.status, Status::Valid);
+            assert!(mismatch.is_none());
+
+            ctx.spawn_case(NativeTestCase::for_choices(
+                &[ChoiceValue::Boolean(true)],
+                None,
+                None,
+            ));
+            let err = ctx.drain_in_flight().await.unwrap_err();
+            assert!(matches!(err, crate::backend::RunError::NonDeterministic(_)));
+        },
+    );
+}
+
+/// Same driving-contract violation as
+/// [`resuming_without_completion_at_window_one_is_a_usage_error`], but on a
+/// generation-loop case rather than the initial probe, so the pipelined
+/// wait path reports it too.
+#[test]
+fn resuming_generation_without_completion_at_window_one_is_a_usage_error() {
+    let settings = Settings::new().database(None).verbosity(Verbosity::Quiet);
+    let exchange = CaseExchange::new();
+    let fut = run_main(
+        &settings,
+        None,
+        &exchange,
+        Duration::from_secs(30),
+        Duration::from_secs(300),
+    );
+    let mut fut = core::pin::pin!(fut);
+    let mut cx = core::task::Context::from_waker(core::task::Waker::noop());
+
+    assert!(fut.as_mut().poll(&mut cx).is_pending());
+    let probe = exchange.take().unwrap();
+    let result = match rbool(&*probe) {
+        Ok(_) => TestCaseResult::Valid,
+        Err(()) => TestCaseResult::Overrun,
+    };
+    probe.mark_complete(&result);
+
+    assert!(fut.as_mut().poll(&mut cx).is_pending());
+    let abandoned = exchange.take().unwrap();
+    let result = match fut.as_mut().poll(&mut cx) {
+        core::task::Poll::Ready(out) => out,
+        core::task::Poll::Pending => panic!("expected the run to end in a usage error"),
+    };
+    drop(abandoned);
+    match result {
+        Err(crate::backend::RunError::UsageError(msg)) => {
+            assert!(msg.contains("never marked complete"), "{msg}");
+        }
+        other => panic!("expected RunError::UsageError, got {other:?}"),
+    }
+}

--- a/hegel-c/tests/embedded/settings_tests.rs
+++ b/hegel-c/tests/embedded/settings_tests.rs
@@ -95,3 +95,12 @@ fn settings_default_to_stderr_output_and_carry_a_configured_one() {
     let s = Settings::new().output(Output::callback(|_| {}));
     assert_eq!(format!("{:?}", s.output), "Output(callback)");
 }
+
+#[test]
+fn max_open_test_cases_defaults_to_one_and_is_settable() {
+    assert_eq!(Settings::new().max_open_test_cases, 1);
+    assert_eq!(
+        Settings::new().max_open_test_cases(4).max_open_test_cases,
+        4
+    );
+}

--- a/hegel-macros/src/hegel_main.rs
+++ b/hegel-macros/src/hegel_main.rs
@@ -97,7 +97,7 @@ pub fn expand_main(attr: TokenStream, item: TokenStream) -> TokenStream {
                 #(#explicit_blocks)*
             }
 
-            ::hegel::Hegel::new(|#param_pat: #param_ty| #body)
+            ::hegel::Hegel::new_concurrent(|#param_pat: #param_ty| #body)
             .settings(__hegel_settings)
             .__database_key(format!("{}::{}", module_path!(), #fn_name))
             .test_location(::hegel::TestLocation {
@@ -106,7 +106,7 @@ pub fn expand_main(attr: TokenStream, item: TokenStream) -> TokenStream {
                 class: module_path!().to_string(),
                 begin_line: line!(),
             })
-            .run();
+            .run_concurrent();
         }
     };
 

--- a/hegel-macros/src/hegel_test.rs
+++ b/hegel-macros/src/hegel_test.rs
@@ -125,7 +125,7 @@ pub fn expand_test(attr: TokenStream, item: TokenStream) -> TokenStream {
                 #(#explicit_blocks)*
             }
 
-            ::hegel::Hegel::new(|#param_pat: #param_ty| #body)
+            ::hegel::Hegel::new_concurrent(|#param_pat: #param_ty| #body)
             .settings(__hegel_settings)
             #reproduce_call
             .__database_key(format!("{}::{}", module_path!(), #test_name))
@@ -135,7 +135,7 @@ pub fn expand_test(attr: TokenStream, item: TokenStream) -> TokenStream {
                 class: module_path!().to_string(),
                 begin_line: line!(),
             })
-            .run();
+            .run_concurrent();
         }
     };
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -318,6 +318,28 @@ impl RunHandle {
         }
     }
 
+    /// Pull the next test case without assuming strict alternation: with
+    /// [`Settings::threads`](crate::Settings::threads) above 1 the engine
+    /// may have no case ready until one of the open ones is marked complete,
+    /// reported as [`NextCase::Pending`] (`HEGEL_E_PENDING`) rather than an
+    /// error.
+    pub(crate) fn next_test_case_any(&self) -> NextCase {
+        let mut raw: *mut hegel_c::HegelTestCase = ptr::null_mut();
+        // SAFETY: self.raw is a live run handle; &mut raw is a valid
+        // out-parameter.
+        let rc =
+            with_context(|ctx| unsafe { hegel_c::hegel_next_test_case(ctx, self.raw, &mut raw) });
+        if rc == hegel_result_t::HEGEL_E_PENDING {
+            return NextCase::Pending;
+        }
+        require_ok(rc);
+        if raw.is_null() {
+            NextCase::Finished
+        } else {
+            NextCase::Case(CTestCase { raw })
+        }
+    }
+
     /// Read the aggregate result as an owned snapshot, independent of the
     /// run's lifetime; freed on drop.
     pub(crate) fn result(&self) -> RunResult {
@@ -342,6 +364,14 @@ impl Drop for RunHandle {
             drop(unsafe { Box::from_raw(p) });
         }
     }
+}
+
+/// One [`RunHandle::next_test_case_any`] outcome: a case to run, "nothing
+/// until an open case completes", or the run is finished.
+pub(crate) enum NextCase {
+    Case(CTestCase),
+    Pending,
+    Finished,
 }
 
 /// A libhegel test-case handle plus the per-primitive operations the frontend

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -147,6 +147,11 @@ impl SettingsHandle {
                     raw,
                     settings.test_cases,
                 ));
+                require_ok(hegel_c::hegel_settings_set_max_open_test_cases(
+                    ctx,
+                    raw,
+                    settings.threads,
+                ));
                 require_ok(hegel_c::hegel_settings_set_stateful_step_count(
                     ctx,
                     raw,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -517,7 +517,9 @@ pub use hegel_macros::main;
 /// Behaves like [`test`] for name rewriting, explicit test cases, and
 /// settings parsing. The generated function has the original signature
 /// with the `TestCase` parameter removed, and its body is run as an
-/// [`FnMut`] closure inside [`Hegel::run`].
+/// [`FnMut`] closure inside [`Hegel::run`]. Because of that `FnMut`
+/// wrapping, standalone functions do not yet support
+/// [`Settings::threads`] above 1; requesting it fails with a usage error.
 ///
 /// ```no_run
 /// use hegel::TestCase;

--- a/src/run_lifecycle.rs
+++ b/src/run_lifecycle.rs
@@ -448,10 +448,7 @@ pub(crate) fn drive<F>(
     let output = RunOutput::resolve();
 
     let c_settings = SettingsHandle::build(settings, database_key);
-    let run = match RunHandle::start(&c_settings, output.sink()) {
-        Ok(run) => run,
-        Err(message) => panic!("{message}"), // nocov
-    };
+    let run = start_run(&c_settings, &output);
 
     if mode == Mode::SingleTestCase {
         drive_single_case(&run, &mut test_fn, verbosity, test_location, &output);
@@ -470,6 +467,15 @@ pub(crate) fn drive<F>(
         test_location,
         &output,
     );
+}
+
+/// Start the engine run, surfacing libhegel's diagnostic as a panic if it
+/// could not be started.
+fn start_run(c_settings: &SettingsHandle, output: &RunOutput) -> RunHandle {
+    match RunHandle::start(c_settings, output.sink()) {
+        Ok(run) => run,
+        Err(message) => panic!("{message}"), // nocov
+    }
 }
 
 /// One worker-to-pump notification in [`drive_parallel`]: a test case was
@@ -526,10 +532,7 @@ pub(crate) fn drive_parallel<F>(
     let output = RunOutput::resolve();
 
     let c_settings = SettingsHandle::build(settings, database_key);
-    let run = match RunHandle::start(&c_settings, output.sink()) {
-        Ok(run) => run,
-        Err(message) => panic!("{message}"), // nocov
-    };
+    let run = start_run(&c_settings, &output);
 
     let workers = settings.threads as usize;
     let escaped = std::thread::scope(|scope| {

--- a/src/run_lifecycle.rs
+++ b/src/run_lifecycle.rs
@@ -22,7 +22,7 @@ use crate::control::{
     AssumeFailed, InternalError, InvalidArgument, LoopDone, StopTest, currently_in_test_context,
     hegel_internal_error, with_test_context,
 };
-use crate::ffi::{CTestCase, RunHandle, SettingsHandle};
+use crate::ffi::{CTestCase, NextCase, RunHandle, SettingsHandle};
 use crate::runner::{Mode, Settings, Verbosity};
 use crate::test_case::{RunOutput, TestCase};
 
@@ -445,7 +445,6 @@ pub(crate) fn drive<F>(
     let mut test_fn = test_fn;
     let mode = settings.mode;
     let verbosity = settings.verbosity;
-    let quiet = verbosity == Verbosity::Quiet;
     let output = RunOutput::resolve();
 
     let c_settings = SettingsHandle::build(settings, database_key);
@@ -463,6 +462,165 @@ pub(crate) fn drive<F>(
         run_test_case(c_tc, &mut test_fn, false, mode, verbosity, &output);
     }
 
+    finish_test_run(
+        &run,
+        &c_settings,
+        settings,
+        &mut test_fn,
+        test_location,
+        &output,
+    );
+}
+
+/// One worker-to-pump notification in [`drive_parallel`]: a test case was
+/// marked complete (poll the engine again), or a panic escaped
+/// [`run_test_case`] — an `InvalidArgument` / `InternalError` re-raise — and
+/// the run must tear down and re-raise it on the calling thread.
+enum WorkerEvent {
+    Completed,
+    Escaped(Box<dyn std::any::Any + Send>),
+}
+
+/// Record an escaped payload (first one wins) and report whether the pump
+/// should stop.
+fn record_escape(escaped: &mut Option<Box<dyn std::any::Any + Send>>, event: WorkerEvent) -> bool {
+    match event {
+        WorkerEvent::Completed => false,
+        WorkerEvent::Escaped(payload) => {
+            escaped.get_or_insert(payload);
+            true
+        }
+    }
+}
+
+/// Drive a libhegel run with `settings.threads` worker threads running test
+/// bodies concurrently.
+///
+/// The calling thread is the pump: it is the only thread that touches the
+/// run handle, pulling cases with [`RunHandle::next_test_case_any`] and
+/// handing each to the workers over a channel. Workers run every case
+/// through the same [`run_test_case`] as the sequential drive — the panic
+/// hook and its captures are thread-local, so each worker classifies its own
+/// case's panic — and signal the pump after each `mark_complete`, which is
+/// what wakes the pump from [`NextCase::Pending`]. A payload that escapes
+/// `run_test_case` (an invalid-argument or internal-error re-raise) is
+/// forwarded to the pump, which stops pumping, lets the scope join, and
+/// resumes it — dropping the [`RunHandle`] on the way completes every case
+/// still open in the engine.
+///
+/// Everything after the search — final replays, the failure report, the
+/// closing re-raise — runs on the calling thread via [`finish_test_run`],
+/// exactly as in the sequential drive.
+pub(crate) fn drive_parallel<F>(
+    test_fn: &F,
+    settings: &Settings,
+    database_key: Option<&str>,
+    test_location: Option<&TestLocation>,
+) where
+    F: Fn(TestCase) + Sync,
+{
+    init_panic_hook();
+    require_antithesis_feature();
+    let mode = settings.mode;
+    let verbosity = settings.verbosity;
+    let output = RunOutput::resolve();
+
+    let c_settings = SettingsHandle::build(settings, database_key);
+    let run = match RunHandle::start(&c_settings, output.sink()) {
+        Ok(run) => run,
+        Err(message) => panic!("{message}"), // nocov
+    };
+
+    let workers = settings.threads as usize;
+    let escaped = std::thread::scope(|scope| {
+        let (case_tx, case_rx) = std::sync::mpsc::channel::<CTestCase>();
+        let case_rx = Arc::new(std::sync::Mutex::new(case_rx));
+        let (event_tx, event_rx) = std::sync::mpsc::channel::<WorkerEvent>();
+        for _ in 0..workers {
+            let case_rx = Arc::clone(&case_rx);
+            let event_tx = event_tx.clone();
+            let output = &output;
+            scope.spawn(move || {
+                let mut body = |tc: TestCase| test_fn(tc);
+                loop {
+                    let next = case_rx.lock().unwrap().recv();
+                    let Ok(c_tc) = next else { return };
+                    let outcome = catch_unwind(AssertUnwindSafe(|| {
+                        run_test_case(c_tc, &mut body, false, mode, verbosity, output);
+                    }));
+                    match outcome {
+                        Ok(_) => {
+                            let _ = event_tx.send(WorkerEvent::Completed);
+                        }
+                        Err(payload) => {
+                            let _ = event_tx.send(WorkerEvent::Escaped(payload));
+                            return;
+                        }
+                    }
+                }
+            });
+        }
+
+        let mut escaped: Option<Box<dyn std::any::Any + Send>> = None;
+        loop {
+            match run.next_test_case_any() {
+                NextCase::Case(c_tc) => {
+                    let _ = case_tx.send(c_tc);
+                }
+                NextCase::Pending => {
+                    // The pump holds an event_tx of its own, so recv can
+                    // only block for the next completion, never disconnect.
+                    let event = event_rx.recv().unwrap();
+                    if record_escape(&mut escaped, event) {
+                        break;
+                    }
+                }
+                NextCase::Finished => break,
+            }
+        }
+        // Closing the case channel ends the workers once each finishes its
+        // current case; dropping the pump's event_tx then lets the drain
+        // below end once the last worker is gone, doubling as a join
+        // barrier that also picks up any escape the pump raced past.
+        drop(case_tx);
+        drop(event_tx);
+        for event in event_rx.iter() {
+            record_escape(&mut escaped, event);
+        }
+        escaped
+    });
+
+    if let Some(payload) = escaped {
+        drop(run);
+        std::panic::resume_unwind(payload);
+    }
+
+    finish_test_run(
+        &run,
+        &c_settings,
+        settings,
+        &mut |tc| test_fn(tc),
+        test_location,
+        &output,
+    );
+}
+
+/// Read a drained run's aggregate result and produce the closing report:
+/// surface a run-level error, replay each discovered counterexample as a
+/// final case (printing its diagnostic and reproducer line), and re-raise
+/// the failing test's own panic. Shared by [`drive`] and [`drive_parallel`];
+/// runs entirely on the calling thread.
+fn finish_test_run(
+    run: &RunHandle,
+    c_settings: &SettingsHandle,
+    settings: &Settings,
+    test_fn: &mut dyn FnMut(TestCase),
+    test_location: Option<&TestLocation>,
+    output: &RunOutput,
+) {
+    let mode = settings.mode;
+    let verbosity = settings.verbosity;
+    let quiet = verbosity == Verbosity::Quiet;
     let result = run.result();
     use hegel_c::hegel_run_status_t as RunStatus;
     let status = result.status();
@@ -493,12 +651,12 @@ pub(crate) fn drive<F>(
                     .failure(index)
                     .reproduce_blob
                     .unwrap_or_else(|| hegel_internal_error!("failure {index} has no blob"));
-                let c_tc = match CTestCase::from_blob(&c_settings, &blob, output.sink()) {
+                let c_tc = match CTestCase::from_blob(c_settings, &blob, output.sink()) {
                     Ok(c_tc) => c_tc,
                     Err(message) => panic!("{message}"), // nocov
                 };
                 let (tc_result, payload, diagnostic) =
-                    run_test_case(c_tc, &mut test_fn, true, mode, verbosity, &output);
+                    run_test_case(c_tc, test_fn, true, mode, verbosity, output);
                 if !matches!(tc_result, TestCaseResult::Interesting(_)) {
                     panic!("{FLAKY_DIAGNOSTIC}");
                 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -490,8 +490,30 @@ where
     /// Run the property-based tests.
     ///
     /// Panics if any test case fails.
+    ///
+    /// Supports single-threaded execution only: with
+    /// [`Settings::threads`] above 1 it fails with a usage error, since
+    /// running test-case bodies concurrently needs the stronger
+    /// `Fn(TestCase) + Sync` bound of [`run_concurrent`](Self::run_concurrent).
     pub fn run(self) {
-        let settings = self.settings.with_env_overrides();
+        let settings = self.settings.clone().with_env_overrides();
+        if wants_parallel(&settings, self.reproduce_failure.is_some()) {
+            panic!(
+                "Settings::threads is {}, but this entry point runs test cases on a \
+                 single thread only: parallel execution needs a test function that \
+                 is Fn + Sync, via Hegel::run_concurrent. #[hegel::test] and \
+                 #[hegel::main] use run_concurrent automatically; \
+                 #[hegel::standalone_function] does not yet support threads > 1.",
+                settings.threads
+            );
+        }
+        self.run_with(settings);
+    }
+
+    /// Dispatch a run whose settings already have environment overrides
+    /// applied: blob replay when a reproduce blob is set, the sequential
+    /// drive otherwise.
+    fn run_with(self, settings: Settings) {
         if let Some(blob) = self.reproduce_failure {
             crate::run_lifecycle::drive_blob_replay(
                 self.test_fn,
@@ -510,6 +532,55 @@ where
             self.test_location.as_ref(),
         );
     }
+}
+
+impl<F> Hegel<F>
+where
+    F: Fn(TestCase) + Sync,
+{
+    /// Like [`new`](Self::new), for a test function that may run
+    /// concurrently.
+    ///
+    /// The `Fn(TestCase) + Sync` bound is what lets
+    /// [`run_concurrent`](Self::run_concurrent) share the test function
+    /// across worker threads. A builder headed for `run_concurrent` must be
+    /// constructed through this entry point: a closure handed to
+    /// [`new`](Self::new) has its kind pinned to `FnMut` by inference and
+    /// cannot be upgraded afterwards.
+    pub fn new_concurrent(test_fn: F) -> Self {
+        Self::new(test_fn)
+    }
+
+    /// Run the property-based tests, honouring [`Settings::threads`].
+    ///
+    /// With `threads` at its default of 1 this is exactly [`run`](Self::run).
+    /// Above 1, test-case bodies run concurrently on that many worker
+    /// threads during generation — which is why this entry point requires
+    /// `Fn(TestCase) + Sync` — while shrinking, replay, and the failure
+    /// report stay sequential on the calling thread.
+    /// `#[hegel::test]` and `#[hegel::main]` call this automatically.
+    ///
+    /// Panics if any test case fails.
+    pub fn run_concurrent(self) {
+        let settings = self.settings.clone().with_env_overrides();
+        if wants_parallel(&settings, self.reproduce_failure.is_some()) {
+            crate::run_lifecycle::drive_parallel(
+                &self.test_fn,
+                &settings,
+                self.database_key.as_deref(),
+                self.test_location.as_ref(),
+            );
+            return;
+        }
+        self.run_with(settings);
+    }
+}
+
+/// Whether this run should execute test-case bodies in parallel: more than
+/// one thread requested, in a mode that actually explores
+/// ([`Mode::SingleTestCase`] and blob replay ignore `threads`).
+fn wants_parallel(settings: &Settings, replaying_blob: bool) -> bool {
+    settings.threads > 1 && settings.mode == Mode::TestRun && !replaying_blob
 }
 
 #[cfg(test)]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -124,6 +124,7 @@ pub enum Verbosity {
 pub struct Settings {
     pub(crate) mode: Mode,
     pub(crate) test_cases: u64,
+    pub(crate) threads: u64,
     pub(crate) stateful_step_count: i64,
     pub(crate) verbosity: Verbosity,
     pub(crate) seed: Option<u64>,
@@ -149,6 +150,7 @@ impl Settings {
         Self {
             mode: Mode::TestRun,
             test_cases: 100,
+            threads: 1,
             stateful_step_count: 50,
             verbosity: Verbosity::Normal,
             seed: None,
@@ -197,6 +199,31 @@ impl Settings {
     /// smoke pass) without editing source.
     pub fn test_cases(mut self, n: u64) -> Self {
         self.test_cases = n;
+        self
+    }
+
+    /// Set how many worker threads run test-case bodies (default: 1).
+    ///
+    /// With `n` above 1, the engine keeps up to `n` test cases open at once
+    /// during generation and `n` worker threads run their bodies
+    /// concurrently; shrinking, database replay, and the final failure
+    /// replays stay sequential. The test function must then be `Fn + Sync`
+    /// — use [`Hegel::run_concurrent`](crate::Hegel::run_concurrent), which
+    /// `#[hegel::test]` and `#[hegel::main]` do automatically.
+    ///
+    /// With threads above 1 the *search* is not schedule-reproducible even
+    /// with a fixed [`seed`](Settings::seed): which test case is generated
+    /// next depends on the order completions land. What matters stays
+    /// deterministic — every discovered failure is shrunk sequentially,
+    /// replays exactly via the database and its reproduce blob, and
+    /// [`reproduce_failure`](crate::Hegel::reproduce_failure) is unaffected.
+    ///
+    /// `n` must be at least 1; a smaller value makes the run fail with a
+    /// usage error. The `HEGEL_THREADS` environment variable, when set and
+    /// non-empty, overrides this value at runtime, like `HEGEL_TEST_CASES`.
+    /// [`Mode::SingleTestCase`] and blob replay ignore it.
+    pub fn threads(mut self, n: u64) -> Self {
+        self.threads = n;
         self
     }
 
@@ -309,6 +336,14 @@ impl Settings {
                 match value.parse::<u64>() {
                     Ok(n) if n > 0 => self.test_cases = n,
                     _ => panic!("HEGEL_TEST_CASES must be a positive integer, got {value:?}"),
+                }
+            }
+        }
+        if let Some(value) = env("HEGEL_THREADS") {
+            if !value.is_empty() {
+                match value.parse::<u64>() {
+                    Ok(n) if n > 0 => self.threads = n,
+                    _ => panic!("HEGEL_THREADS must be a positive integer, got {value:?}"),
                 }
             }
         }

--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -147,7 +147,10 @@ pub(crate) struct TestCaseLocalData {
 /// # Threading
 ///
 /// `TestCase` is `Send` but not `Sync`. To drive generation from another
-/// thread, clone the test case and move the clone. Each clone generates
+/// thread, clone the test case and move the clone. (This is about threads
+/// *inside* one test case; to run whole test-case bodies concurrently, see
+/// [`Settings::threads`](crate::Settings::threads) — each body still gets
+/// its own `TestCase`.) Each clone generates
 /// from its own *independent stream* of choices: draws on one clone never
 /// perturb the values any other clone (or the original) produces, so
 /// several threads can generate concurrently and the test stays fully

--- a/tests/embedded/runner_tests.rs
+++ b/tests/embedded/runner_tests.rs
@@ -361,3 +361,39 @@ mod reproduce {
         );
     }
 }
+
+#[test]
+fn test_threads_defaults_to_one_and_is_settable() {
+    assert_eq!(Settings::new().threads, 1);
+    assert_eq!(Settings::new().threads(4).threads, 4);
+}
+
+#[test]
+fn test_env_override_replaces_threads() {
+    let s = Settings::new()
+        .threads(2)
+        .with_env_overrides_from(|key| (key == "HEGEL_THREADS").then(|| "8".to_string()));
+    assert_eq!(s.threads, 8);
+}
+
+#[test]
+fn test_env_override_threads_empty_is_ignored() {
+    let s = Settings::new()
+        .threads(2)
+        .with_env_overrides_from(|key| (key == "HEGEL_THREADS").then(String::new));
+    assert_eq!(s.threads, 2);
+}
+
+#[test]
+#[should_panic(expected = "HEGEL_THREADS must be a positive integer, got \"many\"")]
+fn test_env_override_threads_non_numeric_is_a_usage_error() {
+    Settings::new()
+        .with_env_overrides_from(|key| (key == "HEGEL_THREADS").then(|| "many".to_string()));
+}
+
+#[test]
+#[should_panic(expected = "HEGEL_THREADS must be a positive integer, got \"0\"")]
+fn test_env_override_threads_zero_is_a_usage_error() {
+    Settings::new()
+        .with_env_overrides_from(|key| (key == "HEGEL_THREADS").then(|| "0".to_string()));
+}

--- a/tests/test_parallel.rs
+++ b/tests/test_parallel.rs
@@ -1,0 +1,244 @@
+//! Parallel test-case execution via `Settings::threads`.
+//!
+//! Every assertion here is schedule-independent: which test case is
+//! generated next under `threads > 1` depends on completion order, but the
+//! failure count, the shrunk minimum, blob/database replay, health checks,
+//! and error propagation must not.
+
+mod common;
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use common::utils::{capture_hegel_output, expect_panic};
+use hegel::generators as gs;
+use hegel::{Hegel, Settings, TestCase};
+
+fn parallel_settings() -> Settings {
+    Settings::new().database(None).threads(4)
+}
+
+#[test]
+fn test_parallel_passing_suite_passes() {
+    Hegel::new_concurrent(|tc: TestCase| {
+        let n: u64 = tc.draw(gs::integers::<u64>());
+        let m: u64 = tc.draw(gs::integers::<u64>());
+        assert_eq!(n.wrapping_add(m), m.wrapping_add(n));
+    })
+    .settings(parallel_settings())
+    .run_concurrent();
+}
+
+#[test]
+fn test_parallel_failure_shrinks_to_the_sequential_minimum() {
+    expect_panic(
+        || {
+            Hegel::new_concurrent(|tc: TestCase| {
+                let n: i64 = tc.draw(gs::integers::<i64>().min_value(0).max_value(1000));
+                assert!(n < 10, "n was {n}");
+            })
+            .settings(parallel_settings())
+            .run_concurrent();
+        },
+        "n was 10",
+    );
+}
+
+#[test]
+fn test_parallel_reports_exactly_one_failure() {
+    let (lines, result) = capture_hegel_output(|| {
+        Hegel::new_concurrent(|tc: TestCase| {
+            let n: i64 = tc.draw(gs::integers::<i64>().min_value(0).max_value(1000));
+            assert!(n < 10, "n was {n}");
+        })
+        .settings(parallel_settings())
+        .run_concurrent();
+    });
+    assert!(result.is_err());
+    assert!(
+        !lines.iter().any(|l| l.contains("distinct failures")),
+        "a single bug must not be reported as multiple failures: {lines:?}"
+    );
+}
+
+#[test]
+fn test_parallel_printed_blob_replays() {
+    let (lines, result) = capture_hegel_output(|| {
+        Hegel::new_concurrent(|tc: TestCase| {
+            let n: i64 = tc.draw(gs::integers::<i64>().min_value(0).max_value(1000));
+            assert!(n < 10, "n was {n}");
+        })
+        .settings(parallel_settings().print_blob(true))
+        .run_concurrent();
+    });
+    assert!(result.is_err());
+    let blob_line = lines
+        .iter()
+        .find(|l| l.contains("reproduce_failure"))
+        .expect("print_blob must print a reproducer line");
+    let blob = blob_line
+        .split('"')
+        .nth(1)
+        .expect("the reproducer line quotes the blob")
+        .to_string();
+
+    expect_panic(
+        || {
+            Hegel::new(|tc: TestCase| {
+                let n: i64 = tc.draw(gs::integers::<i64>().min_value(0).max_value(1000));
+                assert!(n < 10, "n was {n}");
+            })
+            .settings(Settings::new().database(None))
+            .reproduce_failure(blob)
+            .run();
+        },
+        "n was 10",
+    );
+}
+
+#[test]
+fn test_parallel_database_entry_replays_sequentially() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().to_str().unwrap().to_string();
+    let key = "test_parallel_database_entry_replays_sequentially";
+
+    expect_panic(
+        || {
+            Hegel::new_concurrent(|tc: TestCase| {
+                let n: i64 = tc.draw(gs::integers::<i64>().min_value(0).max_value(1000));
+                assert!(n < 10, "n was {n}");
+            })
+            .settings(
+                Settings::new()
+                    .database(Some(path.clone()))
+                    .derandomize(false)
+                    .threads(4),
+            )
+            .__database_key(key.to_string())
+            .run_concurrent();
+        },
+        "n was 10",
+    );
+
+    let calls = AtomicUsize::new(0);
+    expect_panic(
+        || {
+            Hegel::new(|tc: TestCase| {
+                calls.fetch_add(1, Ordering::SeqCst);
+                let n: i64 = tc.draw(gs::integers::<i64>().min_value(0).max_value(1000));
+                assert!(n < 10, "n was {n}");
+            })
+            .settings(
+                Settings::new()
+                    .database(Some(path.clone()))
+                    .derandomize(false),
+            )
+            .__database_key(key.to_string())
+            .run();
+        },
+        "n was 10",
+    );
+    assert!(
+        calls.load(Ordering::SeqCst) <= 3,
+        "the stored minimum must replay without a fresh search, ran {} cases",
+        calls.load(Ordering::SeqCst)
+    );
+}
+
+#[test]
+fn test_parallel_filter_too_much_fires() {
+    expect_panic(
+        || {
+            Hegel::new_concurrent(|tc: TestCase| {
+                let n: i64 = tc.draw(gs::integers::<i64>());
+                tc.assume(n == i64::MIN);
+            })
+            .settings(parallel_settings())
+            .run_concurrent();
+        },
+        "FilterTooMuch",
+    );
+}
+
+#[test]
+fn test_parallel_bodies_actually_overlap() {
+    let live = Arc::new(AtomicUsize::new(0));
+    let peak = Arc::new(AtomicUsize::new(0));
+    let live_in = Arc::clone(&live);
+    let peak_in = Arc::clone(&peak);
+    Hegel::new_concurrent(move |tc: TestCase| {
+        tc.draw(gs::booleans());
+        let now = live_in.fetch_add(1, Ordering::SeqCst) + 1;
+        peak_in.fetch_max(now, Ordering::SeqCst);
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        live_in.fetch_sub(1, Ordering::SeqCst);
+    })
+    .settings(parallel_settings().test_cases(100))
+    .run_concurrent();
+    assert!(
+        peak.load(Ordering::SeqCst) > 1,
+        "100 cases of ~10ms on 4 threads must overlap at least once"
+    );
+}
+
+#[test]
+fn test_parallel_invalid_argument_in_a_worker_surfaces_as_the_run_error() {
+    expect_panic(
+        || {
+            Hegel::new_concurrent(|tc: TestCase| {
+                tc.target(f64::NAN);
+            })
+            .settings(parallel_settings())
+            .run_concurrent();
+        },
+        "requires a finite score",
+    );
+}
+
+#[test]
+fn test_run_rejects_threads_above_one() {
+    expect_panic(
+        || {
+            Hegel::new(|_tc: TestCase| {})
+                .settings(parallel_settings())
+                .run();
+        },
+        "standalone_function.*does not yet support threads > 1",
+    );
+}
+
+#[test]
+fn test_run_concurrent_with_one_thread_is_the_sequential_run() {
+    expect_panic(
+        || {
+            Hegel::new_concurrent(|tc: TestCase| {
+                let n: i64 = tc.draw(gs::integers::<i64>().min_value(0).max_value(1000));
+                assert!(n < 10, "n was {n}");
+            })
+            .settings(Settings::new().database(None).threads(1))
+            .run_concurrent();
+        },
+        "n was 10",
+    );
+}
+
+#[test]
+fn test_single_test_case_mode_ignores_threads() {
+    Hegel::new_concurrent(|tc: TestCase| {
+        tc.draw(gs::booleans());
+    })
+    .settings(
+        Settings::new()
+            .database(None)
+            .mode(hegel::Mode::SingleTestCase)
+            .threads(4),
+    )
+    .run_concurrent();
+}
+
+#[hegel::test(threads = 2, test_cases = 20)]
+fn test_hegel_test_macro_accepts_threads(tc: TestCase) {
+    let n: u32 = tc.draw(gs::integers::<u32>());
+    let m = n;
+    assert_eq!(n, m);
+}

--- a/tests/test_parallel.rs
+++ b/tests/test_parallel.rs
@@ -18,181 +18,235 @@ fn parallel_settings() -> Settings {
     Settings::new().database(None).threads(4)
 }
 
-#[test]
-fn test_parallel_passing_suite_passes() {
-    Hegel::new_concurrent(|tc: TestCase| {
-        let n: u64 = tc.draw(gs::integers::<u64>());
-        let m: u64 = tc.draw(gs::integers::<u64>());
-        assert_eq!(n.wrapping_add(m), m.wrapping_add(n));
-    })
-    .settings(parallel_settings())
-    .run_concurrent();
+/// Fail instead of hanging CI if a parallel run deadlocks: run the test body
+/// on its own thread with a generous bound.
+fn watchdog_with<F: FnOnce() + Send + 'static>(bound: std::time::Duration, body: F) {
+    let (done_tx, done_rx) = std::sync::mpsc::channel();
+    let runner = std::thread::spawn(move || {
+        body();
+        let _ = done_tx.send(());
+    });
+    match done_rx.recv_timeout(bound) {
+        Ok(()) => runner.join().unwrap(),
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            std::panic::resume_unwind(runner.join().unwrap_err());
+        }
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            panic!(
+                "watchdog: the parallel test did not finish within {bound:?} (possible deadlock)"
+            )
+        }
+    }
+}
+
+fn with_watchdog<F: FnOnce() + Send + 'static>(body: F) {
+    watchdog_with(std::time::Duration::from_secs(60), body);
 }
 
 #[test]
-fn test_parallel_failure_shrinks_to_the_sequential_minimum() {
+fn test_watchdog_propagates_the_body_panic() {
+    expect_panic(|| with_watchdog(|| panic!("inner boom")), "inner boom");
+}
+
+#[test]
+fn test_watchdog_fires_on_a_hung_body() {
     expect_panic(
         || {
-            Hegel::new_concurrent(|tc: TestCase| {
-                let n: i64 = tc.draw(gs::integers::<i64>().min_value(0).max_value(1000));
-                assert!(n < 10, "n was {n}");
+            watchdog_with(std::time::Duration::from_millis(50), || {
+                std::thread::sleep(std::time::Duration::from_secs(2))
             })
-            .settings(parallel_settings())
-            .run_concurrent();
         },
-        "n was 10",
+        "watchdog",
     );
 }
 
 #[test]
-fn test_parallel_reports_exactly_one_failure() {
-    let (lines, result) = capture_hegel_output(|| {
+fn test_parallel_passing_suite_passes() {
+    with_watchdog(|| {
         Hegel::new_concurrent(|tc: TestCase| {
-            let n: i64 = tc.draw(gs::integers::<i64>().min_value(0).max_value(1000));
-            assert!(n < 10, "n was {n}");
+            let n: u64 = tc.draw(gs::integers::<u64>());
+            let m: u64 = tc.draw(gs::integers::<u64>());
+            assert_eq!(n.wrapping_add(m), m.wrapping_add(n));
         })
         .settings(parallel_settings())
         .run_concurrent();
     });
-    assert!(result.is_err());
-    assert!(
-        !lines.iter().any(|l| l.contains("distinct failures")),
-        "a single bug must not be reported as multiple failures: {lines:?}"
-    );
+}
+
+#[test]
+fn test_parallel_failure_shrinks_to_the_sequential_minimum() {
+    with_watchdog(|| {
+        expect_panic(
+            || {
+                Hegel::new_concurrent(|tc: TestCase| {
+                    let n: i64 = tc.draw(gs::integers::<i64>().min_value(0).max_value(1000));
+                    assert!(n < 10, "n was {n}");
+                })
+                .settings(parallel_settings())
+                .run_concurrent();
+            },
+            "n was 10",
+        );
+    });
+}
+
+#[test]
+fn test_parallel_reports_exactly_one_failure() {
+    with_watchdog(|| {
+        let (lines, result) = capture_hegel_output(|| {
+            Hegel::new_concurrent(|tc: TestCase| {
+                let n: i64 = tc.draw(gs::integers::<i64>().min_value(0).max_value(1000));
+                assert!(n < 10, "n was {n}");
+            })
+            .settings(parallel_settings())
+            .run_concurrent();
+        });
+        assert!(result.is_err());
+        assert!(
+            !lines.iter().any(|l| l.contains("distinct failures")),
+            "a single bug must not be reported as multiple failures: {lines:?}"
+        );
+    });
 }
 
 #[test]
 fn test_parallel_printed_blob_replays() {
-    let (lines, result) = capture_hegel_output(|| {
-        Hegel::new_concurrent(|tc: TestCase| {
-            let n: i64 = tc.draw(gs::integers::<i64>().min_value(0).max_value(1000));
-            assert!(n < 10, "n was {n}");
-        })
-        .settings(parallel_settings().print_blob(true))
-        .run_concurrent();
-    });
-    assert!(result.is_err());
-    let blob_line = lines
-        .iter()
-        .find(|l| l.contains("reproduce_failure"))
-        .expect("print_blob must print a reproducer line");
-    let blob = blob_line
-        .split('"')
-        .nth(1)
-        .expect("the reproducer line quotes the blob")
-        .to_string();
-
-    expect_panic(
-        || {
-            Hegel::new(|tc: TestCase| {
+    with_watchdog(|| {
+        let (lines, result) = capture_hegel_output(|| {
+            Hegel::new_concurrent(|tc: TestCase| {
                 let n: i64 = tc.draw(gs::integers::<i64>().min_value(0).max_value(1000));
                 assert!(n < 10, "n was {n}");
             })
-            .settings(Settings::new().database(None))
-            .reproduce_failure(blob)
-            .run();
-        },
-        "n was 10",
-    );
+            .settings(parallel_settings().print_blob(true))
+            .run_concurrent();
+        });
+        assert!(result.is_err());
+        let blob_line = lines
+            .iter()
+            .find(|l| l.contains("reproduce_failure"))
+            .unwrap();
+        let blob = blob_line.split('"').nth(1).unwrap().to_string();
+
+        expect_panic(
+            || {
+                Hegel::new(|tc: TestCase| {
+                    let n: i64 = tc.draw(gs::integers::<i64>().min_value(0).max_value(1000));
+                    assert!(n < 10, "n was {n}");
+                })
+                .settings(Settings::new().database(None))
+                .reproduce_failure(blob)
+                .run();
+            },
+            "n was 10",
+        );
+    });
 }
 
 #[test]
 fn test_parallel_database_entry_replays_sequentially() {
-    let dir = tempfile::TempDir::new().unwrap();
-    let path = dir.path().to_str().unwrap().to_string();
-    let key = "test_parallel_database_entry_replays_sequentially";
+    with_watchdog(|| {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().to_str().unwrap().to_string();
+        let key = "test_parallel_database_entry_replays_sequentially";
 
-    expect_panic(
-        || {
-            Hegel::new_concurrent(|tc: TestCase| {
-                let n: i64 = tc.draw(gs::integers::<i64>().min_value(0).max_value(1000));
-                assert!(n < 10, "n was {n}");
-            })
-            .settings(
-                Settings::new()
-                    .database(Some(path.clone()))
-                    .derandomize(false)
-                    .threads(4),
-            )
-            .__database_key(key.to_string())
-            .run_concurrent();
-        },
-        "n was 10",
-    );
+        expect_panic(
+            || {
+                Hegel::new_concurrent(|tc: TestCase| {
+                    let n: i64 = tc.draw(gs::integers::<i64>().min_value(0).max_value(1000));
+                    assert!(n < 10, "n was {n}");
+                })
+                .settings(
+                    Settings::new()
+                        .database(Some(path.clone()))
+                        .derandomize(false)
+                        .threads(4),
+                )
+                .__database_key(key.to_string())
+                .run_concurrent();
+            },
+            "n was 10",
+        );
 
-    let calls = AtomicUsize::new(0);
-    expect_panic(
-        || {
-            Hegel::new(|tc: TestCase| {
-                calls.fetch_add(1, Ordering::SeqCst);
-                let n: i64 = tc.draw(gs::integers::<i64>().min_value(0).max_value(1000));
-                assert!(n < 10, "n was {n}");
-            })
-            .settings(
-                Settings::new()
-                    .database(Some(path.clone()))
-                    .derandomize(false),
-            )
-            .__database_key(key.to_string())
-            .run();
-        },
-        "n was 10",
-    );
-    assert!(
-        calls.load(Ordering::SeqCst) <= 3,
-        "the stored minimum must replay without a fresh search, ran {} cases",
-        calls.load(Ordering::SeqCst)
-    );
+        let calls = AtomicUsize::new(0);
+        expect_panic(
+            || {
+                Hegel::new(|tc: TestCase| {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    let n: i64 = tc.draw(gs::integers::<i64>().min_value(0).max_value(1000));
+                    assert!(n < 10, "n was {n}");
+                })
+                .settings(
+                    Settings::new()
+                        .database(Some(path.clone()))
+                        .derandomize(false),
+                )
+                .__database_key(key.to_string())
+                .run();
+            },
+            "n was 10",
+        );
+        assert!(
+            calls.load(Ordering::SeqCst) <= 3,
+            "the stored minimum must replay without a fresh search, ran {} cases",
+            calls.load(Ordering::SeqCst)
+        );
+    });
 }
 
 #[test]
 fn test_parallel_filter_too_much_fires() {
-    expect_panic(
-        || {
-            Hegel::new_concurrent(|tc: TestCase| {
-                let n: i64 = tc.draw(gs::integers::<i64>());
-                tc.assume(n == i64::MIN);
-            })
-            .settings(parallel_settings())
-            .run_concurrent();
-        },
-        "FilterTooMuch",
-    );
+    with_watchdog(|| {
+        expect_panic(
+            || {
+                Hegel::new_concurrent(|tc: TestCase| {
+                    let n: i64 = tc.draw(gs::integers::<i64>());
+                    tc.assume(n == i64::MIN);
+                })
+                .settings(parallel_settings())
+                .run_concurrent();
+            },
+            "FilterTooMuch",
+        );
+    });
 }
 
 #[test]
 fn test_parallel_bodies_actually_overlap() {
-    let live = Arc::new(AtomicUsize::new(0));
-    let peak = Arc::new(AtomicUsize::new(0));
-    let live_in = Arc::clone(&live);
-    let peak_in = Arc::clone(&peak);
-    Hegel::new_concurrent(move |tc: TestCase| {
-        tc.draw(gs::booleans());
-        let now = live_in.fetch_add(1, Ordering::SeqCst) + 1;
-        peak_in.fetch_max(now, Ordering::SeqCst);
-        std::thread::sleep(std::time::Duration::from_millis(10));
-        live_in.fetch_sub(1, Ordering::SeqCst);
-    })
-    .settings(parallel_settings().test_cases(100))
-    .run_concurrent();
-    assert!(
-        peak.load(Ordering::SeqCst) > 1,
-        "100 cases of ~10ms on 4 threads must overlap at least once"
-    );
+    with_watchdog(|| {
+        let live = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let live_in = Arc::clone(&live);
+        let peak_in = Arc::clone(&peak);
+        Hegel::new_concurrent(move |tc: TestCase| {
+            tc.draw(gs::booleans());
+            let now = live_in.fetch_add(1, Ordering::SeqCst) + 1;
+            peak_in.fetch_max(now, Ordering::SeqCst);
+            std::thread::sleep(std::time::Duration::from_millis(10));
+            live_in.fetch_sub(1, Ordering::SeqCst);
+        })
+        .settings(parallel_settings().test_cases(100))
+        .run_concurrent();
+        assert!(
+            peak.load(Ordering::SeqCst) > 1,
+            "100 cases of ~10ms on 4 threads must overlap at least once"
+        );
+    });
 }
 
 #[test]
 fn test_parallel_invalid_argument_in_a_worker_surfaces_as_the_run_error() {
-    expect_panic(
-        || {
-            Hegel::new_concurrent(|tc: TestCase| {
-                tc.target(f64::NAN);
-            })
-            .settings(parallel_settings())
-            .run_concurrent();
-        },
-        "requires a finite score",
-    );
+    with_watchdog(|| {
+        expect_panic(
+            || {
+                Hegel::new_concurrent(|tc: TestCase| {
+                    tc.target(f64::NAN);
+                })
+                .settings(parallel_settings())
+                .run_concurrent();
+            },
+            "requires a finite score",
+        );
+    });
 }
 
 #[test]
@@ -237,8 +291,14 @@ fn test_single_test_case_mode_ignores_threads() {
 }
 
 #[hegel::test(threads = 2, test_cases = 20)]
-fn test_hegel_test_macro_accepts_threads(tc: TestCase) {
+#[ignore = "fixture: run via the watchdog wrapper below"]
+fn hegel_test_macro_threads_fixture(tc: TestCase) {
     let n: u32 = tc.draw(gs::integers::<u32>());
     let m = n;
     assert_eq!(n, m);
+}
+
+#[test]
+fn test_hegel_test_macro_accepts_threads() {
+    with_watchdog(hegel_test_macro_threads_fixture);
 }


### PR DESCRIPTION
Adds `Settings::threads(n)`: the engine keeps up to `n` test cases open at once during generation and the frontend runs their bodies on `n` worker threads, while shrinking, replay, and reporting stay sequential and fully deterministic. The C ABI grows an additive `max_open_test_cases` setting and `HEGEL_E_PENDING` protocol so other bindings can do the same. Default behavior (threads = 1) is byte-for-byte unchanged.

<details>
<summary>Details (AI-generated)</summary>

## Design

The engine stays a single logical thread (no_std-safe); parallelism is expressed as a bounded window of open test cases. The one-slot exchange became a queue; the engine offers up to `max_open_test_cases` speculatively and harvests completions in arrival order — `record_run` is order-independent (tree recording per-path, `update_interesting` commutative min, persister per-origin monotone, targeting commutative max). Everything logically sequential (initial probe, Reuse replay, targeting, span mutation, shrinking, flaky-verify) runs unchanged via an `await_case` primitive; the pipeline drains at phase boundaries. On INTERESTING: drain, don't cancel. TooSlow now measures generation-phase wall clock (marginally sooner for sequential runs; noted in RELEASE.md).

## Commits

10 commits, each independently `just check`-green: exchange queue → `try_conclusion` peek → engine setting → pipelined generation → additive ABI (`HEGEL_E_PENDING = -10`, run-handle `try_lock` → `HEGEL_E_CONCURRENT_USE` instead of UB, `open_window.c` example in `just c-test`) → `Settings::threads` + `HEGEL_THREADS` → `drive_parallel` (pump + scoped workers, no `'static` bounds, per-worker panic capture) → docs/release → race fix + review follow-ups.

## API notes / open decisions

- `#[hegel::test]` / `#[hegel::main]` work with `threads` transparently. `Hegel::run_concurrent` requires `Fn(TestCase) + Sync`; a separate `new_concurrent` constructor is genuinely forced by closure-kind inference (both single-constructor alternatives break existing callers — verified empirically against the repo's 277 `Hegel::new` call sites). `Hegel` remains `#[doc(hidden)]`.
- `#[hegel::standalone_function]` keeps its `FnMut` path and panics with a clear message under `threads > 1` — avoiding a `Sync` tax on captured arguments for users who never enable threads. Lifting this is a possible follow-up.
- With `threads > 1`, `seed`/`derandomize` fix the distribution, not the exact test-case sequence; failures stay exactly reproducible via database entries and reproduce blobs (tested).

## Testing

Ordering-sensitive engine logic is tested without threads: a scripted driver completes open cases in adversarial orders (reverse, round-robin, seeded permutations), deterministically and Miri-friendly. Threaded integration tests assert only schedule-independent invariants and run under a 60s watchdog so a deadlock fails fast instead of hanging CI. threads=1 verified byte-for-byte against main on fixed seeds (output, blobs, exact body-call counts).

Review history: an independent review deterministically reproduced a completion-publication race (worker preempted inside `mark_complete` between the completed-flag CAS and the conclusion write could falsely conclude the run with "Internal error in hegel") — fixed by publishing a separate `concluded` flag only after the conclusion write, with the repro committed as a regression test and the fix re-verified analytically and under 38/38 stress runs.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
