### PR TITLE
Add a delete_spans shrink pass to fix stateful no-op steps

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+RELEASE_TYPE: patch
+
+This patch improves the shrinking of stateful test failures: shrunk rule
+sequences no longer keep redundant steps, such as inserts whose effect a
+later step overwrites
+([#441](https://github.com/hegeldev/hegel-rust/issues/441)). Previously a
+step could only be deleted as a short run of individual choices, so machines
+with several invariants or draw-heavy rules shrank to sequences padded with
+no-op steps.

--- a/hegel-c/RELEASE.md
+++ b/hegel-c/RELEASE.md
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This patch adds a shrink pass that deletes whole spans. The existing
+deletion passes only try windows of up to eight choices, so a stateful step
+whose rule draws and sampled invariant checks together cost more than that
+could never be deleted, and shrunk rule sequences kept redundant steps
+([#441](https://github.com/hegeldev/hegel-rust/issues/441)).

--- a/hegel-c/src/native/shrinker/mod.rs
+++ b/hegel-c/src/native/shrinker/mod.rs
@@ -566,6 +566,7 @@ impl<'a> Shrinker<'a> {
                 "remove_discarded",
                 Box::new(|sh| boxed_pass(async move { sh.remove_discarded().await.map(|_| ()) })),
             ),
+            ShrinkPass::new("delete_spans", Box::new(|sh| boxed_pass(sh.delete_spans()))),
             ShrinkPass::new(
                 "try_trivial_spans",
                 Box::new(|sh| boxed_pass(sh.try_trivial_spans())),

--- a/hegel-c/src/native/shrinker/spans.rs
+++ b/hegel-c/src/native/shrinker/spans.rs
@@ -7,6 +7,7 @@
 use super::ordering::{PermutationJudge, shrink_ordering};
 use super::{ShrinkResult, ShrinkRun, Shrinker};
 use crate::control::{hegel_internal_debug_assert, hegel_internal_debug_assert_eq};
+use crate::native::HashSet;
 use crate::native::core::{ChoiceNode, sort_key};
 use alloc::boxed::Box;
 use alloc::string::String;
@@ -45,6 +46,53 @@ impl PermutationJudge for ReorderJudge<'_, '_> {
 }
 
 impl<'a> Shrinker<'a> {
+    /// Try deleting each span outright: first the span's own extent, then,
+    /// when that fails, the extent widened to the start of the next span,
+    /// which also removes any spanless choices recorded after the span
+    /// closed.
+    ///
+    /// This handles deletions too wide for
+    /// [`delete_chunks`](Self::delete_chunks), which tries windows of at
+    /// most eight choices. A stateful round's rule span plus the
+    /// per-invariant sampling draws after it can cost well over eight
+    /// choices, and only the widened extent removes the sampling draws in
+    /// the same attempt.
+    pub(crate) async fn delete_spans(&mut self) -> ShrinkResult<()> {
+        let mut attempted: HashSet<(usize, usize)> = HashSet::default();
+        let mut epoch = self.improvements;
+        let mut i = 0;
+        while i < self.current_spans.len() {
+            let span = self.current_spans[i].clone();
+            i += 1;
+            if self.improvements != epoch {
+                epoch = self.improvements;
+                attempted.clear();
+            }
+            if span.end > self.current_nodes.len() || span.end.saturating_sub(span.start) < 2 {
+                continue;
+            }
+            let widened_end = self
+                .current_spans
+                .iter()
+                .map(|s| s.start)
+                .filter(|&s| s >= span.end)
+                .min()
+                .unwrap_or(self.current_nodes.len());
+            for end in [span.end, widened_end] {
+                let deletes_everything = span.start == 0 && end == self.current_nodes.len();
+                if deletes_everything || !attempted.insert((span.start, end)) {
+                    continue;
+                }
+                let mut attempt = self.current_nodes[..span.start].to_vec();
+                attempt.extend_from_slice(&self.current_nodes[end..]);
+                if self.consider(&attempt).await? {
+                    break;
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Delete every contiguous non-overlapping discarded span in one pass.
     ///
     /// Useful for rejection-sampling data left behind by filtered
@@ -286,6 +334,10 @@ impl<'a> Shrinker<'a> {
 #[cfg(test)]
 #[path = "../../../tests/embedded/native/shrinker_remove_discarded_tests.rs"]
 mod remove_discarded_tests;
+
+#[cfg(test)]
+#[path = "../../../tests/embedded/native/shrinker_delete_spans_tests.rs"]
+mod delete_spans_tests;
 
 #[cfg(test)]
 #[path = "../../../tests/embedded/native/shrinker_pass_to_descendant_tests.rs"]

--- a/hegel-c/tests/embedded/native/shrinker_delete_spans_tests.rs
+++ b/hegel-c/tests/embedded/native/shrinker_delete_spans_tests.rs
@@ -1,0 +1,171 @@
+//! Tests for `Shrinker::delete_spans`.
+//!
+//! Covers:
+//! * A span whose own extent can't be deleted (trailing spanless choices
+//!   misalign the remainder) is removed by the widened attempt that extends
+//!   to the next span's start.
+//! * The final span widens to the end of the sequence when no span follows.
+//! * Skips: spans stale against the current nodes, spans narrower than two
+//!   choices, extents already attempted, and attempts that would delete
+//!   every choice.
+//! * The attempted-extent memory resets after an accepted improvement.
+
+use crate::exchange::drive_no_yield;
+use crate::native::bignum::BigInt;
+use crate::native::core::choices::IntegerChoice;
+use crate::native::core::{ChoiceNode, ChoiceValue, Span, Spans};
+use crate::native::shrinker::{ShrinkRun, Shrinker};
+use alloc::boxed::Box;
+use alloc::string::ToString;
+use alloc::sync::Arc;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+fn int_node(value: i128) -> ChoiceNode {
+    ChoiceNode::integer(
+        IntegerChoice {
+            min_value: BigInt::from(0),
+            max_value: BigInt::from(i128::MAX),
+            shrink_towards: BigInt::from(0),
+        },
+        BigInt::from(value),
+        false,
+    )
+}
+
+fn span(start: usize, end: usize) -> Span {
+    Span {
+        start,
+        end,
+        label: "block".to_string(),
+        depth: 0,
+        parent: None,
+        discarded: false,
+    }
+}
+
+fn values(nodes: &[ChoiceNode]) -> Vec<i128> {
+    nodes
+        .iter()
+        .map(|n| match n.value() {
+            ChoiceValue::Integer(v) => i128::try_from(&v).unwrap(),
+            other => panic!("unexpected choice value {other:?}"),
+        })
+        .collect()
+}
+
+/// Two four-choice "rounds", each a three-choice span plus one spanless
+/// trailing choice. A sequence is interesting when its length is a whole
+/// number of rounds and the last round is all twos, so deleting the first
+/// span's extent alone misaligns the rounds and only the widened four-choice
+/// deletion is accepted.
+#[test]
+fn widened_deletion_removes_a_span_with_its_trailing_choices() {
+    let initial = vec![
+        int_node(1),
+        int_node(1),
+        int_node(1),
+        int_node(1),
+        int_node(2),
+        int_node(2),
+        int_node(2),
+        int_node(2),
+    ];
+    let mut initial_spans = Spans::new();
+    initial_spans.push(span(0, 3));
+    initial_spans.push(span(4, 7));
+
+    let mut shrinker = Shrinker::with_probe(
+        Box::new(|run: ShrinkRun<'_>| match run {
+            ShrinkRun::Full(nodes) => {
+                let vals = values(nodes);
+                let interesting = !vals.is_empty()
+                    && vals.len() % 4 == 0
+                    && vals[vals.len() - 4..].iter().all(|&v| v == 2);
+                let mut spans = Spans::new();
+                if nodes.len() >= 3 {
+                    spans.push(span(0, 3));
+                }
+                (interesting, nodes.to_vec(), spans)
+            }
+            ShrinkRun::Probe { .. } => (false, Vec::new(), Spans::new()),
+        }),
+        initial,
+        initial_spans,
+    );
+
+    drive_no_yield(shrinker.delete_spans()).unwrap();
+    assert_eq!(values(&shrinker.current_nodes), [2, 2, 2, 2]);
+}
+
+#[test]
+fn stale_narrow_and_duplicate_spans_cost_no_test_calls() {
+    let initial = vec![int_node(1), int_node(1), int_node(1)];
+    let mut initial_spans = Spans::new();
+    initial_spans.push(span(0, 2));
+    initial_spans.push(span(0, 2));
+    initial_spans.push(span(1, 2));
+    initial_spans.push(span(0, 7));
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls_in_probe = Arc::clone(&calls);
+    let mut shrinker = Shrinker::with_probe(
+        Box::new(move |run: ShrinkRun<'_>| match run {
+            ShrinkRun::Full(nodes) => {
+                calls_in_probe.fetch_add(1, Ordering::Relaxed);
+                (false, nodes.to_vec(), Spans::new())
+            }
+            ShrinkRun::Probe { .. } => (false, Vec::new(), Spans::new()),
+        }),
+        initial,
+        initial_spans,
+    );
+
+    drive_no_yield(shrinker.delete_spans()).unwrap();
+    // The first span costs one call for its own extent; its widened extent
+    // covers the whole sequence and is skipped. The duplicate, the
+    // single-choice span, and the stale span cost nothing.
+    assert_eq!(calls.load(Ordering::Relaxed), 1);
+    assert_eq!(values(&shrinker.current_nodes), [1, 1, 1]);
+}
+
+/// After an accepted deletion the attempted-extent memory resets: the same
+/// numeric extent describes different choices in the shrunk sequence, so it
+/// is tried again rather than skipped.
+#[test]
+fn attempted_extents_reset_after_an_improvement() {
+    let initial = vec![
+        int_node(1),
+        int_node(1),
+        int_node(2),
+        int_node(2),
+        int_node(3),
+    ];
+    let mut initial_spans = Spans::new();
+    initial_spans.push(span(0, 2));
+    initial_spans.push(span(2, 4));
+
+    let mut shrinker = Shrinker::with_probe(
+        Box::new(|run: ShrinkRun<'_>| match run {
+            ShrinkRun::Full(nodes) => {
+                let vals = values(nodes);
+                let interesting = vals.last() == Some(&3);
+                let mut spans = Spans::new();
+                if nodes.len() >= 2 {
+                    spans.push(span(0, 2));
+                    spans.push(span(0, 2));
+                }
+                (interesting, nodes.to_vec(), spans)
+            }
+            ShrinkRun::Probe { .. } => (false, Vec::new(), Spans::new()),
+        }),
+        initial,
+        initial_spans,
+    );
+
+    drive_no_yield(shrinker.delete_spans()).unwrap();
+    // Extent (0, 2) is deleted, the memory resets, and the refreshed
+    // extent (0, 2), now holding the twos, is deleted in the same sweep.
+    assert_eq!(values(&shrinker.current_nodes), [3]);
+}

--- a/tests/test_shrink_quality/stateful.rs
+++ b/tests/test_shrink_quality/stateful.rs
@@ -3,6 +3,7 @@
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::{Arc, Mutex};
 
+use hegel::Generator;
 use hegel::generators as gs;
 use hegel::stateful::{Pool, pool};
 use hegel::{Hegel, Settings, TestCase};
@@ -299,5 +300,239 @@ fn test_noisy_triple_increment_shrinks_to_four_ops() {
             ["new v0", "incr v0", "incr v0", "incr v0"],
             "seed {seed}"
         );
+    }
+}
+
+const DOMAIN_MIN: i32 = -50;
+const DOMAIN_MAX: i32 = 50;
+
+fn domain_ranges() -> impl gs::PrintableGenerator<std::ops::Range<i32>> {
+    gs::integers::<i32>()
+        .min_value(DOMAIN_MIN)
+        .max_value(DOMAIN_MAX - 1)
+        .flat_map(|start| {
+            gs::integers::<i32>()
+                .min_value(start + 1)
+                .max_value(DOMAIN_MAX)
+                .map(move |end| start..end)
+        })
+}
+
+#[derive(Clone, Debug)]
+enum MapOp {
+    Insert(std::ops::Range<i32>, u8),
+    Remove(std::ops::Range<i32>),
+}
+
+/// The number of coalesced ranges an interval map holds after `ops`,
+/// computed on a per-point model.
+fn stored_ranges_after<'a>(ops: impl Iterator<Item = &'a MapOp>) -> usize {
+    let mut points = std::collections::BTreeMap::new();
+    for op in ops {
+        match op {
+            MapOp::Insert(range, value) => {
+                for p in range.clone() {
+                    points.insert(p, *value);
+                }
+            }
+            MapOp::Remove(range) => {
+                for p in range.clone() {
+                    points.remove(&p);
+                }
+            }
+        }
+    }
+    let mut runs = 0;
+    let mut prev: Option<(i32, u8)> = None;
+    for (&p, &v) in &points {
+        if prev != Some((p - 1, v)) {
+            runs += 1;
+        }
+        prev = Some((p, v));
+    }
+    runs
+}
+
+type Ops = Arc<Mutex<Vec<MapOp>>>;
+
+/// An interval map modelled per point, with the invariant-heavy shape of a
+/// real model-based suite (rangemap's): several always-true invariants plus
+/// one planted failing one. Each sampled invariant adds a boolean draw to
+/// every step's choice footprint.
+struct IntervalMapModel {
+    points: std::collections::BTreeMap<i32, u8>,
+    ops: Ops,
+    trace: Trace,
+}
+
+impl IntervalMapModel {
+    fn stored_ranges(&self) -> usize {
+        stored_ranges_after(self.ops.lock().unwrap().iter())
+    }
+}
+
+#[hegel::state_machine]
+impl IntervalMapModel {
+    #[rule]
+    fn insert(&mut self, tc: TestCase) {
+        let range = tc.draw(domain_ranges());
+        let value = tc.draw(gs::integers::<u8>().max_value(2));
+        self.trace
+            .lock()
+            .unwrap()
+            .push(format!("insert {range:?} v{value}"));
+        self.ops
+            .lock()
+            .unwrap()
+            .push(MapOp::Insert(range.clone(), value));
+        for p in range {
+            self.points.insert(p, value);
+        }
+    }
+
+    #[rule]
+    fn remove(&mut self, tc: TestCase) {
+        let range = tc.draw(domain_ranges());
+        self.trace.lock().unwrap().push(format!("remove {range:?}"));
+        self.ops.lock().unwrap().push(MapOp::Remove(range.clone()));
+        for p in range {
+            self.points.remove(&p);
+        }
+    }
+
+    #[invariant]
+    fn points_in_domain(&mut self, _tc: TestCase) {
+        assert!(
+            self.points
+                .keys()
+                .all(|&p| (DOMAIN_MIN..DOMAIN_MAX).contains(&p))
+        );
+    }
+
+    #[invariant]
+    fn values_small(&mut self, _tc: TestCase) {
+        assert!(self.points.values().all(|&v| v <= 2));
+    }
+
+    #[invariant]
+    fn runs_not_more_than_points(&mut self, _tc: TestCase) {
+        assert!(self.stored_ranges() <= self.points.len());
+    }
+
+    #[invariant]
+    fn planted_few_ranges(&mut self, _tc: TestCase) {
+        assert!(self.stored_ranges() <= 3, "map holds more than 3 ranges");
+    }
+}
+
+#[test]
+fn test_interval_map_shrinks_to_a_one_deletion_minimal_sequence() {
+    for seed in 0..10u64 {
+        let ops: Ops = Arc::new(Mutex::new(Vec::new()));
+        let ops_in_body = Arc::clone(&ops);
+        let trace = minimal_stateful_trace(
+            move |tc, trace| {
+                ops_in_body.lock().unwrap().clear();
+                let m = IntervalMapModel {
+                    points: std::collections::BTreeMap::new(),
+                    ops: Arc::clone(&ops_in_body),
+                    trace,
+                };
+                hegel::stateful::run(m, tc);
+            },
+            Some(seed),
+        );
+        let ops = ops.lock().unwrap().clone();
+        assert!(
+            stored_ranges_after(ops.iter()) > 3,
+            "seed {seed}: {trace:?}"
+        );
+        for skip in 0..ops.len() {
+            let without = ops
+                .iter()
+                .enumerate()
+                .filter(|&(i, _)| i != skip)
+                .map(|(_, op)| op);
+            assert!(
+                stored_ranges_after(without) <= 3,
+                "seed {seed}: step {} is redundant in {trace:?}",
+                skip + 1,
+            );
+        }
+    }
+}
+
+/// `DoubleIncrement` above, plus enough always-true invariants that a step's
+/// choice footprint (stop draw + rule selection + pool draw + one sampled
+/// boolean per invariant) exceeds the shrinker's largest deletion window.
+struct InvariantHeavyDoubleIncrement {
+    handles: Pool<usize>,
+    counters: Vec<u32>,
+    trace: Trace,
+}
+
+#[hegel::state_machine]
+impl InvariantHeavyDoubleIncrement {
+    #[rule]
+    fn new_counter(&mut self, _tc: TestCase) {
+        let id = self.counters.len();
+        self.counters.push(0);
+        self.handles.add(id);
+        self.trace.lock().unwrap().push(format!("new v{id}"));
+    }
+
+    #[rule]
+    fn increment(&mut self, tc: TestCase) {
+        let id = *tc.draw(self.handles.values_reusable());
+        self.counters[id] += 1;
+        self.trace.lock().unwrap().push(format!("incr v{id}"));
+    }
+
+    #[invariant]
+    fn ids_dense(&mut self, _tc: TestCase) {
+        assert!(self.handles.len() == self.counters.len());
+    }
+
+    #[invariant]
+    fn counts_fit(&mut self, _tc: TestCase) {
+        assert!(self.counters.iter().all(|&c| c < 100));
+    }
+
+    #[invariant]
+    fn sum_fits(&mut self, _tc: TestCase) {
+        assert!(self.counters.iter().sum::<u32>() < 10_000);
+    }
+
+    #[invariant]
+    fn non_negative_len(&mut self, _tc: TestCase) {
+        assert!(self.counters.capacity() >= self.counters.len());
+    }
+
+    #[invariant]
+    fn handles_populated(&mut self, _tc: TestCase) {
+        assert!(self.handles.len() <= self.counters.len());
+    }
+
+    #[invariant]
+    fn planted_below_two(&mut self, _tc: TestCase) {
+        assert!(self.counters.iter().all(|&c| c < 2), "counter reached 2");
+    }
+}
+
+#[test]
+fn test_invariant_heavy_double_increment_shrinks_to_three_ops() {
+    for seed in 0..5u64 {
+        let trace = minimal_stateful_trace(
+            |tc, trace| {
+                let m = InvariantHeavyDoubleIncrement {
+                    handles: pool(&tc),
+                    counters: Vec::new(),
+                    trace,
+                };
+                hegel::stateful::run(m, tc);
+            },
+            Some(seed),
+        );
+        assert_eq!(trace, ["new v0", "incr v0", "incr v0"], "seed {seed}");
     }
 }


### PR DESCRIPTION
<details>
<summary>This PR description was AI generated.</summary>

Fixes #441.

A stateful round costs one stop draw, one rule-selection draw, the rule body's draws, and one invariant-sampling draw per invariant, recorded after the rule span closes. The widest deletion the shrinker could attempt was `delete_chunks`' eight-choice window, so on any machine where a round costs more than that, no single attempt could remove a step, and shrunk rule sequences kept steps with no effect on the failure.

The first commit adds two failing shrink-quality tests: an interval-map machine modelled on the rangemap port, asserting every shrunk trace is one-deletion minimal, and an invariant-heavy counter machine asserting an exact three-step trace. The second commit adds a `delete_spans` shrink pass and both tests pass. For each span it tries deleting the span's own extent, then the extent widened to the next span's start, which removes the trailing invariant-sampling draws in the same attempt. Embedded unit tests cover the pass directly.

</details>
