### PR TITLE
General cleanup of redundant tests

### DIFF
--- a/hegel-c/tests/embedded/native/database_tests.rs
+++ b/hegel-c/tests/embedded/native/database_tests.rs
@@ -100,18 +100,6 @@ fn move_value_falls_back_to_delete_save_when_rename_fails() {
 }
 
 #[test]
-fn round_trip_integer_choices() {
-    let choices = vec![
-        ChoiceValue::Integer(BigInt::from(0)),
-        ChoiceValue::Integer(BigInt::from(-1)),
-        ChoiceValue::Integer(BigInt::from(i128::MAX)),
-        ChoiceValue::Integer(BigInt::from(i128::MIN)),
-    ];
-    let bytes = serialize_choices(&choices);
-    assert_eq!(deserialize_choices(&bytes), Some(choices));
-}
-
-#[test]
 fn round_trip_mixed_choices() {
     let choices = vec![
         ChoiceValue::Boolean(false),

--- a/hegel-c/tests/embedded/native/draws/internet_tests.rs
+++ b/hegel-c/tests/embedded/native/draws/internet_tests.rs
@@ -274,13 +274,6 @@ fn generate_domain_rejects_tiny_max_length_as_invalid_argument() {
 }
 
 #[test]
-fn domain_spec_validates_max_length_range() {
-    assert!(DomainSpec::new(3).is_err());
-    assert!(DomainSpec::new(4).is_ok());
-    assert!(DomainSpec::new(255).is_ok());
-}
-
-#[test]
 fn domain_max_length_above_255_is_an_invalid_argument() {
     for max_length in [256, 100_000] {
         let err = DomainSpec::new(max_length).unwrap_err();

--- a/hegel-c/tests/embedded/native/re_parser_tests.rs
+++ b/hegel-c/tests/embedded/native/re_parser_tests.rs
@@ -897,11 +897,6 @@ fn err_class_named_unicode_escape_not_supported() {
 }
 
 #[test]
-fn parses_inline_locale_flag_bytes() {
-    parse_pattern("(?L)abc", SRE_FLAG_LOCALE).unwrap_err();
-}
-
-#[test]
 fn parses_ascii_flag_inline() {
     parse_pattern("(?a)abc", 0).unwrap();
 }
@@ -917,11 +912,6 @@ fn parses_hex_escape_in_class() {
 }
 
 #[test]
-fn parses_short_unicode_escape_in_class() {
-    parse_pattern(r"[A]", 0).unwrap();
-}
-
-#[test]
 fn parses_long_unicode_escape_in_class() {
     parse_pattern(r"[\U00000041]", 0).unwrap();
 }
@@ -929,11 +919,6 @@ fn parses_long_unicode_escape_in_class() {
 #[test]
 fn parses_octal_escape_in_class() {
     parse_pattern(r"[\101]", 0).unwrap();
-}
-
-#[test]
-fn parses_short_unicode_escape() {
-    parse_pattern(r"A", 0).unwrap();
 }
 
 #[test]
@@ -947,11 +932,6 @@ fn parses_octal_escape_three_digits() {
 }
 
 #[test]
-fn parses_hex_escape() {
-    parse_pattern(r"\x41", 0).unwrap();
-}
-
-#[test]
 fn parses_class_leading_dash() {
     parse_pattern("[-]", 0).unwrap();
 }
@@ -959,11 +939,6 @@ fn parses_class_leading_dash() {
 #[test]
 fn parses_class_trailing_dash() {
     parse_pattern("[a-]", 0).unwrap();
-}
-
-#[test]
-fn parses_class_dash_escape_range() {
-    parse_pattern(r"[\d-a]", 0).unwrap_err();
 }
 
 #[test]
@@ -994,16 +969,6 @@ fn parses_open_lower_bound_min() {
 #[test]
 fn parses_inline_global_flag_at_start_only() {
     parse_pattern("(?im)abc", 0).unwrap();
-}
-
-#[test]
-fn parses_lookbehind_positive() {
-    parse_pattern("(?<=abc)", 0).unwrap();
-}
-
-#[test]
-fn parses_lookbehind_negative() {
-    parse_pattern("(?<!abc)", 0).unwrap();
 }
 
 #[test]
@@ -1136,22 +1101,6 @@ fn err_conditional_unterminated() {
 }
 
 #[test]
-fn err_named_unicode_escape_in_set_not_supported() {
-    let err = parse_err(r"[\N{LATIN SMALL LETTER A}]");
-    assert!(err.msg.contains("named unicode escapes not yet supported"));
-}
-
-#[test]
-fn err_decimal_backref_to_open_group() {
-    let err = parse_err(r"(\1)");
-    assert!(
-        err.msg.contains("cannot refer to an open group"),
-        "{}",
-        err.msg
-    );
-}
-
-#[test]
 fn parses_empty_negative_lookahead_explicit_failure() {
     let p = parse_pattern("(?!)", 0).unwrap();
     assert_eq!(p.pattern.data, vec![OpCode::Failure]);
@@ -1160,26 +1109,6 @@ fn parses_empty_negative_lookahead_explicit_failure() {
 #[test]
 fn parses_complex_class_flattening() {
     parse_pattern(r"[[abc][def]]", 0).unwrap();
-}
-
-#[test]
-fn parses_long_unicode_escape_in_set() {
-    parse_pattern(r"[\U00000041]", 0).unwrap();
-}
-
-#[test]
-fn parses_global_inline_flag_unicode() {
-    parse_pattern("(?u)abc", 0).unwrap();
-}
-
-#[test]
-fn parses_global_inline_flag_ascii() {
-    parse_pattern("(?a)abc", 0).unwrap();
-}
-
-#[test]
-fn parses_multiple_inline_flags() {
-    parse_pattern("(?ims)abc", 0).unwrap();
 }
 
 #[test]
@@ -1220,11 +1149,6 @@ fn parses_brace_no_digits_no_close() {
 }
 
 #[test]
-fn parses_class_escape_short_unicode() {
-    parse_pattern(r"[A]", 0).unwrap();
-}
-
-#[test]
 fn err_class_decimal_escape_8_or_9() {
     let err = parse_err(r"[\8]");
     assert!(err.msg.contains("bad escape"), "{}", err.msg);
@@ -1236,17 +1160,6 @@ fn parses_class_with_non_letter_escape() {
 }
 
 #[test]
-fn err_class_escape_unknown_letter() {
-    let err = parse_err(r"[\p]");
-    assert!(err.msg.contains("bad escape"), "{}", err.msg);
-}
-
-#[test]
-fn parses_class_octal_escape_three_digits() {
-    parse_pattern(r"[\077]", 0).unwrap();
-}
-
-#[test]
 fn parses_outer_escape_non_letter() {
     parse_pattern(r"\!", 0).unwrap();
 }
@@ -1255,11 +1168,6 @@ fn parses_outer_escape_non_letter() {
 fn err_outer_escape_unknown_letter() {
     let err = parse_err(r"\p");
     assert!(err.msg.contains("bad escape"), "{}", err.msg);
-}
-
-#[test]
-fn parses_outer_octal_three_digits() {
-    parse_pattern(r"\077", 0).unwrap();
 }
 
 #[test]
@@ -1301,12 +1209,6 @@ fn err_inline_flag_missing_colon_after_minus() {
 fn err_inline_flag_eof_after_qmark() {
     let err = parse_err("(?-");
     assert!(err.msg.contains("missing flag"), "{}", err.msg);
-}
-
-#[test]
-fn err_global_flag_cannot_disable_global() {
-    let err = parse_err("(?-i)abc");
-    assert!(err.msg.contains("missing :"), "{}", err.msg);
 }
 
 #[test]
@@ -1380,37 +1282,9 @@ fn err_conditional_groupref_overflow_u32() {
 }
 
 #[test]
-fn parses_short_unicode_escape_in_class_form() {
-    parse_pattern(r"[A]", 0).unwrap();
-}
-
-#[test]
-fn err_class_short_unicode_escape_incomplete() {
-    let err = parse_err(r"[\u00]");
-    assert!(err.msg.contains("incomplete escape"), "{}", err.msg);
-}
-
-#[test]
 fn err_class_long_unicode_escape_incomplete() {
     let err = parse_err(r"[\U0000]");
     assert!(err.msg.contains("incomplete escape"), "{}", err.msg);
-}
-
-#[test]
-fn err_class_bad_letter_escape() {
-    let err = parse_err(r"[\q]");
-    assert!(err.msg.contains("bad escape"), "{}", err.msg);
-}
-
-#[test]
-fn err_outer_unicode_escape_incomplete() {
-    let err = parse_err(r"\u00");
-    assert!(err.msg.contains("incomplete escape"), "{}", err.msg);
-}
-
-#[test]
-fn parses_class_escape_lookup_category() {
-    parse_pattern(r"[\w]", 0).unwrap();
 }
 
 #[test]
@@ -1430,45 +1304,9 @@ fn err_decimal_backref_to_open_group_from_named() {
 }
 
 #[test]
-fn err_subpattern_lookbehind_unterminated_lt() {
-    let err = parse_err(r"(?<");
-    assert!(err.msg.contains("unexpected end of pattern"), "{}", err.msg);
-}
-
-#[test]
-fn err_subpattern_extension_unterminated_p() {
-    let err = parse_err(r"(?P");
-    assert!(err.msg.contains("unexpected end of pattern"), "{}", err.msg);
-}
-
-#[test]
 fn err_inline_flag_no_terminator() {
     let err = parse_err(r"(?i");
     assert!(err.msg.contains("missing -, : or )"), "{}", err.msg);
-}
-
-#[test]
-fn err_inline_flag_unknown_after_initial() {
-    let err = parse_err(r"(?Z)");
-    assert!(err.msg.contains("unknown flag") || err.msg.contains("unknown extension"));
-}
-
-#[test]
-fn err_inline_flag_missing_after_dash() {
-    let err = parse_err(r"(?i-");
-    assert!(err.msg.contains("missing flag"), "{}", err.msg);
-}
-
-#[test]
-fn err_inline_flag_disable_no_colon() {
-    let err = parse_err(r"(?i-i:");
-    assert!(err.msg.contains("flag turned on and off"), "{}", err.msg);
-}
-
-#[test]
-fn err_inline_flag_disable_unknown() {
-    let err = parse_err(r"(?-Z:abc)");
-    assert!(err.msg.contains("unknown flag"), "{}", err.msg);
 }
 
 #[test]
@@ -1482,64 +1320,15 @@ fn err_repetition_too_large_braces() {
 }
 
 #[test]
-fn parses_max_repeat_with_only_lower_bound() {
-    parse_pattern("a{3}", 0).unwrap();
-}
-
-#[test]
 fn err_repetition_with_repeat_after() {
     let err = parse_err(r"a{3}+?");
     assert!(err.msg.contains("multiple repeat"), "{}", err.msg);
 }
 
 #[test]
-fn err_named_group_empty_at_open() {
-    let err = parse_err("(?P<>x)");
-    assert!(err.msg.contains("missing group name"), "{}", err.msg);
-}
-
-#[test]
-fn err_named_group_eof_with_content() {
-    let err = parse_err("(?P<foo");
-    assert!(err.msg.contains("missing >"), "{}", err.msg);
-}
-
-#[test]
 fn err_named_backref_no_chars() {
     let err = parse_err("(?P=");
     assert!(err.msg.contains("missing group name"), "{}", err.msg);
-}
-
-#[test]
-fn err_named_group_bad_char_at_open_via_getuntil() {
-    let err = parse_err("(?P<1>x)");
-    assert!(
-        err.msg.contains("bad character in group name"),
-        "{}",
-        err.msg
-    );
-}
-
-#[test]
-fn parses_class_with_long_unicode_escape() {
-    parse_pattern(r"[A]", 0).unwrap();
-}
-
-#[test]
-fn err_class_escape_two_char_unknown_letter() {
-    let err = parse_err(r"[\h]");
-    assert!(err.msg.contains("bad escape"), "{}", err.msg);
-}
-
-#[test]
-fn err_outer_octal_overflow() {
-    let err = parse_err(r"\99999999999");
-    assert!(err.msg.contains("bad escape") || err.msg.contains("invalid group reference"));
-}
-
-#[test]
-fn parses_class_unicode_short_escape_in_set() {
-    parse_pattern(r"[A]", 0).unwrap();
 }
 
 #[test]
@@ -1566,16 +1355,6 @@ fn err_inline_flag_global_unknown() {
 }
 
 #[test]
-fn err_inline_flag_disable_global() {
-    let err = parse_err("(?-u:abc)");
-    assert!(
-        err.msg.contains("cannot turn off flags 'a', 'u' and 'L'"),
-        "{}",
-        err.msg
-    );
-}
-
-#[test]
 fn err_brace_repeat_overflow_lower() {
     let err = parse_err("a{99999999999999999999,5}");
     assert!(
@@ -1589,11 +1368,6 @@ fn err_brace_repeat_overflow_lower() {
 fn err_inline_flag_eof_no_minus_colon_close() {
     let err = parse_err("(?i:");
     assert!(err.msg.contains("missing )"), "{}", err.msg);
-}
-
-#[test]
-fn parses_atomic_group_simple() {
-    parse_pattern(r"(?>abc)", 0).unwrap();
 }
 
 #[test]
@@ -1639,24 +1413,8 @@ fn parses_quantifier_on_noncapturing_group_lazy() {
 }
 
 #[test]
-fn err_class_long_unicode_escape_unreachable_hex() {
-    let err = parse_err(r"[\U7FFFFFFF]");
-    assert!(err.msg.contains("bad escape"), "{}", err.msg);
-}
-
-#[test]
-fn parses_class_with_class_escape_category() {
-    parse_pattern(r"[\d]", 0).unwrap();
-}
-
-#[test]
 fn parses_class_short_unicode_escape_hex() {
     parse_pattern("[\\u0041]", 0).unwrap();
-}
-
-#[test]
-fn parses_outer_short_unicode_escape_hex() {
-    parse_pattern("\\u0041", 0).unwrap();
 }
 
 #[test]
@@ -1685,59 +1443,15 @@ fn parses_class_literal_escape() {
 }
 
 #[test]
-fn parses_outer_octal_three_digit_padded() {
-    parse_pattern(r"\077", 0).unwrap();
-}
-
-#[test]
-fn err_outer_decimal_groupref_overflow_long() {
-    let err = parse_err(r"\99999999999");
-    assert!(err.msg.contains("bad escape") || err.msg.contains("invalid group reference"));
-}
-
-#[test]
-fn err_outer_escape_letter_unknown() {
-    let err = parse_err(r"\h");
-    assert!(err.msg.contains("bad escape"), "{}", err.msg);
-}
-
-#[test]
-fn err_outer_unicode_short_incomplete_explicit() {
-    let err = parse_err(r"\u123");
-    assert!(err.msg.contains("incomplete escape"), "{}", err.msg);
-}
-
-#[test]
-fn parses_conditional_referencing_first_group() {
-    parse_pattern("(a)(?(1)b)", 0).unwrap();
-}
-
-#[test]
 fn err_conditional_named_unterminated() {
     let err = parse_err("(?(foo");
     assert!(err.msg.contains("missing )") || err.msg.contains("unknown group name"));
 }
 
 #[test]
-fn err_inline_flag_global_then_invalid_letter() {
-    let err = parse_err("(?xZ");
-    assert!(err.msg.contains("unknown flag"), "{}", err.msg);
-}
-
-#[test]
 fn err_inline_flag_after_minus_unknown() {
     let err = parse_err("(?-Z");
     assert!(err.msg.contains("unknown flag") || err.msg.contains("missing"));
-}
-
-#[test]
-fn err_inline_flag_disable_no_colon_close_paren() {
-    let err = parse_err("(?i-i)");
-    assert!(
-        err.msg.contains("missing :") || err.msg.contains("flag turned on"),
-        "{}",
-        err.msg
-    );
 }
 
 #[test]
@@ -1751,42 +1465,9 @@ fn err_inline_flag_global_unicode_then_dash() {
 }
 
 #[test]
-fn parses_class_with_class_escape_literal() {
-    parse_pattern(r"[\t]", 0).unwrap();
-}
-
-#[test]
-fn err_class_unicode_short_incomplete_explicit() {
-    let err = parse_err(r"[\u12]");
-    assert!(err.msg.contains("incomplete escape"), "{}", err.msg);
-}
-
-#[test]
 fn err_outer_hex_escape_incomplete() {
     let err = parse_err(r"\x4");
     assert!(err.msg.contains("incomplete escape"), "{}", err.msg);
-}
-
-#[test]
-fn err_class_hex_escape_no_digits() {
-    let err = parse_err(r"[\xz]");
-    assert!(err.msg.contains("incomplete escape"), "{}", err.msg);
-}
-
-#[test]
-fn err_outer_escape_punct_unknown() {
-    parse_pattern(r"\#", 0).unwrap();
-}
-
-#[test]
-fn err_unknown_outer_escape_letter() {
-    let err = parse_err(r"\Q");
-    assert!(err.msg.contains("bad escape"), "{}", err.msg);
-}
-
-#[test]
-fn parses_outer_octal_three_digits_returns() {
-    parse_pattern(r"\077", 0).unwrap();
 }
 
 #[test]
@@ -1800,53 +1481,9 @@ fn parses_nested_class_with_inner_class_and_more() {
 }
 
 #[test]
-fn err_class_range_with_class_escape_endpoint_invalid() {
-    let err = parse_err(r"[\d-z]");
-    assert!(err.msg.contains("bad character range"), "{}", err.msg);
-}
-
-#[test]
-fn err_conditional_named_unknown() {
-    let err = parse_err("(?(abc)x|y)");
-    assert!(err.msg.contains("unknown group name"), "{}", err.msg);
-}
-
-#[test]
-fn err_inline_flag_unknown_first_char() {
-    let err = parse_err("(?-Q)");
-    assert!(err.msg.contains("missing flag") || err.msg.contains("unknown flag"));
-}
-
-#[test]
-fn err_inline_flag_negate_global_in_subgroup() {
-    let err = parse_err("(?u-i)abc");
-    assert!(
-        err.msg.contains("cannot turn on global flag") || err.msg.contains("missing :"),
-        "{}",
-        err.msg
-    );
-}
-
-#[test]
 fn err_inline_flag_eof_after_dash_letter() {
     let err = parse_err("(?-i");
     assert!(err.msg.contains("missing :"), "{}", err.msg);
-}
-
-#[test]
-fn err_inline_flag_disable_global_at_end() {
-    let err = parse_err("(?-u)abc");
-    assert!(
-        err.msg.contains("cannot turn off") || err.msg.contains("missing :"),
-        "{}",
-        err.msg
-    );
-}
-
-#[test]
-fn err_class_range_right_endpoint_is_class_escape() {
-    let err = parse_err(r"[a-\d]");
-    assert!(err.msg.contains("bad character range"), "{}", err.msg);
 }
 
 #[test]
@@ -1878,12 +1515,6 @@ fn parses_outer_octal_three_digit_non_zero_lead() {
 }
 
 #[test]
-fn err_outer_octal_three_digit_out_of_range() {
-    let err = parse_err(r"\477");
-    assert!(err.msg.contains("octal escape value"), "{}", err.msg);
-}
-
-#[test]
 fn err_conditional_named_unknown_named_after_first_group() {
     let err = parse_err("(a)(?(unknown)x|y)");
     assert!(err.msg.contains("unknown group name"), "{}", err.msg);
@@ -1900,37 +1531,9 @@ fn err_inline_flag_global_in_subgroup_via_partial_parse() {
 }
 
 #[test]
-fn err_inline_flag_eof_after_qmark_letter() {
-    let err = parse_err("(?i");
-    assert!(err.msg.contains("missing -, : or )"), "{}", err.msg);
-}
-
-#[test]
-fn err_inline_flag_disable_then_eof_after_letter() {
-    let err = parse_err("(?i-i");
-    assert!(err.msg.contains("missing :"), "{}", err.msg);
-}
-
-#[test]
 fn err_inline_flag_after_enable_unknown_letter() {
     let err = parse_err("(?-iZ");
     assert!(err.msg.contains("unknown flag"), "{}", err.msg);
-}
-
-#[test]
-fn err_inline_flag_disable_global_specifically() {
-    let err = parse_err("(?i-u:abc)");
-    assert!(
-        err.msg.contains("cannot turn off") || err.msg.contains("global flag"),
-        "{}",
-        err.msg
-    );
-}
-
-#[test]
-fn err_named_group_starts_with_digit() {
-    let err = parse_err("(?P<1abc>x)");
-    assert!(err.msg.contains("bad character in group name"));
 }
 
 #[test]
@@ -1939,23 +1542,6 @@ fn err_named_backref_starts_with_digit() {
     assert!(
         err.msg.contains("bad character in group name") || err.msg.contains("unknown group name")
     );
-}
-
-#[test]
-fn err_named_unterminated_no_terminator_char() {
-    let err = parse_err("(?P<foo");
-    assert!(err.msg.contains("missing >"));
-}
-
-#[test]
-fn parses_nested_negated_class_disables_flatten() {
-    parse_pattern("[a[^b]]", 0).unwrap();
-}
-
-#[test]
-fn err_class_range_with_category_endpoint() {
-    let err = parse_err(r"[\d-z]");
-    assert!(err.msg.contains("bad character range"), "{}", err.msg);
 }
 
 #[test]

--- a/hegel-c/tests/embedded/native/shrinker_scheduling_tests.rs
+++ b/hegel-c/tests/embedded/native/shrinker_scheduling_tests.rs
@@ -432,29 +432,6 @@ fn fixate_emits_debug_per_pass_step_when_debug_set() {
 }
 
 #[test]
-fn fixate_emits_no_debug_when_no_callback_set() {
-    let initial = vec![int_node(5)];
-    let mut shrinker = Shrinker::with_probe(
-        Box::new(|run: ShrinkRun<'_>| match run {
-            ShrinkRun::Full(nodes) => (true, nodes.to_vec(), Spans::new()),
-            ShrinkRun::Probe { .. } => (false, Vec::new(), Spans::new()),
-        }),
-        initial,
-        Spans::new(),
-    );
-    let mut passes = vec![ShrinkPass::new(
-        "zero_choices",
-        Box::new(|sh| Box::pin(sh.zero_choices())),
-    )];
-    drive_no_yield(shrinker.fixate_shrink_passes(&mut passes)).unwrap();
-    let v = match &shrinker.current_nodes[0].value() {
-        ChoiceValue::Integer(v) => i128::try_from(v).unwrap(),
-        _ => unreachable!(),
-    };
-    assert_eq!(v, 0);
-}
-
-#[test]
 fn shrink_emits_profile_report_when_debug_set() {
     use std::sync::{Arc, Mutex};
     let log = Arc::new(Mutex::new(Vec::<String>::new()));

--- a/hegel-c/tests/embedded/native/state_tests.rs
+++ b/hegel-c/tests/embedded/native/state_tests.rs
@@ -121,20 +121,6 @@ fn spans_into_iterator() {
 }
 
 #[test]
-fn spans_index_usize() {
-    let mut spans = Spans::new();
-    spans.push(Span {
-        start: 0,
-        end: 1,
-        label: "idx".to_string(),
-        depth: 0,
-        parent: None,
-        discarded: false,
-    });
-    assert_eq!(spans[0usize].label, "idx");
-}
-
-#[test]
 fn draw_integer_forced_records_a_forced_node_without_consuming_the_prefix() {
     let prefix = vec![ChoiceValue::Integer(BigInt::from(9))];
     let mut tc = NativeTestCase::for_choices_and_template(
@@ -518,14 +504,6 @@ fn for_simplest_draws_integer_clamped_to_range_when_target_above() {
 }
 
 #[test]
-fn for_simplest_propagates_across_many_draws() {
-    let mut tc = NativeTestCase::for_simplest(BUFFER_SIZE).unwrap();
-    for _ in 0..10 {
-        assert_eq!(tc.draw_integer::<i128>(0, 99).ok().unwrap(), 0);
-    }
-}
-
-#[test]
 fn for_simplest_draws_float_at_zero() {
     let mut tc = NativeTestCase::for_simplest(BUFFER_SIZE).unwrap();
     let v = tc
@@ -665,21 +643,6 @@ fn for_simplest_wrapper_matches_template_with_count_none() {
         assert_eq!(va, vb);
         assert_eq!(va, 0);
     }
-}
-
-#[test]
-fn template_overrun_status_matches_max_size_overrun() {
-    let mut tc_count = NativeTestCase::for_choices_and_template(
-        &[],
-        None,
-        Some(ChoiceTemplate::simplest(Some(2)).unwrap()),
-        100,
-        None,
-    );
-    assert_eq!(tc_count.draw_integer::<i128>(0, 100).ok().unwrap(), 0);
-    assert_eq!(tc_count.draw_integer::<i128>(0, 100).ok().unwrap(), 0);
-    assert!(tc_count.draw_integer::<i128>(0, 100).is_err());
-    assert_eq!(tc_count.status(), Some(Status::EarlyStop));
 }
 
 #[test]

--- a/hegel-c/tests/embedded/sys_tests.rs
+++ b/hegel-c/tests/embedded/sys_tests.rs
@@ -12,14 +12,6 @@ fn temp_path(dir: &TempDir, name: &str) -> String {
 }
 
 #[test]
-fn fs_write_read_round_trips() {
-    let dir = TempDir::new().unwrap();
-    let path = temp_path(&dir, "file");
-    fs::write(&path, b"contents").unwrap();
-    assert_eq!(fs::read(&path).unwrap(), b"contents".to_vec());
-}
-
-#[test]
 fn fs_write_truncates_an_existing_file() {
     let dir = TempDir::new().unwrap();
     let path = temp_path(&dir, "file");

--- a/hegel-c/tests/smoke.rs
+++ b/hegel-c/tests/smoke.rs
@@ -870,37 +870,6 @@ fn libhegel_blob_test_case_replays_the_counterexample() {
 }
 
 #[test]
-fn libhegel_test_case_from_blob_rejects_bad_input() {
-    let lib = unsafe { load() };
-    let a = unsafe { bind(&lib) };
-
-    unsafe {
-        let ctx = (a.context_new)();
-        let s = a.settings_new(ctx);
-
-        let garbage = CString::new("!!! not a blob !!!").unwrap();
-        let tc = a.test_case_from_blob(ctx, s, garbage.as_ptr());
-        assert!(tc.is_null());
-        let err = CStr::from_ptr(a.context_last_error(ctx)).to_string_lossy();
-        assert!(
-            err.contains("could not be decoded"),
-            "unexpected error: {err}"
-        );
-
-        let tc = a.test_case_from_blob(ctx, s, ptr::null());
-        assert!(tc.is_null());
-        assert!(!CStr::from_ptr(a.context_last_error(ctx)).is_empty());
-        let blob = CString::new("AAEC").unwrap();
-        let tc = a.test_case_from_blob(ctx, ptr::null(), blob.as_ptr());
-        assert!(tc.is_null());
-        assert!(!CStr::from_ptr(a.context_last_error(ctx)).is_empty());
-
-        a.settings_free(ctx, s);
-        (a.context_free)(ctx);
-    }
-}
-
-#[test]
 fn libhegel_frees_run_owned_test_cases() {
     let lib = unsafe { load() };
     let a = unsafe { bind(&lib) };

--- a/tests/chrono/datetime.rs
+++ b/tests/chrono/datetime.rs
@@ -128,20 +128,6 @@ fn test_datetimes_utc_property(tc: hegel::TestCase) {
 }
 
 #[test]
-#[should_panic(expected = "max_value < min_value")]
-fn test_datetimes_utc_min_greater_than_max() {
-    let g = chrono_gs::datetimes()
-        .timezones(gs::just(Utc))
-        .min_value(
-            DateTime::<Utc>::from_timestamp(2_000_000_000, 0)
-                .unwrap()
-                .naive_utc(),
-        )
-        .max_value(DateTime::<Utc>::from_timestamp(0, 0).unwrap().naive_utc());
-    check_can_generate_examples(g);
-}
-
-#[test]
 fn test_datetimes_full_range_bounds() {
     check_can_generate_examples(
         chrono_gs::datetimes()

--- a/tests/embedded/runner_tests.rs
+++ b/tests/embedded/runner_tests.rs
@@ -2,11 +2,6 @@ use super::*;
 use crate::runner::Phase;
 
 #[test]
-fn test_settings_verbosity() {
-    let _ = Settings::new().verbosity(Verbosity::Debug);
-}
-
-#[test]
 fn test_settings_phases() {
     let s = Settings::new().phases([Phase::Explicit, Phase::Generate]);
     assert_eq!(s.phases, vec![Phase::Explicit, Phase::Generate]);

--- a/tests/test_collections.rs
+++ b/tests/test_collections.rs
@@ -269,12 +269,6 @@ fn test_vec_non_basic_generator_with_max_size(tc: TestCase) {
     assert!(vec.len() <= 5);
 }
 
-#[hegel::test]
-fn test_vec_unique_sampled_from_no_duplicates(tc: TestCase) {
-    let vec: Vec<i64> = tc.draw(gs::vecs(gs::sampled_from(vec![0_i64; 100])).unique(true));
-    assert!(vec.len() <= 1);
-}
-
 mod simple_collections {
     //!
     //! `test_find_non_empty_collection_gives_single_zero` and
@@ -473,14 +467,6 @@ mod nocover_sets {
             |s: &HashSet<i64>| s.is_empty(),
         );
     }
-
-    #[test]
-    fn test_bounded_size_sets() {
-        assert_all_examples(
-            gs::hashsets(gs::integers::<i64>()).max_size(2),
-            |s: &HashSet<i64>| s.len() <= 2,
-        );
-    }
 }
 
 mod nocover_large_examples {
@@ -525,9 +511,7 @@ mod sampled_from {
     //! optimization. The `enumerate_values` path handles both rare-value and
     //! unsatisfiable cases correctly.
 
-    use super::common::utils::{
-        assert_all_examples, assert_simple_property, check_can_generate_examples, expect_panic,
-    };
+    use super::common::utils::{assert_all_examples, check_can_generate_examples, expect_panic};
     use hegel::generators::{self as gs, Generator};
     use hegel::{HealthCheck, Hegel, Settings};
     use std::collections::{HashMap, HashSet};
@@ -569,14 +553,6 @@ mod sampled_from {
                 .run();
             },
             "(?i)(health.check|FailedHealthCheck|Unsatisfiable|filter)",
-        );
-    }
-
-    #[test]
-    fn test_easy_filtered_sampling() {
-        assert_simple_property(
-            gs::sampled_from((0..100).collect::<Vec<i64>>()).filter(|x: &i64| *x == 0),
-            |x: &i64| *x == 0,
         );
     }
 

--- a/tests/test_combinators.rs
+++ b/tests/test_combinators.rs
@@ -1,8 +1,8 @@
 mod common;
 
-use common::utils::{assert_all_examples, expect_panic, find_any};
+use common::utils::{assert_all_examples, find_any};
+use hegel::TestCase;
 use hegel::generators::{self as gs, Generator};
-use hegel::{Hegel, Settings, TestCase};
 
 #[hegel::test]
 fn test_sampled_from_returns_element_from_list(tc: TestCase) {
@@ -49,16 +49,6 @@ fn test_one_of_enumerable_children_feed_the_filter_pool() {
         .filter(|x: &i64| x % 2 == 1),
         |x: &i64| *x == 1 || *x == 3,
     );
-}
-
-#[test]
-fn test_optional_can_generate_some() {
-    find_any(gs::optional(gs::integers::<i32>()), |v| v.is_some());
-}
-
-#[test]
-fn test_optional_can_generate_none() {
-    find_any(gs::optional(gs::integers::<i32>()), |v| v.is_none());
 }
 
 #[hegel::test]
@@ -128,25 +118,6 @@ fn test_one_of_single_component(tc: TestCase) {
     assert_eq!(tc.draw(hegel::one_of!(gs::just(42))), 42);
     assert_eq!(tc.draw(hegel::one_of!(gs::just(43),)), 43);
     assert_eq!(tc.draw_silent(hegel::one_of!(gs::just(44))), 44);
-}
-
-#[hegel::test]
-fn test_one_of_twelve_components(tc: TestCase) {
-    let value = tc.draw(hegel::one_of!(
-        gs::just(0),
-        gs::just(1),
-        gs::just(2),
-        gs::just(3),
-        gs::just(4),
-        gs::just(5),
-        gs::just(6),
-        gs::just(7),
-        gs::just(8),
-        gs::just(9),
-        gs::just(10),
-        gs::just(11),
-    ));
-    assert!((0..12).contains(&value));
 }
 
 #[hegel::test]
@@ -275,23 +246,6 @@ fn test_sampled_from_filter_produces_only_valid_values() {
     assert_all_examples(
         gs::sampled_from(vec![1_i64, 2, 3, 4, 5]).filter(|x: &i64| *x > 2),
         |x: &i64| *x > 2,
-    );
-}
-
-/// When all elements are rejected, panic immediately with a clear message
-/// rather than triggering FilterTooMuch or silently passing vacuously.
-#[test]
-fn test_sampled_from_unsatisfiable_filter_panics() {
-    expect_panic(
-        || {
-            Hegel::new(|tc| {
-                let _: i64 =
-                    tc.draw(gs::sampled_from((0..10_i64).collect::<Vec<i64>>()).filter(|x| *x < 0));
-            })
-            .settings(Settings::new().database(None))
-            .run();
-        },
-        "(?i)(unsatisfiable|filter)",
     );
 }
 

--- a/tests/test_composite.rs
+++ b/tests/test_composite.rs
@@ -65,14 +65,6 @@ mod composite {
     }
 
     #[test]
-    fn test_can_pass_through_arguments_6() {
-        assert_eq!(
-            minimal(badly_draw_lists(6), |_: &Vec<i32>| true),
-            vec![0; 6]
-        );
-    }
-
-    #[test]
     fn test_can_assume_in_draw() {
         Hegel::new(|tc| {
             let (x, y) = tc.draw(&hegel::compose!(|tc| {

--- a/tests/test_derive.rs
+++ b/tests/test_derive.rs
@@ -146,12 +146,6 @@ fn test_derive_struct_with_constrained_field() {
 }
 
 #[test]
-fn test_derive_struct_builder_only_overrides_specified_field() {
-    let g = Point::default_generator().x(gs::just(0));
-    assert_all_examples(g, |p: &Point| p.x == 0);
-}
-
-#[test]
 fn test_derive_struct_with_mapped_field() {
     let g = Point::default_generator().x(gs::integers::<i32>().map(|x| x.saturating_abs()));
     assert_all_examples(g, |p: &Point| p.x >= 0);
@@ -167,11 +161,6 @@ fn test_derive_struct_with_filtered_field() {
 fn test_default_supports_struct_builder() {
     let g = gs::default::<Point>().x(gs::just(42));
     assert_all_examples(g, |p: &Point| p.x == 42);
-}
-
-#[test]
-fn test_derive_unit_enum() {
-    check_can_generate_examples(gs::default::<Color>());
 }
 
 #[test]

--- a/tests/test_draw_named.rs
+++ b/tests/test_draw_named.rs
@@ -315,19 +315,6 @@ draw_lines_case!(
 );
 
 draw_lines_case!(
-    test_limitation_draw_not_in_let_binding,
-    draw_not_in_let_binding_fixture,
-    tc,
-    {
-        let _ = vec![
-            tc.draw(gs::integers::<i32>()),
-            tc.draw(gs::integers::<i32>()),
-        ];
-    },
-    ["let draw_1 = 0;", "let draw_2 = 0;"]
-);
-
-draw_lines_case!(
     test_limitation_destructuring_pattern,
     destructuring_pattern_fixture,
     tc,
@@ -406,16 +393,6 @@ fn test_draw_named_non_repeatable_reuse_panics() {
     );
 }
 
-#[test]
-fn test_draw_named_repeatable_skips_taken_name() {
-    hegel::Hegel::new(|tc: hegel::TestCase| {
-        tc.__draw_named(gs::booleans(), "x_1", false);
-        tc.__draw_named(gs::booleans(), "x", true);
-    })
-    .settings(hegel::Settings::new().test_cases(1))
-    .run();
-}
-
 mod draw_names {
     //! pbtkit's `draw_names` module is a Python-source rewriter (libcst + runtime
     //! `inspect.getsource` + import-time monkey-patching of `TestCase`) that turns
@@ -423,7 +400,6 @@ mod draw_names {
     //! equivalent is the `#[hegel::test]` proc macro, which does the same rewrite
     //! at compile time.
 
-    use super::common::utils::expect_panic;
     use hegel::generators as gs;
 
     draw_lines_case!(
@@ -503,36 +479,6 @@ mod draw_names {
         ["let x_1 = 1;", "let x_2 = 2;", "let x_3 = 3;"]
     );
 
-    #[test]
-    fn test_draw_named_non_repeatable_reuse_raises() {
-        expect_panic(
-            || {
-                hegel::Hegel::new(|tc: hegel::TestCase| {
-                    tc.__draw_named(gs::booleans(), "x", false);
-                    tc.__draw_named(gs::booleans(), "x", false);
-                })
-                .settings(hegel::Settings::new().test_cases(1))
-                .run();
-            },
-            r#"__draw_named.*"x".*more than once"#,
-        );
-    }
-
-    #[test]
-    fn test_draw_named_inconsistent_flags_raises() {
-        expect_panic(
-            || {
-                hegel::Hegel::new(|tc: hegel::TestCase| {
-                    tc.__draw_named(gs::booleans(), "x", false);
-                    tc.__draw_named(gs::booleans(), "x", true);
-                })
-                .settings(hegel::Settings::new().test_cases(1))
-                .run();
-            },
-            r#"__draw_named.*inconsistent.*repeatable"#,
-        );
-    }
-
     draw_lines_case!(
         test_draw_named_different_names_ok,
         draw_named_different_names_ok_fixture,
@@ -567,57 +513,6 @@ mod draw_names {
     );
 
     draw_lines_case!(
-        test_rewriter_while_loop_body_is_repeatable,
-        rewriter_while_loop_body_is_repeatable_fixture,
-        tc,
-        {
-            let mut i = 0;
-            while i < 1 {
-                let x = tc.draw(gs::just(0i32));
-                i += 1;
-            }
-        },
-        ["let x_1 = 0;"]
-    );
-
-    draw_lines_case!(
-        test_rewriter_if_body_is_repeatable,
-        rewriter_if_body_is_repeatable_fixture,
-        tc,
-        {
-            if true {
-                let x = tc.draw(gs::just(0i32));
-            }
-        },
-        ["let x_1 = 0;"]
-    );
-
-    draw_lines_case!(
-        test_rewriter_nested_block_is_repeatable,
-        rewriter_nested_block_is_repeatable_fixture,
-        tc,
-        {
-            {
-                let x = tc.draw(gs::just(0i32));
-            }
-        },
-        ["let x_1 = 0;"]
-    );
-
-    draw_lines_case!(
-        test_rewriter_name_seen_at_top_and_loop_all_repeatable,
-        rewriter_name_seen_at_top_and_loop_all_repeatable_fixture,
-        tc,
-        {
-            let x = tc.draw(gs::just(0i32));
-            for _ in 0..1 {
-                let x = tc.draw(gs::just(0i32));
-            }
-        },
-        ["let x_1 = 0;", "let x_2 = 0;"]
-    );
-
-    draw_lines_case!(
         test_rewriter_no_draws_is_noop,
         rewriter_no_draws_is_noop_fixture,
         tc,
@@ -644,72 +539,6 @@ mod draw_names {
         },
         ["let draw_1 = (0, 0);"]
     );
-
-    draw_lines_case!(
-        test_rewrite_draws_output_is_named,
-        rewrite_draws_output_is_named_fixture,
-        tc,
-        {
-            let value = tc.draw(gs::just(0i32));
-        },
-        ["let value = 0;"]
-    );
-
-    draw_lines_case!(
-        test_rewrite_draws_two_draws,
-        rewrite_draws_two_draws_fixture,
-        tc,
-        {
-            let first = tc.draw(gs::just(0i32));
-            let second = tc.draw(gs::just(0i32));
-        },
-        ["let first = 0;", "let second = 0;"]
-    );
-
-    draw_lines_case!(
-        test_rewrite_draws_final_replay_uses_rewritten_function,
-        rewrite_draws_final_replay_uses_rewritten_function_fixture,
-        tc,
-        {
-            let answer = tc.draw(gs::just(0i32));
-        },
-        ["let answer = 0;"]
-    );
-
-    draw_lines_case!(
-        test_rewrite_draws_loop_output_numbered,
-        rewrite_draws_loop_output_numbered_fixture,
-        tc,
-        {
-            for _ in 0..2 {
-                let item = tc.draw(gs::just(0i32));
-            }
-        },
-        ["let item_1 = 0;", "let item_2 = 0;"]
-    );
-
-    draw_lines_case!(
-        test_rewrite_draws_no_error_for_no_draw_function,
-        rewrite_draws_no_error_for_no_draw_function_fixture,
-        tc,
-        {},
-        []
-    );
-
-    #[test]
-    fn test_draw_named_validation_runs_outside_composite() {
-        expect_panic(
-            || {
-                hegel::Hegel::new(|tc: hegel::TestCase| {
-                    tc.__draw_named(gs::booleans(), "x", false);
-                    tc.__draw_named(gs::booleans(), "x", false);
-                })
-                .settings(hegel::Settings::new().test_cases(1))
-                .run();
-            },
-            r#"__draw_named.*"x".*more than once"#,
-        );
-    }
 
     #[test]
     fn test_draw_named_no_validation_inside_composite() {

--- a/tests/test_explicit_test_case.rs
+++ b/tests/test_explicit_test_case.rs
@@ -34,13 +34,6 @@ fn test_multiple_explicit_cases(tc: TestCase) {
 }
 
 #[hegel::test(test_cases = 1)]
-#[hegel::explicit_test_case(x = 42i32)]
-fn test_explicit_case_with_property_test(tc: TestCase) {
-    let x: i32 = tc.draw(generators::integers());
-    assert_eq!(x, x);
-}
-
-#[hegel::test(test_cases = 1)]
 #[hegel::explicit_test_case(x = 42u32)]
 fn test_explicit_case_type_annotated_draw_uses_name(tc: TestCase) {
     let x: u32 = tc.draw(generators::integers());
@@ -54,25 +47,11 @@ struct Point {
 }
 
 #[hegel::test(test_cases = 1)]
-#[hegel::explicit_test_case(p = Point { x: 3, y: 4 })]
-fn test_explicit_case_with_user_defined_struct(tc: TestCase) {
-    let p: Point = tc.draw(generators::just(Point { x: 0, y: 0 }));
-    assert_eq!(p, p);
-}
-
-#[hegel::test(test_cases = 1)]
 #[hegel::explicit_test_case(p = Point { x: 3, y: 4 }, q = Point { x: -1, y: 0 })]
 fn test_explicit_case_with_multiple_structs(tc: TestCase) {
     let p: Point = tc.draw(generators::just(Point { x: 0, y: 0 }));
     let q: Point = tc.draw(generators::just(Point { x: 0, y: 0 }));
     let _ = (p, q);
-}
-
-#[hegel::test(test_cases = 1)]
-#[hegel::explicit_test_case(n = vec![1i32, 2, 3].into_iter().sum::<i32>())]
-fn test_explicit_case_with_function_evaluation(tc: TestCase) {
-    let n: i32 = tc.draw(generators::integers());
-    let _ = n;
 }
 
 #[hegel::test(test_cases = 1)]

--- a/tests/test_find_quality/floats.rs
+++ b/tests/test_find_quality/floats.rs
@@ -136,15 +136,6 @@ fn test_half_bounded_generates_zero() {
 }
 
 #[test]
-fn test_is_float() {
-    Hegel::new(|tc| {
-        tc.draw(gs::floats::<f64>());
-    })
-    .settings(Settings::new().test_cases(1000).database(None))
-    .run();
-}
-
-#[test]
 fn test_negation_is_self_inverse() {
     Hegel::new(|tc| {
         let x: f64 = tc.draw(gs::floats::<f64>().allow_nan(false));

--- a/tests/test_floats.rs
+++ b/tests/test_floats.rs
@@ -168,40 +168,6 @@ mod pbtkit_floats {
     use hegel::{Hegel, Settings};
 
     #[test]
-    fn test_floats_bounded() {
-        Hegel::new(|tc| {
-            let f: f64 = tc.draw(
-                gs::floats::<f64>()
-                    .min_value(0.0)
-                    .max_value(1.0)
-                    .allow_nan(false),
-            );
-            assert!((0.0..=1.0).contains(&f));
-        })
-        .settings(Settings::new().test_cases(100).database(None))
-        .run();
-    }
-
-    #[test]
-    fn test_floats_unbounded() {
-        Hegel::new(|tc| {
-            tc.draw(gs::floats::<f64>());
-        })
-        .settings(Settings::new().test_cases(200).database(None))
-        .run();
-    }
-
-    #[test]
-    fn test_draw_unbounded_float_rejects_nan() {
-        Hegel::new(|tc| {
-            let f: f64 = tc.draw(gs::floats::<f64>().allow_nan(false));
-            assert!(!f.is_nan());
-        })
-        .settings(Settings::new().test_cases(1000).database(None))
-        .run();
-    }
-
-    #[test]
     fn test_floats_shrinks_to_zero() {
         let f = minimal(gs::floats::<f64>().allow_nan(false), |f: &f64| *f != 0.0);
         assert_ne!(f, 0.0);
@@ -222,29 +188,6 @@ mod pbtkit_floats {
     #[test]
     fn test_floats_no_nan() {
         assert_all_examples(gs::floats::<f64>().allow_nan(false), |f: &f64| !f.is_nan());
-    }
-
-    #[test]
-    fn test_floats_no_infinity() {
-        assert_all_examples(
-            gs::floats::<f64>().allow_infinity(false).allow_nan(false),
-            |f: &f64| f.is_finite(),
-        );
-    }
-
-    #[test]
-    fn test_floats_negative_range() {
-        Hegel::new(|tc| {
-            let f: f64 = tc.draw(
-                gs::floats::<f64>()
-                    .min_value(-10.0)
-                    .max_value(-1.0)
-                    .allow_nan(false),
-            );
-            assert!((-10.0..=-1.0).contains(&f));
-        })
-        .settings(Settings::new().test_cases(100).database(None))
-        .run();
     }
 
     #[test]
@@ -342,13 +285,6 @@ mod pbtkit_floats {
         })
         .settings(Settings::new().test_cases(200).database(None))
         .run();
-    }
-
-    #[test]
-    fn test_floats_half_bounded_with_infinity() {
-        find_any(gs::floats::<f64>().min_value(0.0), |f: &f64| {
-            f.is_infinite()
-        });
     }
 
     #[test]
@@ -628,11 +564,6 @@ mod float_nastiness {
         assert_all_examples(gs::floats::<f64>().min_value(0.0), |x: &f64| {
             !x.is_sign_negative()
         });
-    }
-
-    #[test]
-    fn test_filter_nan() {
-        assert_all_examples(gs::floats::<f64>().allow_nan(false), |x: &f64| !x.is_nan());
     }
 
     #[test]
@@ -917,14 +848,6 @@ mod nocover_floating {
         .max_attempts(1000)
         .suppress_health_check(HealthCheck::FilterTooMuch)
         .run();
-    }
-
-    #[test]
-    fn test_largest_range() {
-        assert_all_examples(
-            gs::floats::<f64>().min_value(-f64::MAX).max_value(f64::MAX),
-            |x: &f64| !x.is_infinite(),
-        );
     }
 
     #[test]

--- a/tests/test_hegel_main.rs
+++ b/tests/test_hegel_main.rs
@@ -29,13 +29,6 @@ fn test_main_cli_overrides_test_cases() {
 }
 
 #[test]
-fn test_main_default_matches_attribute() {
-    let output = fixture(BASIC_MAIN).run();
-    let count = output.stderr.matches("ran").count();
-    assert_eq!(count, 7, "stderr:\n{}", output.stderr);
-}
-
-#[test]
 fn test_main_unknown_arg_exits_with_error() {
     let output = fixture(BASIC_MAIN)
         .arg("--not-a-real-arg")

--- a/tests/test_hegel_test.rs
+++ b/tests/test_hegel_test.rs
@@ -1,5 +1,5 @@
 // nocover_baseexception, nocover_nesting, nocover_limits,
-// nocover_unusual_settings_configs, pytest_runs, nocover_completion,
+// nocover_unusual_settings_configs, nocover_completion,
 
 mod common;
 
@@ -399,18 +399,6 @@ mod testdecorators {
     }
 
     #[test]
-    fn test_can_run_without_database() {
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            Hegel::new(|_tc| {
-                panic!("AssertionError");
-            })
-            .settings(Settings::new().database(None))
-            .run();
-        }));
-        assert!(result.is_err());
-    }
-
-    #[test]
     fn test_can_run_with_database_in_thread() {
         use std::sync::{Arc, Mutex};
         use std::thread;
@@ -445,11 +433,6 @@ mod testdecorators {
             handle.join().unwrap();
         }
         assert_eq!(*results.lock().unwrap(), vec!["success", "success"]);
-    }
-
-    #[test]
-    fn test_can_call_an_argument_f() {
-        assert_all_examples(gs::integers::<i64>(), |_f: &i64| true);
     }
 
     #[test]
@@ -582,24 +565,6 @@ mod flakiness {
                     panic!("AssertionError");
                 })
                 .settings(Settings::new().verbosity(Verbosity::Quiet).database(None))
-                .run();
-            },
-            "Flaky test detected",
-        );
-    }
-
-    #[test]
-    fn test_does_not_attempt_to_shrink_flaky_errors() {
-        let values: Arc<Mutex<Vec<i64>>> = Arc::new(Mutex::new(Vec::new()));
-        expect_panic(
-            move || {
-                Hegel::new(move |tc: TestCase| {
-                    let x: i64 = tc.draw(gs::integers());
-                    values.lock().unwrap().push(x);
-                    let n = values.lock().unwrap().len();
-                    assert!(n != 1);
-                })
-                .settings(Settings::new().database(None))
                 .run();
             },
             "Flaky test detected",
@@ -782,33 +747,6 @@ mod nocover_unusual_settings_configs {
     }
 }
 
-mod pytest_runs {
-    use hegel::generators::{self as gs};
-    use hegel::{Hegel, Settings};
-
-    #[test]
-    fn test_ints_are_ints() {
-        Hegel::new(|tc| {
-            tc.draw(gs::integers::<i64>());
-        })
-        .settings(Settings::new().test_cases(100).database(None))
-        .run();
-    }
-
-    #[test]
-    fn test_ints_are_floats() {
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            Hegel::new(|tc| {
-                tc.draw(gs::integers::<i64>());
-                panic!("x is not a float");
-            })
-            .settings(Settings::new().test_cases(100).database(None))
-            .run();
-        }));
-        assert!(result.is_err());
-    }
-}
-
 mod nocover_completion {
     use hegel::Hegel;
 
@@ -819,24 +757,8 @@ mod nocover_completion {
 }
 
 mod hypothesis_core {
-    use super::common::utils::minimal;
     use hegel::generators as gs;
     use hegel::{Hegel, Settings};
-
-    #[test]
-    fn test_given_shrinks_pytest_helper_errors() {
-        let value = minimal(gs::integers::<i64>(), |x: &i64| *x > 100);
-        assert_eq!(value, 101);
-    }
-
-    #[test]
-    fn test_can_find_with_db_eq_none() {
-        Hegel::new(|tc| {
-            let _: i64 = tc.draw(gs::integers::<i64>());
-        })
-        .settings(Settings::new().test_cases(100).database(None))
-        .run();
-    }
 
     #[test]
     fn test_characters_codec_ascii_unbounded() {

--- a/tests/test_integers.rs
+++ b/tests/test_integers.rs
@@ -116,86 +116,10 @@ fn test_usize() {
     find_any(gs::integers::<usize>(), |&n| n == usize::MAX);
 }
 
-mod numerics {
-    use hegel::generators as gs;
-    use hegel::{HealthCheck, Hegel, Settings};
-
-    #[test]
-    fn test_fuzz_floats_bounds() {
-        Hegel::new(|tc| {
-            let (mut low, mut high): (Option<f64>, Option<f64>) = tc.draw(gs::tuples!(
-                gs::optional(gs::floats::<f64>().allow_nan(false)),
-                gs::optional(gs::floats::<f64>().allow_nan(false)),
-            ));
-            if let (Some(l), Some(h)) = (low, high) {
-                if l > h {
-                    std::mem::swap(&mut low, &mut high);
-                }
-            }
-            tc.assume(!low.is_some_and(|l| l.is_infinite()));
-            tc.assume(!high.is_some_and(|h| h.is_infinite()));
-
-            let exmin = low.is_some() && tc.draw(gs::booleans());
-            let exmax = high.is_some() && tc.draw(gs::booleans());
-
-            if let (Some(l), Some(h)) = (low, high) {
-                let lo = if exmin { l.next_up() } else { l };
-                let hi = if exmax { h.next_down() } else { h };
-                tc.assume(lo <= hi);
-                if lo == 0.0 && hi == 0.0 {
-                    tc.assume(!exmin && !exmax && (1.0_f64).copysign(lo) <= (1.0_f64).copysign(hi));
-                }
-            }
-
-            let mut s = gs::floats::<f64>();
-            if let Some(l) = low {
-                s = s.min_value(l);
-            }
-            if let Some(h) = high {
-                s = s.max_value(h);
-            }
-            s = s.exclude_min(exmin).exclude_max(exmax);
-            let val: f64 = tc.draw(s);
-            tc.assume(val != 0.0);
-
-            if let Some(l) = low {
-                assert!(l <= val);
-            }
-            if let Some(h) = high {
-                assert!(val <= h);
-            }
-            if exmin {
-                assert_ne!(low.unwrap(), val);
-            }
-            if exmax {
-                assert_ne!(high.unwrap(), val);
-            }
-        })
-        .settings(
-            Settings::new()
-                .suppress_health_check(HealthCheck::all())
-                .database(None),
-        )
-        .run();
-    }
-}
-
 mod nocover_simple_numbers {
     use super::common::utils::{Minimal, minimal};
     use hegel::generators as gs;
     use hegel::{Hegel, Settings};
-
-    #[test]
-    fn test_minimize_negative_int() {
-        assert_eq!(minimal(gs::integers::<i64>(), |x: &i64| *x < 0), -1);
-        assert_eq!(minimal(gs::integers::<i64>(), |x: &i64| *x < -1), -2);
-    }
-
-    #[test]
-    fn test_positive_negative_int() {
-        assert_eq!(minimal(gs::integers::<i64>(), |x: &i64| *x > 0), 1);
-        assert_eq!(minimal(gs::integers::<i64>(), |x: &i64| *x > 1), 2);
-    }
 
     fn boundaries() -> Vec<i64> {
         let mut bs: Vec<i64> = Vec::new();
@@ -360,14 +284,6 @@ mod nocover_simple_numbers {
     }
 
     #[test]
-    fn test_minimal_infinite_float_is_positive() {
-        assert_eq!(
-            minimal(gs::floats::<f64>(), |x: &f64| x.is_infinite()),
-            f64::INFINITY
-        );
-    }
-
-    #[test]
     fn test_can_minimal_infinite_negative_float() {
         let x = minimal(gs::floats::<f64>(), |x: &f64| *x < -f64::MAX);
         assert!(x < -f64::MAX);
@@ -378,11 +294,6 @@ mod nocover_simple_numbers {
         minimal(gs::floats::<f64>(), |x: &f64| {
             *x + 1.0 == *x && !x.is_infinite()
         });
-    }
-
-    #[test]
-    fn test_minimize_nan() {
-        assert!(minimal(gs::floats::<f64>(), |x: &f64| x.is_nan()).is_nan());
     }
 
     #[test]
@@ -501,53 +412,11 @@ mod nocover_simple_numbers {
     }
 
     #[test]
-    fn test_no_allow_infinity_upper() {
-        Hegel::new(|tc| {
-            let x: f64 = tc.draw(gs::floats::<f64>().min_value(0.0).allow_infinity(false));
-            assert!(!x.is_infinite());
-        })
-        .settings(Settings::new().test_cases(100).database(None))
-        .run();
-    }
-
-    #[test]
-    fn test_no_allow_infinity_lower() {
-        Hegel::new(|tc| {
-            let x: f64 = tc.draw(gs::floats::<f64>().max_value(0.0).allow_infinity(false));
-            assert!(!x.is_infinite());
-        })
-        .settings(Settings::new().test_cases(100).database(None))
-        .run();
-    }
-
-    #[test]
-    fn test_floats_are_floats_unbounded() {
-        Hegel::new(|tc| {
-            tc.draw(gs::floats::<f64>());
-        })
-        .settings(Settings::new().test_cases(100).database(None))
-        .run();
-    }
-
-    #[test]
     fn test_floats_are_floats_int_float_bounds() {
         Hegel::new(|tc| {
             tc.draw(
                 gs::floats::<f64>()
                     .min_value(0.0)
-                    .max_value(u64::MAX as f64),
-            );
-        })
-        .settings(Settings::new().test_cases(100).database(None))
-        .run();
-    }
-
-    #[test]
-    fn test_floats_are_floats_float_float_bounds() {
-        Hegel::new(|tc| {
-            tc.draw(
-                gs::floats::<f64>()
-                    .min_value(0.0_f64)
                     .max_value(u64::MAX as f64),
             );
         })

--- a/tests/test_output.rs
+++ b/tests/test_output.rs
@@ -333,16 +333,6 @@ mod verbosity {
         .settings(Settings::new().verbosity(Verbosity::Verbose).database(None))
         .run();
     }
-
-    #[test]
-    fn test_no_indexerror_in_quiet_mode_report_multiple() {
-        report_failing("quiet").run();
-    }
-
-    #[test]
-    fn test_no_indexerror_in_quiet_mode_report_one() {
-        report_failing("quiet").run();
-    }
 }
 
 mod verbose_per_test_case_output {

--- a/tests/test_quality.rs
+++ b/tests/test_quality.rs
@@ -10,18 +10,6 @@ mod shrink_quality {
     use std::collections::{HashMap, HashSet};
 
     #[test]
-    fn test_integers_from_minimizes_leftwards() {
-        let v: i64 = minimal(gs::integers::<i64>().min_value(101), |_| true);
-        assert_eq!(v, 101);
-    }
-
-    #[test]
-    fn test_minimize_bounded_integers_to_zero() {
-        let v: i64 = minimal(gs::integers::<i64>().min_value(-10).max_value(10), |_| true);
-        assert_eq!(v, 0);
-    }
-
-    #[test]
     fn test_minimize_bounded_integers_to_positive() {
         let v: i64 = minimal(
             gs::integers::<i64>()
@@ -34,59 +22,9 @@ mod shrink_quality {
     }
 
     #[test]
-    fn test_minimize_string_to_empty() {
-        let s: String = minimal(gs::text(), |_| true);
-        assert_eq!(s, "");
-    }
-
-    #[derive(Debug, Clone, PartialEq)]
-    enum Mixed {
-        Int(i64),
-        Text(String),
-        Bool(bool),
-    }
-
-    #[test]
-    fn test_minimize_one_of() {
-        let v = minimal(
-            gs::one_of(vec![
-                gs::integers::<i64>().map(Mixed::Int).boxed(),
-                gs::text().map(Mixed::Text).boxed(),
-                gs::booleans().map(Mixed::Bool).boxed(),
-            ]),
-            |_| true,
-        );
-        let ok = matches!(&v, Mixed::Int(0))
-            || matches!(&v, Mixed::Text(s) if s.is_empty())
-            || matches!(&v, Mixed::Bool(false));
-        assert!(ok, "got {v:?}");
-    }
-
-    #[test]
-    fn test_minimize_mixed_list() {
-        let mixed = minimal(
-            gs::vecs(gs::one_of(vec![
-                gs::integers::<i64>().map(Mixed::Int).boxed(),
-                gs::text().map(Mixed::Text).boxed(),
-            ])),
-            |x: &Vec<Mixed>| x.len() >= 10,
-        );
-        for v in &mixed {
-            let ok = matches!(v, Mixed::Int(0)) || matches!(v, Mixed::Text(s) if s.is_empty());
-            assert!(ok, "got element {v:?} in {mixed:?}");
-        }
-    }
-
-    #[test]
     fn test_minimize_longer_string() {
         let s = minimal(gs::text(), |x: &String| x.chars().count() >= 10);
         assert_eq!(s, "0".repeat(10));
-    }
-
-    #[test]
-    fn test_minimize_longer_list_of_strings() {
-        let xs = minimal(gs::vecs(gs::text()), |x: &Vec<String>| x.len() >= 10);
-        assert_eq!(xs, vec![String::new(); 10]);
     }
 
     #[test]
@@ -117,105 +55,6 @@ mod shrink_quality {
         );
         let expected: HashSet<i64> = [0_i64, 1, 2].into_iter().collect();
         assert_eq!(xs, expected);
-    }
-
-    #[test]
-    fn test_can_simplify_flatmap_with_bounded_left_hand_size() {
-        let g = gs::booleans().flat_map(|x: bool| gs::vecs(gs::just(x)));
-        let v = minimal(g, |xs: &Vec<bool>| xs.len() >= 10);
-        assert_eq!(v, vec![false; 10]);
-    }
-
-    #[test]
-    fn test_can_simplify_across_flatmap_of_just() {
-        let v = minimal(
-            gs::integers::<i64>().flat_map(gs::just::<i64>),
-            |_: &i64| true,
-        );
-        assert_eq!(v, 0);
-    }
-
-    #[test]
-    fn test_can_simplify_on_right_hand_strategy_of_flatmap() {
-        let v = minimal(
-            gs::integers::<i64>().flat_map(|x: i64| gs::vecs(gs::just(x))),
-            |_| true,
-        );
-        assert_eq!(v, Vec::<i64>::new());
-    }
-
-    #[test]
-    fn test_can_ignore_left_hand_side_of_flatmap() {
-        let v = minimal(
-            gs::integers::<i64>().flat_map(|_| gs::vecs(gs::integers::<i64>())),
-            |xs: &Vec<i64>| xs.len() >= 10,
-        );
-        assert_eq!(v, vec![0_i64; 10]);
-    }
-
-    #[test]
-    fn test_can_simplify_on_both_sides_of_flatmap() {
-        let v = minimal(
-            gs::integers::<i64>().flat_map(|x: i64| gs::vecs(gs::just(x))),
-            |xs: &Vec<i64>| xs.len() >= 10,
-        );
-        assert_eq!(v, vec![0_i64; 10]);
-    }
-
-    #[test]
-    fn test_flatmap_rectangles() {
-        let lengths = gs::integers::<i64>().min_value(0).max_value(10);
-        let g = lengths.flat_map(|w: i64| {
-            let n = w.max(0) as usize;
-            gs::vecs(
-                gs::vecs(gs::sampled_from(vec!["a".to_string(), "b".to_string()]))
-                    .min_size(n)
-                    .max_size(n),
-            )
-        });
-        let xs = Minimal::new(g, |x: &Vec<Vec<String>>| {
-            let target = vec!["a".to_string(), "b".to_string()];
-            x.contains(&target)
-        })
-        .test_cases(2000)
-        .run();
-        let target = vec!["a".to_string(), "b".to_string()];
-        assert_eq!(xs, vec![target]);
-    }
-
-    #[test]
-    fn test_dictionary_empty() {
-        let t: HashMap<i64, String> =
-            minimal(gs::hashmaps(gs::integers::<i64>(), gs::text()), |_| true);
-        assert!(t.is_empty());
-    }
-
-    #[test]
-    fn test_dictionary_size_3() {
-        let t: HashMap<i64, String> = minimal(
-            gs::hashmaps(gs::integers::<i64>(), gs::text()),
-            |t: &HashMap<i64, String>| t.len() >= 3,
-        );
-        let value_set: HashSet<&String> = t.values().collect();
-        assert_eq!(value_set.len(), 1);
-        assert!(value_set.iter().next().unwrap().is_empty());
-        let keys: HashSet<i64> = t.keys().copied().collect();
-        for k in &keys {
-            if *k < 0 {
-                assert!(
-                    keys.contains(&(*k + 1)),
-                    "negative key {k} but {} not in keys {keys:?}",
-                    *k + 1
-                );
-            }
-            if *k > 0 {
-                assert!(
-                    keys.contains(&(*k - 1)),
-                    "positive key {k} but {} not in keys {keys:?}",
-                    *k - 1
-                );
-            }
-        }
     }
 
     #[test]
@@ -310,22 +149,6 @@ mod shrink_quality {
     }
 
     #[test]
-    #[ignore = "flaky: duplicate generation is too slow — see #350. Over random \
-                seeds the first qualifying example appears at a median of ~1100 \
-                executions (well above this budget), so the pass/fail here is a \
-                seed lottery rather than a real signal."]
-    fn test_duplicate_containment() {
-        let (xs, x): (Vec<i64>, i64) = Minimal::new(
-            gs::tuples!(gs::vecs(gs::integers::<i64>()), gs::integers::<i64>()),
-            |(xs, x): &(Vec<i64>, i64)| xs.iter().filter(|&&v| v == *x).count() > 1,
-        )
-        .test_cases(1000)
-        .run();
-        assert_eq!(xs, vec![0, 0]);
-        assert_eq!(x, 0);
-    }
-
-    #[test]
     fn test_reordering_bytes() {
         let xs: Vec<i64> = minimal(gs::vecs(gs::integers::<i64>()), |x: &Vec<i64>| {
             x.iter().map(|&v| i128::from(v)).sum::<i128>() >= 10 && x.len() >= 3
@@ -333,32 +156,6 @@ mod shrink_quality {
         let mut sorted = xs.clone();
         sorted.sort();
         assert_eq!(xs, sorted);
-    }
-
-    #[test]
-    fn test_minimize_long_list() {
-        let xs: Vec<bool> = minimal(gs::vecs(gs::booleans()).min_size(50), |x: &Vec<bool>| {
-            x.len() >= 70
-        });
-        assert_eq!(xs, vec![false; 70]);
-    }
-
-    #[test]
-    fn test_minimize_list_of_longish_lists() {
-        let size = 5;
-        let xs: Vec<Vec<bool>> = minimal(
-            gs::vecs(gs::vecs(gs::booleans())),
-            move |x: &Vec<Vec<bool>>| {
-                x.iter()
-                    .filter(|t| t.iter().any(|&b| b) && t.len() >= 2)
-                    .count()
-                    >= size
-            },
-        );
-        assert_eq!(xs.len(), size);
-        for v in &xs {
-            assert_eq!(v, &vec![false, true]);
-        }
     }
 
     #[test]
@@ -381,24 +178,6 @@ mod shrink_quality {
                 reversed > *x && x.len() > 3
             });
         assert_eq!(xs.len(), 4);
-    }
-
-    #[test]
-    fn test_list_with_wide_gap() {
-        let mut xs: Vec<i64> = minimal(gs::vecs(gs::integers::<i64>()), |x: &Vec<i64>| {
-            if x.is_empty() {
-                return false;
-            }
-            let mx = *x.iter().max().unwrap();
-            let mn = *x.iter().min().unwrap();
-            let Some(threshold) = mn.checked_add(10) else {
-                return false;
-            };
-            mx > threshold && threshold > 0
-        });
-        assert_eq!(xs.len(), 2);
-        xs.sort();
-        assert_eq!(xs[1], 11 + xs[0]);
     }
 
     #[test]
@@ -430,24 +209,6 @@ mod shrink_quality {
         );
         let single: HashSet<bool> = std::iter::once(false).collect();
         assert_eq!(xs, vec![single; 3]);
-    }
-
-    #[test]
-    fn test_minimize_list_of_lists() {
-        let xs: Vec<Vec<i64>> = minimal(
-            gs::vecs(gs::vecs(gs::integers::<i64>())),
-            |x: &Vec<Vec<i64>>| x.iter().filter(|inner| !inner.is_empty()).count() >= 3,
-        );
-        assert_eq!(xs, vec![vec![0_i64]; 3]);
-    }
-
-    #[test]
-    fn test_minimize_list_of_tuples() {
-        let xs: Vec<(i64, i64)> = minimal(
-            gs::vecs(gs::tuples!(gs::integers::<i64>(), gs::integers::<i64>())),
-            |x: &Vec<(i64, i64)>| x.len() >= 2,
-        );
-        assert_eq!(xs, vec![(0_i64, 0_i64), (0_i64, 0_i64)]);
     }
 
     #[test]
@@ -510,18 +271,6 @@ mod shrink_quality {
     }
 
     #[test]
-    fn test_sum_of_pair_int() {
-        let (a, b) = minimal(
-            gs::tuples!(
-                gs::integers::<i64>().min_value(0).max_value(1000),
-                gs::integers::<i64>().min_value(0).max_value(1000)
-            ),
-            |(a, b): &(i64, i64)| a + b > 1000,
-        );
-        assert_eq!((a, b), (1, 1000));
-    }
-
-    #[test]
     fn test_sum_of_pair_float() {
         let (a, b) = minimal(
             gs::tuples!(
@@ -558,20 +307,6 @@ mod shrink_quality {
         );
         assert_eq!(a, 1);
         assert_eq!(b, 1000.0);
-    }
-
-    #[test]
-    fn test_sum_of_pair_separated_int() {
-        let separated_sum = hegel::compose!(|tc| {
-            let n1 = tc.draw(gs::integers::<i64>().min_value(0).max_value(1000));
-            tc.draw(gs::text());
-            tc.draw(gs::booleans());
-            tc.draw(gs::integers::<i64>());
-            let n2 = tc.draw(gs::integers::<i64>().min_value(0).max_value(1000));
-            (n1, n2)
-        });
-        let (a, b) = minimal(separated_sum, |(a, b): &(i64, i64)| a + b > 1000);
-        assert_eq!((a, b), (1, 1000));
     }
 
     #[test]
@@ -707,18 +442,6 @@ mod shrink_quality {
             Box::new(Expr::Add(Box::new(Expr::Int(0)), Box::new(Expr::Int(0)))),
         );
         assert_eq!(x, expected);
-    }
-
-    #[test]
-    fn test_one_of_slip() {
-        let v: i64 = minimal(
-            gs::one_of(vec![
-                gs::integers::<i64>().min_value(101).max_value(200).boxed(),
-                gs::integers::<i64>().min_value(0).max_value(100).boxed(),
-            ]),
-            |_| true,
-        );
-        assert_eq!(v, 101);
     }
 
     fn check_perfectly_shrinks_integer(n: i64) {

--- a/tests/test_shrink_quality/collections.rs
+++ b/tests/test_shrink_quality/collections.rs
@@ -216,47 +216,6 @@ fn test_can_find_list() {
 }
 
 #[test]
-fn test_can_collectively_minimize_integers() {
-    let n = 10usize;
-    let xs = Minimal::new(
-        gs::vecs(gs::integers::<i64>()).min_size(n).max_size(n),
-        |x: &Vec<i64>| x.iter().collect::<HashSet<_>>().len() >= 2,
-    )
-    .test_cases(2000)
-    .run();
-    assert_eq!(xs.len(), n);
-    let distinct = xs.iter().collect::<HashSet<_>>().len();
-    assert!((2..=3).contains(&distinct));
-}
-
-#[test]
-fn test_can_collectively_minimize_booleans() {
-    let n = 10usize;
-    let xs = Minimal::new(
-        gs::vecs(gs::booleans()).min_size(n).max_size(n),
-        |x: &Vec<bool>| x.iter().collect::<HashSet<_>>().len() >= 2,
-    )
-    .test_cases(2000)
-    .run();
-    assert_eq!(xs.len(), n);
-    assert_eq!(xs.iter().collect::<HashSet<_>>().len(), 2);
-}
-
-#[test]
-fn test_can_collectively_minimize_text() {
-    let n = 10usize;
-    let xs = Minimal::new(
-        gs::vecs(gs::text()).min_size(n).max_size(n),
-        |x: &Vec<String>| x.iter().collect::<HashSet<_>>().len() >= 2,
-    )
-    .test_cases(2000)
-    .run();
-    assert_eq!(xs.len(), n);
-    let distinct = xs.iter().collect::<HashSet<_>>().len();
-    assert!((2..=3).contains(&distinct));
-}
-
-#[test]
 fn test_sorting_pass_survives_type_changes_from_lists() {
     expect_panic(
         || {
@@ -427,33 +386,4 @@ fn test_multiple_empty_lists_are_independent() {
     );
     assert_eq!(xs.len(), 2);
     assert!(xs[0].is_empty() && xs[1].is_empty());
-}
-
-/// The empty hashmap is the minimal counterexample for any-predicate;
-/// a `len >= 3` predicate shrinks to a 3-entry map with simplest keys
-/// and empty string values.
-#[test]
-fn test_dictionary_empty_is_minimal() {
-    let result = minimal(
-        gs::hashmaps(gs::integers::<i64>(), gs::text()),
-        |_: &HashMap<i64, String>| true,
-    );
-    assert!(result.is_empty());
-}
-
-#[test]
-fn test_dictionary_at_least_three_entries() {
-    let x = minimal(
-        gs::hashmaps(gs::integers::<i64>(), gs::text()),
-        |t: &HashMap<i64, String>| t.len() >= 3,
-    );
-    assert!(x.len() >= 3);
-    let values: HashSet<&String> = x.values().collect();
-    assert_eq!(values.len(), 1);
-    assert_eq!(*values.iter().next().unwrap(), "");
-    for k in x.keys() {
-        if *k < 0 {
-            assert!(x.contains_key(&(*k + 1)));
-        }
-    }
 }

--- a/tests/test_shrink_quality/integers.rs
+++ b/tests/test_shrink_quality/integers.rs
@@ -75,11 +75,6 @@ fn test_can_find_an_int() {
 }
 
 #[test]
-fn test_can_find_an_int_above_13() {
-    assert_eq!(minimal(gs::integers::<i64>(), |x: &i64| *x >= 13), 13);
-}
-
-#[test]
 fn test_minimizes_towards_zero() {
     assert_eq!(
         minimal(

--- a/tests/test_single_test_case.rs
+++ b/tests/test_single_test_case.rs
@@ -20,15 +20,6 @@ fn test_single_test_case_runs_exactly_one_case() {
 }
 
 #[test]
-fn test_single_test_case_passing() {
-    hegel::Hegel::new(|tc| {
-        tc.draw(gs::booleans());
-    })
-    .settings(hegel::Settings::new().mode(Mode::SingleTestCase))
-    .run();
-}
-
-#[test]
 fn test_single_test_case_failing_propagates() {
     expect_panic(
         || {

--- a/tests/test_standard_generators.rs
+++ b/tests/test_standard_generators.rs
@@ -509,11 +509,6 @@ mod direct_strategies {
     }
 
     #[test]
-    fn test_has_lower_bound() {
-        assert_all_examples(gs::integers::<i64>().min_value(100), |x: &i64| *x >= 100);
-    }
-
-    #[test]
     fn test_is_in_bounds() {
         assert_all_examples(
             gs::integers::<i64>().min_value(1).max_value(2),
@@ -555,14 +550,6 @@ mod direct_strategies {
         expected.insert(false, 0);
         expected.insert(true, 0);
         assert_eq!(v, expected);
-    }
-
-    #[test]
-    fn test_dictionaries_respect_size() {
-        assert_all_examples(
-            gs::hashmaps(gs::integers::<i64>(), gs::integers::<i64>()).max_size(5),
-            |d: &HashMap<i64, i64>| d.len() <= 5,
-        );
     }
 
     #[test]
@@ -733,9 +720,8 @@ mod provisional_strategies {
 mod pbtkit_generators {
     use std::collections::HashMap;
 
-    use super::common::utils::{assert_all_examples, expect_panic, minimal};
+    use super::common::utils::{assert_all_examples, minimal};
     use hegel::generators::{self as gs, Generator};
-    use hegel::{Hegel, Settings};
 
     #[test]
     fn test_mapped_possibility() {
@@ -776,32 +762,10 @@ mod pbtkit_generators {
     }
 
     #[test]
-    fn test_cannot_witness_empty_one_of() {
-        expect_panic(
-            || {
-                let empty: Vec<gs::BoxedGenerator<i32>> = vec![];
-                gs::one_of(empty);
-            },
-            "one_of requires at least one generator",
-        );
-    }
-
-    #[test]
     fn test_one_of_single() {
         assert_all_examples(
             hegel::one_of!(gs::integers::<i64>().min_value(0).max_value(10)),
             |n: &i64| (0..=10).contains(n),
-        );
-    }
-
-    #[test]
-    fn test_can_draw_mixture() {
-        assert_all_examples(
-            hegel::one_of!(
-                gs::integers::<i64>().min_value(-5).max_value(0),
-                gs::integers::<i64>().min_value(2).max_value(5),
-            ),
-            |m: &i64| (-5..=5).contains(m) && *m != 1,
         );
     }
 
@@ -813,34 +777,6 @@ mod pbtkit_generators {
                 .max_size(3),
             |ls: &Vec<i64>| (1..=3).contains(&ls.len()),
         );
-    }
-
-    #[test]
-    fn test_fixed_size_list() {
-        assert_all_examples(
-            gs::vecs(gs::integers::<i64>().min_value(0).max_value(10))
-                .min_size(3)
-                .max_size(3),
-            |ls: &Vec<i64>| ls.len() == 3,
-        );
-    }
-
-    #[test]
-    fn test_many_with_small_max() {
-        Hegel::new(|tc| {
-            let ls: Vec<i64> =
-                tc.draw(gs::vecs(gs::integers::<i64>().min_value(0).max_value(10)).max_size(2));
-            assert!(ls.len() <= 2);
-        })
-        .settings(Settings::new().test_cases(200).database(None))
-        .run();
-    }
-
-    #[test]
-    fn test_sampled_from() {
-        assert_all_examples(gs::sampled_from(vec!["a", "b", "c"]), |v: &&'static str| {
-            matches!(*v, "a" | "b" | "c")
-        });
     }
 
     #[test]
@@ -857,22 +793,6 @@ mod pbtkit_generators {
         assert_all_examples(gs::sampled_from(vec!["only"]), |v: &&'static str| {
             *v == "only"
         });
-    }
-
-    #[test]
-    fn test_sampled_from_empty() {
-        expect_panic(
-            || {
-                let empty: Vec<i32> = vec![];
-                gs::sampled_from(empty);
-            },
-            "cannot be empty",
-        );
-    }
-
-    #[test]
-    fn test_booleans() {
-        assert_all_examples(gs::booleans(), |_: &bool| true);
     }
 
     #[test]

--- a/tests/test_strings.rs
+++ b/tests/test_strings.rs
@@ -327,14 +327,6 @@ mod pbtkit_text {
     }
 
     #[test]
-    fn test_text_ascii() {
-        assert_all_examples(
-            gs::text().min_codepoint(32).max_codepoint(126),
-            |s: &String| s.chars().all(|c| (32..=126).contains(&(c as u32))),
-        );
-    }
-
-    #[test]
     fn test_text_shrinks_to_short() {
         let s = minimal(
             gs::text()
@@ -522,11 +514,6 @@ mod simple_strings {
     }
 
     #[test]
-    fn test_binary_respects_max_size() {
-        assert_all_examples(gs::binary().max_size(5), |x: &Vec<u8>| x.len() <= 5);
-    }
-
-    #[test]
     fn test_does_not_simplify_into_surrogates() {
         let f = minimal(gs::text(), |s: &String| s.as_str() >= "\u{e000}");
         assert_eq!(f, "\u{e000}");
@@ -542,27 +529,6 @@ mod simple_strings {
     fn test_respects_alphabet_if_list() {
         assert_all_examples(gs::text().alphabet("ab"), |s: &String| {
             s.chars().all(|c| c == 'a' || c == 'b')
-        });
-    }
-
-    #[test]
-    fn test_respects_alphabet_if_string() {
-        assert_all_examples(gs::text().alphabet("cdef"), |s: &String| {
-            s.chars().all(|c| "cdef".contains(c))
-        });
-    }
-
-    #[test]
-    fn test_can_encode_as_utf8() {
-        assert_all_examples(gs::text(), |s: &String| {
-            std::str::from_utf8(s.as_bytes()).is_ok()
-        });
-    }
-
-    #[test]
-    fn test_can_blacklist_newlines() {
-        assert_all_examples(gs::text().exclude_characters("\n"), |s: &String| {
-            !s.contains('\n')
         });
     }
 
@@ -1159,11 +1125,6 @@ mod regex_tests {
     fn test_fullmatch_is_the_default() {
         let re = Regex::new(r"\A[ab]+\z").unwrap();
         assert_all_examples(gs::from_regex("[ab]+"), move |s: &String| re.is_match(s));
-    }
-
-    #[test]
-    fn test_fullmatch_generates_example_literal() {
-        find_any(gs::from_regex("a").fullmatch(true), |s: &String| s == "a");
     }
 
     #[test]

--- a/tests/test_time.rs
+++ b/tests/test_time.rs
@@ -91,11 +91,6 @@ mod datetimes {
     }
 
     #[test]
-    fn test_allow_imaginary_is_not_an_error_for_naive_datetimes() {
-        assert_all_examples(gs::datetime_strings(), |_: &String| true);
-    }
-
-    #[test]
     fn test_can_find_after_the_year_2000() {
         let d = minimal(gs::date_strings(), |s: &String| date_year(s) > 2000);
         assert_eq!(date_year(&d), 2001);
@@ -146,13 +141,6 @@ mod datetimes {
         assert_eq!(minute, 0);
         assert_eq!(second, 0);
         assert_eq!(microsecond, 0);
-    }
-
-    #[test]
-    fn test_can_generate_naive_time() {
-        find_any(gs::time_strings(), |s: &String| {
-            !s.contains('+') && !s.contains('Z')
-        });
     }
 
     #[test]

--- a/tests/test_tuples.rs
+++ b/tests/test_tuples.rs
@@ -4,11 +4,6 @@ use common::utils::{assert_all_examples, find_any};
 use hegel::TestCase;
 use hegel::generators::{self as gs, Generator};
 
-#[hegel::test]
-fn test_tuple0_basic(tc: TestCase) {
-    let _: () = tc.draw(gs::tuples!());
-}
-
 #[test]
 fn test_tuple0_all_examples() {
     assert_all_examples(gs::tuples!(), |_| true);
@@ -20,21 +15,9 @@ fn test_tuple0_default_generator() {
 }
 
 #[hegel::test]
-fn test_tuple1_basic(tc: TestCase) {
-    let (a,): (i32,) = tc.draw(gs::tuples!(gs::integers(),));
-    let _ = a;
-}
-
-#[hegel::test]
 fn test_tuple1_respects_bounds(tc: TestCase) {
     let (a,): (i32,) = tc.draw(gs::tuples!(gs::integers().min_value(0).max_value(10),));
     assert!((0..=10).contains(&a));
-}
-
-#[hegel::test]
-fn test_tuple2_basic(tc: TestCase) {
-    let (a, b): (i32, bool) = tc.draw(gs::tuples!(gs::integers(), gs::booleans(),));
-    let _ = (a, b);
 }
 
 #[hegel::test]
@@ -45,13 +28,6 @@ fn test_tuple2_respects_bounds(tc: TestCase) {
     ));
     assert!((0..=10).contains(&a));
     assert!((100..=200).contains(&b));
-}
-
-#[hegel::test]
-fn test_tuple3_basic(tc: TestCase) {
-    let (a, b, c): (i32, String, bool) =
-        tc.draw(gs::tuples!(gs::integers(), gs::text(), gs::booleans(),));
-    let _ = (a, b, c);
 }
 
 #[hegel::test]
@@ -248,27 +224,4 @@ fn test_tuple2_can_find_both_true_and_false() {
     find_any(gs::tuples!(gs::booleans(), gs::booleans()), |(a, b)| {
         !*a && *b
     });
-}
-
-#[test]
-fn test_tuple2_all_examples_in_bounds() {
-    assert_all_examples(
-        gs::tuples!(
-            gs::integers::<i32>().min_value(0).max_value(10),
-            gs::integers::<i32>().min_value(0).max_value(10),
-        ),
-        |(a, b)| (0..=10).contains(a) && (0..=10).contains(b),
-    );
-}
-
-#[test]
-fn test_tuple3_all_examples_in_bounds() {
-    assert_all_examples(
-        gs::tuples!(
-            gs::integers::<i32>().min_value(-5).max_value(5),
-            gs::integers::<i32>().min_value(10).max_value(20),
-            gs::integers::<i32>().min_value(100).max_value(200),
-        ),
-        |(a, b, c)| (-5..=5).contains(a) && (10..=20).contains(b) && (100..=200).contains(c),
-    );
 }

--- a/tests/test_validation.rs
+++ b/tests/test_validation.rs
@@ -42,22 +42,6 @@ fn test_integers_min_greater_than_max() {
 }
 
 #[test]
-fn test_floats_allow_nan_with_min_value() {
-    expect_draw_panic(
-        gs::floats::<f64>().allow_nan(true).min_value(0.0),
-        "allow_nan=true",
-    );
-}
-
-#[test]
-fn test_floats_min_greater_than_max() {
-    expect_draw_panic(
-        gs::floats::<f64>().min_value(10.0).max_value(5.0),
-        "max_value < min_value",
-    );
-}
-
-#[test]
 fn test_floats_pos_zero_min_neg_zero_max() {
     expect_draw_panic(
         gs::floats::<f64>().min_value(0.0).max_value(-0.0),
@@ -70,17 +54,6 @@ fn test_floats_pos_zero_min_neg_zero_max_f32() {
     expect_draw_panic(
         gs::floats::<f32>().min_value(0.0).max_value(-0.0),
         "InvalidArgument",
-    );
-}
-
-#[test]
-fn test_floats_allow_infinity_with_both_bounds() {
-    expect_draw_panic(
-        gs::floats::<f64>()
-            .allow_infinity(true)
-            .min_value(0.0)
-            .max_value(1.0),
-        "allow_infinity=true",
     );
 }
 
@@ -315,14 +288,6 @@ mod validation {
         check_can_generate_examples(gs::vecs(gs::integers::<i64>()).min_size(50));
         check_can_generate_examples(gs::hashsets(gs::integers::<i64>()).min_size(50));
         check_can_generate_examples(gs::vecs(gs::integers::<i64>()).min_size(50).unique(true));
-    }
-
-    #[test]
-    fn test_min_before_max() {
-        expect_draw_panic(
-            gs::integers::<i64>().min_value(1).max_value(0),
-            "max_value < min_value",
-        );
     }
 
     #[test]


### PR DESCRIPTION
I suspected we've accrued a number of redundant tests over time.

<details>

<summary>AI-generated justification for every deleted test</summary>

# Deleted redundant tests

Every deletion was individually verified before removal: the candidate and its claimed survivor were both read, and the survivor was confirmed to exercise the same code paths with equal-or-stronger assertions (engine-side claims were traced to the actual branch in the source). `just check` and `just check-coverage` pass after the change; the nocov ratchet is unchanged at 102.

---

## tests/test_quality.rs (23)

The `shrink_quality` module here was a "merged from hypothesis" grab-bag that
duplicated the topic-organized `tests/test_shrink_quality/` suite.

- `test_integers_from_minimizes_leftwards` — identical test in `test_shrink_quality/integers.rs`.
- `test_minimize_bounded_integers_to_zero` — identical test in `integers.rs`.
- `test_minimize_string_to_empty` — identical test in `strings.rs`.
- `test_minimize_longer_list_of_strings` — identical test in `strings.rs`.
- `test_can_simplify_flatmap_with_bounded_left_hand_size` — identical test in `flatmap.rs`.
- `test_can_simplify_across_flatmap_of_just` — identical test in `flatmap.rs`.
- `test_can_simplify_on_right_hand_strategy_of_flatmap` — identical test in `flatmap.rs`.
- `test_can_ignore_left_hand_side_of_flatmap` — identical test in `flatmap.rs`.
- `test_can_simplify_on_both_sides_of_flatmap` — identical test in `flatmap.rs`.
- `test_flatmap_rectangles` — `flatmap.rs` version identical modulo `String` vs `&str` elements (`sampled_from` is generic); same 2000-case budget and assertion.
- `test_minimize_long_list` — identical test in `collections.rs`.
- `test_minimize_list_of_longish_lists` — identical test in `collections.rs`.
- `test_list_with_wide_gap` — identical predicate and assertions in `collections.rs`.
- `test_minimize_list_of_lists` — identical test in `collections.rs`.
- `test_minimize_list_of_tuples` — identical test in `collections.rs`.
- `test_sum_of_pair_int` — subsumed by `integers.rs::test_reduces_additive_pairs`: same `tuples!` generator, bounds, predicate `a+b>1000`, exact assertion `(1, 1000)`, larger case budget.
- `test_sum_of_pair_separated_int` — identical `compose!` body and assertion in `composite.rs::test_sum_of_pair_separated`.
- `test_one_of_slip` — identical test in `mixed_types.rs`.
- `test_minimize_one_of` — subsumed by `mixed_types.rs::test_minimize_one_of_mixed`: same three-branch `one_of` and disjunctive assertion, run 10 times.
- `test_minimize_mixed_list` — subsumed by `mixed_types.rs::test_minimize_mixed_list`: same generator/predicate, additionally asserts `len == 10`.
- `test_dictionary_empty` — identical to `collections.rs::test_dictionary_minimizes_to_empty`.
- `test_dictionary_size_3` — subsumed by `collections.rs::test_dictionary_minimizes_values`: same generator/predicate, asserts both key-neighbor directions plus `len >= 3`.
- `test_duplicate_containment` — was `#[ignore]`d as flaky (issue #350) so it ran nowhere; the active bounded-generator version in `collections.rs::test_duplicate_containment` asserts the same minimal `([0, 0], 0)`.

Also removed: the `Mixed` enum, whose only users were the two deleted one_of tests.

## tests/test_shrink_quality/collections.rs (5)

- `test_dictionary_empty_is_minimal` — byte-identical to `test_dictionary_minimizes_to_empty` in the same file (two merge waves).
- `test_dictionary_at_least_three_entries` — strictly weaker than same-file `test_dictionary_minimizes_values`, which checks both key-neighbor directions (this one checked only the negative direction).
- `test_can_collectively_minimize_integers` — duplicated by `test_quality.rs`'s parametrized `collective_minimization` checker: same n=10 fixed-size vec, distinct≥2 predicate, 2000-case budget, distinct-in-2..=3 assertion.
- `test_can_collectively_minimize_booleans` — same; for bools "distinct in 2..=3" and "distinct == 2" are equivalent (only two values exist).
- `test_can_collectively_minimize_text` — same setup and assertions as the `test_quality.rs` checker instance.

## tests/test_shrink_quality/integers.rs (1)

- `test_can_find_an_int_above_13` — the unbounded-i64 `x >= n → shrinks to n` shape is already pinned at n ∈ {3, 7, 42} by same-file `test_perfectly_shrinks_integers_positive` and at ±{0, 1, 1000, 10⁶} by `test_quality.rs::test_perfectly_shrinks_integers`.

## hegel-c/tests/embedded/native/re_parser_tests.rs (69)

An original AST-asserting suite was later extended with waves of `parses_*`/`err_*`
smoke tests that re-parse the same or trivially-varied patterns. Each family below
was verified against the branch it hits in `hegel-c/src/native/re/parser.rs` before
deletion. 198 tests remain.

Byte-identical (or same-pattern, weaker-assertion) duplicates:

- `parses_short_unicode_escape_in_class`, `parses_class_escape_short_unicode`, `parses_short_unicode_escape_in_class_form`, `parses_class_with_long_unicode_escape`, `parses_class_unicode_short_escape_in_set` — all five were `parse_pattern(r"[A]", 0).unwrap()` (despite the names, `[A]` contains no escape); kept `char_class_single_literal_unwraps`, which asserts the AST.
- `parses_short_unicode_escape` — `r"A"` is a plain literal; kept `literal_single_char` (AST-asserted).
- `parses_outer_octal_three_digits`, `parses_outer_octal_three_digit_padded`, `parses_outer_octal_three_digits_returns` — three byte-identical `\077` tests; kept `parses_octal_escape_three_digits`. (`\107` kept separately — non-zero-lead octal is a distinct branch.)
- `parses_long_unicode_escape_in_set` — byte-identical `[\U00000041]`; kept `parses_long_unicode_escape_in_class`.
- `parses_global_inline_flag_ascii` — byte-identical `(?a)abc`; kept `parses_ascii_flag_inline`.
- `parses_global_inline_flag_unicode` — byte-identical `(?u)abc`; kept `parses_unicode_flag_inline`.
- `err_named_unicode_escape_in_set_not_supported` — identical pattern and assertion; kept `err_class_named_unicode_escape_not_supported`.
- `err_named_group_eof_with_content`, `err_named_unterminated_no_terminator_char` — identical `(?P<foo` → "missing >" tests; kept `err_unterminated_named_group_name`.
- `err_subpattern_extension_unterminated_p` — identical `(?P` EOF test; kept `err_unknown_p_extension_eof`.
- `err_subpattern_lookbehind_unterminated_lt` — identical `(?<` test; kept `err_subpattern_eof_after_lookbehind_qmark`.
- `err_inline_flag_eof_after_qmark_letter` — identical `(?i` test; kept `err_inline_flag_no_terminator`.
- `err_inline_flag_unknown_after_initial` — identical `(?Z)`; `Z` fails the extension dispatch before any flag logic; kept `err_unknown_extension`.
- `err_inline_flag_disable_unknown` — identical `(?-Z:abc)`; kept `err_inline_flag_unknown_after_dash`.
- `err_named_group_empty_at_open` — `(?P<>x)` vs kept `err_missing_group_name`'s `(?P<>a)`: the error fires at the empty name, the body char is unreachable.
- `parses_nested_negated_class_disables_flatten` — byte-identical `[a[^b]]`; kept `parses_nested_class_flatten_inner_negated`.
- `err_inline_flag_negate_global_in_subgroup` — `(?u-i)abc` errors at the `)` exactly as kept `err_inline_flag_global_unicode_then_dash`'s `(?u-i)`; the trailing text is never reached.
- `err_inline_flag_global_then_invalid_letter` — `(?xZ` errors at `Z` before the terminator matters; kept `err_inline_flag_global_unknown` (`(?xZ)`).

Same-branch families (letters/constants that don't select different code):

- `parses_class_dash_escape_range`, `err_class_range_with_class_escape_endpoint_invalid`, `err_class_range_right_endpoint_is_class_escape`, `err_class_range_with_category_endpoint` — kept `char_class_range_category_endpoint_is_an_error`, which already tests both `[\d-z]` and `[a-\d]` with message assertions; two of these repeated those patterns verbatim, the others were `is_err`-only.
- `err_class_escape_unknown_letter`, `err_class_bad_letter_escape` (`[\q]`), `err_class_escape_two_char_unknown_letter` (`[\h]`) — all unknown ASCII-letter class escapes hit the single branch at parser.rs ~554; kept `err_class_bad_escape` (`[\p]`).
- `err_outer_escape_letter_unknown` (`\h`), `err_unknown_outer_escape_letter` (`\Q`) — same unknown-letter branch (~689); kept `err_outer_escape_unknown_letter` (`\p`). (The `\z` test kept — deliberate anchor-parity.)
- `err_outer_escape_punct_unknown` — misnamed (it's a success test); `\#` and `\!` both hit the non-letter fall-through; kept `parses_outer_escape_non_letter`.
- `err_class_short_unicode_escape_incomplete`, `err_class_unicode_short_incomplete_explicit` — same length check (~503), digit count doesn't branch; kept `err_class_incomplete_unicode_escape`.
- `err_outer_unicode_escape_incomplete`, `err_outer_unicode_short_incomplete_explicit` — same length check (~603); kept `err_incomplete_unicode_escape`.
- `err_class_long_unicode_escape_unreachable_hex` — same `char::from_u32` rejection; kept `err_class_long_unicode_escape_out_of_range`.
- `err_class_hex_escape_no_digits` — 0 vs 1 hex digits fail the same count check; kept `err_class_hex_escape_incomplete`.
- `err_outer_octal_three_digit_out_of_range` (`\477`) — same `n > 0o377` check; kept `err_octal_escape_out_of_range` (`\400`).
- `err_outer_octal_overflow`, `err_outer_decimal_groupref_overflow_long` — byte-identical `\99999999999`; kept `err_groupref_decimal_overflow`.
- `parses_class_octal_escape_three_digits` (`[\077]`) — same class-octal branch, no boundary value; kept `parses_octal_escape_in_class` and `char_class_range_with_escaped_endpoints`.
- `parses_hex_escape` — same `\x41`; kept `literal_hex_escape` (AST-asserted).
- `parses_outer_short_unicode_escape_hex` — same outer `\u` success branch; kept `literal_unicode_u_escape` (AST-asserted).
- `parses_class_escape_lookup_category` (`[\w]`), `parses_class_with_class_escape_category` (`[\d]`) — same category-lookup branch (~480); kept `char_class_with_category` (AST-asserted).
- `parses_class_with_class_escape_literal` (`[\t]`) — both are table hits in `lookup_escape_literal`, the letter doesn't branch; kept `parses_class_literal_escape` (`[\n]`).
- `err_named_group_bad_char_at_open_via_getuntil` (`(?P<1>x)`), `err_named_group_starts_with_digit` (`(?P<1abc>x)`) — digit-leading names hit the same name-validity check; kept `err_bad_character_in_group_name`.
- `err_inline_flag_disable_global`, `err_inline_flag_disable_global_specifically`, `err_inline_flag_disable_global_at_end` — `a` and `u` are both TYPE_FLAGS; all hit the single can't-turn-off check (~1415), which fires before the terminator; kept `err_cannot_turn_off_ascii`.
- `err_inline_flag_disable_no_colon` (`(?i-i:`) — the on-and-off check fires at the `:` in both; kept `err_flag_turned_on_and_off` (`(?i-i:abc)`).
- `err_global_flag_cannot_disable_global` (`(?-i)abc`), `err_inline_flag_disable_no_colon_close_paren` (`(?i-i)`) — all end the del-flag loop on `)`, the "missing :" branch (~1434); kept `err_inline_flag_missing_colon_after_minus` (`(?-i)`).
- `err_inline_flag_missing_after_dash` (`(?i-`) — EOF immediately after `-`, same branch (~1400); kept `err_inline_flag_eof_after_qmark` (`(?-`).
- `err_inline_flag_disable_then_eof_after_letter` (`(?i-i`) — EOF inside the del loop (~1423); kept `err_inline_flag_eof_after_dash_letter` (`(?-i`).
- `err_inline_flag_unknown_first_char` (`(?-Q)`) — alphabetic non-flag as first char after `-` (~1405); kept `err_inline_flag_unknown_after_dash`.
- `parses_inline_locale_flag_bytes` — patterns are always `&str` here, so `(?L)` hits the same inline-L rejection (~1364) as kept `err_inline_locale_flag_str`; the external-LOCALE path stays covered by `err_external_flag_locale_with_str`.
- `err_conditional_named_unknown` — same unknown-name lookup in the conditional; kept `err_conditional_unknown_named_group`.
- `err_decimal_backref_to_open_group` (`(\1)`) — same open-group self-reference check (~675); kept `err_open_group_self_reference` (`(a\1)`).
- `parses_max_repeat_with_only_lower_bound` — same `a{3}`; kept `max_repeat_braces_fixed` (AST-asserted).
- `parses_multiple_inline_flags` (`(?ims)abc`) — a third flag letter only re-runs the loop iteration the second already exercises; kept `parses_inline_global_flag_at_start_only` (`(?im)abc`).
- `parses_lookbehind_positive`, `parses_lookbehind_negative` — same constructs AST-asserted by kept `assert_lookbehind` / `assert_not_lookbehind`.
- `parses_atomic_group_simple` — body length doesn't change the atomic-group branch; kept `atomic_group` (AST-asserted).
- `parses_conditional_referencing_first_group` — same yes-only numeric conditional parse; kept `parses_conditional_backref_yes_only`.

## tests/test_floats.rs (8)

- `test_filter_nan` — byte-identical claim to `test_floats_no_nan` (`allow_nan(false)` ⇒ never NaN), in a different ported module.
- `test_draw_unbounded_float_rejects_nan` — same config and predicate as `test_floats_no_nan`, hand-rolled via `Hegel::new` instead of `assert_all_examples`.
- `test_floats_no_infinity` — identical config and `is_finite` assertion to the `float_tests!` macro's `finite` case, which also covers f32.
- `test_largest_range` — `[-MAX, MAX]` containment asserted by `test_floats_are_in_range_full` on the identical generator implies non-infinite (INF falls outside, NaN fails both comparisons).
- `test_floats_half_bounded_with_infinity` — `test_standard_generators.rs::test_float_can_find_max_value_inf` asserts `minimal(min_value(0.0), is_infinite) == INFINITY`, which strictly implies this `find_any`.
- `test_floats_unbounded` — assertion-free smoke draw; kept `test_is_float` and the macro smoke pair.
- `test_floats_bounded` — fixed-constant in-range check subsumed by the fuzzed `with_min_and_max` macro case, `test_floats_are_in_range`, and the identical fixed config in `test_floats_shrinks_small_positive`.
- `test_floats_negative_range` — same, with `test_floats_shrinks_negative` sharing its exact config.

## tests/test_integers.rs (9)

- `test_floats_are_floats_float_float_bounds` — token-identical to `test_floats_are_floats_int_float_bounds` apart from a `_f64` suffix (`0.0` vs `0.0_f64` are the same literal; the Python int-vs-float-bound distinction doesn't exist in Rust).
- `test_minimize_nan` — identical claim to `test_floats.rs::test_floats_shrinks_nan_only`, duplicated across files.
- `test_minimal_infinite_float_is_positive` — identical claim to `test_floats.rs::test_floats_shrinks_neg_inf`.
- `numerics::test_fuzz_floats_bounds` — same fuzz of optional bounds + exclusions as the `float_tests!` macro's `fuzz_floats_bounds` (which also covers f32); the emptied `numerics` module was removed.
- `test_minimize_negative_int` — `test_minimizes_int_up_to_boundary`'s loop includes boundaries 1 and 2, and on integers `x < 0` ≡ `x <= -1`, so it asserts both cases verbatim.
- `test_positive_negative_int` — same argument on the positive side via `test_minimizes_int_down_to_boundary`.
- `test_no_allow_infinity_upper` — `test_standard_generators.rs::test_no_infinity_for_min_value_values` runs the identical assertion over several bound values including this one.
- `test_no_allow_infinity_lower` — same via `test_no_infinity_for_max_value_values`.
- `test_floats_are_floats_unbounded` — trivial smoke draw of unbounded floats; survivors as for `test_floats_unbounded`.

## tests/test_collections.rs (3)

- `test_vec_unique_sampled_from_no_duplicates` — identical generator (`vecs(sampled_from(vec![0;100])).unique(true)`) and identical `len <= 1` assertion as same-file `test_does_not_include_duplicates_even_when_duplicated_in_collection`.
- `test_easy_filtered_sampling` — identical generator+predicate as `test_combinators.rs::test_sampled_from_filter_rare_value`, whose harness is strictly stronger (`assert_all_examples`, 100 cases vs 15).
- `test_bounded_size_sets` — fixed `max_size(2)` length check; subsumed by fuzzed `test_hashset_with_max_size` and `test_sets_are_size_bounded`.

## tests/test_combinators.rs (4)

- `test_sampled_from_unsatisfiable_filter_panics` — identical setup and `expect_panic` as `test_collections.rs::test_unsat_filtered_sampling`.
- `test_one_of_twelve_components` — `test_one_of_every_arity_reaches_every_alternative`'s arity-12 case asserts the drawn set equals exactly {0..12}, strictly stronger than "value in 0..12".
- `test_optional_can_generate_some` — same `find_any` through the same `OptionalGenerator` code as same-file `test_optional_mapped_find_any`; rates asserted by `test_distributions.rs::optional_generates_both_none_and_some`.
- `test_optional_can_generate_none` — same.

## tests/test_standard_generators.rs (9)

- `test_cannot_witness_empty_one_of` — same empty-`one_of` panic as `test_combinators.rs::test_one_of_empty`.
- `test_sampled_from_empty` — same construction-time panic as same-file `test_sampled_from_rejects_empty`, which matches a more specific message.
- `test_sampled_from` — identical generator and membership predicate as the `sampled_from_strings` macro instantiation, which also tests the `vecs` wrapper.
- `test_fixed_size_list` — `min_size(n).max_size(n) ⇒ len == n` asserted with other constants same-file (`test_has_specified_length`) and for n=0..10 in `test_collections.rs::test_lists_of_fixed_length`.
- `test_many_with_small_max` — fixed `max_size(2)` subsumed by fuzzed `test_collections.rs::test_vec_with_max_size` and same-file `test_none_lists_respect_max_size`.
- `test_has_lower_bound` — identical `min_value(k) ⇒ x >= k` claim as the `integers_min` macro instantiation.
- `test_can_draw_mixture` — `one_of!` of disjoint ranges asserting union membership; `test_combinators.rs` survivors additionally prove both branches are reached.
- `test_booleans` — `assert_all_examples(gs::booleans(), |_| true)` is a pure smoke draw; kept the macro smoke and `test_distributions.rs::unweighted_booleans_are_roughly_fair`.
- `test_dictionaries_respect_size` — fixed `max_size(5)` subsumed by fuzzed `test_collections.rs::test_hashmap_with_max_size` and stronger same-file `test_dictionaries`.

## tests/test_tuples.rs (6)

- `test_tuple0_basic`, `test_tuple1_basic`, `test_tuple2_basic`, `test_tuple3_basic` — assertion-free draws of each arity; the paired `test_tuple0_all_examples` / `test_tupleN_respects_bounds` tests draw the same arity and assert per-slot bounds.
- `test_tuple2_all_examples_in_bounds`, `test_tuple3_all_examples_in_bounds` — same in-bounds property; the surviving `respects_bounds` tests use disjoint per-slot ranges, which also catch slot-swap bugs.

## tests/test_strings.rs (6)

- `test_binary_respects_max_size` — `binary().max_size(k) ⇒ len <= k` asserted in `test_collections.rs::test_binary_with_max_size` and same-file `test_binary_respects_size_bounds`.
- `test_respects_alphabet_if_string` — the Python list-vs-string alphabet distinction collapses in Rust (both pass `&str` to the same builder); kept `test_respects_alphabet_if_list` and the fuzzed `test_text_alphabet`.
- `test_can_blacklist_newlines` — fixed `exclude_characters("\n")` is a constant instance of the fuzzed `test_text_exclude_characters` on the same builder path.
- `test_can_encode_as_utf8` — tautology in Rust: a `String` is always valid UTF-8; asserted nothing beyond the type system.
- `test_text_ascii` — fixed codepoint range (32, 126) strictly generalized by the fuzzed `test_text_codepoint_range`.
- `test_fullmatch_generates_example_literal` — fullmatch on pattern `"a"` forces every example to equal `"a"`, so kept `test_fullmatch_matches_literal_a` implies the `find_any`.

## tests/test_hegel_test.rs (7)

Overlapping upstream pytest/hypothesis-core/pbtkit ports landed the same scenarios
in multiple modules. The emptied `pytest_runs` module was removed.

- `pytest_runs::test_ints_are_ints` — byte-identical to `test_can_find_with_db_eq_none`; both subsumed by `nocover_limits::test_max_examples_are_respected` (same config plus a case-count assertion).
- `hypothesis_core::test_can_find_with_db_eq_none` — same (its identical twin; the counting variant survives).
- `pytest_runs::test_ints_are_floats` — same draw + unconditional panic + `database(None)` as `test_exception_propagates_fine`, which also asserts the panic payload.
- `testdecorators::test_can_run_without_database` — `database(None)` + panic asserting only `is_err()`; subsumed by `test_exception_propagates_fine` and by `test_can_run_with_database_in_thread`'s first block (a no-draw panic with `database(None)`).
- `flakiness::test_does_not_attempt_to_shrink_flaky_errors` — same fail-only-on-first-invocation + "Flaky test detected" as `test_fails_only_once_is_flaky`; its recorded values vector was only an invocation counter.
- `testdecorators::test_can_call_an_argument_f` — trivially-true property over plain integers; its upstream purpose (an argument literally named `f`) has no Rust counterpart; kept `test_abs_non_negative`.
- `hypothesis_core::test_given_shrinks_pytest_helper_errors` — `minimal(integers, x > 100) == 101` vs kept `test_still_minimizes_on_non_assertion_failures`'s `minimal(integers, x >= 10) == 10`: same shrink path, only the constant differs.

## tests/test_output.rs (2)

- `verbosity::test_no_indexerror_in_quiet_mode_report_multiple` — body was exactly `report_failing("quiet").run()`; kept `test_does_not_log_in_quiet_mode` runs the identical invocation and asserts stderr is empty. (The upstream one-vs-multiple-failures distinction was never ported.)
- `verbosity::test_no_indexerror_in_quiet_mode_report_one` — byte-identical to the above.

## tests/test_explicit_test_case.rs (3)

An early "does it run" generation of macro tests was superseded by `should_panic`
twins with identical attribute configurations that also prove the value was injected.

- `test_explicit_case_with_property_test` — kept `test_macro_explicit_case_output` (`should_panic(expected = "fail: 42")`).
- `test_explicit_case_with_user_defined_struct` — kept `test_macro_explicit_case_with_struct` (asserts the injected `Point { x: 3, y: 4 }`).
- `test_explicit_case_with_function_evaluation` — kept `test_macro_explicit_case_with_computed_expression` (asserts the computed `fail: 60`).

## tests/test_draw_named.rs (14)

A ported `mod draw_names`/rewriter sub-suite re-tested the same proc-macro rewrite
arms as the top-level `draw_lines_case!` suite.

- `test_draw_named_non_repeatable_reuse_raises` — byte-identical to `test_draw_named_non_repeatable_reuse_panics`.
- `test_draw_named_validation_runs_outside_composite` — third copy of the same double-`__draw_named("x", false)` panic; the inside-composite counterpart was kept.
- `test_draw_named_inconsistent_flags_raises` — identical false-then-true body to `test_draw_named_mixed_repeatable_panics`; the reverse-order test was kept.
- `test_draw_named_repeatable_skips_taken_name` — asserted only "does not panic"; kept `test_draw_named_repeatable_skips_taken_suffixes` (asserts exact output), `test_macro_repeatable_skips_taken_name`, and the embedded `repeatable_display_name_skips_a_taken_name`.
- `test_rewrite_draws_no_error_for_no_draw_function` — identical empty fixture to `test_rewriter_no_draws_is_noop`.
- `test_rewrite_draws_output_is_named` — same single top-level-let rewrite arm as kept `test_rewriter_top_level_assignment` / `test_macro_output_uses_variable_name`.
- `test_rewrite_draws_final_replay_uses_rewritten_function` — same arm again.
- `test_rewrite_draws_two_draws` — same two-distinct-names shape as `test_macro_unique_names_at_top_level`.
- `test_rewrite_draws_loop_output_numbered` — identical to kept `test_rewriter_for_loop_body_is_repeatable`.
- `test_rewriter_while_loop_body_is_repeatable` — same while-loop case as `test_macro_while_loop_is_repeatable` with fewer iterations.
- `test_rewriter_if_body_is_repeatable` — `test_macro_draw_in_if_is_repeatable` covers the same numbering plus a following top-level draw staying unsuffixed.
- `test_rewriter_nested_block_is_repeatable` — identical bare-block case to `test_macro_bare_block_output_has_suffix`.
- `test_rewriter_name_seen_at_top_and_loop_all_repeatable` — its shape is the first half of `test_macro_shadowing_across_block_types`, which additionally covers a closure.
- `test_limitation_draw_not_in_let_binding` — same not-rewritten fallback as `test_macro_non_assignment_draw_not_rewritten`, only the element generator differs.

## tests/test_validation.rs (4)

The `mod validation` Hypothesis port repeated checks the top-level suite already has.

- `validation::test_min_before_max` — same generic integer min>max `invalid_argument!` line as `test_integers_min_greater_than_max` (i64 vs i32 is the same generic source).
- `test_floats_min_greater_than_max` — `validation::test_float_ranges`' second sub-case is the identical plain f64 min>max check.
- `test_floats_allow_nan_with_min_value` — `test_float_range_and_allow_nan_cannot_both_be_enabled` checks the same rejection for both min-only and max-only.
- `test_floats_allow_infinity_with_both_bounds` — identical configuration and message as `test_float_finite_range_and_allow_infinity_cannot_both_be_enabled`.

## Other frontend files (9)

- `tests/test_composite.rs::test_can_pass_through_arguments_6` — copy-paste of `test_can_pass_through_arguments_5` with 6 args (an unrolled Python parametrize on the same path).
- `tests/test_derive.rs::test_derive_struct_builder_only_overrides_specified_field` — identical shape to `test_derive_struct_with_custom_field_generator`; the "only overrides" intent was never actually asserted (`y` was never checked).
- `tests/test_derive.rs::test_derive_unit_enum` — `check_can_generate_examples` on the same generator that `test_derive_unit_enum_generates_all_variants` draws with variant-coverage assertions.
- `tests/test_hegel_main.rs::test_main_default_matches_attribute` — byte-identical body to `test_basic_main_runs` (same fixture, no args, same `count == 7` assertion).
- `tests/test_single_test_case.rs::test_single_test_case_passing` — same passing single-case run as `test_single_test_case_runs_exactly_one_case`, which additionally asserts the case count.
- `tests/test_time.rs::test_can_generate_naive_time` — `find_any(P)` on the same generator/predicate is strictly weaker than kept `test_naive_times_are_naive`'s `assert_all_examples(P)`.
- `tests/test_time.rs::test_allow_imaginary_is_not_an_error_for_naive_datetimes` — trivial `|_| true` predicate over the generator `test_default_datetimes_are_naive` checks with a real predicate; the name references a Python-only parameter.
- `tests/test_find_quality/floats.rs::test_is_float` — assertion-free smoke draw; `test_inversion_is_imperfect` draws the same default-float generator 1000 times.
- `tests/chrono/datetime.rs::test_datetimes_utc_min_greater_than_max` — `DateTimeGenerator` delegates bound validation to `naive_datetimes()` before touching the timezone generator (verified in `src/extras/chrono/generators.rs`), so the UTC variant hit the identical `invalid_argument!` path as kept `test_datetimes_min_greater_than_max`.

## hegel-c engine tests (7, beyond re_parser)

- `tests/smoke.rs::libhegel_test_case_from_blob_rejects_bad_input` — every error branch it asserted is asserted more strongly in-process by `c_abi_inprocess.rs::from_blob_rejects_bad_input` (garbage/null/bad-UTF-8 blobs with message checks) and `null_handles_are_rejected_without_crashing`; smoke.rs drives an uninstrumented dlopened cdylib (contributes no coverage), error-return behavior is identical in-process, and the dlopen from_blob happy path survives in `libhegel_blob_test_case_replays_the_counterexample`.
- `tests/embedded/sys_tests.rs::fs_write_read_round_trips` — `fs_write_truncates_an_existing_file` performs write-to-new-file, write-to-existing, and the same read-back equality assertion: a strict superset.
- `native/state_tests.rs::template_overrun_status_matches_max_size_overrun` — despite its name, it only re-asserted draw-error + `Status::EarlyStop` for a finite-count template, exactly what `template_simplest_finite_count_n_produces_exactly_n_values` asserts (and `template_count_decrements_on_each_draw` checks the counter too).
- `native/state_tests.rs::for_simplest_propagates_across_many_draws` — `for_simplest_is_independent_of_seed` asserts 5 repeated simplest draws each equal 0; 10 vs 5 iterations exercises no additional path.
- `native/state_tests.rs::spans_index_usize` — the explicit `impl Index<usize> for Spans` is exercised by indexing expressions in `spans_get_mut_returns_mutable_reference` and `spans_from_vec` with identical assertions.
- `native/shrinker_scheduling_tests.rs::fixate_emits_no_debug_when_no_callback_set` — ran the identical zero_choices-via-fixate scenario with no debug callback (the default configuration of virtually every test in the file) and asserted a strict subset; "no debug output" is unobservable without a callback.
- `native/draws/internet_tests.rs::domain_spec_validates_max_length_range` — the file's `domain_draw` helper propagates `DomainSpec::new` errors before generation, so each arm was a weaker repeat of `generate_domain_rejects_tiny_max_length_as_invalid_argument` (new(3) err with variant match), `generate_domain_respects_max_length_4`, and `generate_domain_default_max_length`.

## Runner/embedded (2)

- `tests/embedded/runner_tests.rs::test_settings_verbosity` — invoked the `verbosity` builder with no assertion; the setter is executed by many surviving `.verbosity(...)` callers (test_output.rs verbosity tests, reproduce helpers, `test_hard_to_find_single_example`).
- `hegel-c/.../native/database_tests.rs::round_trip_integer_choices` — `serialize_any_integer` unconditionally uses the single BigInt sub-tag encode path for every write (verified in `native/database.rs`), and `serialize_roundtrips_various_integer_values` spans every magnitude/sign the candidate covered (0, small negatives, `i128::MIN`, beyond-i128 values).

</details>