### PR TITLE
Sample stateful invariants instead of running them every step

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,7 @@
-RELEASE_TYPE: patch
+RELEASE_TYPE: minor
 
-This patch fixes a silent size collapse in `generators::recursive()` values whose branch generator stacks several combinators per recursion level (e.g. `one_of!` arms pairing subtrees with `tuples!`). Each combinator layer opens a span, and the engine's span-depth guard sat low enough that deep values were discarded as invalid, collapsing typical sizes by roughly 7x. The guard now sits far above any depth legitimate generation reaches.
+This release changes when stateful invariants run. `#[invariant]` methods previously ran after every rule; they now run in full on the machine's initial and final state, and are sampled in between — after any given rule, each invariant runs with probability 1/`stateful_step_count`. This keeps an invariant's expected cost per test case constant as the step count grows, and a violation that persists to the end of a test case is still always caught; what is given up is observing most intermediate states, so a violation a later rule *undoes* is only caught when a sampled check lands inside the window. This applies to both sequential and concurrent state machines.
+
+This release also fixes a silent size collapse in `generators::recursive()` values whose branch generator stacks several combinators per recursion level (e.g. `one_of!` arms pairing subtrees with `tuples!`). Each combinator layer opens a span, and the engine's span-depth guard sat low enough that deep values were discarded as invalid, collapsing typical sizes by roughly 7x. The guard now sits far above any depth legitimate generation reaches.
 
 `compose!` now also accepts the `move` keyword on its closure; captures were already by move, so `compose!(move |tc| { .. })` is identical to `compose!(|tc| { .. })`.

--- a/hegel-c/RELEASE.md
+++ b/hegel-c/RELEASE.md
@@ -1,3 +1,5 @@
 RELEASE_TYPE: patch
 
 This patch fixes a silent size collapse in recursively generated values. The nested-span-depth guard (100) was within reach of legitimate generation — a recursive generator opens several spans per recursion level — and values that crossed it were concluded invalid mid-generation, collapsing typical sizes by roughly 7x for grammars written as a choice over operator arms with tuple-drawn subtrees. The cap is now 1000: far above legitimate depths, still low enough to catch runaway recursion before it overflows the stack.
+
+This patch also adds `hegel_state_machine_should_check_invariant`: the engine-side sampling decision for stateful invariant checks, a recorded boolean draw that is true with probability 1/`stateful_step_count`. Frontends call it per invariant at each join point and run their guaranteed initial and final checks unconditionally.

--- a/hegel-c/include/hegel.h
+++ b/hegel-c/include/hegel.h
@@ -1618,6 +1618,34 @@ hegel_result_t hegel_state_machine_rule_rejected(hegel_context_t *ctx,
                                                  int64_t worker_index);
 
 /*
+ Decide whether the caller should run invariant `invariant_index` at the
+ current join point, writing the decision into `*out_should_check`: a
+ recorded boolean draw that is true with probability
+ `1 / stateful_step_count`, so each invariant's expected number of
+ sampled runs over a full-length test case is one, regardless of the
+ step count. The caller owns the machine's guaranteed invariant checks —
+ its initial state, and its final state once
+ `hegel_state_machine_next_group` signals termination — and should run
+ those unconditionally, without calling this.
+
+ `invariant_index` identifies the invariant by its position in the
+ creating `invariant_names`. Call once per invariant per join point,
+ from the same handle that makes the `hegel_state_machine_next_group`
+ calls.
+
+ Returns `HEGEL_OK`, `HEGEL_E_INVALID_ARG` when `invariant_index` is
+ outside the machine's registered invariants or `out_should_check` is
+ null, or `HEGEL_E_STOP_TEST` when the engine's choice budget is
+ exhausted (the caller should abort the body and call
+ `hegel_mark_complete` with `HEGEL_STATUS_OVERRUN`).
+ */
+hegel_result_t hegel_state_machine_should_check_invariant(hegel_context_t *ctx,
+                                                          hegel_test_case_t *tc,
+                                                          hegel_state_machine_t *state_machine,
+                                                          int64_t invariant_index,
+                                                          bool *out_should_check);
+
+/*
  Release a state-machine handle from `hegel_new_state_machine`. Safe to
  call with NULL (a no-op that returns `HEGEL_OK`), and safe at any point
  in any order relative to freeing the test case or the run. Each handle

--- a/hegel-c/src/backend.rs
+++ b/hegel-c/src/backend.rs
@@ -243,6 +243,20 @@ pub trait DataSource: Send + Sync {
         worker_index: i64,
     ) -> Result<(), DataSourceError>;
 
+    /// Decide whether the caller should run invariant `invariant_index` at
+    /// the current join point: a recorded boolean draw that is `true` with
+    /// probability `1 / stateful_step_count`, so each invariant's expected
+    /// number of sampled runs over a full-length test case is one. The
+    /// caller runs its guaranteed checks — the machine's initial state and
+    /// its final state after the last round — without consulting this.
+    /// Errors with `InvalidArgument` when `invariant_index` is outside the
+    /// machine's registered invariants.
+    fn state_machine_should_check_invariant(
+        &self,
+        machine: &mut NativeStateMachine,
+        invariant_index: i64,
+    ) -> Result<bool, DataSourceError>;
+
     /// Draw a boolean that is `true` with probability `p`.
     ///
     /// If `forced` is `Some`, the choice is still recorded (so replay and

--- a/hegel-c/src/lib.rs
+++ b/hegel-c/src/lib.rs
@@ -2848,6 +2848,70 @@ pub unsafe extern "C" fn hegel_state_machine_rule_rejected(
     }
 }
 
+/// Decide whether the caller should run invariant `invariant_index` at the
+/// current join point, writing the decision into `*out_should_check`: a
+/// recorded boolean draw that is true with probability
+/// `1 / stateful_step_count`, so each invariant's expected number of
+/// sampled runs over a full-length test case is one, regardless of the
+/// step count. The caller owns the machine's guaranteed invariant checks —
+/// its initial state, and its final state once
+/// `hegel_state_machine_next_group` signals termination — and should run
+/// those unconditionally, without calling this.
+///
+/// `invariant_index` identifies the invariant by its position in the
+/// creating `invariant_names`. Call once per invariant per join point,
+/// from the same handle that makes the `hegel_state_machine_next_group`
+/// calls.
+///
+/// Returns `HEGEL_OK`, `HEGEL_E_INVALID_ARG` when `invariant_index` is
+/// outside the machine's registered invariants or `out_should_check` is
+/// null, or `HEGEL_E_STOP_TEST` when the engine's choice budget is
+/// exhausted (the caller should abort the body and call
+/// `hegel_mark_complete` with `HEGEL_STATUS_OVERRUN`).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn hegel_state_machine_should_check_invariant(
+    ctx: *mut HegelContext,
+    tc: *mut HegelTestCase,
+    state_machine: *mut HegelStateMachine,
+    invariant_index: i64,
+    out_should_check: *mut bool,
+) -> hegel_result_t {
+    clear_last_error(ctx);
+    let (tc, _guard) =
+        match unsafe { tc_guard(ctx, "hegel_state_machine_should_check_invariant", tc) } {
+            Ok(t) => t,
+            Err(rc) => return rc,
+        };
+    let state_machine = match unsafe {
+        state_machine_ref(
+            ctx,
+            "hegel_state_machine_should_check_invariant",
+            state_machine,
+        )
+    } {
+        Ok(m) => m,
+        Err(rc) => return rc,
+    };
+    if out_should_check.is_null() {
+        set_last_error(
+            ctx,
+            "hegel_state_machine_should_check_invariant: out parameter is null",
+        );
+        return HEGEL_E_INVALID_ARG;
+    }
+    let mut machine = state_machine.machine.lock();
+    match tc
+        .stream
+        .state_machine_should_check_invariant(&mut machine, invariant_index)
+    {
+        Ok(should_check) => {
+            unsafe { *out_should_check = should_check };
+            HEGEL_OK
+        }
+        Err(e) => translate_ds_error(ctx, e),
+    }
+}
+
 /// Release a state-machine handle from `hegel_new_state_machine`. Safe to
 /// call with NULL (a no-op that returns `HEGEL_OK`), and safe at any point
 /// in any order relative to freeing the test case or the run. Each handle

--- a/hegel-c/src/native/core/state_machine.rs
+++ b/hegel-c/src/native/core/state_machine.rs
@@ -199,6 +199,9 @@ pub struct NativeStateMachine {
     /// round counts and rejections refund only the worker's within-round
     /// budget.
     rounds_rejected: i64,
+    /// Number of registered invariants, bounding the indices
+    /// [`Self::should_check_invariant`] accepts.
+    num_invariants: usize,
     workers: Vec<WorkerState>,
 }
 
@@ -211,6 +214,7 @@ impl NativeStateMachine {
     pub fn new(
         ntc: &mut NativeTestCase,
         rule_groups: Vec<i64>,
+        num_invariants: usize,
         min_concurrency: i64,
         max_concurrency: i64,
     ) -> Result<Self, EngineError> {
@@ -253,6 +257,7 @@ impl NativeStateMachine {
             current_group: 0,
             rounds_started: 0,
             rounds_rejected: 0,
+            num_invariants,
             workers,
         })
     }
@@ -405,6 +410,34 @@ impl NativeStateMachine {
             self.rounds_rejected += 1;
         }
         Ok(())
+    }
+
+    /// Decide whether the caller should run invariant `invariant_index` at
+    /// the current join point: a recorded boolean draw that is `true` with
+    /// probability `1 / stateful_step_count`, so over a full-length test
+    /// case each invariant's expected number of sampled runs is one,
+    /// regardless of the step count. The caller owns the machine's
+    /// guaranteed checks — its initial state and the final state after the
+    /// last round — and runs those without consulting this draw.
+    ///
+    /// Errors with `InvalidArgument` when `invariant_index` is outside the
+    /// registered invariants.
+    pub fn should_check_invariant(
+        &mut self,
+        ntc: &mut NativeTestCase,
+        invariant_index: i64,
+    ) -> Result<bool, EngineError> {
+        let valid = usize::try_from(invariant_index)
+            .ok()
+            .filter(|&i| i < self.num_invariants);
+        if valid.is_none() {
+            return Err(EngineError::InvalidArgument(format!(
+                "invariant_index must be in [0, {}), got {invariant_index}",
+                self.num_invariants
+            )));
+        }
+        let p = 1.0 / ntc.family().stateful_step_count() as f64;
+        ntc.weighted_precise(p, None)
     }
 
     /// Validate a caller-supplied worker index against the drawn

--- a/hegel-c/src/native/data_source.rs
+++ b/hegel-c/src/native/data_source.rs
@@ -292,7 +292,7 @@ impl DataSource for NativeDataSource {
         &self,
         rule_names: Vec<String>,
         rule_groups: Vec<i64>,
-        _invariant_names: Vec<String>,
+        invariant_names: Vec<String>,
         min_concurrency: i64,
         max_concurrency: i64,
     ) -> Result<NativeStateMachine, DataSourceError> {
@@ -323,7 +323,13 @@ impl DataSource for NativeDataSource {
                     return Err(EngineError::AssumeViolation);
                 }
             }
-            NativeStateMachine::new(ntc, rule_groups, min_concurrency, max_concurrency)
+            NativeStateMachine::new(
+                ntc,
+                rule_groups,
+                invariant_names.len(),
+                min_concurrency,
+                max_concurrency,
+            )
         })
     }
 
@@ -348,6 +354,14 @@ impl DataSource for NativeDataSource {
         worker_index: i64,
     ) -> Result<(), DataSourceError> {
         self.with_ntc(|_ntc| machine.rule_rejected(worker_index))
+    }
+
+    fn state_machine_should_check_invariant(
+        &self,
+        machine: &mut NativeStateMachine,
+        invariant_index: i64,
+    ) -> Result<bool, DataSourceError> {
+        self.with_ntc(|ntc| machine.should_check_invariant(ntc, invariant_index))
     }
 
     fn generate_boolean(&self, p: f64, forced: Option<bool>) -> Result<bool, DataSourceError> {

--- a/hegel-c/tests/c_abi_inprocess.rs
+++ b/hegel-c/tests/c_abi_inprocess.rs
@@ -29,9 +29,9 @@ use hegel_c::{
     hegel_settings_set_phases, hegel_settings_set_report_multiple_failures,
     hegel_settings_set_suppress_health_check, hegel_start_span, hegel_state_machine_free,
     hegel_state_machine_next_group, hegel_state_machine_next_rule,
-    hegel_state_machine_rule_rejected, hegel_status_t, hegel_stop_span, hegel_target,
-    hegel_test_case_clone, hegel_test_case_free, hegel_test_case_from_blob,
-    hegel_test_case_is_nondeterministic, hegel_version,
+    hegel_state_machine_rule_rejected, hegel_state_machine_should_check_invariant, hegel_status_t,
+    hegel_stop_span, hegel_target, hegel_test_case_clone, hegel_test_case_free,
+    hegel_test_case_from_blob, hegel_test_case_is_nondeterministic, hegel_version,
 };
 use std::ffi::{CString, c_void};
 use std::os::raw::c_char;
@@ -1440,7 +1440,8 @@ fn primitives_after_overrun_all_report_stop_test() {
 /// Exercise the state-machine and weighted-boolean C-ABI entry points
 /// (`hegel_new_state_machine`, `hegel_state_machine_next_group`,
 /// `hegel_state_machine_next_rule`, `hegel_state_machine_rule_rejected`,
-/// `hegel_generate_boolean`) in-process: the invalid-handle and
+/// `hegel_state_machine_should_check_invariant`, `hegel_generate_boolean`)
+/// in-process: the invalid-handle and
 /// argument-validation paths, plus the happy paths. The smoke test that
 /// drives these over dlopen doesn't contribute coverage, so they are
 /// measured here.
@@ -1779,6 +1780,59 @@ fn state_machine_and_primitive_boolean_paths() {
         }
         assert!(rounds >= 1);
         assert_eq!(hegel_state_machine_free(ctx, machine), HEGEL_OK);
+
+        let inv_a = CString::new("inv").unwrap();
+        let invariants: [*const c_char; 1] = [inv_a.as_ptr()];
+        let mut checked: *mut HegelStateMachine = ptr::null_mut();
+        assert_eq!(
+            hegel_new_state_machine(
+                ctx,
+                tc,
+                rules.as_ptr(),
+                rule_groups.as_ptr(),
+                1,
+                invariants.as_ptr(),
+                1,
+                1,
+                1,
+                &mut checked,
+                &mut out_concurrency,
+            ),
+            HEGEL_OK
+        );
+        let mut should_check = false;
+        assert_eq!(
+            hegel_state_machine_should_check_invariant(ctx, null_tc, checked, 0, &mut should_check),
+            HEGEL_E_INVALID_HANDLE
+        );
+        assert_eq!(
+            hegel_state_machine_should_check_invariant(
+                ctx,
+                tc,
+                ptr::null_mut(),
+                0,
+                &mut should_check
+            ),
+            HEGEL_E_INVALID_HANDLE
+        );
+        assert!(last_error(ctx).contains("state machine handle is null"));
+        assert_eq!(
+            hegel_state_machine_should_check_invariant(ctx, tc, checked, 0, ptr::null_mut()),
+            HEGEL_E_INVALID_ARG
+        );
+        assert!(last_error(ctx).contains("out parameter is null"));
+        assert_eq!(
+            hegel_state_machine_should_check_invariant(ctx, tc, checked, 1, &mut should_check),
+            HEGEL_E_INVALID_ARG
+        );
+        assert!(last_error(ctx).contains("invariant_index must be in [0, 1)"));
+        for _ in 0..20 {
+            assert_eq!(
+                hegel_state_machine_should_check_invariant(ctx, tc, checked, 0, &mut should_check),
+                HEGEL_OK
+            );
+        }
+        assert_eq!(hegel_state_machine_free(ctx, checked), HEGEL_OK);
 
         let mut ranged: *mut HegelStateMachine = ptr::null_mut();
         assert_eq!(

--- a/hegel-c/tests/embedded/native/state_machine_tests.rs
+++ b/hegel-c/tests/embedded/native/state_machine_tests.rs
@@ -14,11 +14,11 @@ fn machine_concurrent(
     num_rules: usize,
     concurrency: i64,
 ) -> NativeStateMachine {
-    NativeStateMachine::new(ntc, vec![0; num_rules], concurrency, concurrency).unwrap()
+    NativeStateMachine::new(ntc, vec![0; num_rules], 0, concurrency, concurrency).unwrap()
 }
 
 fn grouped_machine(ntc: &mut NativeTestCase, rule_groups: &[i64]) -> NativeStateMachine {
-    NativeStateMachine::new(ntc, rule_groups.to_vec(), 1, 1).unwrap()
+    NativeStateMachine::new(ntc, rule_groups.to_vec(), 0, 1, 1).unwrap()
 }
 
 fn replay(prefix: &[ChoiceValue], max_size: usize) -> NativeTestCase {
@@ -544,7 +544,7 @@ fn a_rule_outstanding_at_the_join_point_is_not_rejectable_next_round() {
 #[test]
 fn fixed_concurrency_bounds_consume_no_entropy() {
     let mut ntc = replay(&[int(0), int(0), int(0)], 8);
-    let sm = NativeStateMachine::new(&mut ntc, vec![0], 3, 3).unwrap();
+    let sm = NativeStateMachine::new(&mut ntc, vec![0], 0, 3, 3).unwrap();
     assert_eq!(sm.concurrency(), 3);
     assert_eq!(ntc.nodes.len(), 3);
 }
@@ -553,7 +553,7 @@ fn fixed_concurrency_bounds_consume_no_entropy() {
 fn concurrency_draw_is_max_when_the_weighted_choice_hits() {
     let prefix = [ChoiceValue::Boolean(true), int(0), int(0), int(0), int(0)];
     let mut ntc = replay(&prefix, 8);
-    let sm = NativeStateMachine::new(&mut ntc, vec![0], 1, 4).unwrap();
+    let sm = NativeStateMachine::new(&mut ntc, vec![0], 0, 1, 4).unwrap();
     assert_eq!(sm.concurrency(), 4);
     assert_eq!(
         ntc.spans[0usize].label,
@@ -565,7 +565,7 @@ fn concurrency_draw_is_max_when_the_weighted_choice_hits() {
 fn concurrency_draw_falls_back_to_a_uniform_level() {
     let prefix = [ChoiceValue::Boolean(false), int(2), int(0), int(0)];
     let mut ntc = replay(&prefix, 8);
-    let sm = NativeStateMachine::new(&mut ntc, vec![0], 1, 4).unwrap();
+    let sm = NativeStateMachine::new(&mut ntc, vec![0], 0, 1, 4).unwrap();
     assert_eq!(sm.concurrency(), 2);
 }
 
@@ -573,7 +573,7 @@ fn concurrency_draw_falls_back_to_a_uniform_level() {
 fn drawn_concurrency_respects_bounds() {
     for seed in 0..20 {
         let mut ntc = NativeTestCase::new_random(EngineRng::seeded(seed)).unwrap();
-        let sm = NativeStateMachine::new(&mut ntc, vec![0], 2, 5).unwrap();
+        let sm = NativeStateMachine::new(&mut ntc, vec![0], 0, 2, 5).unwrap();
         assert!((2..=5).contains(&sm.concurrency()));
     }
 }
@@ -582,7 +582,7 @@ fn drawn_concurrency_respects_bounds() {
 fn overrun_while_drawing_the_concurrency_level_propagates() {
     let mut ntc = replay(&[], 0);
     assert!(matches!(
-        NativeStateMachine::new(&mut ntc, vec![0], 1, 4),
+        NativeStateMachine::new(&mut ntc, vec![0], 0, 1, 4),
         Err(EngineError::Overrun)
     ));
 }
@@ -616,7 +616,7 @@ fn try_machine(
     ntc: &mut NativeTestCase,
     num_rules: usize,
 ) -> Result<NativeStateMachine, EngineError> {
-    NativeStateMachine::new(ntc, vec![0; num_rules], 1, 1)
+    NativeStateMachine::new(ntc, vec![0; num_rules], 0, 1, 1)
 }
 
 #[test]
@@ -754,12 +754,55 @@ fn no_rules_is_error() {
 #[should_panic(expected = "Stateful testing: concurrency bounds must satisfy 1 <= min <= max")]
 fn zero_min_concurrency_is_error() {
     let mut ntc = NativeTestCase::new_random(EngineRng::seeded(0)).unwrap();
-    NativeStateMachine::new(&mut ntc, vec![0], 0, 1).unwrap();
+    NativeStateMachine::new(&mut ntc, vec![0], 0, 0, 1).unwrap();
 }
 
 #[test]
 #[should_panic(expected = "Stateful testing: concurrency bounds must satisfy 1 <= min <= max")]
 fn inverted_concurrency_bounds_is_error() {
     let mut ntc = NativeTestCase::new_random(EngineRng::seeded(0)).unwrap();
-    NativeStateMachine::new(&mut ntc, vec![0], 2, 1).unwrap();
+    NativeStateMachine::new(&mut ntc, vec![0], 0, 2, 1).unwrap();
+}
+
+#[test]
+fn should_check_invariant_rejects_out_of_range_indices() {
+    let mut ntc = NativeTestCase::new_random(EngineRng::seeded(0)).unwrap();
+    let mut sm = NativeStateMachine::new(&mut ntc, vec![0], 2, 1, 1).unwrap();
+    assert!(matches!(
+        sm.should_check_invariant(&mut ntc, 2),
+        Err(EngineError::InvalidArgument(_))
+    ));
+    assert!(matches!(
+        sm.should_check_invariant(&mut ntc, -1),
+        Err(EngineError::InvalidArgument(_))
+    ));
+}
+
+#[test]
+fn should_check_invariant_is_always_true_at_step_count_one() {
+    let mut ntc = NativeTestCase::new_random(EngineRng::seeded(0)).unwrap();
+    ntc.family().set_stateful_step_count(1);
+    let mut sm = NativeStateMachine::new(&mut ntc, vec![0], 1, 1, 1).unwrap();
+    for _ in 0..10 {
+        assert!(sm.should_check_invariant(&mut ntc, 0).unwrap());
+    }
+}
+
+#[test]
+fn should_check_invariant_samples_at_one_over_step_count() {
+    let mut trues = 0;
+    for seed in 0..20 {
+        let mut ntc = NativeTestCase::new_random(EngineRng::seeded(seed)).unwrap();
+        ntc.family().set_stateful_step_count(50);
+        let mut sm = NativeStateMachine::new(&mut ntc, vec![0], 1, 1, 1).unwrap();
+        for _ in 0..100 {
+            if sm.should_check_invariant(&mut ntc, 0).unwrap() {
+                trues += 1;
+            }
+        }
+    }
+    assert!(
+        (10..=100).contains(&trues),
+        "expected about 40 sampled checks in 2000, got {trues}"
+    );
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -879,6 +879,28 @@ impl CTestCase {
         rc_to_value(rc, ())
     }
 
+    /// Ask the engine whether invariant `invariant_index` should run at the
+    /// current join point: a recorded draw that is true with probability
+    /// `1 / stateful_step_count`. The guaranteed initial and final checks
+    /// are the caller's and run without asking.
+    pub(crate) fn state_machine_should_check_invariant(
+        &self,
+        state_machine: &StateMachineHandle,
+        invariant_index: i64,
+    ) -> Result<bool, hegel_result_t> {
+        let mut out = false;
+        let rc = with_context(|ctx| unsafe {
+            hegel_c::hegel_state_machine_should_check_invariant(
+                ctx,
+                self.raw,
+                state_machine.raw,
+                invariant_index,
+                &mut out,
+            )
+        });
+        rc_to_value(rc, out)
+    }
+
     pub(crate) fn target(&self, score: f64, label: &str) -> Result<(), hegel_result_t> {
         let c_label = cstring_lossy(label);
         rc_to_unit(with_context(|ctx| unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -525,7 +525,8 @@ pub use hegel_macros::state_machine;
 ///
 /// Methods annotated `#[rule(group = "name")]` become rules assigned to the
 /// named concurrency group; methods annotated `#[invariant]` become
-/// invariants, checked at the join points between rounds. Rules in the same
+/// invariants, checked in full on the machine's initial and final state and
+/// sampled at the join points between rounds. Rules in the same
 /// group may run concurrently with each other; rules in different groups
 /// never overlap.
 ///

--- a/src/stateful.rs
+++ b/src/stateful.rs
@@ -2,8 +2,10 @@
 //!
 //! State machines are defined using the [`state_machine`](crate::state_machine) attribute macro.
 //! Methods annotated with `#[rule]` become rules (actions applied to the state machine) and
-//! methods annotated with `#[invariant]` become invariants (checked after each successful rule
-//! application). Both take a [`TestCase`] parameter and borrow the state machine: rules
+//! methods annotated with `#[invariant]` become invariants (checked on the machine's initial
+//! and final state, and sampled in between — each invariant runs after any given rule with
+//! probability `1 / stateful_step_count`, so its expected cost per test case stays constant
+//! as the step count grows). Both take a [`TestCase`] parameter and borrow the state machine: rules
 //! typically have signature `fn(&mut self, tc: TestCase)` and invariants
 //! `fn(&self, tc: TestCase)`, but either kind of method may use `&self` or `&mut self`.
 //!
@@ -496,12 +498,28 @@ pub fn concurrent_pool<T>(tc: &TestCase) -> ConcurrentPool<T> {
 pub trait StateMachine {
     /// The rules (actions) that can be applied to this state machine.
     fn rules(&self) -> Vec<Rule<Self>>;
-    /// Invariants checked after each successful rule application.
+    /// Invariants: checked on the machine's initial and final state, and
+    /// sampled after rules in between with probability
+    /// `1 / stateful_step_count` each.
     fn invariants(&self) -> Vec<Rule<Self>>;
 }
 
-fn check_invariants<M: StateMachine>(m: &mut M, invariants: &[Rule<M>], tc: &TestCase) {
-    for invariant in invariants {
+/// Run invariants at a join point. With a machine, each invariant runs only
+/// when the engine's sampling draw says to (see
+/// [`machine_should_check_invariant`]); with `None` — the guaranteed checks
+/// of the machine's initial and final state — every invariant runs.
+fn check_invariants<M: StateMachine>(
+    m: &mut M,
+    invariants: &[Rule<M>],
+    tc: &TestCase,
+    machine: Option<&StateMachineHandle>,
+) {
+    for (index, invariant) in invariants.iter().enumerate() {
+        if let Some(machine) = machine {
+            if !machine_should_check_invariant(tc, machine, index as i64) {
+                continue;
+            }
+        }
         let inv_tc = tc.child(2); // nocov
         (invariant.apply)(m, inv_tc); // nocov
     }
@@ -545,15 +563,34 @@ fn machine_rule_rejected(tc: &TestCase, machine: &StateMachineHandle, worker_ind
     }
 }
 
+/// Ask the engine whether invariant `invariant_index` should run at the
+/// current join point — a recorded draw that is true with probability
+/// `1 / stateful_step_count`, making an invariant's expected sampled runs
+/// per test case one regardless of step count.
+fn machine_should_check_invariant(
+    tc: &TestCase,
+    machine: &StateMachineHandle,
+    invariant_index: i64,
+) -> bool {
+    match tc.with_ctc(|ctc| ctc.state_machine_should_check_invariant(machine, invariant_index)) {
+        Ok(should_check) => should_check,
+        Err(rc) => raise_for_rc(rc),
+    }
+}
+
 /// Execute a stateful test by repeatedly applying random rules and checking invariants.
 ///
 /// A sequential machine is the special case of the engine's concurrent
 /// state-machine protocol with a single group and concurrency 1: the engine
-/// hands out exactly one rule per round, so the join-point invariant check
-/// after each round runs after each rule. One consequence of the join-point
-/// timing: the invariants run after a rule that stopped on a violated
-/// assumption too (rules are expected to reject before mutating the model,
-/// and nothing restores model state on rejection anyway).
+/// hands out exactly one rule per round, so the join points where sampled
+/// invariant checks may run fall after each rule. Invariants run in full on
+/// the machine's initial and final state; in between, each invariant runs at
+/// a join point only when the engine's sampling draw (probability
+/// `1 / stateful_step_count`) says to, keeping an invariant's expected cost
+/// per test case constant as the step count grows. One consequence of the
+/// join-point timing: a sampled check can land after a rule that stopped on
+/// a violated assumption (rules are expected to reject before mutating the
+/// model, and nothing restores model state on rejection anyway).
 pub fn run<M: StateMachine>(mut m: M, tc: TestCase) {
     let rules = m.rules();
     let rule_names: Vec<&str> = rules.iter().map(|r| r.name.as_str()).collect();
@@ -568,7 +605,7 @@ pub fn run<M: StateMachine>(mut m: M, tc: TestCase) {
     };
 
     tc.note("Initial invariant check.");
-    check_invariants(&mut m, &invariants, &tc);
+    check_invariants(&mut m, &invariants, &tc, None);
 
     let mut steps_attempted: i64 = 0;
 
@@ -614,8 +651,11 @@ pub fn run<M: StateMachine>(mut m: M, tc: TestCase) {
         }
         tc.stop_span(round_rejected);
 
-        check_invariants(&mut m, &invariants, &tc);
+        check_invariants(&mut m, &invariants, &tc, Some(&machine));
     }
+
+    tc.note("Final invariant check.");
+    check_invariants(&mut m, &invariants, &tc, None);
 }
 
 /// A rule of a [`ConcurrentStateMachine`]: an action worker threads may
@@ -691,17 +731,27 @@ pub trait ConcurrentStateMachine {
     /// The rules (actions) that worker threads may apply to this state
     /// machine, each with its concurrency-group assignment.
     fn rules(&self) -> Vec<ConcurrentRule<Self>>;
-    /// Invariants checked at every join point, on the main thread, while
-    /// the worker threads are parked.
+    /// Invariants, run on the main thread while the worker threads are
+    /// parked: checked on the machine's initial and final state, and
+    /// sampled at the join points in between with probability
+    /// `1 / stateful_step_count` each.
     fn invariants(&self) -> Vec<ConcurrentInvariant<Self>>;
 }
 
+/// Concurrent counterpart of [`check_invariants`]: sampled per invariant
+/// when given a machine, a guaranteed full sweep with `None`.
 fn check_concurrent_invariants<M: ConcurrentStateMachine + ?Sized>(
     m: &M,
     invariants: &[ConcurrentInvariant<M>],
     tc: &TestCase,
+    machine: Option<&StateMachineHandle>,
 ) {
-    for invariant in invariants {
+    for (index, invariant) in invariants.iter().enumerate() {
+        if let Some(machine) = machine {
+            if !machine_should_check_invariant(tc, machine, index as i64) {
+                continue;
+            }
+        }
         let inv_tc = tc.child(2);
         (invariant.apply)(m, inv_tc);
     }
@@ -854,8 +904,10 @@ fn worker_loop<M: ConcurrentStateMachine + ?Sized>(
 /// thread then runs a short (possibly empty) random sequence of rules from
 /// that group — and only that group — concurrently with the other workers. Rules in the same
 /// group may overlap each other, and rules in different groups never
-/// overlap. Once every worker has finished its rules for the round, we run
-/// all invariants.
+/// overlap. Once every worker has finished its rules for the round, the
+/// main thread runs the invariants the engine's sampling draws select
+/// (probability `1 / stateful_step_count` each); every invariant runs in
+/// full on the machine's initial and final state.
 ///
 /// The number of worker threads is drawn per test case, when the state
 /// machine is created, in `[min_concurrency, max_concurrency]` and weighted
@@ -949,7 +1001,7 @@ pub fn run_concurrent<M: ConcurrentStateMachine + Sync>(
     tc.note(&format!("Concurrency level: {concurrency}"));
 
     tc.note("Initial invariant check.");
-    check_concurrent_invariants(&m, &invariants, &tc);
+    check_concurrent_invariants(&m, &invariants, &tc, None);
 
     let capture_backtraces = run_lifecycle::backtrace_capture_enabled();
     let concurrency = concurrency as usize;
@@ -1000,8 +1052,11 @@ pub fn run_concurrent<M: ConcurrentStateMachine + Sync>(
 
             resolve_round(events, &tc);
 
-            check_concurrent_invariants(m, &invariants, &tc);
+            check_concurrent_invariants(m, &invariants, &tc, Some(machine));
         }
+
+        tc.note("Final invariant check.");
+        check_concurrent_invariants(m, &invariants, &tc, None);
     });
 }
 

--- a/tests/test_stateful.rs
+++ b/tests/test_stateful.rs
@@ -528,6 +528,91 @@ mod stateful {
         }
     }
 
+    struct SampledInvariantMachine {
+        rules_run: Arc<Mutex<i64>>,
+        invariants_run: Arc<Mutex<i64>>,
+    }
+
+    impl StateMachine for SampledInvariantMachine {
+        fn rules(&self) -> Vec<Rule<Self>> {
+            vec![Rule::new(
+                "count_rule",
+                |m: &mut SampledInvariantMachine, _tc: TestCase| {
+                    *m.rules_run.lock().unwrap() += 1;
+                },
+            )]
+        }
+        fn invariants(&self) -> Vec<Rule<Self>> {
+            vec![Rule::new(
+                "count_invariant",
+                |m: &mut SampledInvariantMachine, _tc: TestCase| {
+                    *m.invariants_run.lock().unwrap() += 1;
+                },
+            )]
+        }
+    }
+
+    #[test]
+    fn test_invariants_are_sampled_rather_than_run_after_every_rule() {
+        let rules_run = Arc::new(Mutex::new(0i64));
+        let invariants_run = Arc::new(Mutex::new(0i64));
+        let rules_in = Arc::clone(&rules_run);
+        let invariants_in = Arc::clone(&invariants_run);
+        Hegel::new(move |tc: TestCase| {
+            let m = SampledInvariantMachine {
+                rules_run: Arc::clone(&rules_in),
+                invariants_run: Arc::clone(&invariants_in),
+            };
+            hegel::stateful::run(m, tc);
+        })
+        .settings(
+            Settings::new()
+                .test_cases(20)
+                .stateful_step_count(50)
+                .database(None),
+        )
+        .run();
+        let rules_run = *rules_run.lock().unwrap();
+        let invariants_run = *invariants_run.lock().unwrap();
+        assert!(invariants_run >= 2);
+        assert!(
+            invariants_run < rules_run / 4,
+            "expected sampled invariant runs ({invariants_run}) to stay far below \
+             rule runs ({rules_run})"
+        );
+    }
+
+    struct BreakOnceMachine {
+        broken: bool,
+    }
+
+    #[hegel::state_machine]
+    impl BreakOnceMachine {
+        #[rule]
+        fn break_it(&mut self, _tc: TestCase) {
+            self.broken = true;
+        }
+
+        #[invariant]
+        fn not_broken(&mut self, _tc: TestCase) {
+            assert!(!self.broken, "machine is broken");
+        }
+    }
+
+    #[test]
+    fn test_persistent_violations_are_always_caught_despite_sampling() {
+        expect_panic(
+            || {
+                Hegel::new(|tc: TestCase| {
+                    hegel::stateful::run(BreakOnceMachine { broken: false }, tc);
+                })
+                .settings(Settings::new().database(None))
+                .run();
+            },
+            "machine is broken",
+        );
+    }
+
     #[test]
     fn test_always_runs_at_least_one_step() {
         Hegel::new(|tc: TestCase| {


### PR DESCRIPTION
<details>
<summary>PR description (AI generated)</summary>

Invariants now run in full on the machine's initial and final state and are sampled in between: after any given rule, each invariant runs with probability 1/`stateful_step_count`, decided by a recorded engine draw (new ABI: `hegel_state_machine_should_check_invariant`), so replay and shrinking stay deterministic. An invariant's expected cost per test case is now constant as the step count grows.

A violation that persists to the end of a case is still always caught by the guaranteed final sweep; a violation a later rule undoes is only caught when a sampled check lands inside the window. Applies to sequential and concurrent machines.

RELEASE.md (minor) and hegel-c/RELEASE.md (patch) carry the changelog entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>