### PR TITLE
Add a delete_between_repeats shrink pass to fix wide-element deletion

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+RELEASE_TYPE: patch
+
+This patch improves shrinking for collections whose elements each cost
+more than eight choices to generate. Previously such an element could
+only be deleted a few choices at a time, so shrunk counterexamples kept
+collection elements with no effect on the failure.

--- a/hegel-c/RELEASE.md
+++ b/hegel-c/RELEASE.md
@@ -1,9 +1,4 @@
 RELEASE_TYPE: patch
 
-This patch adds a shrink pass that deletes the region between two
-occurrences of a repeated run of choice values. The existing deletion
-passes only try windows of up to eight choices, so a collection element
-costing more than that could never be deleted, and shrunk collections
-kept elements with no effect on the failure. Value shrinking makes
-sibling elements identical, and the repeats then mark the element
-boundaries, so whole elements can be deleted at any width.
+This patch adds a new shrink pass that is able to delete regions of the test case where it would previously have got stuck.
+You should see improvements in cases where there were previously redundant elements that were "obviously" deletable but that the shrinker was for some reason struggling with.

--- a/hegel-c/RELEASE.md
+++ b/hegel-c/RELEASE.md
@@ -1,0 +1,9 @@
+RELEASE_TYPE: patch
+
+This patch adds a shrink pass that deletes the region between two
+occurrences of a repeated run of choice values. The existing deletion
+passes only try windows of up to eight choices, so a collection element
+costing more than that could never be deleted, and shrunk collections
+kept elements with no effect on the failure. Value shrinking makes
+sibling elements identical, and the repeats then mark the element
+boundaries, so whole elements can be deleted at any width.

--- a/hegel-c/src/native/shrinker/deletion.rs
+++ b/hegel-c/src/native/shrinker/deletion.rs
@@ -1,5 +1,8 @@
-use crate::native::HashMap;
+use core::hash::BuildHasher;
+
+use crate::native::{HashMap, HashSet};
 use alloc::vec::Vec;
+use rustc_hash::FxBuildHasher;
 
 use crate::native::bignum::BigInt;
 use crate::native::core::{ChoiceData, ChoiceNode, ChoiceValue};
@@ -346,6 +349,83 @@ impl<'a> Shrinker<'a> {
         let epoch = self.improvements;
         Ok(self.consider(&attempt).await? && self.improvements > epoch)
     }
+
+    /// Try deleting the region from the start of one occurrence of a
+    /// repeated n-gram of choice values to the start of the next.
+    ///
+    /// A repeated n-gram is evidence that two positions play the same role
+    /// (e.g. the heads of consecutive collection elements), so the region
+    /// between them is likely to be a deletable unit even when it is far
+    /// wider than any window `delete_chunks` proposes. Value shrinking
+    /// creates the repeats: once sibling elements have minimized to the
+    /// same values, this pass can delete whole elements of any width.
+    ///
+    /// Adjacent occurrences (distance 1) are skipped: runs of a repeated
+    /// value would propose only single-node deletions, which
+    /// `delete_chunks` already covers.
+    pub(super) async fn delete_between_repeats(&mut self) -> ShrinkResult<()> {
+        let fingerprints: Vec<u64> = self.current_nodes.iter().map(node_fingerprint).collect();
+        let len = fingerprints.len();
+        let mut proposals: Vec<(usize, usize)> = Vec::new();
+        let mut seen: HashSet<(usize, usize)> = HashSet::default();
+        for n in [4usize, 3, 2, 1] {
+            if n > len {
+                continue;
+            }
+            let mut last_at: HashMap<u64, usize> = HashMap::default();
+            for i in 0..=(len - n) {
+                let gram = FxBuildHasher.hash_one(&fingerprints[i..i + n]);
+                if let Some(&prev) = last_at.get(&gram) {
+                    if i - prev >= 2
+                        && grams_match(
+                            &self.current_nodes[prev..prev + n],
+                            &self.current_nodes[i..i + n],
+                        )
+                        && seen.insert((prev, i))
+                    {
+                        proposals.push((prev, i));
+                    }
+                }
+                last_at.insert(gram, i);
+            }
+        }
+        proposals.sort_unstable_by(|a, b| b.cmp(a));
+        for (start, end) in proposals {
+            if end > self.current_nodes.len() {
+                continue;
+            }
+            let mut attempt = self.current_nodes[..start].to_vec();
+            attempt.extend_from_slice(&self.current_nodes[end..]);
+            self.consider(&attempt).await?;
+        }
+        Ok(())
+    }
+}
+
+/// Whether two windows repeat each other for [`Shrinker::delete_between_repeats`]:
+/// pairwise node equality, except that any two clone nodes match regardless
+/// of payload.
+fn grams_match(a: &[ChoiceNode], b: &[ChoiceNode]) -> bool {
+    a.iter().zip(b).all(|(x, y)| {
+        matches!(
+            (&x.data, &y.data),
+            (ChoiceData::Clone(_), ChoiceData::Clone(_))
+        ) || x == y
+    })
+}
+
+/// Hash of a node's kind tag and value, ignoring constraints. Collisions and
+/// constraint mismatches are filtered by [`grams_match`]. Clone nodes all
+/// share one fingerprint.
+fn node_fingerprint(node: &ChoiceNode) -> u64 {
+    match &node.data {
+        ChoiceData::Integer(_, v) => FxBuildHasher.hash_one((1u8, v)),
+        ChoiceData::Boolean(_, v) => FxBuildHasher.hash_one((2u8, v)),
+        ChoiceData::Float(_, v) => FxBuildHasher.hash_one((3u8, v.to_bits())),
+        ChoiceData::Bytes(_, v) => FxBuildHasher.hash_one((4u8, v)),
+        ChoiceData::String(_, v) => FxBuildHasher.hash_one((5u8, v)),
+        ChoiceData::Clone(_) => FxBuildHasher.hash_one(6u8),
+    }
 }
 
 #[cfg(test)]
@@ -355,3 +435,7 @@ mod minimize_individual_choices_tests;
 #[cfg(test)]
 #[path = "../../../tests/embedded/native/shrinker_node_program_tests.rs"]
 mod node_program_tests;
+
+#[cfg(test)]
+#[path = "../../../tests/embedded/native/shrinker_delete_between_repeats_tests.rs"]
+mod delete_between_repeats_tests;

--- a/hegel-c/src/native/shrinker/mod.rs
+++ b/hegel-c/src/native/shrinker/mod.rs
@@ -603,6 +603,10 @@ impl<'a> Shrinker<'a> {
                 "delete_chunks",
                 Box::new(|sh| boxed_pass(sh.delete_chunks())),
             ),
+            ShrinkPass::new(
+                "delete_between_repeats",
+                Box::new(|sh| boxed_pass(sh.delete_between_repeats())),
+            ),
             ShrinkPass::new("zero_choices", Box::new(|sh| boxed_pass(sh.zero_choices()))),
             ShrinkPass::new(
                 "swap_integer_sign",

--- a/hegel-c/tests/embedded/native/shrinker_delete_between_repeats_tests.rs
+++ b/hegel-c/tests/embedded/native/shrinker_delete_between_repeats_tests.rs
@@ -1,0 +1,286 @@
+//! Unit tests for `Shrinker::delete_between_repeats`.
+
+use std::sync::Arc;
+
+use crate::exchange::drive_no_yield;
+use crate::native::bignum::BigInt;
+use crate::native::core::choices::{BooleanChoice, FloatChoice, IntegerChoice};
+use crate::native::core::{
+    BytesChoice, ChoiceNode, ChoiceValueRef, RealizedStream, Spans, StringChoice,
+};
+use crate::native::intervalsets::IntervalSet;
+use crate::native::shrinker::{ShrinkRun, Shrinker};
+use alloc::boxed::Box;
+use alloc::vec;
+use alloc::vec::Vec;
+
+fn int_node(value: i128) -> ChoiceNode {
+    ChoiceNode::integer(
+        IntegerChoice {
+            min_value: BigInt::from(0),
+            max_value: BigInt::from(100),
+            shrink_towards: BigInt::from(0),
+        },
+        BigInt::from(value),
+        false,
+    )
+}
+
+fn bool_node(value: bool) -> ChoiceNode {
+    ChoiceNode::boolean(BooleanChoice { p: 0.5 }, value, false)
+}
+
+fn clone_node(children: Vec<ChoiceNode>) -> ChoiceNode {
+    ChoiceNode::clone_stream(
+        Arc::new(RealizedStream::new(children, Vec::new(), Vec::new())),
+        false,
+    )
+}
+
+fn int_value(node: &ChoiceNode) -> Option<i128> {
+    match node.data.value_ref() {
+        ChoiceValueRef::Integer(v) => i128::try_from(v.clone()).ok(),
+        _ => None,
+    }
+}
+
+fn bool_value(node: &ChoiceNode) -> Option<bool> {
+    match node.data.value_ref() {
+        ChoiceValueRef::Boolean(v) => Some(v),
+        _ => None,
+    }
+}
+
+/// Parse `nodes` as the choice-sequence shape of a collection of
+/// fixed-width elements: repeat { boolean true, `width` integers },
+/// terminated by a boolean false. Returns the elements, or None if the
+/// nodes don't have that shape.
+fn parse_chunks(nodes: &[ChoiceNode], width: usize) -> Option<Vec<Vec<i128>>> {
+    let mut chunks = Vec::new();
+    let mut rest = nodes;
+    loop {
+        let (gate, tail) = rest.split_first()?;
+        if !bool_value(gate)? {
+            return tail.is_empty().then_some(chunks);
+        }
+        if tail.len() < width {
+            return None;
+        }
+        let (chunk, tail) = tail.split_at(width);
+        chunks.push(chunk.iter().map(int_value).collect::<Option<_>>()?);
+        rest = tail;
+    }
+}
+
+fn chunk_shrinker(initial: Vec<ChoiceNode>, width: usize) -> Shrinker<'static> {
+    Shrinker::with_probe(
+        Box::new(move |run: ShrinkRun<'_>| match run {
+            ShrinkRun::Full(nodes) => {
+                let interesting = parse_chunks(nodes, width)
+                    .is_some_and(|chunks| chunks.iter().any(|c| c[width - 1] == 7));
+                (interesting, nodes.to_vec(), Spans::new())
+            }
+            ShrinkRun::Probe { .. } => (false, Vec::new(), Spans::new()),
+        }),
+        initial,
+        Spans::new(),
+    )
+}
+
+/// Each element costs 11 choices (a gate plus ten digits), wider than any
+/// window `delete_chunks` proposes, but the minimized elements repeat each
+/// other, so gate-to-gate deletions remove them whole.
+#[test]
+fn deletes_wide_elements_between_repeated_grams() {
+    let width = 10;
+    let mut initial = Vec::new();
+    for chunk in 0..4 {
+        initial.push(bool_node(true));
+        for i in 0..width {
+            let last_of_failing_chunk = chunk == 3 && i == width - 1;
+            initial.push(int_node(if last_of_failing_chunk { 7 } else { 0 }));
+        }
+    }
+    initial.push(bool_node(false));
+
+    let mut shrinker = chunk_shrinker(initial, width);
+    drive_no_yield(shrinker.delete_between_repeats()).unwrap();
+
+    let mut expected = vec![0i128; width];
+    expected[width - 1] = 7;
+    assert_eq!(
+        parse_chunks(&shrinker.current_nodes, width),
+        Some(vec![expected])
+    );
+}
+
+/// A run of one repeated value only has occurrences at distance 1, which
+/// the pass skips, so it proposes nothing. The three-node sequence also
+/// exercises skipping gram sizes longer than the sequence.
+#[test]
+fn adjacent_repeats_propose_nothing() {
+    let initial = vec![int_node(0), int_node(0), int_node(0)];
+    let mut shrinker = Shrinker::with_probe(
+        Box::new(|run: ShrinkRun<'_>| match run {
+            ShrinkRun::Full(nodes) => (true, nodes.to_vec(), Spans::new()),
+            ShrinkRun::Probe { .. } => (false, Vec::new(), Spans::new()),
+        }),
+        initial.clone(),
+        Spans::new(),
+    );
+    drive_no_yield(shrinker.delete_between_repeats()).unwrap();
+    assert_eq!(shrinker.calls, 0);
+    assert_eq!(shrinker.current_nodes, initial);
+}
+
+/// Equal values under different constraints share a fingerprint but are
+/// not repeats, so they propose nothing.
+#[test]
+fn equal_values_with_different_constraints_are_not_repeats() {
+    let narrow = ChoiceNode::integer(
+        IntegerChoice {
+            min_value: BigInt::from(0),
+            max_value: BigInt::from(10),
+            shrink_towards: BigInt::from(0),
+        },
+        BigInt::from(5),
+        false,
+    );
+    let initial = vec![int_node(5), bool_node(true), narrow, bool_node(false)];
+    let mut shrinker = Shrinker::with_probe(
+        Box::new(|run: ShrinkRun<'_>| match run {
+            ShrinkRun::Full(nodes) => (true, nodes.to_vec(), Spans::new()),
+            ShrinkRun::Probe { .. } => (false, Vec::new(), Spans::new()),
+        }),
+        initial.clone(),
+        Spans::new(),
+    );
+    drive_no_yield(shrinker.delete_between_repeats()).unwrap();
+    assert_eq!(shrinker.calls, 0);
+    assert_eq!(shrinker.current_nodes, initial);
+}
+
+/// Clone nodes are opaque values to this pass: two clones with different
+/// payloads still count as repeats, so the region between them is proposed.
+#[test]
+fn clones_with_different_payloads_are_repeats() {
+    let initial = vec![
+        clone_node(vec![int_node(1)]),
+        int_node(3),
+        clone_node(vec![int_node(2), int_node(9)]),
+        int_node(42),
+    ];
+    let mut shrinker = Shrinker::with_probe(
+        Box::new(|run: ShrinkRun<'_>| match run {
+            ShrinkRun::Full(nodes) => {
+                let interesting = nodes.last().and_then(int_value) == Some(42);
+                (interesting, nodes.to_vec(), Spans::new())
+            }
+            ShrinkRun::Probe { .. } => (false, Vec::new(), Spans::new()),
+        }),
+        initial,
+        Spans::new(),
+    );
+    drive_no_yield(shrinker.delete_between_repeats()).unwrap();
+    assert_eq!(shrinker.current_nodes.len(), 2);
+    let survivor = shrinker.current_nodes[0].data.as_clone().unwrap();
+    assert_eq!(survivor.nodes().len(), 2);
+}
+
+/// Float, bytes, and string values all participate in fingerprints: a
+/// repeated heterogeneous block is deleted like any other repeat.
+#[test]
+fn fingerprints_cover_all_value_kinds() {
+    let float = || {
+        ChoiceNode::float(
+            FloatChoice {
+                min_value: 0.0,
+                max_value: 100.0,
+                allow_nan: false,
+                allow_infinity: false,
+                smallest_nonzero_magnitude: 5e-324,
+            },
+            2.5,
+            false,
+        )
+    };
+    let bytes = || {
+        ChoiceNode::bytes(
+            BytesChoice {
+                min_size: 0,
+                max_size: 8,
+            },
+            vec![1, 2],
+            false,
+        )
+    };
+    let string = || {
+        ChoiceNode::string(
+            StringChoice {
+                intervals: IntervalSet::new(vec![(97, 122)]).unwrap().into(),
+                min_size: 0,
+                max_size: 8,
+            },
+            vec![97, 98],
+            false,
+        )
+    };
+    let initial = vec![
+        float(),
+        bytes(),
+        string(),
+        float(),
+        bytes(),
+        string(),
+        int_node(42),
+    ];
+    let mut shrinker = Shrinker::with_probe(
+        Box::new(|run: ShrinkRun<'_>| match run {
+            ShrinkRun::Full(nodes) => {
+                let interesting = nodes.last().and_then(int_value) == Some(42);
+                (interesting, nodes.to_vec(), Spans::new())
+            }
+            ShrinkRun::Probe { .. } => (false, Vec::new(), Spans::new()),
+        }),
+        initial,
+        Spans::new(),
+    );
+    drive_no_yield(shrinker.delete_between_repeats()).unwrap();
+    assert_eq!(shrinker.current_nodes.len(), 1);
+}
+
+/// An accepted attempt can come back much shorter than the candidate (the
+/// test body exits early), leaving later proposals out of range. They are
+/// skipped rather than sliced out of bounds.
+#[test]
+fn stale_proposals_beyond_the_new_length_are_skipped() {
+    let initial = vec![
+        int_node(9),
+        int_node(1),
+        int_node(2),
+        int_node(9),
+        int_node(1),
+        int_node(2),
+        int_node(9),
+        int_node(42),
+    ];
+    let mut shrinker = Shrinker::with_probe(
+        Box::new(|run: ShrinkRun<'_>| match run {
+            ShrinkRun::Full(nodes) => {
+                let interesting = nodes.last().and_then(int_value) == Some(42);
+                let actual = if interesting && nodes.len() < 8 {
+                    vec![int_node(42)]
+                } else {
+                    nodes.to_vec()
+                };
+                (interesting, actual, Spans::new())
+            }
+            ShrinkRun::Probe { .. } => (false, Vec::new(), Spans::new()),
+        }),
+        initial,
+        Spans::new(),
+    );
+    drive_no_yield(shrinker.delete_between_repeats()).unwrap();
+    assert_eq!(shrinker.calls, 1);
+    assert_eq!(shrinker.current_nodes.len(), 1);
+}

--- a/tests/common/utils.rs
+++ b/tests/common/utils.rs
@@ -380,6 +380,7 @@ where
     generator: G,
     condition: P,
     test_cases: u64,
+    seed: Option<u64>,
     _marker: std::marker::PhantomData<T>,
 }
 
@@ -394,6 +395,7 @@ where
             generator,
             condition,
             test_cases: 500,
+            seed: None,
             _marker: std::marker::PhantomData,
         }
     }
@@ -404,14 +406,23 @@ where
         self
     }
 
+    #[allow(dead_code)]
+    pub fn seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
+    }
+
     pub fn run(self) -> T {
         let generator = self.generator;
-        MinimalWith::new(
+        let mut with = MinimalWith::new(
             move |tc: &TestCase| tc.draw_silent(&generator),
             self.condition,
         )
-        .test_cases(self.test_cases)
-        .run()
+        .test_cases(self.test_cases);
+        if let Some(seed) = self.seed {
+            with = with.seed(seed);
+        }
+        with.run()
     }
 }
 
@@ -441,6 +452,7 @@ where
     body: F,
     condition: P,
     test_cases: u64,
+    seed: Option<u64>,
     _marker: std::marker::PhantomData<T>,
 }
 
@@ -455,6 +467,7 @@ where
             body,
             condition,
             test_cases: 500,
+            seed: None,
             _marker: std::marker::PhantomData,
         }
     }
@@ -465,10 +478,17 @@ where
         self
     }
 
+    #[allow(dead_code)]
+    pub fn seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
+    }
+
     pub fn run(self) -> T {
         let found: Arc<Mutex<Option<T>>> = Arc::new(Mutex::new(None));
         let found_clone = Arc::clone(&found);
         let test_cases = self.test_cases;
+        let seed = self.seed;
         let body = self.body;
         let condition = self.condition;
 
@@ -484,6 +504,7 @@ where
                 Settings::new()
                     .test_cases(test_cases)
                     .database(None)
+                    .seed(seed)
                     .derandomize(true)
                     .report_multiple_failures(true),
             )

--- a/tests/test_shrink_quality/collections.rs
+++ b/tests/test_shrink_quality/collections.rs
@@ -392,6 +392,42 @@ fn test_sort_stale_indices_after_punning() {
     }));
 }
 
+fn digit_chunks(width: usize) -> impl Generator<Vec<Vec<i64>>> {
+    gs::vecs(hegel::compose!(move |tc| {
+        (0..width)
+            .map(|_| tc.draw(gs::integers::<i64>().min_value(0).max_value(9)))
+            .collect::<Vec<i64>>()
+    }))
+    .max_size(20)
+}
+
+fn assert_deletes_down_to_one_chunk(width: usize) {
+    let mut expected = vec![0i64; width];
+    expected[width - 1] = 7;
+    for seed in 1..=5 {
+        let result = Minimal::new(digit_chunks(width), move |x: &Vec<Vec<i64>>| {
+            x.iter().any(|chunk| chunk[width - 1] == 7)
+        })
+        .test_cases(300)
+        .seed(seed)
+        .run();
+        assert_eq!(result, vec![expected.clone()], "seed {seed}");
+    }
+}
+
+#[test]
+fn test_deletes_thin_collection_elements() {
+    assert_deletes_down_to_one_chunk(7);
+}
+
+/// Deleting an element takes one attempt that removes its continuation choice
+/// and every choice inside it, so elements wider than `delete_chunks`' window
+/// need span deletion.
+#[test]
+fn test_deletes_fat_collection_elements() {
+    assert_deletes_down_to_one_chunk(11);
+}
+
 /// The shrinker should reduce to two distinct empty inner lists.
 #[test]
 fn test_multiple_empty_lists_are_independent() {

--- a/tests/test_shrink_quality/collections.rs
+++ b/tests/test_shrink_quality/collections.rs
@@ -428,6 +428,38 @@ fn test_deletes_fat_collection_elements() {
     assert_deletes_down_to_one_chunk(11);
 }
 
+struct SpanlessChunk {
+    width: usize,
+}
+
+impl Generator<Vec<i64>> for SpanlessChunk {
+    fn do_draw(&self, tc: &hegel::TestCase) -> Vec<i64> {
+        (0..self.width)
+            .map(|_| tc.draw_silent(gs::integers::<i64>().min_value(0).max_value(9)))
+            .collect()
+    }
+}
+
+/// Like `test_deletes_fat_collection_elements`, but the element generator is a
+/// hand-written `Generator` impl that opens no span, so span-based deletion
+/// passes get no help finding element boundaries.
+#[test]
+fn test_deletes_fat_collection_elements_without_spans() {
+    let width = 11;
+    let mut expected = vec![0i64; width];
+    expected[width - 1] = 7;
+    for seed in 1..=5 {
+        let result = Minimal::new(
+            gs::vecs(SpanlessChunk { width }).max_size(20),
+            move |x: &Vec<Vec<i64>>| x.iter().any(|chunk| chunk[width - 1] == 7),
+        )
+        .test_cases(300)
+        .seed(seed)
+        .run();
+        assert_eq!(result, vec![expected.clone()], "seed {seed}");
+    }
+}
+
 /// The shrinker should reduce to two distinct empty inner lists.
 #[test]
 fn test_multiple_empty_lists_are_independent() {


### PR DESCRIPTION
<details>
<summary>This PR description was AI generated.</summary>

Fixes a shrink-quality gap reported by Max: a collection whose elements each cost more than eight choices kept elements the shrinker had minimized to all zeros but could not delete. #452's `delete_spans` fixed this where a span covers each element, but an element generator that opens no span (a hand-written `Generator::do_draw` making raw draws) stayed stuck.

The first commit adds seeded shrink-quality tests for deleting wide collection elements, and a `.seed()` builder on the `Minimal` test helpers. The second adds the `delete_between_repeats` pass and a span-less variant of the test that fails without it. The pass fingerprints each choice by kind and value, finds consecutive occurrences of repeated n-grams, and tries deleting from the start of one occurrence to the start of the next. Value shrinking makes sibling elements identical, and the repeats then mark the element boundaries, so whole elements are deleted at any width with no spans needed. Clone nodes count as repeats of each other regardless of payload. Embedded unit tests cover the pass directly.

Measured on the repro shape (up to 20 elements, element widths 8 to 13, seeds 1 to 10, spans on and off): every case now shrinks to the one-element minimum, where before the shrunk counterexamples kept up to 20 all-zero elements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>