### PR TITLE
feat: add prelude for common imports

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,6 @@ This patch adds `hegel::prelude`, which brings the items most tests need into sc
 
 ```rust
 use hegel::prelude::*;
-use hegel::generators as gs;
 
 #[composite]
 fn even_integers(tc: &TestCase) -> i32 {
@@ -19,6 +18,6 @@ fn test_sum_of_even_integers_is_even(tc: TestCase) {
 }
 ```
 
-The prelude re-exports `TestCase`, the `Generator` trait, the `generators` module, and `#[composite]`. The `Generator` import is important: without it in scope, `map` and `filter` resolve against `Iterator` and rustc reports that your generator "is not an iterator".
+The prelude re-exports `TestCase`, the `Generator` trait, `#[composite]`, and the `generators` module under both its full name and the conventional `gs` alias. The `Generator` import is important: without it in scope, `map` and `filter` resolve against `Iterator` and rustc reports that your generator "is not an iterator". If you bind `gs` to something of your own, your explicit import shadows the prelude's without an ambiguity error.
 
-It omits `hegel::test`, whose name would collide with the standard `#[test]` attribute, so keep writing `#[hegel::test]` on your test functions. Generators are conventionally reached through a `gs` alias rather than the glob-imported `generators` name, so most tests will still want that second import.
+It omits `hegel::test`, whose name would collide with the standard `#[test]` attribute, so keep writing `#[hegel::test]` on your test functions.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,24 @@
+RELEASE_TYPE: patch
+
+This patch adds `hegel::prelude`, which brings the items most tests need into scope in one import ([#75](https://github.com/hegeldev/hegel-rust/issues/75)):
+
+```rust
+use hegel::prelude::*;
+use hegel::generators as gs;
+
+#[composite]
+fn even_integers(tc: &TestCase) -> i32 {
+    tc.draw(gs::integers::<i32>().map(|n: i32| n.wrapping_mul(2)))
+}
+
+#[hegel::test]
+fn test_sum_of_even_integers_is_even(tc: TestCase) {
+    let xs = tc.draw(gs::vecs(even_integers()));
+    let total = xs.iter().fold(0i32, |acc, n| acc.wrapping_add(*n));
+    assert_eq!(total % 2, 0);
+}
+```
+
+The prelude re-exports `TestCase`, the `Generator` trait, the `generators` module, and `#[composite]`. The `Generator` import is important: without it in scope, `map` and `filter` resolve against `Iterator` and rustc reports that your generator "is not an iterator".
+
+It omits `hegel::test`, whose name would collide with the standard `#[test]` attribute, so keep writing `#[hegel::test]` on your test functions. Generators are conventionally reached through a `gs` alias rather than the glob-imported `generators` name, so most tests will still want that second import.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,6 +225,7 @@
 //!
 //! - Browse the [`generators`] module for the full list of available generators.
 //! - See [`Settings`] for more configuration settings to customise how your test runs.
+//! - Use [`prelude`] (`use hegel::prelude::*;`) to import the items most tests need.
 
 #![forbid(future_incompatible)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
@@ -239,6 +240,7 @@ pub mod explicit_test_case;
 pub mod extras;
 pub(crate) mod ffi;
 pub mod generators;
+pub mod prelude;
 pub mod pretty;
 #[doc(hidden)]
 pub mod run_lifecycle;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,37 @@
+//! The items you need in almost every Hegel test, in one import.
+//!
+//! ```no_run
+//! use hegel::prelude::*;
+//! use hegel::generators as gs;
+//!
+//! #[composite]
+//! fn even_integers(tc: &TestCase) -> i32 {
+//!     tc.draw(gs::integers::<i32>().map(|n: i32| n.wrapping_mul(2)))
+//! }
+//!
+//! #[hegel::test]
+//! fn test_sum_of_even_integers_is_even(tc: TestCase) {
+//!     let xs = tc.draw(gs::vecs(even_integers()));
+//!     let total = xs.iter().fold(0i32, |acc, n| acc.wrapping_add(*n));
+//!     assert_eq!(total % 2, 0);
+//! }
+//! ```
+//!
+//! Three of the names above come from the prelude: [`TestCase`], the
+//! [`composite`](macro@crate::composite) attribute (written bare rather than
+//! as `#[hegel::composite]`), and the [`Generator`] trait, which has to be in
+//! scope for the [`map`](crate::generators::Generator::map) call. Without it,
+//! `map` resolves against [`Iterator`] and rustc reports the generator "is not
+//! an iterator". The prelude also re-exports the [`generators`] module.
+//!
+//! It omits [`hegel::test`](macro@crate::test), whose name would collide with
+//! the standard `#[test]` attribute. Write `#[hegel::test]` on your test
+//! functions, as above.
+//!
+//! Generators are conventionally reached through a `gs` alias
+//! (`use hegel::generators as gs;`) rather than the glob-imported
+//! [`generators`] name, so most tests will still want that second import.
+
+pub use crate::TestCase;
+pub use crate::composite;
+pub use crate::generators::{self, Generator};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,7 +2,6 @@
 //!
 //! ```no_run
 //! use hegel::prelude::*;
-//! use hegel::generators as gs;
 //!
 //! #[composite]
 //! fn even_integers(tc: &TestCase) -> i32 {
@@ -17,21 +16,25 @@
 //! }
 //! ```
 //!
-//! Three of the names above come from the prelude: [`TestCase`], the
+//! Every name in that test comes from the prelude: [`TestCase`], the
 //! [`composite`](macro@crate::composite) attribute (written bare rather than
-//! as `#[hegel::composite]`), and the [`Generator`] trait, which has to be in
-//! scope for the [`map`](crate::generators::Generator::map) call. Without it,
-//! `map` resolves against [`Iterator`] and rustc reports the generator "is not
-//! an iterator". The prelude also re-exports the [`generators`] module.
+//! as `#[hegel::composite]`), the [`Generator`] trait, which has to be in
+//! scope for the [`map`](crate::generators::Generator::map) call, and `gs`.
+//! Without `Generator`, `map` resolves against [`Iterator`] instead and rustc
+//! reports that your generator "is not an iterator".
 //!
-//! It omits [`hegel::test`](macro@crate::test), whose name would collide with
-//! the standard `#[test]` attribute. Write `#[hegel::test]` on your test
-//! functions, as above.
+//! `gs` is the conventional alias for the [`generators`] module, which the
+//! prelude re-exports under both names. They are the same module, so
+//! `gs::integers()` and `generators::integers()` are interchangeable; the
+//! short form is the one the rest of this documentation uses. If you bind
+//! `gs` to something of your own, your explicit import shadows the prelude's
+//! without an ambiguity error.
 //!
-//! Generators are conventionally reached through a `gs` alias
-//! (`use hegel::generators as gs;`) rather than the glob-imported
-//! [`generators`] name, so most tests will still want that second import.
+//! The prelude omits [`hegel::test`](macro@crate::test), whose name would
+//! collide with the standard `#[test]` attribute. Write `#[hegel::test]` on
+//! your test functions, as above.
 
 pub use crate::TestCase;
 pub use crate::composite;
+pub use crate::generators as gs;
 pub use crate::generators::{self, Generator};

--- a/tests/test_prelude.rs
+++ b/tests/test_prelude.rs
@@ -1,0 +1,37 @@
+use hegel::generators as gs;
+use hegel::prelude::*;
+
+#[composite]
+fn even_integers(tc: &TestCase) -> i32 {
+    tc.draw(gs::integers::<i32>().map(|n: i32| n.wrapping_mul(2)))
+}
+
+#[hegel::test]
+fn test_prelude_supplies_test_case_composite_and_generator_trait(tc: TestCase) {
+    let xs = tc.draw(gs::vecs(even_integers()));
+    let total = xs.iter().fold(0i32, |acc, n| acc.wrapping_add(*n));
+    assert_eq!(total % 2, 0);
+}
+
+mod generators_module {
+    use hegel::prelude::generators as gs;
+    use hegel::prelude::*;
+
+    #[hegel::test]
+    fn test_prelude_provides_generators_module(tc: TestCase) {
+        let n = tc.draw(gs::integers::<i32>().filter(|n: &i32| n % 2 == 0));
+        assert_eq!(n % 2, 0);
+    }
+}
+
+mod standard_test_attribute {
+    use hegel::prelude::*;
+
+    #[test]
+    fn test_prelude_does_not_shadow_the_standard_test_attribute() {
+        assert_eq!(
+            std::any::type_name::<TestCase>(),
+            std::any::type_name::<hegel::TestCase>()
+        );
+    }
+}

--- a/tests/test_prelude.rs
+++ b/tests/test_prelude.rs
@@ -1,4 +1,3 @@
-use hegel::generators as gs;
 use hegel::prelude::*;
 
 #[composite]
@@ -7,20 +6,37 @@ fn even_integers(tc: &TestCase) -> i32 {
 }
 
 #[hegel::test]
-fn test_prelude_supplies_test_case_composite_and_generator_trait(tc: TestCase) {
+fn test_prelude_alone_supplies_a_whole_test(tc: TestCase) {
     let xs = tc.draw(gs::vecs(even_integers()));
     let total = xs.iter().fold(0i32, |acc, n| acc.wrapping_add(*n));
     assert_eq!(total % 2, 0);
 }
 
-mod generators_module {
-    use hegel::prelude::generators as gs;
+mod module_alias {
     use hegel::prelude::*;
 
     #[hegel::test]
-    fn test_prelude_provides_generators_module(tc: TestCase) {
-        let n = tc.draw(gs::integers::<i32>().filter(|n: &i32| n % 2 == 0));
-        assert_eq!(n % 2, 0);
+    fn test_gs_and_generators_name_the_same_module(tc: TestCase) {
+        let g: generators::IntegerGenerator<i32> = gs::integers::<i32>();
+        let n = tc.draw(g.min_value(0).max_value(10));
+        assert!((0..=10).contains(&n));
+    }
+}
+
+mod shadowing {
+    use self::my_generators as gs;
+    use hegel::prelude::*;
+
+    mod my_generators {
+        pub fn integers() -> &'static str {
+            "shadowed"
+        }
+    }
+
+    #[hegel::test]
+    fn test_an_explicit_gs_shadows_the_prelude(tc: TestCase) {
+        assert_eq!(gs::integers(), "shadowed");
+        assert_eq!(tc.draw(super::even_integers()) % 2, 0);
     }
 }
 


### PR DESCRIPTION
Hi,

addressing #75 - this comes with 2 commits. The first commit basically does what the issue asks for. The second commit also adds the `gs` alias to the prelude - I am not sure here, as `gs` is not very self descriptive but all examples use it and without it the added value of a prelude seems smaller than it could be as it would in most cases require a second import. 

Happy to drop the second commit. I can also take `Not relevant anymore, pls close :)`

just targets are all green.

Disclaimer: Claude helped me here a bit - I would have missed the changelog file.