### PR TITLE
Document the path/git dependency key naming trap

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 
 To install: `cargo add --dev hegeltest`.
 
+The package is named `hegeltest` but the library is `hegel`. If you write a `path =` or `git =` dependency by hand, name the key `hegel`: `hegel = { path = "...", package = "hegeltest" }`. Writing `package = "hegeltest"` under the key `hegeltest` renames the library and breaks every `use hegel::...`.
+
 ## Quickstart
 
 Here's a quick example of how to write a Hegel test:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,11 @@
 //! cargo add --dev hegeltest
 //! ```
 //!
+//! The package is named `hegeltest` but the library is `hegel`. If you write a `path =` or
+//! `git =` dependency by hand, name the key `hegel`:
+//! `hegel = { path = "...", package = "hegeltest" }`. Writing `package = "hegeltest"` under
+//! the key `hegeltest` renames the library and breaks every `use hegel::...`.
+//!
 //! ## Write your first test
 //!
 //! You're now ready to write your first test. We'll use Cargo as a test runner for the


### PR DESCRIPTION
Fixes #444.

<details>
<summary>Description (written by Claude, AI-generated)</summary>

Adds a note to the README and crate-level rustdoc install sections: for `path =`/`git =` dependencies, name the key `hegel` (`hegel = { path = "...", package = "hegeltest" }`), because `package = "hegeltest"` under the key `hegeltest` renames the library and breaks `use hegel::...`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
