### PR TITLE
Point dev-dependency users at pretty_print_as_debug!

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch improves the printability diagnostics and documentation for libraries that use hegel as a dev-dependency. The advice to add `#[derive(hegel::PrettyPrintable)]` to your own type cannot be followed in that setup, so the diagnostics now also point at invoking `hegel::pretty_print_as_debug!` from `#[cfg(test)]` code ([#448](https://github.com/hegeldev/hegel-rust/issues/448)).

--- a/src/generators/generators.rs
+++ b/src/generators/generators.rs
@@ -217,6 +217,7 @@ pub trait Generator<T> {
     message = "`{Self}` cannot print the values it draws",
     label = "`{Self}` does not implement `PrintableGenerator<{T}>`",
     note = "if `{T}` is your own type and does not implement `PrettyPrintable`, implementing it — `#[derive(hegel::PrettyPrintable)]`, or `hegel::pretty_print_as_debug!` for a `Debug` type — fixes every generator of `{T}` at once",
+    note = "when hegel is only a dev-dependency the derive cannot go on the type: invoke `hegel::pretty_print_as_debug!` from `#[cfg(test)]` code instead",
     note = "otherwise, make this generator printable with `.print_as_debug()` (any `Debug` value), `.print_as_value()` (any `PrettyPrintable` value), or `.print_with(|value, printer| ..)`",
     note = "a `-> impl Generator<..>` return type or `.boxed()` erases printability: return `impl PrintableGenerator<..>` instead, and box a printing generator with `.boxed_printable()`",
     note = "or draw without reporting the value via `tc.draw_silent(..)`",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,9 +404,10 @@ pub use hegel_macros::DefaultGenerator;
 /// parameter is given a [`PrettyPrintable`] bound, mirroring how
 /// `derive(Debug)` bounds `Debug`.
 ///
-/// For a type whose `Debug` output is already the representation you want
-/// (or one you cannot add a derive to), use
-/// [`pretty_print_as_debug!`](crate::pretty_print_as_debug) instead.
+/// For a type whose `Debug` output is already the representation you want,
+/// or one this derive cannot go on — hegel only a dev-dependency, say — use
+/// [`pretty_print_as_debug!`](crate::pretty_print_as_debug) instead: it
+/// works from `#[cfg(test)]` code.
 ///
 /// A field whose type cannot implement [`PrettyPrintable`] — a foreign type
 /// the orphan rule keeps out, say — can opt out with `#[pretty(debug)]`:

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -62,7 +62,9 @@
 //!   documentation](derive@crate::PrettyPrintable).
 //! - [`pretty_print_as_debug!`](crate::pretty_print_as_debug) implements
 //!   the trait via the type's existing `Debug` representation, re-laid-out
-//!   through the layout engine.
+//!   through the layout engine. When hegel is only a dev-dependency — a
+//!   library testing itself — the derive cannot go on the type, but this
+//!   macro works from `#[cfg(test)]` code.
 //! - A hand-written impl gives full control. Print in Rust-expression
 //!   syntax where possible, using the group machinery so large values wrap
 //!   (see [`PrettyPrinter`], and [`print_debug_repr`] to embed a `Debug`
@@ -843,6 +845,7 @@ fn emit_debug_nodes(nodes: &[DebugNode], printer: &mut PrettyPrinter) {
     message = "`{Self}` has no printed representation",
     label = "`{Self}` does not implement `PrettyPrintable`",
     note = "for your own type, add `#[derive(hegel::PrettyPrintable)]` (or `hegel::pretty_print_as_debug!` for a `Debug` type)",
+    note = "when hegel is only a dev-dependency the derive cannot go on the type: invoke `hegel::pretty_print_as_debug!` from `#[cfg(test)]` code instead",
     note = "for a foreign type, make the generator printable instead: `.print_as_debug()` prints any `Debug` value, `.print_with(|value, printer| ..)` prints a custom representation",
     note = "or draw without reporting the value via `tc.draw_silent(..)`",
     note = "the `hegel::pretty` module docs walk through the whole printing system"
@@ -888,6 +891,10 @@ impl<T: PrettyPrintable + ?Sized> PrettyPrintableField for T {
 /// library). To print a foreign type by its `Debug` representation, make
 /// the *generator* printable instead with
 /// [`print_as_debug`](crate::Generator::print_as_debug).
+///
+/// It is also the route when hegel is only a dev-dependency: the derive
+/// cannot go on the type then, but this macro works from `#[cfg(test)]`
+/// code.
 ///
 /// ```
 /// use hegel::{Document, PrettyPrintable};

--- a/tests/ui-printability/derive_non_printable_field_draw-current.stderr
+++ b/tests/ui-printability/derive_non_printable_field_draw-current.stderr
@@ -12,6 +12,7 @@ help: the trait `PrintableGenerator<String>` is not implemented for `SilentText`
 LL | struct SilentText;
  | ^^^^^^^^^^^^^^^^^
  = note: if `String` is your own type and does not implement `PrettyPrintable`, implementing it — `#[derive(hegel::PrettyPrintable)]`, or `hegel::pretty_print_as_debug!` for a `Debug` type — fixes every generator of `String` at once
+ = note: when hegel is only a dev-dependency the derive cannot go on the type: invoke `hegel::pretty_print_as_debug!` from `#[cfg(test)]` code instead
  = note: otherwise, make this generator printable with `.print_as_debug()` (any `Debug` value), `.print_as_value()` (any `PrettyPrintable` value), or `.print_with(|value, printer| ..)`
  = note: a `-> impl Generator<..>` return type or `.boxed()` erases printability: return `impl PrintableGenerator<..>` instead, and box a printing generator with `.boxed_printable()`
  = note: or draw without reporting the value via `tc.draw_silent(..)`

--- a/tests/ui-printability/derive_non_printable_field_draw-msrv.stderr
+++ b/tests/ui-printability/derive_non_printable_field_draw-msrv.stderr
@@ -8,6 +8,7 @@ LL |     let _: Config = tc.draw(generator);
  |
  = help: the trait `PrintableGenerator<String>` is not implemented for `SilentText`
  = note: if `String` is your own type and does not implement `PrettyPrintable`, implementing it — `#[derive(hegel::PrettyPrintable)]`, or `hegel::pretty_print_as_debug!` for a `Debug` type — fixes every generator of `String` at once
+ = note: when hegel is only a dev-dependency the derive cannot go on the type: invoke `hegel::pretty_print_as_debug!` from `#[cfg(test)]` code instead
  = note: otherwise, make this generator printable with `.print_as_debug()` (any `Debug` value), `.print_as_value()` (any `PrettyPrintable` value), or `.print_with(|value, printer| ..)`
  = note: a `-> impl Generator<..>` return type or `.boxed()` erases printability: return `impl PrintableGenerator<..>` instead, and box a printing generator with `.boxed_printable()`
  = note: or draw without reporting the value via `tc.draw_silent(..)`

--- a/tests/ui-printability/one_of_non_printable_draw.stderr
+++ b/tests/ui-printability/one_of_non_printable_draw.stderr
@@ -12,6 +12,7 @@ LL | |     ));
  |
  = help: the trait `PrettyPrintable` is not implemented for `OsString`
  = note: for your own type, add `#[derive(hegel::PrettyPrintable)]` (or `hegel::pretty_print_as_debug!` for a `Debug` type)
+ = note: when hegel is only a dev-dependency the derive cannot go on the type: invoke `hegel::pretty_print_as_debug!` from `#[cfg(test)]` code instead
  = note: for a foreign type, make the generator printable instead: `.print_as_debug()` prints any `Debug` value, `.print_with(|value, printer| ..)` prints a custom representation
  = note: or draw without reporting the value via `tc.draw_silent(..)`
  = note: the `hegel::pretty` module docs walk through the whole printing system


### PR DESCRIPTION
Fixes #448.

<details>
<summary>Description written by Claude (AI generated)</summary>

The printability diagnostics recommended `#[derive(hegel::PrettyPrintable)]` for your own type, but when hegel is only a dev-dependency the derive cannot go on the type. This adds a note to the `PrettyPrintable` and `PrintableGenerator` diagnostics pointing at `hegel::pretty_print_as_debug!` from `#[cfg(test)]` code, and covers the same case in the `pretty` module docs, the derive rustdoc, and the macro rustdoc. Golden stderr files regenerated on stable and 1.86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>