### PR TITLE
Add subsequences() and permutations() generators

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,15 @@
+RELEASE_TYPE: patch
+
+This patch adds two new generators for rearranging a fixed list of values: `gs::permutations()`, which generates the elements in a randomly chosen order, and `gs::subsequences()`, which generates subsets of the elements in their original order.
+
+```rust
+use hegel::generators as gs;
+
+#[hegel::test]
+fn my_test(tc: hegel::TestCase) {
+    let perm: Vec<i32> = tc.draw(gs::permutations(vec![1, 2, 3, 4, 5]));
+    let sub: Vec<i32> = tc.draw(gs::subsequences(vec![1, 2, 3, 4, 5]));
+}
+```
+
+Both support `min_size` and `max_size` bounds. On `subsequences` these constrain how many elements are included; setting them on `permutations` generates an ordered sample without replacement — a permutation of a subset of the elements — instead of reordering all of them. Permutations shrink towards the original order, and subsequences towards fewer elements taken from earlier in the list.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 RELEASE_TYPE: patch
 
-This patch adds two new generators for rearranging a fixed list of values: `gs::permutations()`, which generates the elements in a randomly chosen order, and `gs::subsequences()`, which generates subsets of the elements in their original order.
+This patch adds three new generators that draw from a fixed list of values: `gs::permutations()` generates all of the elements in a randomly chosen order, `gs::subsequences()` generates subsets of the elements in their original order, and `gs::samples()` generates samples of the elements — with replacement by default, or without replacement via `without_replacement()`.
 
 ```rust
 use hegel::generators as gs;
@@ -9,7 +9,8 @@ use hegel::generators as gs;
 fn my_test(tc: hegel::TestCase) {
     let perm: Vec<i32> = tc.draw(gs::permutations(vec![1, 2, 3, 4, 5]));
     let sub: Vec<i32> = tc.draw(gs::subsequences(vec![1, 2, 3, 4, 5]));
+    let sample: Vec<i32> = tc.draw(gs::samples(vec![1, 2, 3, 4, 5]).max_size(10));
 }
 ```
 
-Both support `min_size` and `max_size` bounds. On `subsequences` these constrain how many elements are included; setting them on `permutations` generates an ordered sample without replacement — a permutation of a subset of the elements — instead of reordering all of them. Permutations shrink towards the original order, and subsequences towards fewer elements taken from earlier in the list.
+`subsequences` and `samples` support `min_size` and `max_size` bounds on how many elements are included. Permutations shrink towards the original order; subsequences and samples shrink towards fewer elements, taken from earlier in the list.

--- a/src/generators/mod.rs
+++ b/src/generators/mod.rs
@@ -54,7 +54,10 @@ pub use generators::{
 pub use misc::{BoolGenerator, JustGenerator, booleans, just, unit, weighted_booleans};
 pub use numeric::{Float, FloatGenerator, Integer, IntegerGenerator, floats, integers};
 pub use recursive::{RecursiveGenerator, SubtreeGenerator, recursive};
-pub use sequences::{PermutationGenerator, SubsequenceGenerator, permutations, subsequences};
+pub use sequences::{
+    PermutationGenerator, SampleGenerator, SubsequenceGenerator, permutations, samples,
+    subsequences,
+};
 pub use strings::{
     BinaryGenerator, CharactersGenerator, DateStringGenerator, DateTimeStringGenerator,
     DomainGenerator, EmailGenerator, IpAddressGenerator, Ipv4AddressGenerator,

--- a/src/generators/mod.rs
+++ b/src/generators/mod.rs
@@ -16,6 +16,7 @@ mod generators;
 mod misc;
 mod numeric;
 mod recursive;
+mod sequences;
 mod strings;
 mod time;
 mod tuples;
@@ -53,6 +54,7 @@ pub use generators::{
 pub use misc::{BoolGenerator, JustGenerator, booleans, just, unit, weighted_booleans};
 pub use numeric::{Float, FloatGenerator, Integer, IntegerGenerator, floats, integers};
 pub use recursive::{RecursiveGenerator, SubtreeGenerator, recursive};
+pub use sequences::{PermutationGenerator, SubsequenceGenerator, permutations, subsequences};
 pub use strings::{
     BinaryGenerator, CharactersGenerator, DateStringGenerator, DateTimeStringGenerator,
     DomainGenerator, EmailGenerator, IpAddressGenerator, Ipv4AddressGenerator,

--- a/src/generators/sequences.rs
+++ b/src/generators/sequences.rs
@@ -1,0 +1,205 @@
+use super::{Collection, Generator, TestCase, fnv1a_hash};
+use crate::test_case::invalid_argument;
+use std::borrow::Cow;
+
+const SUBSEQUENCE_LABEL: u64 = fnv1a_hash(b"hegel:subsequence");
+const PERMUTATION_LABEL: u64 = fnv1a_hash(b"hegel:permutation");
+
+/// Draw between `min_size` and `max_size` distinct indices in `0..n`, without
+/// replacement, in draw order. Shrinks towards fewer indices and towards the
+/// earliest not-yet-taken index, so the minimal sample is `0..min_size` in
+/// increasing order.
+fn draw_index_sample(tc: &TestCase, n: usize, min_size: usize, max_size: usize) -> Vec<usize> {
+    let mut remaining: Vec<usize> = (0..n).collect();
+    let mut chosen = Vec::new();
+    let mut collection = Collection::new(tc, min_size, Some(max_size));
+    while !remaining.is_empty() && collection.more() {
+        let j = tc.generate_integer_i64(0, remaining.len() as i64 - 1) as usize;
+        chosen.push(remaining.remove(j));
+    }
+    chosen
+}
+
+/// Generator that picks a subsequence of a fixed list of values: each drawn
+/// `Vec` contains a subset of the elements, in their original order.
+/// Created by [`subsequences()`].
+pub struct SubsequenceGenerator<'a, T: Clone> {
+    elements: Cow<'a, [T]>,
+    min_size: usize,
+    max_size: Option<usize>,
+}
+
+impl<'a, T: Clone> SubsequenceGenerator<'a, T> {
+    /// Set the minimum number of elements to include.
+    pub fn min_size(mut self, min_size: usize) -> Self {
+        self.min_size = min_size;
+        self
+    }
+
+    /// Set the maximum number of elements to include.
+    pub fn max_size(mut self, max_size: usize) -> Self {
+        self.max_size = Some(max_size);
+        self
+    }
+}
+
+impl<'a, T: Clone + Send + Sync + 'a> Generator<Vec<T>> for SubsequenceGenerator<'a, T> {
+    fn do_draw(&self, tc: &TestCase) -> Vec<T> {
+        let n = self.elements.len();
+        if let Some(max) = self.max_size {
+            if self.min_size > max {
+                invalid_argument!("Cannot have max_size < min_size");
+            }
+        }
+        if self.min_size > n {
+            invalid_argument!(
+                "Cannot generate a subsequence: min_size {} is larger than the {} elements in the sequence",
+                self.min_size,
+                n
+            );
+        }
+        let max_size = self.max_size.map_or(n, |m| m.min(n));
+        tc.start_span(SUBSEQUENCE_LABEL);
+        let mut indices = draw_index_sample(tc, n, self.min_size, max_size);
+        tc.stop_span(false);
+        indices.sort_unstable();
+        indices
+            .into_iter()
+            .map(|i| self.elements[i].clone())
+            .collect()
+    }
+}
+
+/// Generate subsequences of a fixed list of values.
+///
+/// Each drawn `Vec` contains a subset of the elements — anywhere from none of
+/// them to all of them, unless constrained with
+/// [`min_size`](SubsequenceGenerator::min_size) and
+/// [`max_size`](SubsequenceGenerator::max_size) — in their original order.
+/// Duplicates in the input are treated as distinct elements, so they can
+/// appear in the output up to as many times as they appear in the input.
+/// Shrinks towards fewer elements, taken from earlier in the list.
+///
+/// Accepts anything convertible into `Cow<[T]>`, including:
+/// - `Vec<T>` (consumed without re-allocation)
+/// - `&[T]` where `T: Clone` (borrowed, zero allocation)
+/// - `&Vec<T>` or `&[T; N]` (via coercion to `&[T]`)
+///
+/// # Example
+///
+/// ```no_run
+/// use hegel::generators as gs;
+///
+/// #[hegel::test]
+/// fn my_test(tc: hegel::TestCase) {
+///     let sub: Vec<i32> = tc.draw(gs::subsequences(vec![1, 2, 3, 4, 5]));
+///     assert!(sub.len() <= 5);
+/// }
+/// ```
+pub fn subsequences<'a, T, S>(elements: S) -> SubsequenceGenerator<'a, T>
+where
+    T: Clone + Send + Sync,
+    S: Into<Cow<'a, [T]>>,
+{
+    SubsequenceGenerator {
+        elements: elements.into(),
+        min_size: 0,
+        max_size: None,
+    }
+}
+
+/// Generator that reorders a fixed list of values. Created by
+/// [`permutations()`].
+pub struct PermutationGenerator<'a, T: Clone> {
+    elements: Cow<'a, [T]>,
+    min_size: Option<usize>,
+    max_size: Option<usize>,
+}
+
+impl<'a, T: Clone> PermutationGenerator<'a, T> {
+    /// Set the minimum number of elements to include. Setting either size
+    /// bound makes the generator draw a permutation of a subset of the
+    /// elements instead of all of them; the unset bound defaults to 0
+    /// (for `min_size`) or the full length (for `max_size`).
+    pub fn min_size(mut self, min_size: usize) -> Self {
+        self.min_size = Some(min_size);
+        self
+    }
+
+    /// Set the maximum number of elements to include. See
+    /// [`min_size`](Self::min_size) for how size bounds change what is
+    /// generated.
+    pub fn max_size(mut self, max_size: usize) -> Self {
+        self.max_size = Some(max_size);
+        self
+    }
+}
+
+impl<'a, T: Clone + Send + Sync + 'a> Generator<Vec<T>> for PermutationGenerator<'a, T> {
+    fn do_draw(&self, tc: &TestCase) -> Vec<T> {
+        let n = self.elements.len();
+        if let (Some(min), Some(max)) = (self.min_size, self.max_size) {
+            if min > max {
+                invalid_argument!("Cannot have max_size < min_size");
+            }
+        }
+        let min_size = if self.min_size.is_none() && self.max_size.is_none() {
+            n
+        } else {
+            self.min_size.unwrap_or(0)
+        };
+        if min_size > n {
+            invalid_argument!(
+                "Cannot generate a permutation: min_size {} is larger than the {} elements in the sequence",
+                min_size,
+                n
+            );
+        }
+        let max_size = self.max_size.map_or(n, |m| m.min(n));
+        tc.start_span(PERMUTATION_LABEL);
+        let indices = draw_index_sample(tc, n, min_size, max_size);
+        tc.stop_span(false);
+        indices
+            .into_iter()
+            .map(|i| self.elements[i].clone())
+            .collect()
+    }
+}
+
+/// Generate permutations of a fixed list of values.
+///
+/// By default each drawn `Vec` contains all of the elements in a randomly
+/// chosen order, shrinking towards the original order. Setting
+/// [`min_size`](PermutationGenerator::min_size) or
+/// [`max_size`](PermutationGenerator::max_size) instead draws an ordered
+/// sample without replacement: a permutation of a subset of the elements,
+/// with a size in the given bounds, shrinking towards fewer elements, taken
+/// from earlier in the list, in their original order.
+///
+/// Accepts anything convertible into `Cow<[T]>`, including:
+/// - `Vec<T>` (consumed without re-allocation)
+/// - `&[T]` where `T: Clone` (borrowed, zero allocation)
+/// - `&Vec<T>` or `&[T; N]` (via coercion to `&[T]`)
+///
+/// # Example
+///
+/// ```no_run
+/// use hegel::generators as gs;
+///
+/// #[hegel::test]
+/// fn my_test(tc: hegel::TestCase) {
+///     let perm: Vec<i32> = tc.draw(gs::permutations(vec![1, 2, 3, 4, 5]));
+///     assert_eq!(perm.len(), 5);
+/// }
+/// ```
+pub fn permutations<'a, T, S>(elements: S) -> PermutationGenerator<'a, T>
+where
+    T: Clone + Send + Sync,
+    S: Into<Cow<'a, [T]>>,
+{
+    PermutationGenerator {
+        elements: elements.into(),
+        min_size: None,
+        max_size: None,
+    }
+}

--- a/src/generators/sequences.rs
+++ b/src/generators/sequences.rs
@@ -6,6 +6,7 @@ use std::borrow::Cow;
 
 const SUBSEQUENCE_LABEL: u64 = fnv1a_hash(b"hegel:subsequence");
 const PERMUTATION_LABEL: u64 = fnv1a_hash(b"hegel:permutation");
+const SAMPLE_LABEL: u64 = fnv1a_hash(b"hegel:sample");
 
 /// Draw between `min_size` and `max_size` distinct indices in `0..n`, without
 /// replacement, in draw order. Shrinks towards fewer indices and towards the
@@ -122,52 +123,13 @@ where
 /// [`permutations()`].
 pub struct PermutationGenerator<'a, T: Clone> {
     elements: Cow<'a, [T]>,
-    min_size: Option<usize>,
-    max_size: Option<usize>,
-}
-
-impl<'a, T: Clone> PermutationGenerator<'a, T> {
-    /// Set the minimum number of elements to include. Setting either size
-    /// bound makes the generator draw a permutation of a subset of the
-    /// elements instead of all of them; the unset bound defaults to 0
-    /// (for `min_size`) or the full length (for `max_size`).
-    pub fn min_size(mut self, min_size: usize) -> Self {
-        self.min_size = Some(min_size);
-        self
-    }
-
-    /// Set the maximum number of elements to include. See
-    /// [`min_size`](Self::min_size) for how size bounds change what is
-    /// generated.
-    pub fn max_size(mut self, max_size: usize) -> Self {
-        self.max_size = Some(max_size);
-        self
-    }
 }
 
 impl<'a, T: Clone + Send + Sync + 'a> Generator<Vec<T>> for PermutationGenerator<'a, T> {
     fn do_draw(&self, tc: &TestCase) -> Vec<T> {
         let n = self.elements.len();
-        if let (Some(min), Some(max)) = (self.min_size, self.max_size) {
-            if min > max {
-                invalid_argument!("Cannot have max_size < min_size");
-            }
-        }
-        let min_size = if self.min_size.is_none() && self.max_size.is_none() {
-            n
-        } else {
-            self.min_size.unwrap_or(0)
-        };
-        if min_size > n {
-            invalid_argument!(
-                "Cannot generate a permutation: min_size {} is larger than the {} elements in the sequence",
-                min_size,
-                n
-            );
-        }
-        let max_size = self.max_size.map_or(n, |m| m.min(n));
         tc.start_span(PERMUTATION_LABEL);
-        let indices = draw_index_sample(tc, n, min_size, max_size);
+        let indices = draw_index_sample(tc, n, n, n);
         tc.stop_span(false);
         indices
             .into_iter()
@@ -186,13 +148,10 @@ impl<'a, T: Clone + Send + Sync + PrettyPrintable + 'a> PrintableGenerator<Vec<T
 
 /// Generate permutations of a fixed list of values.
 ///
-/// By default each drawn `Vec` contains all of the elements in a randomly
-/// chosen order, shrinking towards the original order. Setting
-/// [`min_size`](PermutationGenerator::min_size) or
-/// [`max_size`](PermutationGenerator::max_size) instead draws an ordered
-/// sample without replacement: a permutation of a subset of the elements,
-/// with a size in the given bounds, shrinking towards fewer elements, taken
-/// from earlier in the list, in their original order.
+/// Each drawn `Vec` contains all of the elements in a randomly chosen order,
+/// shrinking towards the original order. To draw a reordered subset of the
+/// elements instead, use [`samples()`] with
+/// [`without_replacement`](SampleGenerator::without_replacement).
 ///
 /// Accepts anything convertible into `Cow<[T]>`, including:
 /// - `Vec<T>` (consumed without re-allocation)
@@ -217,7 +176,144 @@ where
 {
     PermutationGenerator {
         elements: elements.into(),
-        min_size: None,
+    }
+}
+
+/// Generator that samples from a fixed list of values. Created by
+/// [`samples()`].
+pub struct SampleGenerator<'a, T: Clone> {
+    elements: Cow<'a, [T]>,
+    min_size: usize,
+    max_size: Option<usize>,
+    replacement: bool,
+}
+
+impl<'a, T: Clone> SampleGenerator<'a, T> {
+    /// Set the minimum number of elements to include.
+    pub fn min_size(mut self, min_size: usize) -> Self {
+        self.min_size = min_size;
+        self
+    }
+
+    /// Set the maximum number of elements to include. When sampling without
+    /// replacement this is additionally capped at the number of elements in
+    /// the list.
+    pub fn max_size(mut self, max_size: usize) -> Self {
+        self.max_size = Some(max_size);
+        self
+    }
+
+    /// Sample with replacement: each element of the result is chosen
+    /// independently from the full list, so the same value can appear any
+    /// number of times. This is the default.
+    pub fn with_replacement(mut self) -> Self {
+        self.replacement = true;
+        self
+    }
+
+    /// Sample without replacement: each element of the list is used at most
+    /// once, so the result is a reordered subset of the list. Duplicates in
+    /// the input are treated as distinct elements, so they can appear in the
+    /// output up to as many times as they appear in the input.
+    pub fn without_replacement(mut self) -> Self {
+        self.replacement = false;
+        self
+    }
+}
+
+impl<'a, T: Clone + Send + Sync + 'a> Generator<Vec<T>> for SampleGenerator<'a, T> {
+    fn do_draw(&self, tc: &TestCase) -> Vec<T> {
+        let n = self.elements.len();
+        if let Some(max) = self.max_size {
+            if self.min_size > max {
+                invalid_argument!("Cannot have max_size < min_size");
+            }
+        }
+        if self.replacement {
+            if n == 0 && self.min_size > 0 {
+                invalid_argument!("Cannot generate a non-empty sample from an empty sequence");
+            }
+            let max_size = if n == 0 { Some(0) } else { self.max_size };
+            tc.start_span(SAMPLE_LABEL);
+            let mut collection = Collection::new(tc, self.min_size, max_size);
+            let mut result = Vec::new();
+            while collection.more() {
+                let i = tc.generate_integer_i64(0, n as i64 - 1) as usize;
+                result.push(self.elements[i].clone());
+            }
+            tc.stop_span(false);
+            result
+        } else {
+            if self.min_size > n {
+                invalid_argument!(
+                    "Cannot generate a sample without replacement: min_size {} is larger than the {} elements in the sequence",
+                    self.min_size,
+                    n
+                );
+            }
+            let max_size = self.max_size.map_or(n, |m| m.min(n));
+            tc.start_span(SAMPLE_LABEL);
+            let indices = draw_index_sample(tc, n, self.min_size, max_size);
+            tc.stop_span(false);
+            indices
+                .into_iter()
+                .map(|i| self.elements[i].clone())
+                .collect()
+        }
+    }
+}
+
+impl<'a, T: Clone + Send + Sync + PrettyPrintable + 'a> PrintableGenerator<Vec<T>>
+    for SampleGenerator<'a, T>
+{
+    fn do_draw_and_print(&self, tc: &TestCase, printer: &mut PrettyPrinter) -> Vec<T> {
+        draw_and_print_value(self, tc, printer)
+    }
+}
+
+/// Generate samples from a fixed list of values.
+///
+/// By default each drawn `Vec` is a sample **with replacement**: every
+/// element is chosen independently from the full list, so the same value can
+/// appear any number of times, and the size is unbounded unless constrained
+/// with [`min_size`](SampleGenerator::min_size) and
+/// [`max_size`](SampleGenerator::max_size). Calling
+/// [`without_replacement`](SampleGenerator::without_replacement) switches to
+/// sampling **without replacement**: each element of the list is used at most
+/// once, so the result is a reordered subset of the list, with at most as
+/// many elements as the list itself. Samples shrink towards fewer elements,
+/// taken from earlier in the list.
+///
+/// To draw a single element, use [`sampled_from()`](super::sampled_from); to
+/// reorder the whole list, use [`permutations()`]; to pick a subset while
+/// preserving the original order, use [`subsequences()`].
+///
+/// Accepts anything convertible into `Cow<[T]>`, including:
+/// - `Vec<T>` (consumed without re-allocation)
+/// - `&[T]` where `T: Clone` (borrowed, zero allocation)
+/// - `&Vec<T>` or `&[T; N]` (via coercion to `&[T]`)
+///
+/// # Example
+///
+/// ```no_run
+/// use hegel::generators as gs;
+///
+/// #[hegel::test]
+/// fn my_test(tc: hegel::TestCase) {
+///     let with: Vec<i32> = tc.draw(gs::samples(vec![1, 2, 3]).max_size(10));
+///     let without: Vec<i32> = tc.draw(gs::samples(vec![1, 2, 3]).without_replacement());
+///     assert!(without.len() <= 3);
+/// }
+/// ```
+pub fn samples<'a, T, S>(elements: S) -> SampleGenerator<'a, T>
+where
+    T: Clone + Send + Sync,
+    S: Into<Cow<'a, [T]>>,
+{
+    SampleGenerator {
+        elements: elements.into(),
+        min_size: 0,
         max_size: None,
+        replacement: true,
     }
 }

--- a/src/generators/sequences.rs
+++ b/src/generators/sequences.rs
@@ -1,4 +1,6 @@
-use super::{Collection, Generator, TestCase, fnv1a_hash};
+use super::generators::draw_and_print_value;
+use super::{Collection, Generator, PrintableGenerator, TestCase, fnv1a_hash};
+use crate::pretty::{PrettyPrintable, PrettyPrinter};
 use crate::test_case::invalid_argument;
 use std::borrow::Cow;
 
@@ -67,6 +69,14 @@ impl<'a, T: Clone + Send + Sync + 'a> Generator<Vec<T>> for SubsequenceGenerator
             .into_iter()
             .map(|i| self.elements[i].clone())
             .collect()
+    }
+}
+
+impl<'a, T: Clone + Send + Sync + PrettyPrintable + 'a> PrintableGenerator<Vec<T>>
+    for SubsequenceGenerator<'a, T>
+{
+    fn do_draw_and_print(&self, tc: &TestCase, printer: &mut PrettyPrinter) -> Vec<T> {
+        draw_and_print_value(self, tc, printer)
     }
 }
 
@@ -163,6 +173,14 @@ impl<'a, T: Clone + Send + Sync + 'a> Generator<Vec<T>> for PermutationGenerator
             .into_iter()
             .map(|i| self.elements[i].clone())
             .collect()
+    }
+}
+
+impl<'a, T: Clone + Send + Sync + PrettyPrintable + 'a> PrintableGenerator<Vec<T>>
+    for PermutationGenerator<'a, T>
+{
+    fn do_draw_and_print(&self, tc: &TestCase, printer: &mut PrettyPrinter) -> Vec<T> {
+        draw_and_print_value(self, tc, printer)
     }
 }
 

--- a/tests/test_printable_generators.rs
+++ b/tests/test_printable_generators.rs
@@ -483,6 +483,15 @@ fn subsequences_print_the_drawn_value() {
 }
 
 #[test]
+fn samples_print_the_drawn_value() {
+    let lines = failing_lines(|tc| {
+        let _: Vec<i32> = tc.draw(gs::samples(vec![1, 2, 3]).max_size(5));
+        panic!("boom");
+    });
+    assert_eq!(lines, vec!["let draw_1 = vec![];"]);
+}
+
+#[test]
 fn permutations_print_the_drawn_value() {
     let lines = failing_lines(|tc| {
         let _: Vec<i32> = tc.draw(gs::permutations(vec![1, 2, 3]));

--- a/tests/test_printable_generators.rs
+++ b/tests/test_printable_generators.rs
@@ -474,6 +474,24 @@ fn filtered_sampled_from_prints_the_chosen_value() {
 }
 
 #[test]
+fn subsequences_print_the_drawn_value() {
+    let lines = failing_lines(|tc| {
+        let _: Vec<i32> = tc.draw(gs::subsequences(vec![1, 2, 3]));
+        panic!("boom");
+    });
+    assert_eq!(lines, vec!["let draw_1 = vec![];"]);
+}
+
+#[test]
+fn permutations_print_the_drawn_value() {
+    let lines = failing_lines(|tc| {
+        let _: Vec<i32> = tc.draw(gs::permutations(vec![1, 2, 3]));
+        panic!("boom");
+    });
+    assert_eq!(lines, vec!["let draw_1 = vec![1, 2, 3];"]);
+}
+
+#[test]
 fn invalid_collection_sizes_report_while_printing() {
     for body in [
         (|tc: hegel::TestCase| {

--- a/tests/test_sequences.rs
+++ b/tests/test_sequences.rs
@@ -42,19 +42,44 @@ fn test_permutations_contain_all_elements() {
 }
 
 #[test]
-fn test_permutations_min_size() {
+fn test_samples_default() {
+    check_can_generate_examples(gs::samples(vec![1, 2, 3]));
+}
+
+#[test]
+fn test_samples_min_size() {
+    assert_all_examples(gs::samples(vec![1, 2, 3, 4]).min_size(2), |s: &Vec<i32>| {
+        s.len() >= 2 && s.iter().all(|x| (1..=4).contains(x))
+    });
+}
+
+#[test]
+fn test_samples_max_size() {
+    assert_all_examples(gs::samples(vec![1, 2, 3, 4]).max_size(2), |s: &Vec<i32>| {
+        s.len() <= 2 && s.iter().all(|x| (1..=4).contains(x))
+    });
+}
+
+#[test]
+fn test_samples_with_replacement_can_repeat_elements() {
+    let sample = minimal(
+        gs::samples(vec![1, 2]).with_replacement().max_size(5),
+        |s: &Vec<i32>| s.iter().filter(|&&x| x == 2).count() >= 2,
+    );
+    assert_eq!(sample, vec![2, 2]);
+}
+
+#[test]
+fn test_samples_without_replacement() {
     assert_all_examples(
-        gs::permutations(vec![1, 2, 3, 4]).min_size(2),
-        |p: &Vec<i32>| p.len() >= 2 && is_sample(p, &[1, 2, 3, 4]),
+        gs::samples(vec![1, 2, 3, 4]).without_replacement(),
+        |s: &Vec<i32>| s.len() <= 4 && is_sample(s, &[1, 2, 3, 4]),
     );
 }
 
 #[test]
-fn test_permutations_max_size() {
-    assert_all_examples(
-        gs::permutations(vec![1, 2, 3, 4]).max_size(2),
-        |p: &Vec<i32>| p.len() <= 2 && is_sample(p, &[1, 2, 3, 4]),
-    );
+fn test_samples_of_empty_sequence_are_empty() {
+    assert_all_examples(gs::samples(Vec::<i32>::new()), |s: &Vec<i32>| s.is_empty());
 }
 
 #[test]
@@ -95,6 +120,14 @@ fn test_permutations_in_vec() {
 }
 
 #[test]
+fn test_samples_in_vec() {
+    assert_all_examples(
+        gs::vecs(gs::samples(vec![1, 2, 3]).max_size(3)).max_size(5),
+        |v: &Vec<Vec<i32>>| v.iter().all(|s| s.iter().all(|x| (1..=3).contains(x))),
+    );
+}
+
+#[test]
 fn test_subsequences_in_vec() {
     assert_all_examples(
         gs::vecs(gs::subsequences(vec![1, 2, 3])).max_size(5),
@@ -128,7 +161,7 @@ fn test_permutations_property(tc: TestCase) {
 }
 
 #[hegel::test]
-fn test_permutations_size_property(tc: TestCase) {
+fn test_samples_without_replacement_size_property(tc: TestCase) {
     let source: Vec<i32> = tc.draw(gs::vecs(gs::integers::<i32>()).max_size(10));
     let min = tc.draw(gs::integers::<usize>().min_value(0).max_value(source.len()));
     let max = tc.draw(
@@ -136,9 +169,24 @@ fn test_permutations_size_property(tc: TestCase) {
             .min_value(min)
             .max_value(source.len()),
     );
-    let perm = tc.draw(gs::permutations(source.clone()).min_size(min).max_size(max));
-    assert!(perm.len() >= min && perm.len() <= max);
-    assert!(is_sample(&perm, &source));
+    let sample = tc.draw(
+        gs::samples(source.clone())
+            .without_replacement()
+            .min_size(min)
+            .max_size(max),
+    );
+    assert!(sample.len() >= min && sample.len() <= max);
+    assert!(is_sample(&sample, &source));
+}
+
+#[hegel::test]
+fn test_samples_with_replacement_size_property(tc: TestCase) {
+    let source: Vec<i32> = tc.draw(gs::vecs(gs::integers::<i32>()).min_size(1).max_size(10));
+    let min = tc.draw(gs::integers::<usize>().min_value(0).max_value(20));
+    let max = tc.draw(gs::integers::<usize>().min_value(min).max_value(20));
+    let sample = tc.draw(gs::samples(source.clone()).min_size(min).max_size(max));
+    assert!(sample.len() >= min && sample.len() <= max);
+    assert!(sample.iter().all(|x| source.contains(x)));
 }
 
 #[hegel::test]
@@ -179,4 +227,27 @@ fn test_subsequences_shrink_to_empty() {
 fn test_subsequences_shrink_to_prefix() {
     let sub = minimal(gs::subsequences(vec![1, 2, 3, 4, 5]).min_size(3), |_| true);
     assert_eq!(sub, vec![1, 2, 3]);
+}
+
+#[test]
+fn test_samples_shrink_to_empty() {
+    let sample = minimal(gs::samples(vec![1, 2, 3]).max_size(5), |_| true);
+    assert!(sample.is_empty());
+}
+
+#[test]
+fn test_samples_with_replacement_shrink_to_repeated_first_element() {
+    let sample = minimal(gs::samples(vec![1, 2, 3]).min_size(3).max_size(5), |_| true);
+    assert_eq!(sample, vec![1, 1, 1]);
+}
+
+#[test]
+fn test_samples_without_replacement_shrink_to_prefix() {
+    let sample = minimal(
+        gs::samples(vec![1, 2, 3, 4, 5])
+            .without_replacement()
+            .min_size(3),
+        |_| true,
+    );
+    assert_eq!(sample, vec![1, 2, 3]);
 }

--- a/tests/test_sequences.rs
+++ b/tests/test_sequences.rs
@@ -11,13 +11,15 @@ fn is_subsequence<T: PartialEq>(sub: &[T], source: &[T]) -> bool {
 
 fn is_sample<T: PartialEq + Clone>(sample: &[T], source: &[T]) -> bool {
     let mut pool = source.to_vec();
-    sample.iter().all(|x| match pool.iter().position(|y| y == x) {
-        Some(i) => {
-            pool.remove(i);
-            true
-        }
-        None => false,
-    })
+    sample
+        .iter()
+        .all(|x| match pool.iter().position(|y| y == x) {
+            Some(i) => {
+                pool.remove(i);
+                true
+            }
+            None => false,
+        })
 }
 
 #[test]

--- a/tests/test_sequences.rs
+++ b/tests/test_sequences.rs
@@ -1,0 +1,180 @@
+mod common;
+
+use common::utils::{assert_all_examples, check_can_generate_examples, minimal};
+use hegel::TestCase;
+use hegel::generators as gs;
+
+fn is_subsequence<T: PartialEq>(sub: &[T], source: &[T]) -> bool {
+    let mut it = source.iter();
+    sub.iter().all(|x| it.any(|y| y == x))
+}
+
+fn is_sample<T: PartialEq + Clone>(sample: &[T], source: &[T]) -> bool {
+    let mut pool = source.to_vec();
+    sample.iter().all(|x| match pool.iter().position(|y| y == x) {
+        Some(i) => {
+            pool.remove(i);
+            true
+        }
+        None => false,
+    })
+}
+
+#[test]
+fn test_permutations_default() {
+    check_can_generate_examples(gs::permutations(vec![1, 2, 3]));
+}
+
+#[test]
+fn test_subsequences_default() {
+    check_can_generate_examples(gs::subsequences(vec![1, 2, 3]));
+}
+
+#[test]
+fn test_permutations_contain_all_elements() {
+    assert_all_examples(gs::permutations(vec![1, 2, 3, 4]), |p: &Vec<i32>| {
+        let mut sorted = p.clone();
+        sorted.sort_unstable();
+        sorted == vec![1, 2, 3, 4]
+    });
+}
+
+#[test]
+fn test_permutations_min_size() {
+    assert_all_examples(
+        gs::permutations(vec![1, 2, 3, 4]).min_size(2),
+        |p: &Vec<i32>| p.len() >= 2 && is_sample(p, &[1, 2, 3, 4]),
+    );
+}
+
+#[test]
+fn test_permutations_max_size() {
+    assert_all_examples(
+        gs::permutations(vec![1, 2, 3, 4]).max_size(2),
+        |p: &Vec<i32>| p.len() <= 2 && is_sample(p, &[1, 2, 3, 4]),
+    );
+}
+
+#[test]
+fn test_subsequences_preserve_order() {
+    assert_all_examples(gs::subsequences(vec![1, 2, 3, 4, 5]), |s: &Vec<i32>| {
+        s.len() <= 5 && is_subsequence(s, &[1, 2, 3, 4, 5])
+    });
+}
+
+#[test]
+fn test_subsequences_min_size() {
+    assert_all_examples(
+        gs::subsequences(vec![1, 2, 3, 4, 5]).min_size(2),
+        |s: &Vec<i32>| s.len() >= 2 && is_subsequence(s, &[1, 2, 3, 4, 5]),
+    );
+}
+
+#[test]
+fn test_subsequences_max_size() {
+    assert_all_examples(
+        gs::subsequences(vec![1, 2, 3, 4, 5]).max_size(3),
+        |s: &Vec<i32>| s.len() <= 3 && is_subsequence(s, &[1, 2, 3, 4, 5]),
+    );
+}
+
+#[test]
+fn test_permutations_in_vec() {
+    assert_all_examples(
+        gs::vecs(gs::permutations(vec![1, 2, 3])).max_size(5),
+        |v: &Vec<Vec<i32>>| {
+            v.iter().all(|p| {
+                let mut sorted = p.clone();
+                sorted.sort_unstable();
+                sorted == vec![1, 2, 3]
+            })
+        },
+    );
+}
+
+#[test]
+fn test_subsequences_in_vec() {
+    assert_all_examples(
+        gs::vecs(gs::subsequences(vec![1, 2, 3])).max_size(5),
+        |v: &Vec<Vec<i32>>| v.iter().all(|s| is_subsequence(s, &[1, 2, 3])),
+    );
+}
+
+#[hegel::test]
+fn test_permutations_accepts_slice(tc: TestCase) {
+    const NAMES: &[&str] = &["alice", "bob", "carol"];
+    let perm = tc.draw(gs::permutations(NAMES));
+    assert!(perm.len() == 3 && is_sample(&perm, NAMES));
+}
+
+#[hegel::test]
+fn test_subsequences_accepts_slice(tc: TestCase) {
+    const NAMES: &[&str] = &["alice", "bob", "carol"];
+    let sub = tc.draw(gs::subsequences(NAMES));
+    assert!(is_subsequence(&sub, NAMES));
+}
+
+#[hegel::test]
+fn test_permutations_property(tc: TestCase) {
+    let source: Vec<i32> = tc.draw(gs::vecs(gs::integers::<i32>()).max_size(10));
+    let perm = tc.draw(gs::permutations(source.clone()));
+    let mut expected = source;
+    let mut actual = perm;
+    expected.sort_unstable();
+    actual.sort_unstable();
+    assert_eq!(expected, actual);
+}
+
+#[hegel::test]
+fn test_permutations_size_property(tc: TestCase) {
+    let source: Vec<i32> = tc.draw(gs::vecs(gs::integers::<i32>()).max_size(10));
+    let min = tc.draw(gs::integers::<usize>().min_value(0).max_value(source.len()));
+    let max = tc.draw(
+        gs::integers::<usize>()
+            .min_value(min)
+            .max_value(source.len()),
+    );
+    let perm = tc.draw(gs::permutations(source.clone()).min_size(min).max_size(max));
+    assert!(perm.len() >= min && perm.len() <= max);
+    assert!(is_sample(&perm, &source));
+}
+
+#[hegel::test]
+fn test_subsequences_size_property(tc: TestCase) {
+    let source: Vec<i32> = tc.draw(gs::vecs(gs::integers::<i32>()).max_size(10));
+    let min = tc.draw(gs::integers::<usize>().min_value(0).max_value(source.len()));
+    let max = tc.draw(
+        gs::integers::<usize>()
+            .min_value(min)
+            .max_value(source.len()),
+    );
+    let sub = tc.draw(gs::subsequences(source.clone()).min_size(min).max_size(max));
+    assert!(sub.len() >= min && sub.len() <= max);
+    assert!(is_subsequence(&sub, &source));
+}
+
+#[test]
+fn test_permutations_shrink_to_original_order() {
+    let perm = minimal(gs::permutations(vec![3, 1, 2]), |_| true);
+    assert_eq!(perm, vec![3, 1, 2]);
+}
+
+#[test]
+fn test_permutations_shrink_moves_one_element() {
+    let perm = minimal(gs::permutations(vec![1, 2, 3, 4, 5]), |p: &Vec<i32>| {
+        p[0] == 5
+    });
+    assert_eq!(perm, vec![5, 1, 2, 3, 4]);
+}
+
+#[test]
+fn test_subsequences_shrink_to_empty() {
+    let sub = minimal(gs::subsequences(vec![1, 2, 3, 4, 5]), |_| true);
+    assert!(sub.is_empty());
+}
+
+#[test]
+fn test_subsequences_shrink_to_prefix() {
+    let sub = minimal(gs::subsequences(vec![1, 2, 3, 4, 5]).min_size(3), |_| true);
+    assert_eq!(sub, vec![1, 2, 3]);
+}

--- a/tests/test_validation.rs
+++ b/tests/test_validation.rs
@@ -201,17 +201,25 @@ fn test_hashmaps_min_greater_than_max() {
 }
 
 #[test]
-fn test_permutations_min_greater_than_max() {
+fn test_samples_min_greater_than_max() {
     expect_draw_panic(
-        gs::permutations(vec![1, 2, 3]).min_size(3).max_size(2),
+        gs::samples(vec![1, 2, 3]).min_size(3).max_size(2),
         "max_size < min_size",
     );
 }
 
 #[test]
-fn test_permutations_min_size_too_large() {
+fn test_samples_nonempty_from_empty_sequence() {
     expect_draw_panic(
-        gs::permutations(vec![1, 2, 3]).min_size(4),
+        gs::samples(Vec::<i32>::new()).min_size(1),
+        "non-empty sample from an empty sequence",
+    );
+}
+
+#[test]
+fn test_samples_without_replacement_min_size_too_large() {
+    expect_draw_panic(
+        gs::samples(vec![1, 2, 3]).without_replacement().min_size(4),
         "min_size 4 is larger than the 3 elements",
     );
 }

--- a/tests/test_validation.rs
+++ b/tests/test_validation.rs
@@ -201,6 +201,38 @@ fn test_hashmaps_min_greater_than_max() {
 }
 
 #[test]
+fn test_permutations_min_greater_than_max() {
+    expect_draw_panic(
+        gs::permutations(vec![1, 2, 3]).min_size(3).max_size(2),
+        "max_size < min_size",
+    );
+}
+
+#[test]
+fn test_permutations_min_size_too_large() {
+    expect_draw_panic(
+        gs::permutations(vec![1, 2, 3]).min_size(4),
+        "min_size 4 is larger than the 3 elements",
+    );
+}
+
+#[test]
+fn test_subsequences_min_greater_than_max() {
+    expect_draw_panic(
+        gs::subsequences(vec![1, 2, 3]).min_size(3).max_size(2),
+        "max_size < min_size",
+    );
+}
+
+#[test]
+fn test_subsequences_min_size_too_large() {
+    expect_draw_panic(
+        gs::subsequences(vec![1, 2, 3]).min_size(4),
+        "min_size 4 is larger than the 3 elements",
+    );
+}
+
+#[test]
 fn test_domains_max_length_too_small() {
     expect_draw_panic(
         gs::domains().max_length(2),


### PR DESCRIPTION
<details>
<summary>This PR description was AI generated</summary>

This ports proptest's two missing sequence combinators, `sample::subsequence` and `prop_shuffle`, as generators over a fixed list of values:

- **`gs::subsequences(values)`** draws a subset of the elements in their original order.
- **`gs::permutations(values)`** draws all the elements in a randomly chosen order.

Both accept anything convertible to `Cow<[T]>` (like `sampled_from`) and support `min_size`/`max_size` bounds. Setting size bounds on `permutations` draws an ordered sample without replacement (a k-permutation), which neither proptest nor Hypothesis offers directly.

Both generators share one primitive: drawing distinct indices without replacement from a shrinking pool via the engine's collection protocol, the same approach `hashsets` uses. This gives good shrinking:

- permutations shrink towards the original order (and e.g. "element 5 must come first" shrinks to `[5, 1, 2, 3, 4]`, keeping the remaining elements in order)
- subsequences shrink towards fewer elements, taken from earlier in the list

Tests cover the standard new-generator checklist (sanity, per-builder-method, composition in `vecs`, randomized-bound properties, validation panics) plus shrink-quality tests using `minimal()`.

A `.shuffled()` combinator for generated (rather than fixed) vecs was considered and deliberately left out: a survey of real `prop_shuffle` usage on GitHub showed every pattern is expressible as `tc.draw(gs::permutations(constructed_vec))` thanks to interactive draws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>