### PR TITLE
Raise the span-depth guard from 100 to 1000

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,5 @@
 RELEASE_TYPE: patch
 
-This patch fixes a silent size collapse in `generators::recursive()` values whose branch generator stacks several combinators per recursion level (e.g. `one_of!` arms pairing subtrees with `tuples!`). Each combinator layer opens a span, and the engine's span-depth guard sat low enough that deep values were silently discarded as invalid, collapsing typical sizes by roughly 7x compared with the same grammar written with fewer layers. The guard now sits far above any depth legitimate generation reaches.
+This patch fixes a silent size collapse in `generators::recursive()` values whose branch generator stacks several combinators per recursion level (e.g. `one_of!` arms pairing subtrees with `tuples!`). Each combinator layer opens a span, and the engine's span-depth guard sat low enough that deep values were discarded as invalid, collapsing typical sizes by roughly 7x. The guard now sits far above any depth legitimate generation reaches.
 
 `compose!` now also accepts the `move` keyword on its closure; captures were already by move, so `compose!(move |tc| { .. })` is identical to `compose!(|tc| { .. })`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch fixes a silent size collapse in `generators::recursive()` values whose branch generator stacks several combinators per recursion level (e.g. `one_of!` arms pairing subtrees with `tuples!`). Each combinator layer opens a span, and the engine's span-depth guard sat low enough that deep values were silently discarded as invalid, collapsing typical sizes by roughly 7x compared with the same grammar written with fewer layers. The guard now sits far above any depth legitimate generation reaches.
+
+`compose!` now also accepts the `move` keyword on its closure; captures were already by move, so `compose!(move |tc| { .. })` is identical to `compose!(|tc| { .. })`.

--- a/hegel-c/RELEASE.md
+++ b/hegel-c/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch fixes a silent size collapse in recursively generated values. The nested-span-depth guard (100) was within reach of legitimate generation — a recursive generator opens several spans per recursion level — and values that crossed it were concluded invalid mid-generation, collapsing typical sizes by roughly 7x for grammars written as a choice over operator arms with tuple-drawn subtrees. The cap is now 1000: far above legitimate depths, still low enough to catch runaway recursion before it overflows the stack.

--- a/hegel-c/src/native/core/state.rs
+++ b/hegel-c/src/native/core/state.rs
@@ -1200,7 +1200,16 @@ pub enum SpanEvent {
 
 /// Maximum nested span depth before the engine marks the test case
 /// `Status::Invalid`.
-pub const MAX_DEPTH: u32 = 100;
+///
+/// A guard against runaway recursion: span-only loops (bounded by no other
+/// budget) and recursive generators headed for a stack overflow. It must
+/// sit far above any depth legitimate generation reaches — combinator
+/// layers each open a span, so recursive generators nest several spans per
+/// recursion level, and a cap within reach of real values silently
+/// truncates the distribution. 1000 corresponds to recursion ~150+ levels
+/// deep, several times anything a plausible `max_depth` produces, yet
+/// usually below the depth where the frontend's drawing stack overflows.
+pub const MAX_DEPTH: u32 = 1000;
 
 /// A tag identifying a structural-coverage class for a span label.
 ///

--- a/hegel-c/tests/embedded/native/state_tests.rs
+++ b/hegel-c/tests/embedded/native/state_tests.rs
@@ -1631,3 +1631,21 @@ fn native_variables_add_active_and_consume_round_trip() {
     vars.consume(0);
     assert_eq!(vars.active(), Vec::<i64>::new());
 }
+
+#[test]
+fn spans_nested_to_max_depth_stay_valid() {
+    let mut tc = NativeTestCase::for_choices(&[], None, None);
+    for _ in 0..MAX_DEPTH {
+        tc.start_span(1);
+    }
+    assert_eq!(tc.status(), None);
+}
+
+#[test]
+fn spans_nested_past_max_depth_conclude_invalid() {
+    let mut tc = NativeTestCase::for_choices(&[], None, None);
+    for _ in 0..=MAX_DEPTH {
+        tc.start_span(1);
+    }
+    assert_eq!(tc.status(), Some(Status::Invalid));
+}

--- a/src/generators/compose.rs
+++ b/src/generators/compose.rs
@@ -75,8 +75,8 @@ pub const fn fnv1a_hash(bytes: &[u8]) -> u64 {
 /// other generators within the compose block.
 ///
 /// The closure captures its environment by move whether or not the `move`
-/// keyword is written; `compose!(move |tc| { .. })` is accepted and
-/// identical to `compose!(|tc| { .. })`.
+/// keyword is written; `compose!(move |tc| { .. })` and
+/// `compose!(|tc| { .. })` are identical.
 ///
 /// # Example
 ///

--- a/src/generators/compose.rs
+++ b/src/generators/compose.rs
@@ -74,6 +74,10 @@ pub const fn fnv1a_hash(bytes: &[u8]) -> u64 {
 /// receives a `&TestCase` parameter. Use `tc.draw()` to draw values from
 /// other generators within the compose block.
 ///
+/// The closure captures its environment by move whether or not the `move`
+/// keyword is written; `compose!(move |tc| { .. })` is accepted and
+/// identical to `compose!(|tc| { .. })`.
+///
 /// # Example
 ///
 /// ```no_run
@@ -90,6 +94,9 @@ pub const fn fnv1a_hash(bytes: &[u8]) -> u64 {
 /// ```
 #[macro_export]
 macro_rules! compose {
+    (move |$tc:ident| { $($body:tt)* }) => {
+        $crate::compose!(|$tc| { $($body)* })
+    };
     (|$tc:ident| { $($body:tt)* }) => {{
         const LABEL: u64 = $crate::generators::fnv1a_hash(stringify!($($body)*).as_bytes());
         $crate::generators::ComposedGenerator::new(LABEL, move |$tc: &$crate::TestCase| { $($body)* })

--- a/tests/test_compose.rs
+++ b/tests/test_compose.rs
@@ -13,6 +13,15 @@ fn test_compose_basic(tc: TestCase) {
 }
 
 #[hegel::test]
+fn test_compose_accepts_move_closures(tc: TestCase) {
+    let offset = 10;
+    let value = tc.draw(hegel::compose!(move |tc| {
+        tc.draw(gs::integers::<i32>().min_value(0).max_value(5)) + offset
+    }));
+    assert!((10..=15).contains(&value));
+}
+
+#[hegel::test]
 fn test_compose_dependent_generation(tc: TestCase) {
     let (x, y) = tc.draw(hegel::compose!(|tc| {
         let x = tc.draw(gs::integers::<i32>().min_value(0).max_value(50));

--- a/tests/test_concurrent_stateful.rs
+++ b/tests/test_concurrent_stateful.rs
@@ -264,7 +264,7 @@ struct DeepSpans;
 impl DeepSpans {
     #[rule]
     fn nest(&self, tc: TestCase) {
-        for _ in 0..101 {
+        for _ in 0..1001 {
             tc.start_span(1);
         }
         let _: bool = tc.draw_silent(gs::booleans());
@@ -288,7 +288,7 @@ struct NestAndBoom;
 impl NestAndBoom {
     #[rule]
     fn nest_and_boom(&self, tc: TestCase) {
-        for _ in 0..101 {
+        for _ in 0..1001 {
             tc.start_span(1);
         }
         panic!("this panic must lose to the engine's invalid conclusion");

--- a/tests/test_distributions.rs
+++ b/tests/test_distributions.rs
@@ -689,6 +689,37 @@ mod recursive {
         assert_min_rate(&vs, |e| e.leaf_count() >= 90, 0.003, "near the leaf cap");
     }
 
+    /// The same expression-language grammar spelled with combinators — a
+    /// `one_of` whose binary arms pair subtrees with `tuples!` — nests
+    /// several spans per recursion level, so deep values must survive the
+    /// engine's span-depth guard. Regression test: with the guard at 100,
+    /// every tree past ~24 levels was silently concluded invalid, and the
+    /// size distribution collapsed to a seventh of the `compose!` style's.
+    #[test]
+    fn combinator_style_trees_match_the_compose_style_distribution() {
+        let vs = sample(4000, 0xE7, |tc| {
+            tc.draw_silent(gs::recursive(gs::just(Expr::Value), |exprs| {
+                let mut arms = Vec::new();
+                for _ in 0..17 {
+                    arms.push(exprs.clone().map(|e| Expr::Negate(Box::new(e))).boxed());
+                }
+                for _ in 0..7 {
+                    arms.push(
+                        hegel::tuples!(exprs.clone(), exprs.clone())
+                            .map(|(a, b)| Expr::Add(Box::new(a), Box::new(b)))
+                            .boxed(),
+                    );
+                }
+                gs::one_of(arms)
+            }))
+        });
+        let mean = vs.iter().map(Expr::leaf_count).sum::<usize>() as f64 / vs.len() as f64;
+        assert!(mean > 10.0, "mean leaf count {mean:.2}; expected > 10");
+        assert_min_rate(&vs, |e| e.leaf_count() == 1, 0.1, "single leaf");
+        assert_min_rate(&vs, |e| e.leaf_count() >= 90, 0.003, "near the leaf cap");
+        assert_min_rate(&vs, |e| e.depth() >= 28, 0.15, "28+ levels deep");
+    }
+
     /// A grammar with only unary branches can never grow past one leaf, so
     /// the leaf budget says nothing about it. The adaptive pricing pushes
     /// the branch probability up to its cap instead, spreading chain


### PR DESCRIPTION
<details>
<summary>PR description (AI generated)</summary>

The engine concluded test cases invalid once spans nested past 100. Combinator-built recursive generators (`one_of!` arms pairing subtrees with `tuples!`) open several spans per recursion level and hit the cap at ~24 levels, so deep values were silently discarded and their size distribution collapsed ~7x. The guard now sits at 1000 — far above legitimate generation depth, still low enough to catch runaway span loops before stack overflow.

Also: `compose!` accepts the `move` keyword (captures were already by move, so it changes nothing).

Includes a distribution regression test that fails at the old cap and engine tests pinning the new boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>
