### PR TITLE
Add event statistics

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch adds event statistics. `tc.event(label)` records that a labelled situation occurred in the current test case, and `tc.event_value(label, value)` records a numeric observation; with statistics enabled — `Settings::show_statistics(true)`, or the `HEGEL_STATISTICS` environment variable — the end of the run reports, per label, the fraction of generation-phase test cases each event occurred in and a distribution summary (count, min, median, mean, p90, max) of each numeric observation. Use it to check that the situations a test is meant to exercise actually occur, and at the sizes you expect.

--- a/hegel-c/RELEASE.md
+++ b/hegel-c/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch adds event statistics: `hegel_event` and `hegel_event_value` record labelled observations on the current test case, and with the new `hegel_settings_set_show_statistics` setting the engine prints a statistics block on the run's output at the end of the run — per label, the fraction of generation-phase test cases the event occurred in, and a distribution summary of numeric observations.

--- a/hegel-c/include/hegel.h
+++ b/hegel-c/include/hegel.h
@@ -996,6 +996,20 @@ hegel_result_t hegel_settings_set_report_multiple_failures(hegel_context_t *ctx,
 
 /*
  Parameters:
+ `yes`: When `true`, libhegel prints a statistics block on the run's
+   output at the end of the run: for each label recorded with
+   `hegel_event`, the fraction of generation-phase test cases it
+   occurred in, and for each label recorded with `hegel_event_value`, a
+   distribution summary of the observed values. Defaults to off.
+
+ Returns `HEGEL_OK`.
+ */
+hegel_result_t hegel_settings_set_show_statistics(hegel_context_t *ctx,
+                                                  hegel_settings_t *s,
+                                                  bool yes);
+
+/*
+ Parameters:
  `database`: NULL sets it to the default: `./.hegel/examples/`. `""`
    disables the database entirely. Discovered failures will not be
    stored. Anything else is used as the database root directory. The
@@ -1981,6 +1995,44 @@ hegel_result_t hegel_target(hegel_context_t *ctx,
                             hegel_test_case_t *tc,
                             double value,
                             const char *label);
+
+/*
+ Record an event for the current test case, for the end-of-run
+ statistics report: the report shows, per label, the fraction of
+ generation-phase test cases in which the label was recorded at least
+ once. The report prints only when the `show_statistics` setting is on
+ (`hegel_settings_set_show_statistics`); without it events cost almost
+ nothing and report nothing.
+
+ Parameters:
+ `label`: Non-NULL, valid UTF-8.
+
+ Returns `HEGEL_OK`, or `HEGEL_E_INVALID_ARG` on a null / non-UTF-8
+ label.
+ */
+hegel_result_t hegel_event(hegel_context_t *ctx, hegel_test_case_t *tc, const char *label);
+
+/*
+ Record a numeric observation under `label` for the current test case,
+ for the end-of-run statistics report: the report shows, per label, a
+ summary of the observed distribution (count, min, median, mean, p90,
+ max) over generation-phase test cases. The report prints only when the
+ `show_statistics` setting is on
+ (`hegel_settings_set_show_statistics`); without it observations cost
+ almost nothing and report nothing.
+
+ Parameters:
+ `value`: The observation. Must be finite.
+ `label`: Non-NULL, valid UTF-8. Unlike `hegel_target`, a label may be
+   observed any number of times per test case.
+
+ Returns `HEGEL_OK`, or `HEGEL_E_INVALID_ARG` on a null / non-UTF-8
+ label or a non-finite value.
+ */
+hegel_result_t hegel_event_value(hegel_context_t *ctx,
+                                 hegel_test_case_t *tc,
+                                 double value,
+                                 const char *label);
 
 /*
  Create a printer-options handle with every option at its default

--- a/hegel-c/src/backend.rs
+++ b/hegel-c/src/backend.rs
@@ -291,6 +291,14 @@ pub trait DataSource: Send + Sync {
     /// non-finite or the label has already been observed this test case.
     fn target_observation(&self, score: f64, label: &str) -> Result<(), DataSourceError>;
 
+    /// Record an event observation for the current test case: a bare event
+    /// (`value` is `None`), reported as the fraction of test cases it
+    /// occurred in, or a numeric observation, reported as a distribution
+    /// summary. Shown at the end of the run when the `show_statistics`
+    /// setting is on. Errors with `InvalidArgument` if a numeric
+    /// observation is non-finite.
+    fn event_observation(&self, label: &str, value: Option<f64>) -> Result<(), DataSourceError>;
+
     /// Whether this test case belongs to a run already known to be
     /// nondeterministic.
     fn is_nondeterministic(&self) -> bool;

--- a/hegel-c/src/lib.rs
+++ b/hegel-c/src/lib.rs
@@ -1028,6 +1028,29 @@ pub unsafe extern "C" fn hegel_settings_set_report_multiple_failures(
 }
 
 /// Parameters:
+/// `yes`: When `true`, libhegel prints a statistics block on the run's
+///   output at the end of the run: for each label recorded with
+///   `hegel_event`, the fraction of generation-phase test cases it
+///   occurred in, and for each label recorded with `hegel_event_value`, a
+///   distribution summary of the observed values. Defaults to off.
+///
+/// Returns `HEGEL_OK`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn hegel_settings_set_show_statistics(
+    ctx: *mut HegelContext,
+    s: *mut HegelSettings,
+    yes: bool,
+) -> hegel_result_t {
+    clear_last_error(ctx);
+    let handle = match unsafe { settings_mut(ctx, s, "hegel_settings_set_show_statistics") } {
+        Ok(h) => h,
+        Err(rc) => return rc,
+    };
+    handle.inner = handle.inner.clone().show_statistics(yes);
+    HEGEL_OK
+}
+
+/// Parameters:
 /// `database`: NULL sets it to the default: `./.hegel/examples/`. `""`
 ///   disables the database entirely. Discovered failures will not be
 ///   stored. Anything else is used as the database root directory. The
@@ -3905,6 +3928,82 @@ pub unsafe extern "C" fn hegel_target(
         }
     };
     match tc.stream.target_observation(value, label) {
+        Ok(()) => HEGEL_OK,
+        Err(e) => translate_ds_error(ctx, e),
+    }
+}
+
+/// Record an event for the current test case, for the end-of-run
+/// statistics report: the report shows, per label, the fraction of
+/// generation-phase test cases in which the label was recorded at least
+/// once. The report prints only when the `show_statistics` setting is on
+/// (`hegel_settings_set_show_statistics`); without it events cost almost
+/// nothing and report nothing.
+///
+/// Parameters:
+/// `label`: Non-NULL, valid UTF-8.
+///
+/// Returns `HEGEL_OK`, or `HEGEL_E_INVALID_ARG` on a null / non-UTF-8
+/// label.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn hegel_event(
+    ctx: *mut HegelContext,
+    tc: *mut HegelTestCase,
+    label: *const c_char,
+) -> hegel_result_t {
+    unsafe { event_observation(ctx, tc, "hegel_event", label, None) }
+}
+
+/// Record a numeric observation under `label` for the current test case,
+/// for the end-of-run statistics report: the report shows, per label, a
+/// summary of the observed distribution (count, min, median, mean, p90,
+/// max) over generation-phase test cases. The report prints only when the
+/// `show_statistics` setting is on
+/// (`hegel_settings_set_show_statistics`); without it observations cost
+/// almost nothing and report nothing.
+///
+/// Parameters:
+/// `value`: The observation. Must be finite.
+/// `label`: Non-NULL, valid UTF-8. Unlike `hegel_target`, a label may be
+///   observed any number of times per test case.
+///
+/// Returns `HEGEL_OK`, or `HEGEL_E_INVALID_ARG` on a null / non-UTF-8
+/// label or a non-finite value.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn hegel_event_value(
+    ctx: *mut HegelContext,
+    tc: *mut HegelTestCase,
+    value: f64,
+    label: *const c_char,
+) -> hegel_result_t {
+    unsafe { event_observation(ctx, tc, "hegel_event_value", label, Some(value)) }
+}
+
+/// Shared body of `hegel_event` and `hegel_event_value`.
+unsafe fn event_observation(
+    ctx: *mut HegelContext,
+    tc: *mut HegelTestCase,
+    fn_name: &str,
+    label: *const c_char,
+    value: Option<f64>,
+) -> hegel_result_t {
+    clear_last_error(ctx);
+    let (tc, _guard) = match unsafe { tc_guard(ctx, fn_name, tc) } {
+        Ok(t) => t,
+        Err(rc) => return rc,
+    };
+    if label.is_null() {
+        set_last_error(ctx, &format!("{fn_name}: label is null"));
+        return HEGEL_E_INVALID_ARG;
+    }
+    let label = match unsafe { CStr::from_ptr(label) }.to_str() {
+        Ok(s) => s,
+        Err(_) => {
+            set_last_error(ctx, &format!("{fn_name}: label is not valid UTF-8"));
+            return HEGEL_E_INVALID_ARG;
+        }
+    };
+    match tc.stream.event_observation(label, value) {
         Ok(()) => HEGEL_OK,
         Err(e) => translate_ds_error(ctx, e),
     }

--- a/hegel-c/src/native/core/state.rs
+++ b/hegel-c/src/native/core/state.rs
@@ -1385,6 +1385,10 @@ pub struct FamilyCore {
     /// `tc.target()` observations, keyed by label. Family-wide so the
     /// once-per-test-case label uniqueness holds across clones.
     pub(crate) target_observations: Mutex<HashMap<String, f64>>,
+    /// `tc.event()` / `tc.event_value()` observations, in recording order:
+    /// the label plus the numeric observation for `event_value`. Family-wide
+    /// so clone-stream events land on the same test case.
+    pub(crate) events: Mutex<Vec<(String, Option<f64>)>>,
     /// When set, state machines draw no step cap and never report their
     /// rule sequence as done. Set for single-test-case runs, which explore
     /// one unbounded test case instead of many capped ones.
@@ -1432,6 +1436,7 @@ impl FamilyCore {
             total_draws: AtomicUsize::new(0),
             budget: AtomicUsize::new(budget),
             target_observations: Mutex::new(HashMap::default()),
+            events: Mutex::new(Vec::new()),
             state_machine_steps_unbounded: AtomicBool::new(false),
             stateful_step_count: AtomicI64::new(50),
             concurrent_machine: AtomicBool::new(false),

--- a/hegel-c/src/native/data_source.rs
+++ b/hegel-c/src/native/data_source.rs
@@ -77,6 +77,10 @@ impl NativeDataSource {
         handle.lock().family().target_observations.lock().clone()
     }
 
+    pub fn take_events(handle: &NativeTestCaseHandle) -> Vec<(String, Option<f64>)> {
+        handle.lock().family().events.lock().clone()
+    }
+
     /// The test case's outcome, reconstructed from its family's write-once
     /// conclusion. Whoever concluded the family first — a draw that overran
     /// or hit a terminal assume, or the body via `mark_complete` — set the
@@ -415,6 +419,21 @@ impl DataSource for NativeDataSource {
             )));
         }
         observations.insert(label.to_string(), score);
+        Ok(())
+    }
+
+    fn event_observation(&self, label: &str, value: Option<f64>) -> Result<(), DataSourceError> {
+        if let Some(v) = value {
+            if !v.is_finite() {
+                return Err(DataSourceError::InvalidArgument(format!(
+                    "tc.event_value({label:?}, {v}) requires a finite value; \
+                     got non-finite value"
+                )));
+            }
+        }
+        let family = Arc::clone(self.inner.lock().family());
+        let mut events = family.events.lock();
+        events.push((label.to_string(), value));
         Ok(())
     }
 

--- a/hegel-c/src/native/events.rs
+++ b/hegel-c/src/native/events.rs
@@ -1,0 +1,95 @@
+//! Per-run aggregation of `tc.event()` / `tc.event_value()` observations,
+//! reported at the end of the run when the `show_statistics` setting is on.
+
+use alloc::collections::BTreeMap;
+use alloc::format;
+use alloc::string::String;
+use alloc::vec::Vec;
+
+/// Run-level event statistics, folded in one test case at a time.
+///
+/// Only generation-phase cases with status Valid or Interesting are
+/// recorded: replays during shrinking would re-observe the same shrinking
+/// target over and over and swamp the distribution the user asked about.
+#[derive(Default)]
+pub(crate) struct RunStatistics {
+    /// Test cases folded in, the denominator for event percentages.
+    cases: u64,
+    /// Per label: the number of recorded cases in which the label was
+    /// observed at least once.
+    counts: BTreeMap<String, u64>,
+    /// Per label: every numeric observation from recorded cases.
+    values: BTreeMap<String, Vec<f64>>,
+}
+
+impl RunStatistics {
+    /// Fold in one test case's observations. Bare events are deduplicated
+    /// per case (the report says "in what fraction of cases did this
+    /// happen"); numeric observations all count.
+    pub(crate) fn record_case(&mut self, events: &[(String, Option<f64>)]) {
+        self.cases += 1;
+        let mut seen: Vec<&str> = Vec::new();
+        for (label, value) in events {
+            match value {
+                None => {
+                    if !seen.contains(&label.as_str()) {
+                        seen.push(label);
+                        *self.counts.entry(label.clone()).or_insert(0) += 1;
+                    }
+                }
+                Some(v) => self.values.entry(label.clone()).or_default().push(*v),
+            }
+        }
+    }
+
+    /// Render the end-of-run statistics block.
+    pub(crate) fn render(&self) -> Vec<String> {
+        let mut lines = Vec::new();
+        if self.counts.is_empty() && self.values.is_empty() {
+            lines.push(format!(
+                "Statistics (over {} test cases): no events were recorded; \
+                 record them with tc.event(..) or tc.event_value(..)",
+                self.cases
+            ));
+            return lines;
+        }
+        lines.push(format!("Statistics (over {} test cases):", self.cases));
+        for (label, count) in &self.counts {
+            let percent = 100.0 * *count as f64 / self.cases.max(1) as f64;
+            lines.push(format!("  * {label}: {percent:.1}% of test cases"));
+        }
+        for (label, values) in &self.values {
+            let mut sorted = values.clone();
+            sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            let count = sorted.len();
+            let min = sorted[0];
+            let max = sorted[count - 1];
+            let median = if count % 2 == 1 {
+                sorted[count / 2]
+            } else {
+                (sorted[count / 2 - 1] + sorted[count / 2]) / 2.0
+            };
+            let mean = sorted.iter().sum::<f64>() / count as f64;
+            let p90 = sorted[nearest_rank_index(count, 0.9)];
+            lines.push(format!(
+                "  * {label}: count {count}, min {min}, median {median}, \
+                 mean {mean:.2}, p90 {p90}, max {max}"
+            ));
+        }
+        lines
+    }
+}
+
+/// Nearest-rank index of quantile `q` in a sorted list of `count`
+/// observations: the smallest index whose rank covers `q` of the list.
+/// Distribution tails are where generation problems hide (a collapse can
+/// move a high percentile long before it moves the maximum), so the report
+/// includes p90 alongside the extremes.
+fn nearest_rank_index(count: usize, q: f64) -> usize {
+    let rank = libm::ceil(count as f64 * q) as usize;
+    rank.max(1) - 1
+}
+
+#[cfg(test)]
+#[path = "../../tests/embedded/native/events_tests.rs"]
+mod tests;

--- a/hegel-c/src/native/mod.rs
+++ b/hegel-c/src/native/mod.rs
@@ -9,6 +9,7 @@ pub mod data_source;
 pub mod data_tree;
 pub mod database;
 pub mod draws;
+pub(crate) mod events;
 pub mod floats;
 pub mod intervalsets;
 pub mod printer;

--- a/hegel-c/src/native/test_runner.rs
+++ b/hegel-c/src/native/test_runner.rs
@@ -62,6 +62,10 @@ pub struct RunResult {
     /// for folding into the choice tree. Empty on a result reconstructed from
     /// the tree (the events are already recorded there).
     pub span_events: Vec<(usize, SpanEvent)>,
+    /// `tc.event()` / `tc.event_value()` observations from this execution,
+    /// in recording order. Empty for tests that record no events and on a
+    /// result reconstructed from the tree.
+    pub events: Vec<(String, Option<f64>)>,
 }
 
 const RANDOM_GENERATION_BATCH: u64 = 10;
@@ -286,6 +290,7 @@ impl<'a> Engine<'a> {
         if actually_generate {
             log_phase("Generate", "Start");
         }
+        self.collect_statistics = true;
 
         if settings.phases.contains(&Phase::Generate)
             && !self.test_is_trivial
@@ -463,6 +468,7 @@ impl<'a> Engine<'a> {
         if actually_generate {
             log_phase("Generate", "End");
         }
+        self.collect_statistics = false;
 
         if !self.interesting.is_empty() && !replay_aligned && shrink_phase && !self.nondeterministic
         {
@@ -616,6 +622,12 @@ impl<'a> Engine<'a> {
             if let Some(last) = origins_sorted.pop() {
                 origins_sorted.clear();
                 origins_sorted.push(last);
+            }
+        }
+
+        if settings.show_statistics {
+            for line in self.statistics.render() {
+                output.line(&line);
             }
         }
 
@@ -957,6 +969,13 @@ pub(crate) struct Engine<'a> {
     /// several distinct bugs surface each one.
     pub(crate) interesting: HashMap<String, Vec<ChoiceNode>>,
     pub(crate) targeting: crate::native::targeting::TargetingState,
+    /// Event statistics for the end-of-run report, folded in by
+    /// [`Self::record_run`] while [`Self::collect_statistics`] is set.
+    pub(crate) statistics: crate::native::events::RunStatistics,
+    /// Set for the duration of the generation phase, the only phase whose
+    /// cases feed [`Self::statistics`]: shrinking replays the same target
+    /// over and over and would swamp the reported distributions.
+    pub(crate) collect_statistics: bool,
     pub(crate) calls: u64,
     pub(crate) valid_test_cases: u64,
     pub(crate) invalid_test_cases: u64,
@@ -999,6 +1018,8 @@ impl<'a> Engine<'a> {
             tree_root: crate::native::data_tree::DataTreeNode::default(),
             interesting: HashMap::default(),
             targeting: crate::native::targeting::TargetingState::new(),
+            statistics: crate::native::events::RunStatistics::default(),
+            collect_statistics: false,
             calls: 0,
             valid_test_cases: 0,
             invalid_test_cases: 0,
@@ -1082,6 +1103,9 @@ impl<'a> Engine<'a> {
             let choices: Vec<ChoiceValue> = run.nodes.iter().map(|n| n.value()).collect();
             self.targeting.record(&choices, &run.target_observations);
         }
+        if self.collect_statistics && matches!(run.status, Status::Valid | Status::Interesting) {
+            self.statistics.record_case(&run.events);
+        }
         match run.status {
             Status::Valid => self.valid_test_cases += 1,
             Status::Invalid => self.invalid_test_cases += 1,
@@ -1126,6 +1150,7 @@ impl<'a> Engine<'a> {
         let spans = NativeDataSource::take_spans(&handle);
         let span_events = NativeDataSource::take_span_events(&handle);
         let target_observations = NativeDataSource::take_target_observations(&handle);
+        let events = NativeDataSource::take_events(&handle);
         let tc_result = NativeDataSource::take_outcome(&handle)?;
 
         let (status, origin) = match tc_result {
@@ -1142,6 +1167,7 @@ impl<'a> Engine<'a> {
             origin,
             target_observations,
             span_events,
+            events,
         })
     }
 
@@ -1183,6 +1209,7 @@ impl<'a> Engine<'a> {
                     origin: out.origin,
                     target_observations: out.target_observations,
                     span_events: Vec::new(),
+                    events: Vec::new(),
                 });
             }
         }

--- a/hegel-c/src/settings.rs
+++ b/hegel-c/src/settings.rs
@@ -164,6 +164,9 @@ pub struct Settings {
     pub(crate) suppress_health_check: Vec<HealthCheck>,
     pub(crate) phases: Vec<Phase>,
     pub(crate) report_multiple_failures: bool,
+    /// Print event statistics (`tc.event()` / `tc.event_value()`
+    /// observations from the generation phase) at the end of the run.
+    pub(crate) show_statistics: bool,
     /// The randomness backend, or `None` to let it be chosen automatically
     /// (urandom under Antithesis, the default PRNG otherwise). An explicit
     /// [`Settings::backend`] always wins over the automatic choice.
@@ -199,6 +202,7 @@ impl Settings {
                 Phase::Shrink,
             ],
             report_multiple_failures: true,
+            show_statistics: false,
             backend: None,
         }
     }
@@ -332,6 +336,14 @@ impl Settings {
     /// Maps to Hypothesis's `report_multiple_bugs` setting.
     pub fn report_multiple_failures(mut self, report_multiple_failures: bool) -> Self {
         self.report_multiple_failures = report_multiple_failures;
+        self
+    }
+
+    /// Print event statistics (`tc.event()` / `tc.event_value()`
+    /// observations from the generation phase) on the run's output at the
+    /// end of the run. Defaults to off.
+    pub fn show_statistics(mut self, show_statistics: bool) -> Self {
+        self.show_statistics = show_statistics;
         self
     }
 }

--- a/hegel-c/tests/c_abi_inprocess.rs
+++ b/hegel-c/tests/c_abi_inprocess.rs
@@ -16,9 +16,10 @@ use hegel_c::{
     HEGEL_STATE_MACHINE_DONE, HegelCollection, HegelContext, HegelFailure, HegelPool,
     HegelRecursion, HegelRun, HegelRunResult, HegelStateMachine, HegelTestCase, hegel_backend_t,
     hegel_collection_free, hegel_collection_more, hegel_collection_reject, hegel_context_free,
-    hegel_context_last_error, hegel_context_new, hegel_failure_free, hegel_failure_origin,
-    hegel_failure_reproduction_blob, hegel_generate_boolean, hegel_generate_integer, hegel_label_t,
-    hegel_mark_complete, hegel_mode_t, hegel_new_collection, hegel_new_pool, hegel_new_recursion,
+    hegel_context_last_error, hegel_context_new, hegel_event, hegel_event_value,
+    hegel_failure_free, hegel_failure_origin, hegel_failure_reproduction_blob,
+    hegel_generate_boolean, hegel_generate_integer, hegel_label_t, hegel_mark_complete,
+    hegel_mode_t, hegel_new_collection, hegel_new_pool, hegel_new_recursion,
     hegel_new_state_machine, hegel_next_test_case, hegel_pool_add, hegel_pool_free,
     hegel_pool_generate, hegel_recursion_branch, hegel_recursion_finish, hegel_recursion_free,
     hegel_recursion_leaf, hegel_recursion_retry, hegel_run_free, hegel_run_result,
@@ -137,6 +138,10 @@ fn null_handles_are_rejected_without_crashing() {
         );
         assert_eq!(
             hegel_settings_set_report_multiple_failures(ctx, ptr::null_mut(), true),
+            HEGEL_E_INVALID_HANDLE
+        );
+        assert_eq!(
+            hegel_c::hegel_settings_set_show_statistics(ctx, ptr::null_mut(), true),
             HEGEL_E_INVALID_HANDLE
         );
         assert_eq!(
@@ -894,6 +899,19 @@ fn live_test_case_argument_validation() {
         );
         assert!(last_error(ctx).contains("would overwrite previous"));
 
+        assert_eq!(hegel_event(ctx, tc, ptr::null()), HEGEL_E_INVALID_ARG);
+        assert!(last_error(ctx).contains("label is null"));
+        assert_eq!(hegel_event(ctx, tc, bad_utf8.as_ptr()), HEGEL_E_INVALID_ARG);
+        assert!(last_error(ctx).contains("not valid UTF-8"));
+        assert_eq!(
+            hegel_event_value(ctx, tc, f64::NAN, c"x".as_ptr()),
+            HEGEL_E_INVALID_ARG
+        );
+        assert!(last_error(ctx).contains("finite value"));
+        assert_eq!(hegel_event(ctx, tc, c"seen".as_ptr()), HEGEL_OK);
+        assert_eq!(hegel_event(ctx, tc, c"seen".as_ptr()), HEGEL_OK);
+        assert_eq!(hegel_event_value(ctx, tc, 3.5, c"seen".as_ptr()), HEGEL_OK);
+
         assert_eq!(
             hegel_mark_complete(
                 ctx,
@@ -1489,6 +1507,10 @@ fn state_machine_and_primitive_boolean_paths() {
         let mut bv = false;
         assert_eq!(
             hegel_generate_boolean(ctx, null_tc, 0.5, false, false, &mut bv),
+            HEGEL_E_INVALID_HANDLE
+        );
+        assert_eq!(
+            hegel_event(ctx, null_tc, c"x".as_ptr()),
             HEGEL_E_INVALID_HANDLE
         );
 

--- a/hegel-c/tests/embedded/native/events_tests.rs
+++ b/hegel-c/tests/embedded/native/events_tests.rs
@@ -1,0 +1,90 @@
+use super::*;
+use alloc::string::ToString;
+use alloc::vec;
+
+fn event(label: &str) -> (String, Option<f64>) {
+    (label.to_string(), None)
+}
+
+fn value(label: &str, v: f64) -> (String, Option<f64>) {
+    (label.to_string(), Some(v))
+}
+
+#[test]
+fn no_events_renders_a_pointer_at_the_recording_api() {
+    let mut stats = RunStatistics::default();
+    stats.record_case(&[]);
+    stats.record_case(&[]);
+    let lines = stats.render();
+    assert_eq!(lines.len(), 1);
+    assert!(lines[0].contains("over 2 test cases"));
+    assert!(lines[0].contains("no events were recorded"));
+}
+
+#[test]
+fn bare_events_report_the_fraction_of_cases_deduplicated_within_a_case() {
+    let mut stats = RunStatistics::default();
+    stats.record_case(&[event("hit"), event("hit"), event("other")]);
+    stats.record_case(&[event("hit")]);
+    stats.record_case(&[]);
+    stats.record_case(&[]);
+    let lines = stats.render();
+    assert_eq!(lines[0], "Statistics (over 4 test cases):");
+    assert_eq!(lines[1], "  * hit: 50.0% of test cases");
+    assert_eq!(lines[2], "  * other: 25.0% of test cases");
+}
+
+#[test]
+fn numeric_observations_report_a_distribution_summary() {
+    let mut stats = RunStatistics::default();
+    stats.record_case(&[value("size", 1.0), value("size", 3.0)]);
+    stats.record_case(&[value("size", 2.0), value("size", 10.0)]);
+    let lines = stats.render();
+    assert_eq!(lines.len(), 2);
+    assert_eq!(
+        lines[1],
+        "  * size: count 4, min 1, median 2.5, mean 4.00, p90 10, max 10"
+    );
+}
+
+#[test]
+fn odd_count_median_is_the_middle_observation() {
+    let mut stats = RunStatistics::default();
+    stats.record_case(&[value("n", 5.0), value("n", 1.0), value("n", 2.0)]);
+    let lines = stats.render();
+    assert_eq!(
+        lines[1],
+        "  * n: count 3, min 1, median 2, mean 2.67, p90 5, max 5"
+    );
+}
+
+#[test]
+fn bare_and_numeric_events_render_in_label_order() {
+    let mut stats = RunStatistics::default();
+    stats.record_case(&[value("a-value", 7.0), event("z-event"), event("a-event")]);
+    let lines = stats.render();
+    assert_eq!(
+        lines,
+        vec![
+            "Statistics (over 1 test cases):".to_string(),
+            "  * a-event: 100.0% of test cases".to_string(),
+            "  * z-event: 100.0% of test cases".to_string(),
+            "  * a-value: count 1, min 7, median 7, mean 7.00, p90 7, max 7".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn p90_is_the_nearest_rank_below_an_outlying_maximum() {
+    let mut stats = RunStatistics::default();
+    let observations: Vec<(String, Option<f64>)> = (1..=9)
+        .map(|n| value("n", n as f64))
+        .chain([value("n", 100.0)])
+        .collect();
+    stats.record_case(&observations);
+    let lines = stats.render();
+    assert_eq!(
+        lines[1],
+        "  * n: count 10, min 1, median 5.5, mean 14.50, p90 9, max 100"
+    );
+}

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -171,6 +171,11 @@ impl SettingsHandle {
                     raw,
                     settings.report_multiple_failures,
                 ));
+                require_ok(hegel_c::hegel_settings_set_show_statistics(
+                    ctx,
+                    raw,
+                    settings.show_statistics,
+                ));
                 match &settings.database {
                     Database::Disabled => {
                         let empty = CString::new("").unwrap();
@@ -905,6 +910,20 @@ impl CTestCase {
         let c_label = cstring_lossy(label);
         rc_to_unit(with_context(|ctx| unsafe {
             hegel_c::hegel_target(ctx, self.raw, score, c_label.as_ptr())
+        }))
+    }
+
+    pub(crate) fn event(&self, label: &str) -> Result<(), hegel_result_t> {
+        let c_label = cstring_lossy(label);
+        rc_to_unit(with_context(|ctx| unsafe {
+            hegel_c::hegel_event(ctx, self.raw, c_label.as_ptr())
+        }))
+    }
+
+    pub(crate) fn event_value(&self, label: &str, value: f64) -> Result<(), hegel_result_t> {
+        let c_label = cstring_lossy(label);
+        rc_to_unit(with_context(|ctx| unsafe {
+            hegel_c::hegel_event_value(ctx, self.raw, value, c_label.as_ptr())
         }))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,6 +183,15 @@
 //! When set and non-empty, it takes precedence over any value configured in
 //! source, including explicit `test_cases` attributes.
 //!
+//! To see what a test actually generates, record events with
+//! [`TestCase::event`] and [`TestCase::event_value`] and enable the
+//! end-of-run statistics report with the `HEGEL_STATISTICS` environment
+//! variable (or [`Settings::show_statistics`]):
+//!
+//! ```bash
+//! HEGEL_STATISTICS=1 cargo test my_test -- --nocapture
+//! ```
+//!
 //! ## Threading
 //!
 //! [`TestCase`] is `Send` but not `Sync`: you can clone it and move the clone

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -137,6 +137,7 @@ pub struct Settings {
     pub(crate) suppress_health_check: Vec<HealthCheck>,
     pub(crate) phases: Vec<Phase>,
     pub(crate) report_multiple_failures: bool,
+    pub(crate) show_statistics: bool,
     pub(crate) print_blob: bool,
     /// The randomness backend, or `None` to let it be chosen automatically
     /// (urandom under Antithesis, the default PRNG otherwise). An explicit
@@ -172,6 +173,7 @@ impl Settings {
                 Phase::Shrink,
             ],
             report_multiple_failures: false,
+            show_statistics: false,
             print_blob: false,
             backend: None,
         }
@@ -301,6 +303,21 @@ impl Settings {
         self.phases.contains(&phase)
     }
 
+    /// Print event statistics at the end of the run (default: off): for
+    /// each label recorded with [`TestCase::event`](crate::TestCase::event),
+    /// the fraction of generation-phase test cases it occurred in, and for
+    /// each label recorded with
+    /// [`TestCase::event_value`](crate::TestCase::event_value), a summary of
+    /// the observed distribution.
+    ///
+    /// The `HEGEL_STATISTICS` environment variable, when set to anything
+    /// but `"0"` or the empty string, turns this on at runtime without
+    /// editing source.
+    pub fn show_statistics(mut self, show_statistics: bool) -> Self {
+        self.show_statistics = show_statistics;
+        self
+    }
+
     /// Apply environment-variable overrides to these settings. Called once
     /// per run, after all builder configuration, so the environment wins
     /// over values set in source.
@@ -324,6 +341,11 @@ impl Settings {
                 } else {
                     Database::Path(value)
                 };
+            }
+        }
+        if let Some(value) = env("HEGEL_STATISTICS") {
+            if !value.is_empty() && value != "0" {
+                self.show_statistics = true;
             }
         }
         self

--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -691,6 +691,70 @@ impl TestCase {
         }
     }
 
+    /// Record an event for the end-of-run statistics report.
+    ///
+    /// With statistics enabled
+    /// ([`Settings::show_statistics`](crate::Settings::show_statistics), or
+    /// the `HEGEL_STATISTICS` environment variable), the end of the run
+    /// reports, per label, the fraction of generation-phase test cases in
+    /// which the label was recorded at least once — a quick check that the
+    /// interesting situations in a test actually occur. With statistics
+    /// off, events cost almost nothing and report nothing.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use hegel::generators as gs;
+    ///
+    /// #[hegel::test]
+    /// fn my_test(tc: hegel::TestCase) {
+    ///     let xs: Vec<u8> = tc.draw(gs::vecs(gs::integers()));
+    ///     if xs.is_empty() {
+    ///         tc.event("empty input");
+    ///     }
+    /// }
+    /// ```
+    pub fn event(&self, label: impl AsRef<str>) {
+        self.record_event(|ctc| ctc.event(label.as_ref()));
+    }
+
+    /// Record a numeric observation under `label` for the end-of-run
+    /// statistics report.
+    ///
+    /// With statistics enabled
+    /// ([`Settings::show_statistics`](crate::Settings::show_statistics), or
+    /// the `HEGEL_STATISTICS` environment variable), the end of the run
+    /// reports, per label, a summary of the observed distribution — count,
+    /// min, median, mean, p90, max — over generation-phase test cases, so a test
+    /// can check the sizes or shapes it actually exercises. Unlike
+    /// [`target`](Self::target), a label may be observed any number of
+    /// times per test case, and the observations do not steer generation.
+    ///
+    /// `value` must be finite.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use hegel::generators as gs;
+    ///
+    /// #[hegel::test]
+    /// fn my_test(tc: hegel::TestCase) {
+    ///     let xs: Vec<u8> = tc.draw(gs::vecs(gs::integers()));
+    ///     tc.event_value("input length", xs.len() as f64);
+    /// }
+    /// ```
+    pub fn event_value(&self, label: impl AsRef<str>, value: f64) {
+        self.record_event(|ctc| ctc.event_value(label.as_ref(), value));
+    }
+
+    /// Shared body of [`event`](Self::event) and
+    /// [`event_value`](Self::event_value).
+    fn record_event(&self, record: impl FnOnce(&CTestCase) -> Result<(), hegel_c::hegel_result_t>) {
+        if let Err(rc) = self.with_ctc(record) {
+            raise_for_rc(rc);
+        }
+    }
+
     /// Run `body` in a loop that should runs "logically infinitely" or until
     /// error. Roughly equivalent to a `loop` but with better interaction with
     /// the test runner: This loop will never exit until the test case completes.

--- a/tests/embedded/runner_tests.rs
+++ b/tests/embedded/runner_tests.rs
@@ -120,6 +120,23 @@ fn test_env_override_database_empty_is_ignored() {
 }
 
 #[test]
+fn test_env_override_statistics_enables_reporting() {
+    let s = Settings::new()
+        .with_env_overrides_from(|key| (key == "HEGEL_STATISTICS").then(|| "1".to_string()));
+    assert!(s.show_statistics);
+}
+
+#[test]
+fn test_env_override_statistics_zero_and_empty_are_ignored() {
+    let s = Settings::new()
+        .with_env_overrides_from(|key| (key == "HEGEL_STATISTICS").then(|| "0".to_string()));
+    assert!(!s.show_statistics);
+    let s = Settings::new()
+        .with_env_overrides_from(|key| (key == "HEGEL_STATISTICS").then(String::new));
+    assert!(!s.show_statistics);
+}
+
+#[test]
 fn test_is_in_ci_from_detects_presence_and_value_variables() {
     assert!(!is_in_ci_from(|_| None));
     assert!(is_in_ci_from(|key| (key == "CI").then(String::new)));

--- a/tests/test_statistics.rs
+++ b/tests/test_statistics.rs
@@ -1,0 +1,87 @@
+//! End-of-run event statistics: `tc.event(..)` / `tc.event_value(..)`
+//! observations reported under `Settings::show_statistics`, captured
+//! through `hegel::with_output_override`.
+
+use hegel::generators as gs;
+use hegel::{Hegel, Settings, TestCase};
+use std::sync::{Arc, Mutex};
+
+fn capture_run(settings: Settings, body: impl FnMut(TestCase) + 'static) -> Vec<String> {
+    let buf: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let writer = Arc::clone(&buf);
+    let sink: Arc<dyn Fn(&str) + Send + Sync> =
+        Arc::new(move |s: &str| writer.lock().unwrap().push(s.to_string()));
+    hegel::with_output_override(sink, || {
+        Hegel::new(body).settings(settings).run();
+    });
+    buf.lock().unwrap().clone()
+}
+
+fn settings() -> Settings {
+    Settings::new()
+        .test_cases(50)
+        .database(None)
+        .derandomize(true)
+}
+
+#[test]
+fn test_statistics_report_events_and_value_distributions() {
+    let lines = capture_run(settings().show_statistics(true), |tc: TestCase| {
+        let n: i64 = tc.draw(gs::integers::<i64>().min_value(0).max_value(9));
+        if n == 0 {
+            tc.event("zero");
+        }
+        tc.event_value("n", n as f64);
+    });
+    assert!(lines.iter().any(|l| l.starts_with("Statistics (over ")));
+    assert!(
+        lines
+            .iter()
+            .any(|l| l.contains("* zero: ") && l.contains("% of test cases"))
+    );
+    assert!(
+        lines
+            .iter()
+            .any(|l| l.contains("* n: count ") && l.contains("median"))
+    );
+}
+
+#[test]
+fn test_statistics_are_not_reported_by_default() {
+    let lines = capture_run(settings(), |tc: TestCase| {
+        tc.draw(gs::booleans());
+        tc.event("always");
+    });
+    assert!(!lines.iter().any(|l| l.contains("Statistics")));
+}
+
+#[test]
+fn test_events_from_rejected_test_cases_do_not_count() {
+    let lines = capture_run(settings().show_statistics(true), |tc: TestCase| {
+        if tc.draw(gs::booleans()) {
+            tc.event("rejected");
+            tc.assume(false);
+        }
+        tc.event("kept");
+    });
+    assert!(
+        lines
+            .iter()
+            .any(|l| l.contains("* kept: 100.0% of test cases"))
+    );
+    assert!(!lines.iter().any(|l| l.contains("* rejected:")));
+}
+
+#[hegel::test]
+#[should_panic(expected = "finite value")]
+fn test_event_value_rejects_non_finite_values(tc: TestCase) {
+    tc.event_value("bad", f64::NAN);
+}
+
+#[test]
+fn test_statistics_without_events_point_at_the_recording_api() {
+    let lines = capture_run(settings().show_statistics(true), |tc: TestCase| {
+        tc.draw(gs::booleans());
+    });
+    assert!(lines.iter().any(|l| l.contains("no events were recorded")));
+}


### PR DESCRIPTION
<details>
<summary>PR description (AI generated)</summary>

`tc.event(label)` records that a labelled situation occurred in the current test case; `tc.event_value(label, value)` records a numeric observation. With `Settings::show_statistics(true)` or `HEGEL_STATISTICS=1`, the run ends with a per-label report: the fraction of test cases each event occurred in, and count/min/median/mean/p90/max for numeric observations.

Only generation-phase valid/interesting cases feed the report, so shrink replays and assume-rejected cases cannot skew the distributions. Backed by new ABI functions `hegel_event` / `hegel_event_value` and a `show_statistics` setting, so every binding gets it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>