### PR TITLE
Fix stateful step-label ordering and scope draw names to their rule

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,13 @@
+RELEASE_TYPE: patch
+
+This patch fixes the ordering of step labels in stateful counterexamples. Each label used to print after the draws its rule made, so reading a failing sequence meant shifting every label back by one. Notes are also no longer deferred while an engine span is open, only while a drawn value is mid-print, so a note can never trail the output of a later draw.
+
+Each step now prints as a block, with the rule's draws and notes scoped to it:
+
+```
+Step 1: add {
+  let n = 1;
+}
+```
+
+`#[rule]` and `#[invariant]` bodies now rewrite `tc.draw` calls the way `#[hegel::test]` bodies do, so a rule's draws print under their variable names (`let n = 1;` instead of `let draw_1 = 1;`) and `tc.target` calls get per-expression labels. Draw names are scoped to the rule invocation: a name drawn once per rule prints bare in every step, and only names drawn repeatedly within one invocation get a numeric suffix.

--- a/hegel-macros/src/stateful.rs
+++ b/hegel-macros/src/stateful.rs
@@ -2,12 +2,28 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{Attribute, ImplItem, ItemImpl};
 
+use crate::common::{extract_ident_from_pat, rewrite_draws_in_block};
+
 fn is_rule(a: &Attribute) -> bool {
     a.path().is_ident("rule")
 }
 
 fn is_invariant(a: &Attribute) -> bool {
     a.path().is_ident("invariant")
+}
+
+/// Rewrite `tc.draw` / `tc.target` calls in a rule or invariant body, the
+/// way `#[hegel::test]` does for a test body. Each invocation runs on its
+/// own naming scope, so repeatability is judged within the body alone even
+/// though the body runs once per step.
+fn rewrite_method_draws(method: &mut syn::ImplItemFn) {
+    let tc_ident = match method.sig.inputs.iter().nth(1) {
+        Some(syn::FnArg::Typed(arg)) => extract_ident_from_pat(&arg.pat),
+        _ => None,
+    };
+    if let Some(tc_ident) = tc_ident {
+        rewrite_draws_in_block(&mut method.block, &tc_ident);
+    }
 }
 
 struct MethodInfo {
@@ -154,6 +170,10 @@ pub fn expand_concurrent_state_machine(mut block: ItemImpl) -> TokenStream {
                 }
             }
 
+            if rule_attr.is_some() || has_invariant {
+                rewrite_method_draws(method);
+            }
+
             if let Some(attr) = rule_attr {
                 let group = match rule_group(&attr) {
                     Ok(group) => group,
@@ -220,6 +240,10 @@ pub fn expand_state_machine(mut block: ItemImpl) -> TokenStream {
                     )
                     .to_compile_error();
                 }
+            }
+
+            if has_rule || has_invariant {
+                rewrite_method_draws(method);
             }
 
             let info = || MethodInfo {

--- a/src/stateful.rs
+++ b/src/stateful.rs
@@ -625,7 +625,7 @@ pub fn run<M: StateMachine>(mut m: M, tc: TestCase) {
                 "state_machine_next_rule returned out-of-range rule index {rule_index}"
             );
             let rule = &rules[rule_index as usize];
-            tc.note(&format!("Step {}: {}", steps_attempted + 1, rule.name));
+            tc.note(&format!("Step {}: {} {{", steps_attempted + 1, rule.name));
 
             let rule_tc = tc.child(2);
             let thunk = || (rule.apply)(&mut m, rule_tc);
@@ -633,17 +633,20 @@ pub fn run<M: StateMachine>(mut m: M, tc: TestCase) {
 
             steps_attempted += 1;
             match result {
-                Ok(()) => {}
+                Ok(()) => tc.note("}"),
                 Err(e) if e.downcast_ref::<AssumeFailed>().is_some() => {
                     machine_rule_rejected(&tc, &machine, 0);
                     round_rejected = true;
-                    tc.note("Rule stopped early due to violated assumption.");
+                    tc.child(2)
+                        .note("Rule stopped early due to violated assumption.");
+                    tc.note("}");
                 }
                 // Everything else — including StopTest, so an out-of-data
                 // case is reported as an overrun instead of returning
                 // normally with a half-applied rule — unwinds through the
                 // caller.
                 Err(e) => {
+                    tc.note("}");
                     tc.stop_span(false);
                     resume_unwind(e)
                 }
@@ -837,22 +840,28 @@ fn run_worker_round<M: ConcurrentStateMachine + ?Sized>(
         };
 
         let rule = &rules[rule_index as usize];
-        tc.note(&format!("Rule: {}", rule.name));
+        tc.note(&format!("Rule: {} {{", rule.name));
         let rule_tc = tc.child(2);
         let result = catch_unwind(AssertUnwindSafe(|| (rule.apply)(m, rule_tc)));
         match result {
-            Ok(()) => {}
+            Ok(()) => tc.note("}"),
             Err(e) => match classify_worker_unwind(e) {
                 WorkerEvent::Invalid => {
                     let rejected = catch_unwind(AssertUnwindSafe(|| {
                         machine_rule_rejected(tc, machine, worker as i64);
                     }));
                     if let Err(e) = rejected {
+                        tc.note("}");
                         return classify_worker_unwind(e);
                     }
-                    tc.note("Rule stopped early due to violated assumption.");
+                    tc.child(2)
+                        .note("Rule stopped early due to violated assumption.");
+                    tc.note("}");
                 }
-                event => return event,
+                event => {
+                    tc.note("}");
+                    return event;
+                }
             },
         }
     }

--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -109,13 +109,6 @@ pub(crate) struct TestCaseGlobalData {
     /// [`TestCase::record_named_draw`] (display-name allocation + `Debug`
     /// rendering of the value) can be skipped entirely.
     emit: bool,
-    /// Draw-name bookkeeping shared between every clone of a `TestCase`,
-    /// behind a blocking, non-reentrant mutex. The backend handle is no longer
-    /// shared here — each `TestCase` instance owns its own libhegel handle (so
-    /// clones can be driven concurrently) — so this lock only serialises the
-    /// frontend's own draw-name accounting, never backend traffic. No method
-    /// holds it while calling back into `TestCase`.
-    draw_state: Mutex<DrawState>,
     /// When this test case started, shared by every clone so the
     /// `[worker N +X.XXXms]` offsets stamped on concurrent workers' output
     /// lines are comparable across workers.
@@ -125,27 +118,31 @@ pub(crate) struct TestCaseGlobalData {
 /// The width drawn-value documents are laid out to.
 const PRINTER_MAX_WIDTH: u64 = crate::pretty::DEFAULT_MAX_WIDTH;
 
-/// Marks a printed draw as in progress: `span_depth` is raised for the
+/// Marks a printed draw as in progress: `printing_depth` is raised for the
 /// duration of the enclosing `draw_and_print` call so that a `tc.note()` or
 /// nested `tc.draw` made by a hand-written generator body behaves exactly as
 /// it does inside a combinator span — the note buffers, the nested draw
 /// stays silent — instead of re-entering the printer lock the enclosing draw
-/// already holds. Restored on drop so an unwinding draw (a failed
-/// assumption, a budget stop) leaves the depth balanced.
+/// already holds. Dropping the scope restores the depth and flushes the
+/// buffered notes, so they land right after their draw's line even when the
+/// draw unwinds (a failed assumption, a budget stop). This scope is the only
+/// thing that defers a note: outside it, notes and draw lines write to the
+/// instance's print region directly, in call order.
 struct PrintingDrawScope<'a> {
     tc: &'a TestCase,
 }
 
 impl<'a> PrintingDrawScope<'a> {
     fn new(tc: &'a TestCase) -> Self {
-        tc.local.borrow_mut().span_depth += 1;
+        tc.local.borrow_mut().printing_depth += 1;
         PrintingDrawScope { tc }
     }
 }
 
 impl Drop for PrintingDrawScope<'_> {
     fn drop(&mut self) {
-        self.tc.local.borrow_mut().span_depth -= 1;
+        self.tc.local.borrow_mut().printing_depth -= 1;
+        self.tc.flush_pending_notes();
     }
 }
 
@@ -161,6 +158,7 @@ fn emit_note_line(printer: &mut PrettyPrinter, prefix: &str, indent: usize, mess
     printer.hard_break();
 }
 
+#[derive(Default)]
 pub(crate) struct DrawState {
     named_draw_counts: HashMap<String, usize>,
     named_draw_repeatable: HashMap<String, bool>,
@@ -169,7 +167,13 @@ pub(crate) struct DrawState {
 
 #[derive(Clone)]
 pub(crate) struct TestCaseLocalData {
+    /// Engine spans currently open on this instance (`start_span` without a
+    /// matching `stop_span`). It silences nested named draws and never
+    /// defers notes, which is `printing_depth`'s job.
     span_depth: usize,
+    /// Printed draws currently in progress on this instance (see
+    /// [`PrintingDrawScope`]).
+    printing_depth: usize,
     indent: usize,
     on_draw: OutputSink,
 }
@@ -272,16 +276,23 @@ pub struct TestCase {
     /// clones write concurrently, and the document assembles deterministically
     /// by anchor position.
     printer: RefCell<Option<PrettyPrinter>>,
-    /// Notes recorded while a draw was printing (`span_depth > 0`, e.g. from
-    /// inside a composite body). Emitting them inline would splice text into
-    /// the middle of the draw's `let … = …;` line, so they are buffered here
-    /// and flushed — in order — once the enclosing draw completes. Shared
-    /// with [`child`](TestCase::child) instances — a composite body's `tc`
-    /// notes into the same buffer its enclosing draw flushes — but fresh for
-    /// every [`clone`](TestCase::clone), whose notes belong to its own
-    /// region. The mutex is never contended: children live on their
-    /// parent's thread.
-    pending_notes: Arc<Mutex<Vec<(String, usize, String)>>>,
+    /// Notes recorded while this instance was printing a draw
+    /// (`printing_depth > 0`, e.g. from inside a composite body). Emitting
+    /// them inline would splice text into the middle of the draw's
+    /// `let … = …;` line, so they are buffered here and flushed, in order,
+    /// by the [`PrintingDrawScope`] that deferred them once the draw's line
+    /// is done. A note can only buffer during a printed draw on this same
+    /// instance, so the buffer is instance-local and no other instance can
+    /// flush this one's notes into its own region out of order.
+    pending_notes: RefCell<Vec<(String, usize, String)>>,
+    /// Draw-name bookkeeping for this instance's naming scope, behind a
+    /// blocking, non-reentrant mutex that only serialises the frontend's own
+    /// accounting (no method holds it while calling back into `TestCase`).
+    /// Shared with [`clone`](TestCase::clone) instances (a clone draws for
+    /// the same test body, so its names live in the same scope) but fresh
+    /// for every [`child`](TestCase::child), which opens a new scope: a
+    /// stateful rule's names are scoped to that one invocation.
+    draw_state: Arc<Mutex<DrawState>>,
 }
 
 impl Clone for TestCase {
@@ -291,7 +302,8 @@ impl Clone for TestCase {
             local: RefCell::new(self.local.borrow().clone()),
             handle: Arc::new(self.handle.clone_handle()),
             printer: RefCell::new(None),
-            pending_notes: Arc::new(Mutex::new(Vec::new())),
+            pending_notes: RefCell::new(Vec::new()),
+            draw_state: Arc::clone(&self.draw_state),
         }
     }
 }
@@ -425,31 +437,28 @@ impl TestCase {
         TestCase {
             global: Arc::new(TestCaseGlobalData {
                 emit,
-                draw_state: Mutex::new(DrawState {
-                    named_draw_counts: HashMap::new(),
-                    named_draw_repeatable: HashMap::new(),
-                    allocated_display_names: HashSet::new(),
-                }),
                 case_start: std::time::Instant::now(),
             }),
             local: RefCell::new(TestCaseLocalData {
                 span_depth: 0,
+                printing_depth: 0,
                 indent: 0,
                 on_draw,
             }),
             handle,
             printer: RefCell::new(None),
-            pending_notes: Arc::new(Mutex::new(Vec::new())),
+            pending_notes: RefCell::new(Vec::new()),
+            draw_state: Arc::new(Mutex::new(DrawState::default())),
         }
     }
 
-    /// Acquire the shared draw-name bookkeeping for the duration of `f`.
+    /// Acquire this scope's draw-name bookkeeping for the duration of `f`.
     ///
     /// Held briefly around draw-state updates, never around whole user-visible
     /// operations. The mutex is non-reentrant, so `f` must not call any other
     /// method that also acquires it.
     pub(crate) fn with_draw_state<R>(&self, f: impl FnOnce(&mut DrawState) -> R) -> R {
-        let mut guard = self.global.draw_state.lock();
+        let mut guard = self.draw_state.lock();
         f(&mut guard)
     }
 
@@ -501,7 +510,11 @@ impl TestCase {
         name: &str,
         repeatable: bool,
     ) -> T {
-        if self.local.borrow().span_depth > 0 {
+        let mid_draw = {
+            let local = self.local.borrow();
+            local.span_depth > 0 || local.printing_depth > 0
+        };
+        if mid_draw {
             return generator.do_draw(self);
         }
         let Some(display_name) = self.allocate_display_name(name, repeatable) else {
@@ -509,25 +522,21 @@ impl TestCase {
         };
         let indent = self.local.borrow().indent;
         let prefix = self.worker_line_prefix();
-        let value = {
-            let _printing = PrintingDrawScope::new(self);
-            self.with_printer(|printer| {
-                let mut speculation = printer.speculate();
-                let printer = speculation.printer();
-                printer.text(&prefix);
-                printer.text(&" ".repeat(indent));
-                printer.shift_indent(indent as isize);
-                printer.text(&format!("let {display_name} = "));
-                let value = self.draw_and_print(&generator, printer);
-                printer.text(";");
-                printer.shift_indent(-(indent as isize));
-                printer.hard_break();
-                speculation.commit();
-                value
-            })
-        };
-        self.flush_pending_notes();
-        value
+        let _printing = PrintingDrawScope::new(self);
+        self.with_printer(|printer| {
+            let mut speculation = printer.speculate();
+            let printer = speculation.printer();
+            printer.text(&prefix);
+            printer.text(&" ".repeat(indent));
+            printer.shift_indent(indent as isize);
+            printer.text(&format!("let {display_name} = "));
+            let value = self.draw_and_print(&generator, printer);
+            printer.text(";");
+            printer.shift_indent(-(indent as isize));
+            printer.hard_break();
+            speculation.commit();
+            value
+        })
     }
 
     /// Draw a value from a generator without recording it in the output.
@@ -627,12 +636,12 @@ impl TestCase {
         }
         let (indent, mid_draw) = {
             let local = self.local.borrow();
-            (local.indent, local.span_depth > 0)
+            (local.indent, local.printing_depth > 0)
         };
         let prefix = self.worker_line_prefix();
         if mid_draw {
             self.pending_notes
-                .lock()
+                .borrow_mut()
                 .push((prefix, indent, message.to_string()));
         } else {
             self.with_printer(|printer| emit_note_line(printer, &prefix, indent, message));
@@ -813,12 +822,14 @@ impl TestCase {
             global: self.global.clone(),
             local: RefCell::new(TestCaseLocalData {
                 span_depth: 0,
+                printing_depth: 0,
                 indent: local.indent + extra_indent,
                 on_draw: local.on_draw.clone(),
             }),
             handle: Arc::clone(&self.handle),
             printer: RefCell::new(None),
-            pending_notes: Arc::clone(&self.pending_notes),
+            pending_notes: RefCell::new(Vec::new()),
+            draw_state: Arc::new(Mutex::new(DrawState::default())),
         }
     }
 
@@ -852,7 +863,7 @@ impl TestCase {
     /// Emit any notes recorded while a draw was in progress on this
     /// instance.
     fn flush_pending_notes(&self) {
-        let notes = std::mem::take(&mut *self.pending_notes.lock());
+        let notes = std::mem::take(&mut *self.pending_notes.borrow_mut());
         if notes.is_empty() {
             return;
         }
@@ -874,7 +885,6 @@ impl TestCase {
         if !self.global.emit {
             return;
         }
-        self.flush_pending_notes();
         let output = self.with_printer(|printer| printer.try_value());
         let local = self.local.borrow();
         match output {

--- a/tests/test_concurrent_stateful.rs
+++ b/tests/test_concurrent_stateful.rs
@@ -124,7 +124,7 @@ fn a_worker_panic_is_reported_with_its_real_origin_and_buffered_output() {
         .unwrap()[1];
     assert_matches_regex(
         &text,
-        &format!(r"\[worker {worker} \+\d+\.\d{{3}}ms\]   let draw_\d"),
+        &format!(r"\[worker {worker} \+\d+\.\d{{3}}ms\]   let x = "),
     );
     assert!(
         text.contains("test_concurrent_stateful.rs"),

--- a/tests/test_printable_generators.rs
+++ b/tests/test_printable_generators.rs
@@ -625,6 +625,25 @@ fn note_inside_a_printed_draw_buffers_until_the_line_completes() {
     assert_eq!(lines, vec!["let draw_1 = 5;", "noted mid-draw"]);
 }
 
+/// A hand-written generator that notes and then panics mid-draw, so the
+/// enclosing printed draw unwinds with the note still buffered.
+struct NoteThenPanicGenerator;
+
+impl Generator<i64> for NoteThenPanicGenerator {
+    fn do_draw(&self, tc: &hegel::TestCase) -> i64 {
+        tc.note("noted before the panic");
+        panic!("boom");
+    }
+}
+
+#[test]
+fn note_inside_an_unwinding_draw_still_reaches_the_output() {
+    let lines = failing_lines(|tc| {
+        let _ = tc.draw(NoteThenPanicGenerator.print_with(|v, p| p.text(&format!("{v}"))));
+    });
+    assert_eq!(lines, vec!["noted before the panic"]);
+}
+
 /// A hand-written generator that makes a named `tc.draw` from inside
 /// `do_draw`; during a printed draw the nested draw must stay silent, like a
 /// draw inside any combinator span.

--- a/tests/test_stateful_output.rs
+++ b/tests/test_stateful_output.rs
@@ -1,0 +1,202 @@
+//! Snapshot tests for the printed output of failing stateful tests.
+//!
+//! These pin the exact shape of a stateful counterexample: each step prints
+//! as a `Step N: <rule> {` … `}` block holding that rule's draws and notes,
+//! with draw names scoped to the invocation. They run in-process and capture
+//! output via `hegel::with_output_override`, like `test_loop.rs`.
+
+mod common;
+
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::{Arc, Mutex};
+
+use hegel::TestCase;
+use hegel::generators as gs;
+use hegel::{Hegel, Settings};
+
+/// Run `body` as a Hegel property test and return the lines captured during
+/// the final replay of the shrunk failing case, trimmed of the failure
+/// diagnostic (whose backtrace is machine-specific).
+fn capture_stateful_output<F>(body: F) -> String
+where
+    F: FnMut(TestCase) + 'static,
+{
+    let buf: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let buf_writer = buf.clone();
+    let sink: Arc<dyn Fn(&str) + Send + Sync> =
+        Arc::new(move |s: &str| buf_writer.lock().unwrap().push(s.to_string()));
+
+    let _ = catch_unwind(AssertUnwindSafe(|| {
+        hegel::with_output_override(sink, || {
+            Hegel::new(body)
+                .settings(
+                    Settings::new()
+                        .test_cases(200)
+                        .database(None)
+                        .derandomize(true),
+                )
+                .run();
+        });
+    }));
+
+    let lines = buf.lock().unwrap().clone();
+    lines
+        .iter()
+        .take_while(|line| !line.starts_with("thread '"))
+        .map(String::as_str)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+struct Accumulator {
+    total: i32,
+}
+
+#[hegel::state_machine]
+impl Accumulator {
+    #[rule]
+    fn add(&mut self, tc: TestCase) {
+        let n: i32 = tc.draw(gs::integers::<i32>().min_value(1).max_value(10));
+        self.total += n;
+    }
+
+    #[invariant]
+    fn small(&mut self, _tc: TestCase) {
+        assert!(self.total < 3);
+    }
+}
+
+#[test]
+fn snapshot_step_labels_precede_their_rules_draws() {
+    let output = capture_stateful_output(|tc: TestCase| {
+        hegel::stateful::run(Accumulator { total: 0 }, tc);
+    });
+    insta::assert_snapshot!(output, @"
+    Initial invariant check.
+    Step 1: add {
+      let n = 3;
+    }
+    ");
+}
+
+struct TwoDraws;
+
+#[hegel::state_machine]
+impl TwoDraws {
+    #[rule]
+    fn pair(&mut self, tc: TestCase) {
+        let x: i32 = tc.draw(gs::integers::<i32>().min_value(0).max_value(100));
+        let y: i32 = tc.draw(gs::integers::<i32>().min_value(0).max_value(100));
+        assert!(x + y < 5);
+    }
+}
+
+#[test]
+fn snapshot_multiple_draws_stay_under_one_step_label() {
+    let output = capture_stateful_output(|tc: TestCase| {
+        hegel::stateful::run(TwoDraws, tc);
+    });
+    insta::assert_snapshot!(output, @"
+    Initial invariant check.
+    Step 1: pair {
+      let x = 0;
+      let y = 5;
+    }
+    ");
+}
+
+struct DrawlessSteps {
+    count: i32,
+}
+
+#[hegel::state_machine]
+impl DrawlessSteps {
+    #[rule]
+    fn bump(&mut self, _tc: TestCase) {
+        self.count += 1;
+    }
+
+    #[invariant]
+    fn below_three(&mut self, _tc: TestCase) {
+        assert!(self.count < 3);
+    }
+}
+
+#[test]
+fn snapshot_drawless_steps_and_invariant_notes() {
+    let output = capture_stateful_output(|tc: TestCase| {
+        hegel::stateful::run(DrawlessSteps { count: 0 }, tc);
+    });
+    insta::assert_snapshot!(output, @"
+    Initial invariant check.
+    Step 1: bump {
+    }
+    Step 2: bump {
+    }
+    Step 3: bump {
+    }
+    ");
+}
+
+struct SlowAccumulator {
+    total: i32,
+}
+
+#[hegel::state_machine]
+impl SlowAccumulator {
+    #[rule]
+    fn add_one(&mut self, tc: TestCase) {
+        let n: i32 = tc.draw(gs::integers::<i32>().min_value(1).max_value(1));
+        self.total += n;
+    }
+
+    #[invariant]
+    fn small(&mut self, _tc: TestCase) {
+        assert!(self.total < 3);
+    }
+}
+
+#[test]
+fn snapshot_draw_names_reset_in_each_steps_scope() {
+    let output = capture_stateful_output(|tc: TestCase| {
+        hegel::stateful::run(SlowAccumulator { total: 0 }, tc);
+    });
+    insta::assert_snapshot!(output, @"
+    Initial invariant check.
+    Step 1: add_one {
+      let n = 1;
+    }
+    Step 2: add_one {
+      let n = 1;
+    }
+    Step 3: add_one {
+      let n = 1;
+    }
+    ");
+}
+
+struct NotesInsideRules;
+
+#[hegel::state_machine]
+impl NotesInsideRules {
+    #[rule]
+    fn noted(&mut self, tc: TestCase) {
+        let flag = tc.draw(gs::booleans());
+        tc.note(&format!("flag was {flag}"));
+        assert!(!flag);
+    }
+}
+
+#[test]
+fn snapshot_notes_inside_rules_follow_their_draws() {
+    let output = capture_stateful_output(|tc: TestCase| {
+        hegel::stateful::run(NotesInsideRules, tc);
+    });
+    insta::assert_snapshot!(output, @"
+    Initial invariant check.
+    Step 1: noted {
+      let flag = true;
+      flag was true
+    }
+    ");
+}


### PR DESCRIPTION
<details>
<summary>This PR description is AI generated (Claude)</summary>

Downstream feedback reported that `Step N:` labels in stateful counterexamples printed after the draws they introduce. Notes deferred whenever an engine span was open, and the `STATEFUL_RULE` span tripped that check.

- Notes now defer only while the same `TestCase` instance is printing a draw line, tracked by a new `printing_depth` separate from span depth. The pending buffer is instance-local and flushed by the scope that deferred it, so notes and draw lines cannot reorder.
- Each step prints as a `Step N: <rule> { ... }` block, closed on every exit path (success, violated assumption, panic). The concurrent runner prints `Rule: <name> { ... }` the same way.
- `#[rule]` and `#[invariant]` bodies get the same `tc.draw`/`tc.target` rewriting as `#[hegel::test]`, so draws print under their variable names.
- Draw names are scoped to the rule invocation: `DrawState` moved from case-global to per-instance, shared by clones and fresh for each child. A name drawn once per rule prints bare in every step; only names drawn repeatedly within one invocation get numeric suffixes.
- New insta snapshot tests in `tests/test_stateful_output.rs` pin the printed format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>