### PR TITLE
Make recursive() print compositionally

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,8 @@
+RELEASE_TYPE: minor
+
+This release makes `generators::recursive()` print compositionally: the result is a `PrintableGenerator` exactly when the leaf generator and the generator the branch function returns both are, and drawn values print with those generators' own representations. Previously the result was printable whenever the produced type implemented `PrettyPrintable`, printing by value and ignoring how the component generators print. `SubtreeGenerator` is now a `PrintableGenerator` too, so branch functions can pass subtrees to printable combinators and draw them with `tc.draw(..)`.
+
+Migration notes:
+
+- `RecursiveGenerator` now carries its component generator types (`RecursiveGenerator<T, G, F, R>`), which include closure types, so helper functions can no longer name it as a return type: return `impl Generator<T>` (or `impl PrintableGenerator<T>`) instead, applying `max_depth`/`max_leaves` before returning.
+- A recursive generator whose leaf or branch generator is not printable no longer satisfies `tc.draw(..)` even when the produced type implements `PrettyPrintable`; make the component printable (`.print_as_value()`, `.print_as_debug()`, or `.print_with(..)`) or draw with `tc.draw_silent(..)`.

--- a/src/generators/generators.rs
+++ b/src/generators/generators.rs
@@ -191,7 +191,7 @@ pub trait Generator<T> {
 /// [`Generator`] can still be drawn with [`TestCase::draw_silent`]. Most
 /// generators in the library are printable — leaves unconditionally,
 /// structural combinators (collections, tuples, `optional`, `one_of!`,
-/// `flat_map`) whenever their component generators are, and value-transforming
+/// `flat_map`, `recursive`) whenever their component generators are, and value-transforming
 /// combinators (`map`, `filter`, `just`, `sampled_from`, composites) whenever
 /// the produced type implements [`PrettyPrintable`]. For everything else
 /// there are [`Generator::print_as_value`], [`Generator::print_as_debug`],

--- a/src/generators/recursive.rs
+++ b/src/generators/recursive.rs
@@ -1,6 +1,7 @@
-use super::{Generator, TestCase};
+use super::{Generator, PrintableGenerator, TestCase};
 use crate::control::{AttemptMispriced, LeafBudgetExceeded, raise_control};
 use crate::ffi::RecursionHandle;
+use crate::pretty::PrettyPrinter;
 use crate::test_case::{labels, raise_for_rc};
 use hegel_c::hegel_result_t;
 use std::marker::PhantomData;
@@ -12,30 +13,73 @@ const DEFAULT_MAX_LEAVES: usize = 100;
 
 /// The leaf generator and branch function of a [`recursive()`] generator,
 /// type-erased so that [`SubtreeGenerator`] (which appears in the branch
-/// function's own signature) does not need to name their types.
+/// function's own signature) does not need to name their types. The printer
+/// threads through both methods so one erased object serves both draw
+/// paths; the silent path passes the no-op printer.
 trait SubtreeDraw<T>: Send + Sync {
-    fn draw_leaf(&self, tc: &TestCase) -> T;
-    fn draw_branch(&self, tc: &TestCase, subtrees: SubtreeGenerator<T>) -> T;
+    fn draw_leaf(&self, tc: &TestCase, printer: &mut PrettyPrinter) -> T;
+    fn draw_branch(
+        &self,
+        tc: &TestCase,
+        subtrees: SubtreeGenerator<T>,
+        printer: &mut PrettyPrinter,
+    ) -> T;
 }
 
-struct RecursiveCore<G, F, R> {
-    leaf: G,
-    branch: F,
+/// The erased core of a silent draw: ignores the printer and draws the leaf
+/// and branch generators through [`Generator::do_draw`].
+struct SilentCore<G, F, R> {
+    leaf: Arc<G>,
+    branch: Arc<F>,
     _phantom: PhantomData<fn() -> R>,
 }
 
-impl<T, G, F, R> SubtreeDraw<T> for RecursiveCore<G, F, R>
+impl<T, G, F, R> SubtreeDraw<T> for SilentCore<G, F, R>
 where
     G: Generator<T> + Send + Sync,
     F: Fn(SubtreeGenerator<T>) -> R + Send + Sync,
     R: Generator<T>,
 {
-    fn draw_leaf(&self, tc: &TestCase) -> T {
+    fn draw_leaf(&self, tc: &TestCase, _printer: &mut PrettyPrinter) -> T {
         self.leaf.do_draw(tc)
     }
 
-    fn draw_branch(&self, tc: &TestCase, subtrees: SubtreeGenerator<T>) -> T {
+    fn draw_branch(
+        &self,
+        tc: &TestCase,
+        subtrees: SubtreeGenerator<T>,
+        _printer: &mut PrettyPrinter,
+    ) -> T {
         (self.branch)(subtrees).do_draw(tc)
+    }
+}
+
+/// The erased core of a printing draw: draws the leaf and branch generators
+/// through [`TestCase::draw_and_print`], so each value prints with its own
+/// generator's representation.
+struct PrintingCore<G, F, R> {
+    leaf: Arc<G>,
+    branch: Arc<F>,
+    _phantom: PhantomData<fn() -> R>,
+}
+
+impl<T, G, F, R> SubtreeDraw<T> for PrintingCore<G, F, R>
+where
+    G: PrintableGenerator<T> + Send + Sync,
+    F: Fn(SubtreeGenerator<T>) -> R + Send + Sync,
+    R: PrintableGenerator<T>,
+{
+    fn draw_leaf(&self, tc: &TestCase, printer: &mut PrettyPrinter) -> T {
+        tc.draw_and_print(&*self.leaf, printer)
+    }
+
+    fn draw_branch(
+        &self,
+        tc: &TestCase,
+        subtrees: SubtreeGenerator<T>,
+        printer: &mut PrettyPrinter,
+    ) -> T {
+        tc.draw_and_print((self.branch)(subtrees), printer)
     }
 }
 
@@ -48,6 +92,12 @@ where
 /// Cloning is needed rather than borrowing (`tuples!(&subtrees, &subtrees)`)
 /// because the generator the branch function returns would otherwise borrow
 /// the function's own parameter.
+///
+/// It is a [`PrintableGenerator`], so branch functions can build on
+/// printable combinators and draw sub-values with
+/// [`draw`](crate::TestCase::draw); each sub-value actually prints exactly
+/// when the whole recursive generator does, with the leaf and branch
+/// generators' own representations.
 pub struct SubtreeGenerator<T> {
     core: Arc<dyn SubtreeDraw<T>>,
     recursion: Arc<RecursionHandle>,
@@ -72,22 +122,22 @@ impl<T> SubtreeGenerator<T> {
             depth: self.depth + 1,
         }
     }
-}
 
-impl<T> Generator<T> for SubtreeGenerator<T> {
-    fn do_draw(&self, tc: &TestCase) -> T {
+    /// The one leaf-or-branch body both draw paths run; the silent path
+    /// passes the no-op printer.
+    fn draw_subtree(&self, tc: &TestCase, printer: &mut PrettyPrinter) -> T {
         tc.start_span(labels::RECURSIVE);
         let branch = match tc.with_ctc(|ctc| ctc.recursion_branch(&self.recursion, self.depth)) {
             Ok(branch) => branch,
             Err(rc) => raise_for_rc(rc),
         };
         let result = if branch {
-            self.core.draw_branch(tc, self.child())
+            self.core.draw_branch(tc, self.child(), printer)
         } else {
             if let Err(rc) = tc.with_ctc(|ctc| ctc.recursion_leaf(&self.recursion)) {
                 raise_for_rc(rc);
             }
-            self.core.draw_leaf(tc)
+            self.core.draw_leaf(tc, printer)
         };
         if self.depth == 0 {
             if let Err(rc) = tc.with_ctc(|ctc| ctc.recursion_finish(&self.recursion)) {
@@ -102,14 +152,32 @@ impl<T> Generator<T> for SubtreeGenerator<T> {
     }
 }
 
-/// Generator for recursively defined data. Created by [`recursive()`].
-pub struct RecursiveGenerator<T> {
-    core: Arc<dyn SubtreeDraw<T>>,
-    max_depth: usize,
-    max_leaves: usize,
+impl<T> Generator<T> for SubtreeGenerator<T> {
+    fn do_draw(&self, tc: &TestCase) -> T {
+        self.draw_subtree(tc, &mut PrettyPrinter::noop())
+    }
 }
 
-impl<T> RecursiveGenerator<T> {
+impl<T> PrintableGenerator<T> for SubtreeGenerator<T> {
+    fn do_draw_and_print(&self, tc: &TestCase, printer: &mut PrettyPrinter) -> T {
+        self.draw_subtree(tc, printer)
+    }
+}
+
+/// Generator for recursively defined data. Created by [`recursive()`].
+///
+/// A [`PrintableGenerator`] exactly when the leaf generator and the
+/// generator the branch function returns both are; drawn values then print
+/// with those generators' own representations.
+pub struct RecursiveGenerator<T, G, F, R> {
+    leaf: Arc<G>,
+    branch: Arc<F>,
+    max_depth: usize,
+    max_leaves: usize,
+    _phantom: PhantomData<fn() -> (T, R)>,
+}
+
+impl<T, G, F, R> RecursiveGenerator<T, G, F, R> {
     /// Set the maximum nesting depth of branches (default 32).
     ///
     /// Sub-values at this depth are always leaves, so a `max_depth` of 0
@@ -133,10 +201,16 @@ impl<T> RecursiveGenerator<T> {
         self.max_leaves = max_leaves;
         self
     }
-}
 
-impl<T> Generator<T> for RecursiveGenerator<T> {
-    fn do_draw(&self, tc: &TestCase) -> T {
+    /// The one retry loop both draw paths run: each attempt draws inside a
+    /// speculative print region, so a discarded attempt (over the leaf
+    /// budget, or mispriced) discards whatever it printed.
+    fn draw_recursive(
+        &self,
+        tc: &TestCase,
+        core: Arc<dyn SubtreeDraw<T>>,
+        printer: &mut PrettyPrinter,
+    ) -> T {
         let base_span_depth = tc.open_span_depth();
         let recursion = match tc
             .with_ctc(|ctc| ctc.new_recursion(self.max_depth as u64, self.max_leaves as u64))
@@ -146,19 +220,27 @@ impl<T> Generator<T> for RecursiveGenerator<T> {
         };
         loop {
             let root = SubtreeGenerator {
-                core: Arc::clone(&self.core),
+                core: Arc::clone(&core),
                 recursion: Arc::clone(&recursion),
                 depth: 0,
             };
-            match catch_unwind(AssertUnwindSafe(|| root.do_draw(tc))) {
-                Ok(value) => return value,
+            let mut speculation = printer.speculate();
+            match catch_unwind(AssertUnwindSafe(|| {
+                root.draw_subtree(tc, speculation.printer())
+            })) {
+                Ok(value) => {
+                    speculation.commit();
+                    return value;
+                }
                 Err(payload) if payload.downcast_ref::<LeafBudgetExceeded>().is_some() => {
+                    speculation.abort();
                     match tc.with_ctc(|ctc| ctc.recursion_retry(&recursion)) {
                         Ok(()) => tc.reset_open_spans_to(base_span_depth),
                         Err(rc) => raise_for_rc(rc),
                     }
                 }
                 Err(payload) if payload.downcast_ref::<AttemptMispriced>().is_some() => {
+                    speculation.abort();
                     tc.reset_open_spans_to(base_span_depth);
                 }
                 Err(payload) => resume_unwind(payload),
@@ -167,9 +249,37 @@ impl<T> Generator<T> for RecursiveGenerator<T> {
     }
 }
 
-impl<T: crate::PrettyPrintable> super::PrintableGenerator<T> for RecursiveGenerator<T> {
-    fn do_draw_and_print(&self, tc: &TestCase, printer: &mut crate::PrettyPrinter) -> T {
-        super::generators::draw_and_print_value(self, tc, printer)
+impl<T, G, F, R> Generator<T> for RecursiveGenerator<T, G, F, R>
+where
+    T: 'static,
+    G: Generator<T> + Send + Sync + 'static,
+    F: Fn(SubtreeGenerator<T>) -> R + Send + Sync + 'static,
+    R: Generator<T> + 'static,
+{
+    fn do_draw(&self, tc: &TestCase) -> T {
+        let core: Arc<dyn SubtreeDraw<T>> = Arc::new(SilentCore {
+            leaf: Arc::clone(&self.leaf),
+            branch: Arc::clone(&self.branch),
+            _phantom: PhantomData,
+        });
+        self.draw_recursive(tc, core, &mut PrettyPrinter::noop())
+    }
+}
+
+impl<T, G, F, R> PrintableGenerator<T> for RecursiveGenerator<T, G, F, R>
+where
+    T: 'static,
+    G: PrintableGenerator<T> + Send + Sync + 'static,
+    F: Fn(SubtreeGenerator<T>) -> R + Send + Sync + 'static,
+    R: PrintableGenerator<T> + 'static,
+{
+    fn do_draw_and_print(&self, tc: &TestCase, printer: &mut PrettyPrinter) -> T {
+        let core: Arc<dyn SubtreeDraw<T>> = Arc::new(PrintingCore {
+            leaf: Arc::clone(&self.leaf),
+            branch: Arc::clone(&self.branch),
+            _phantom: PhantomData,
+        });
+        self.draw_recursive(tc, core, printer)
     }
 }
 
@@ -188,6 +298,9 @@ impl<T: crate::PrettyPrintable> super::PrintableGenerator<T> for RecursiveGenera
 /// [`max_leaves`](RecursiveGenerator::max_leaves) (attempts that draw more
 /// leaves than this are discarded and retried with a lower branching
 /// probability).
+///
+/// The result is a [`PrintableGenerator`] exactly when `leaf` and the
+/// generator `branch` returns both are.
 ///
 /// # Example
 ///
@@ -210,7 +323,7 @@ impl<T: crate::PrettyPrintable> super::PrintableGenerator<T> for RecursiveGenera
 ///     ));
 /// }
 /// ```
-pub fn recursive<T, G, F, R>(leaf: G, branch: F) -> RecursiveGenerator<T>
+pub fn recursive<T, G, F, R>(leaf: G, branch: F) -> RecursiveGenerator<T, G, F, R>
 where
     T: 'static,
     G: Generator<T> + Send + Sync + 'static,
@@ -218,12 +331,10 @@ where
     R: Generator<T> + 'static,
 {
     RecursiveGenerator {
-        core: Arc::new(RecursiveCore {
-            leaf,
-            branch,
-            _phantom: PhantomData,
-        }),
+        leaf: Arc::new(leaf),
+        branch: Arc::new(branch),
         max_depth: DEFAULT_MAX_DEPTH,
         max_leaves: DEFAULT_MAX_LEAVES,
+        _phantom: PhantomData,
     }
 }

--- a/tests/test_distributions.rs
+++ b/tests/test_distributions.rs
@@ -613,11 +613,13 @@ mod recursive {
         }
     }
 
-    fn trees() -> gs::RecursiveGenerator<Tree> {
-        gs::recursive(gs::integers::<i32>().map(Tree::Leaf), |subtrees| {
-            hegel::tuples!(subtrees.clone(), subtrees)
-                .map(|(left, right)| Tree::Branch(Box::new(left), Box::new(right)))
-        })
+    macro_rules! trees {
+        () => {
+            gs::recursive(gs::integers::<i32>().map(Tree::Leaf), |subtrees| {
+                hegel::tuples!(subtrees.clone(), subtrees)
+                    .map(|(left, right)| Tree::Branch(Box::new(left), Box::new(right)))
+            })
+        };
     }
 
     /// Sizes must cover the whole range the default caps allow: bare leaves,
@@ -628,7 +630,7 @@ mod recursive {
     /// vanish.
     #[test]
     fn recursive_trees_have_diverse_sizes() {
-        let vs = sample(4000, 0xE3, |tc| tc.draw_silent(trees()));
+        let vs = sample(4000, 0xE3, |tc| tc.draw_silent(trees!()));
         assert_min_rate(&vs, |t| t.leaf_count() == 1, 0.015, "single leaf");
         assert_min_rate(&vs, |t| t.leaf_count() >= 25, 0.06, "25+ leaves");
         assert_min_rate(&vs, |t| t.leaf_count() >= 90, 0.004, "near the leaf cap");
@@ -732,7 +734,7 @@ mod recursive {
     /// not be systematically bigger or branchier than their later siblings.
     #[test]
     fn recursive_trees_are_not_left_biased() {
-        let vs = sample(4000, 0xE2, |tc| tc.draw_silent(trees().max_leaves(8)));
+        let vs = sample(4000, 0xE2, |tc| tc.draw_silent(trees!().max_leaves(8)));
         let mut roots = 0usize;
         let mut left_leaves = 0usize;
         let mut right_leaves = 0usize;

--- a/tests/test_printable_generators.rs
+++ b/tests/test_printable_generators.rs
@@ -738,6 +738,62 @@ fn recursive_draws_print_their_values() {
     assert!(lines[0].starts_with("let draw_1 = "), "{lines:?}");
 }
 
+/// Recursive values print through their component generators — here the
+/// leaf and branch `print_with` representations — not by the produced
+/// value's own `PrettyPrintable` impl (which would print `1` and `2`).
+#[test]
+fn recursive_draws_print_through_their_component_generators() {
+    let lines = failing_lines(|tc| {
+        let total: i64 = tc.draw(
+            gs::recursive(gs::just(1i64).print_with(|_, p| p.text("leaf")), |sub| {
+                hegel::one_of!(
+                    sub.clone(),
+                    hegel::tuples!(sub.clone(), sub)
+                        .map(|(a, b)| a + b)
+                        .print_with(|v, p| p.text(&format!("add({v})"))),
+                )
+            })
+            .max_leaves(4),
+        );
+        assert!(total < 1);
+    });
+    assert_eq!(lines, vec!["let draw_1 = leaf;"]);
+}
+
+/// The minimal example needing one branch prints that branch's own
+/// representation.
+#[test]
+fn recursive_branch_draws_print_through_the_branch_generator() {
+    let lines = failing_lines(|tc| {
+        let total: i64 = tc.draw(
+            gs::recursive(gs::just(1i64).print_with(|_, p| p.text("leaf")), |sub| {
+                hegel::tuples!(sub.clone(), sub)
+                    .map(|(a, b)| a + b)
+                    .print_with(|v, p| p.text(&format!("add({v})")))
+            })
+            .max_leaves(4),
+        );
+        assert!(total < 2);
+    });
+    assert_eq!(lines, vec!["let draw_1 = add(2);"]);
+}
+
+/// The printing path draws exactly like the silent one for every arm shape,
+/// including a bare subtree arm — the one shape that forwards the printer
+/// straight to a `SubtreeGenerator`.
+#[hegel::test]
+fn recursive_printing_path_draws_valid_values(tc: hegel::TestCase) {
+    let g = gs::recursive(gs::just(1i64), |sub| {
+        hegel::one_of!(
+            sub.clone(),
+            hegel::tuples!(sub.clone(), sub).map(|(a, b)| a + b),
+        )
+    })
+    .max_leaves(10);
+    let v = g.do_draw_and_print(&tc, &mut hegel::PrettyPrinter::noop());
+    assert!((1..=10).contains(&v));
+}
+
 #[test]
 fn clone_output_anchors_where_the_clone_was_made() {
     let lines = failing_lines(|tc| {

--- a/tests/test_recursive.rs
+++ b/tests/test_recursive.rs
@@ -4,7 +4,7 @@ use common::utils::{
     assert_all_examples, assert_simple_property, check_can_generate_examples, expect_panic,
     find_any, minimal,
 };
-use hegel::generators::{self as gs, Generator, RecursiveGenerator};
+use hegel::generators::{self as gs, Generator};
 use hegel::{Hegel, Settings, TestCase};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -29,10 +29,12 @@ impl Tree {
     }
 }
 
-fn trees() -> RecursiveGenerator<Tree> {
-    gs::recursive(gs::integers::<i32>().map(Tree::Leaf), |subtrees| {
-        gs::vecs(subtrees).max_size(3).map(Tree::Branch)
-    })
+macro_rules! trees {
+    () => {
+        gs::recursive(gs::integers::<i32>().map(Tree::Leaf), |subtrees| {
+            gs::vecs(subtrees).max_size(3).map(Tree::Branch)
+        })
+    };
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -59,36 +61,38 @@ impl BinTree {
     }
 }
 
-fn bin_trees() -> RecursiveGenerator<BinTree> {
-    gs::recursive(gs::just(BinTree::Leaf), |subtrees| {
-        hegel::tuples!(subtrees.clone(), subtrees)
-            .map(|(left, right)| BinTree::Branch(Box::new(left), Box::new(right)))
-    })
+macro_rules! bin_trees {
+    () => {
+        gs::recursive(gs::just(BinTree::Leaf), |subtrees| {
+            hegel::tuples!(subtrees.clone(), subtrees)
+                .map(|(left, right)| BinTree::Branch(Box::new(left), Box::new(right)))
+        })
+    };
 }
 
 #[test]
 fn test_recursive_default() {
-    check_can_generate_examples(trees());
+    check_can_generate_examples(trees!());
 }
 
 #[test]
 fn test_recursive_max_depth() {
-    assert_all_examples(trees().max_depth(3), |t| t.height() <= 3);
+    assert_all_examples(trees!().max_depth(3), |t| t.height() <= 3);
 }
 
 #[test]
 fn test_recursive_max_leaves() {
-    assert_all_examples(bin_trees().max_leaves(4), |t| t.leaf_count() <= 4);
+    assert_all_examples(bin_trees!().max_leaves(4), |t| t.leaf_count() <= 4);
 }
 
 #[test]
 fn test_recursive_max_leaves_with_collection_branches() {
-    assert_all_examples(trees().max_leaves(5), |t| t.leaf_count() <= 5);
+    assert_all_examples(trees!().max_leaves(5), |t| t.leaf_count() <= 5);
 }
 
 #[test]
 fn test_recursive_zero_max_leaves_generates_leafless_values() {
-    assert_simple_property(trees().max_leaves(0), |t| t.leaf_count() == 0);
+    assert_simple_property(trees!().max_leaves(0), |t| t.leaf_count() == 0);
 }
 
 #[test]
@@ -96,7 +100,7 @@ fn test_recursive_rejects_when_leaves_are_unavoidable_on_zero_budget() {
     expect_panic(
         || {
             Hegel::new(|tc| {
-                tc.draw_silent(bin_trees().max_leaves(0));
+                tc.draw_silent(bin_trees!().max_leaves(0));
             })
             .settings(Settings::new().database(None).seed(Some(0)))
             .run();
@@ -136,7 +140,7 @@ fn test_recursive_on_an_exhausted_stream_is_an_overrun() {
                     }
                 }));
                 assert!(exhausted.is_err(), "the draw budget is finite");
-                tc.draw_silent(trees());
+                tc.draw_silent(trees!());
                 unreachable!("a recursive draw on an exhausted stream must overrun");
             })
             .settings(Settings::new().database(None).seed(Some(0)))
@@ -187,30 +191,30 @@ fn test_recursive_completing_on_an_exhausted_stream_is_an_overrun() {
 
 #[test]
 fn test_recursive_in_vec() {
-    assert_all_examples(gs::vecs(trees().max_depth(2)).max_size(3), |v| {
+    assert_all_examples(gs::vecs(trees!().max_depth(2)).max_size(3), |v| {
         v.iter().all(|t| t.height() <= 2)
     });
 }
 
 #[test]
 fn test_recursive_generates_branches() {
-    find_any(trees(), |t| matches!(t, Tree::Branch(_)));
+    find_any(trees!(), |t| matches!(t, Tree::Branch(_)));
 }
 
 #[test]
 fn test_recursive_generates_nested_branches() {
-    find_any(trees(), |t| t.height() >= 2);
+    find_any(trees!(), |t| t.height() >= 2);
 }
 
 #[test]
 fn test_recursive_shrinks_to_a_leaf() {
-    assert_eq!(minimal(trees(), |_| true), Tree::Leaf(0));
+    assert_eq!(minimal(trees!(), |_| true), Tree::Leaf(0));
 }
 
 #[test]
 fn test_recursive_minimal_branch_is_empty() {
     assert_eq!(
-        minimal(trees(), |t| matches!(t, Tree::Branch(_))),
+        minimal(trees!(), |t| matches!(t, Tree::Branch(_))),
         Tree::Branch(vec![])
     );
 }
@@ -218,7 +222,7 @@ fn test_recursive_minimal_branch_is_empty() {
 #[test]
 fn test_recursive_minimal_binary_branch_is_two_leaves() {
     assert_eq!(
-        minimal(bin_trees(), |t| matches!(t, BinTree::Branch(_, _))),
+        minimal(bin_trees!(), |t| matches!(t, BinTree::Branch(_, _))),
         BinTree::Branch(Box::new(BinTree::Leaf), Box::new(BinTree::Leaf))
     );
 }
@@ -245,16 +249,18 @@ impl IntTree {
     }
 }
 
-fn int_trees() -> RecursiveGenerator<IntTree> {
-    gs::recursive(gs::integers::<i32>().map(IntTree::Leaf), |subtrees| {
-        hegel::tuples!(subtrees.clone(), subtrees)
-            .map(|(left, right)| IntTree::Branch(Box::new(left), Box::new(right)))
-    })
+macro_rules! int_trees {
+    () => {
+        gs::recursive(gs::integers::<i32>().map(IntTree::Leaf), |subtrees| {
+            hegel::tuples!(subtrees.clone(), subtrees)
+                .map(|(left, right)| IntTree::Branch(Box::new(left), Box::new(right)))
+        })
+    };
 }
 
 #[test]
 fn test_recursive_hoists_a_deep_witness_to_the_root() {
-    let t = minimal(int_trees().max_depth(3), |t| {
+    let t = minimal(int_trees!().max_depth(3), |t| {
         t.has_leaf_pair(|a, b| a & 1 == 1 && b & 1 == 1)
     });
     assert_eq!(
@@ -265,7 +271,7 @@ fn test_recursive_hoists_a_deep_witness_to_the_root() {
 
 #[test]
 fn test_recursive_hoists_a_rare_deep_witness_to_the_root() {
-    let t = minimal(int_trees().max_depth(4), |t| {
+    let t = minimal(int_trees!().max_depth(4), |t| {
         t.has_leaf_pair(|a, b| a % 8 == 7 && b % 8 == 7)
     });
     assert_eq!(
@@ -276,14 +282,14 @@ fn test_recursive_hoists_a_rare_deep_witness_to_the_root() {
 
 #[test]
 fn test_recursive_shrinks_a_saturated_budget_to_an_exact_tree() {
-    let t = minimal(bin_trees().max_leaves(8), |t| t.leaf_count() >= 8);
+    let t = minimal(bin_trees!().max_leaves(8), |t| t.leaf_count() >= 8);
     assert_eq!(t.leaf_count(), 8);
     assert_eq!(t.height(), 7);
 }
 
 #[test]
 fn test_recursive_can_generate_and_shrink_large_trees() {
-    let t = minimal(trees(), |t| t.leaf_count() >= 30);
+    let t = minimal(trees!(), |t| t.leaf_count() >= 30);
     assert_eq!(t.leaf_count(), 30);
 }
 
@@ -291,7 +297,7 @@ fn test_recursive_can_generate_and_shrink_large_trees() {
 fn test_recursive_respects_randomized_bounds(tc: TestCase) {
     let max_depth = tc.draw(gs::integers::<usize>().max_value(5));
     let max_leaves = tc.draw(gs::integers::<usize>().min_value(1).max_value(20));
-    let t = tc.draw(bin_trees().max_depth(max_depth).max_leaves(max_leaves));
+    let t = tc.draw(bin_trees!().max_depth(max_depth).max_leaves(max_leaves));
     assert!(t.height() <= max_depth);
     assert!(t.leaf_count() <= max_leaves);
 }


### PR DESCRIPTION
This has some moderately ugly tradeoffs in it around types in order to get printability working. I feel like this can't be the best solution, but I'm not good enough at rust's type system to come up with a better solution (and Claude insists to me that there isn't one, which seems... 60% likely to be true)

<details>
<summary>PR description (AI generated)</summary>

`recursive()` previously printed drawn values through the produced type's `PrettyPrintable` impl, ignoring how the component generators print. It is now a `PrintableGenerator` exactly when the leaf generator and the generator the branch function returns are, and prints with those generators' representations. `SubtreeGenerator` is printable too.

Breaking: `RecursiveGenerator` gains its component type parameters and is no longer nameable as a return type; return `impl Generator<T>` or `impl PrintableGenerator<T>` instead. RELEASE.md has the minor changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>
