### PR TITLE
Add BTreeMap and BTreeSet generators

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-This patch adds `generators::btree_sets` and `generators::btree_maps` for generating `BTreeSet` and `BTreeMap` values, with the same `min_size`/`max_size` builders as `hashsets` and `hashmaps`. Both types also implement `DefaultGenerator`, so `gs::default::<BTreeMap<u8, u8>>()` and `#[derive(DefaultGenerator)]` on structs containing them now work ([#445](https://github.com/hegeldev/hegel-rust/issues/445)).
+This patch adds `generators::btree_sets` and `generators::btree_maps` for generating `BTreeSet` and `BTreeMap` values, with the same `min_size`/`max_size` builders as `hashsets` and `hashmaps`. Both types also implement `DefaultGenerator`, so `gs::default::<BTreeMap<u8, u8>>()` and `#[derive(DefaultGenerator)]` on structs containing them now work.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch adds `generators::btree_sets` and `generators::btree_maps` for generating `BTreeSet` and `BTreeMap` values, with the same `min_size`/`max_size` builders as `hashsets` and `hashmaps`. Both types also implement `DefaultGenerator`, so `gs::default::<BTreeMap<u8, u8>>()` and `#[derive(DefaultGenerator)]` on structs containing them now work ([#445](https://github.com/hegeldev/hegel-rust/issues/445)).

--- a/src/generators/collections.rs
+++ b/src/generators/collections.rs
@@ -2,7 +2,7 @@ use super::{Collection, Generator, PrintableGenerator, TestCase, labels};
 use crate::control::hegel_internal_assert;
 use crate::pretty::PrettyPrinter;
 use crate::test_case::invalid_argument;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::hash::Hash;
 use std::marker::PhantomData;
 
@@ -365,6 +365,250 @@ pub fn hashmaps<KT, VT, K: Generator<KT>, V: Generator<VT>>(
     values: V,
 ) -> HashMapGenerator<K, V, KT, VT> {
     HashMapGenerator {
+        keys,
+        values,
+        min_size: 0,
+        max_size: None,
+        _phantom: PhantomData,
+    }
+}
+
+/// Generator for `BTreeSet<T>`. Created by [`btree_sets()`].
+pub struct BTreeSetGenerator<G, T> {
+    elements: G,
+    min_size: usize,
+    max_size: Option<usize>,
+    _phantom: PhantomData<fn(T)>,
+}
+
+impl<G, T> BTreeSetGenerator<G, T> {
+    /// Set the minimum number of elements.
+    pub fn min_size(mut self, min_size: usize) -> Self {
+        self.min_size = min_size;
+        self
+    }
+
+    /// Set the maximum number of elements.
+    pub fn max_size(mut self, max_size: usize) -> Self {
+        self.max_size = Some(max_size);
+        self
+    }
+}
+
+impl<G, T> BTreeSetGenerator<G, T>
+where
+    T: Ord,
+{
+    fn draw_set(
+        &self,
+        tc: &TestCase,
+        printer: &mut PrettyPrinter,
+        draw: impl Fn(&G, &TestCase, &mut PrettyPrinter) -> T,
+    ) -> BTreeSet<T> {
+        if let Some(max) = self.max_size {
+            if self.min_size > max {
+                invalid_argument!("Cannot have max_size < min_size");
+            }
+        }
+        tc.start_span(labels::SET);
+        printer.begin_group(16, "BTreeSet::from([");
+        let mut collection = Collection::new(tc, self.min_size, self.max_size);
+        let mut set = BTreeSet::new();
+        while collection.more() {
+            let mut speculation = printer.speculate();
+            if !set.is_empty() {
+                speculation.printer().text(",");
+                speculation.printer().breakable(" ");
+            }
+            let element = draw(&self.elements, tc, speculation.printer());
+            if set.contains(&element) {
+                speculation.abort();
+                collection.reject(Some("duplicate element"));
+            } else {
+                speculation.commit();
+                set.insert(element);
+            }
+        }
+        hegel_internal_assert!(set.len() >= self.min_size);
+        printer.end_group("])");
+        tc.stop_span(false);
+        set
+    }
+}
+
+impl<T, G> Generator<BTreeSet<T>> for BTreeSetGenerator<G, T>
+where
+    G: Generator<T>,
+    T: Ord,
+{
+    fn do_draw(&self, tc: &TestCase) -> BTreeSet<T> {
+        self.draw_set(tc, &mut PrettyPrinter::noop(), |elements, tc, _| {
+            elements.do_draw(tc)
+        })
+    }
+}
+
+impl<T, G> PrintableGenerator<BTreeSet<T>> for BTreeSetGenerator<G, T>
+where
+    G: PrintableGenerator<T>,
+    T: Ord,
+{
+    fn do_draw_and_print(&self, tc: &TestCase, printer: &mut PrettyPrinter) -> BTreeSet<T> {
+        self.draw_set(tc, printer, |elements, tc, printer| {
+            tc.draw_and_print(elements, printer)
+        })
+    }
+}
+
+/// Generate B-tree sets with elements from the given generator.
+///
+/// See [`BTreeSetGenerator`] for builder methods.
+///
+/// # Example
+///
+/// ```no_run
+/// use hegel::generators as gs;
+/// use std::collections::BTreeSet;
+///
+/// #[hegel::test]
+/// fn my_test(tc: hegel::TestCase) {
+///     let set: BTreeSet<i32> = tc.draw(gs::btree_sets(gs::integers()).max_size(10));
+///     assert!(set.len() <= 10);
+/// }
+/// ```
+pub fn btree_sets<T, G: Generator<T>>(elements: G) -> BTreeSetGenerator<G, T> {
+    BTreeSetGenerator {
+        elements,
+        min_size: 0,
+        max_size: None,
+        _phantom: PhantomData,
+    }
+}
+
+/// Generator for `BTreeMap<K, V>`. Created by [`btree_maps()`].
+pub struct BTreeMapGenerator<K, V, KT, VT> {
+    keys: K,
+    values: V,
+    min_size: usize,
+    max_size: Option<usize>,
+    _phantom: PhantomData<fn(KT, VT)>,
+}
+
+impl<K, V, KT, VT> BTreeMapGenerator<K, V, KT, VT> {
+    /// Set the minimum number of entries.
+    pub fn min_size(mut self, min_size: usize) -> Self {
+        self.min_size = min_size;
+        self
+    }
+
+    /// Set the maximum number of entries.
+    pub fn max_size(mut self, max_size: usize) -> Self {
+        self.max_size = Some(max_size);
+        self
+    }
+}
+
+impl<K, V, KT, VT> Generator<BTreeMap<KT, VT>> for BTreeMapGenerator<K, V, KT, VT>
+where
+    K: Generator<KT>,
+    V: Generator<VT>,
+    KT: Ord,
+{
+    fn do_draw(&self, tc: &TestCase) -> BTreeMap<KT, VT> {
+        self.draw_map(
+            tc,
+            &mut PrettyPrinter::noop(),
+            |keys, tc, _| keys.do_draw(tc),
+            |values, tc, _| values.do_draw(tc),
+        )
+    }
+}
+
+impl<K, V, KT, VT> BTreeMapGenerator<K, V, KT, VT>
+where
+    KT: Ord,
+{
+    fn draw_map(
+        &self,
+        tc: &TestCase,
+        printer: &mut PrettyPrinter,
+        draw_key: impl Fn(&K, &TestCase, &mut PrettyPrinter) -> KT,
+        draw_value: impl Fn(&V, &TestCase, &mut PrettyPrinter) -> VT,
+    ) -> BTreeMap<KT, VT> {
+        if let Some(max) = self.max_size {
+            if self.min_size > max {
+                invalid_argument!("Cannot have max_size < min_size");
+            }
+        }
+        tc.start_span(labels::MAP);
+        printer.begin_group(16, "BTreeMap::from([");
+        let mut collection = Collection::new(tc, self.min_size, self.max_size);
+        let mut map = BTreeMap::new();
+        while collection.more() {
+            let mut speculation = printer.speculate();
+            if !map.is_empty() {
+                speculation.printer().text(",");
+                speculation.printer().breakable(" ");
+            }
+            speculation.printer().text("(");
+            let key = draw_key(&self.keys, tc, speculation.printer());
+            match map.entry(key) {
+                std::collections::btree_map::Entry::Occupied(_) => {
+                    speculation.abort();
+                    collection.reject(Some("duplicate key"));
+                }
+                std::collections::btree_map::Entry::Vacant(entry) => {
+                    speculation.printer().text(", ");
+                    let value = draw_value(&self.values, tc, speculation.printer());
+                    speculation.printer().text(")");
+                    speculation.commit();
+                    entry.insert(value);
+                }
+            }
+        }
+        hegel_internal_assert!(map.len() >= self.min_size);
+        printer.end_group("])");
+        tc.stop_span(false);
+        map
+    }
+}
+
+impl<K, V, KT, VT> PrintableGenerator<BTreeMap<KT, VT>> for BTreeMapGenerator<K, V, KT, VT>
+where
+    K: PrintableGenerator<KT>,
+    V: PrintableGenerator<VT>,
+    KT: Ord,
+{
+    fn do_draw_and_print(&self, tc: &TestCase, printer: &mut PrettyPrinter) -> BTreeMap<KT, VT> {
+        self.draw_map(
+            tc,
+            printer,
+            |keys, tc, printer| tc.draw_and_print(keys, printer),
+            |values, tc, printer| tc.draw_and_print(values, printer),
+        )
+    }
+}
+
+/// Generate B-tree maps.
+///
+/// See [`BTreeMapGenerator`] for builder methods.
+///
+/// # Example
+///
+/// ```no_run
+/// use hegel::generators as gs;
+/// use std::collections::BTreeMap;
+///
+/// #[hegel::test]
+/// fn my_test(tc: hegel::TestCase) {
+///     let map: BTreeMap<i32, String> = tc.draw(gs::btree_maps(gs::integers(), gs::text()));
+/// }
+/// ```
+pub fn btree_maps<KT, VT, K: Generator<KT>, V: Generator<VT>>(
+    keys: K,
+    values: V,
+) -> BTreeMapGenerator<K, V, KT, VT> {
+    BTreeMapGenerator {
         keys,
         values,
         min_size: 0,

--- a/src/generators/default.rs
+++ b/src/generators/default.rs
@@ -1,13 +1,14 @@
 use crate::generators::binary;
 
 use super::{
-    BoolGenerator, BoxedGenerator, CharactersGenerator, DurationGenerator, FloatGenerator,
-    Generator, HashMapGenerator, HashSetGenerator, IntegerGenerator, IpAddressGenerator,
-    Ipv4AddressGenerator, Ipv6AddressGenerator, OptionalGenerator, TextGenerator, VecGenerator,
-    booleans, characters, collections::ArrayGenerator, durations, floats, hashmaps, hashsets,
-    integers, ip_addresses, optional, text, vecs,
+    BTreeMapGenerator, BTreeSetGenerator, BoolGenerator, BoxedGenerator, CharactersGenerator,
+    DurationGenerator, FloatGenerator, Generator, HashMapGenerator, HashSetGenerator,
+    IntegerGenerator, IpAddressGenerator, Ipv4AddressGenerator, Ipv6AddressGenerator,
+    OptionalGenerator, TextGenerator, VecGenerator, booleans, btree_maps, btree_sets, characters,
+    collections::ArrayGenerator, durations, floats, hashmaps, hashsets, integers, ip_addresses,
+    optional, text, vecs,
 };
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::hash::Hash;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::path::PathBuf;
@@ -279,6 +280,30 @@ where
     type Generator = HashSetGenerator<T::Generator, T>;
     fn default_generator() -> Self::Generator {
         hashsets(T::default_generator())
+    }
+}
+
+impl<K: DefaultGenerator + 'static, V: DefaultGenerator + 'static> DefaultGenerator
+    for BTreeMap<K, V>
+where
+    K: Ord,
+    K::Generator: Send + Sync,
+    V::Generator: Send + Sync,
+{
+    type Generator = BTreeMapGenerator<K::Generator, V::Generator, K, V>;
+    fn default_generator() -> Self::Generator {
+        btree_maps(K::default_generator(), V::default_generator())
+    }
+}
+
+impl<T: DefaultGenerator + 'static> DefaultGenerator for BTreeSet<T>
+where
+    T: Ord,
+    T::Generator: Send + Sync,
+{
+    type Generator = BTreeSetGenerator<T::Generator, T>;
+    fn default_generator() -> Self::Generator {
+        btree_sets(T::default_generator())
     }
 }
 

--- a/src/generators/mod.rs
+++ b/src/generators/mod.rs
@@ -27,8 +27,8 @@ pub use crate::test_case::{Collection, TestCase, labels};
 #[doc(inline)]
 pub use crate::tuples;
 pub use collections::{
-    ArrayGenerator, HashMapGenerator, HashSetGenerator, VecGenerator, arrays, hashmaps, hashsets,
-    vecs,
+    ArrayGenerator, BTreeMapGenerator, BTreeSetGenerator, HashMapGenerator, HashSetGenerator,
+    VecGenerator, arrays, btree_maps, btree_sets, hashmaps, hashsets, vecs,
 };
 #[doc(hidden)]
 pub use combinators::one_of_from_alternatives;

--- a/tests/test_collections.rs
+++ b/tests/test_collections.rs
@@ -1,8 +1,9 @@
 mod common;
 
+use common::utils::check_can_generate_examples;
 use hegel::TestCase;
 use hegel::generators::{self as gs, DefaultGenerator, Generator};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 #[derive(Debug, PartialEq, hegel::DefaultGenerator, hegel::PrettyPrintable)]
 struct Wrapper {
@@ -226,6 +227,113 @@ fn test_hashmap_with_mapped_keys(tc: TestCase) {
         .max_size(10),
     );
     assert!(map.keys().all(|&k| k % 2 == 0));
+}
+
+#[test]
+fn test_btree_sets_default() {
+    check_can_generate_examples(gs::btree_sets(gs::booleans()));
+}
+
+#[hegel::test]
+fn test_btree_set_with_max_size(tc: TestCase) {
+    let max_size: usize = tc.draw(gs::integers());
+    let set: BTreeSet<i32> = tc.draw(gs::btree_sets(gs::integers::<i32>()).max_size(max_size));
+    assert!(set.len() <= max_size);
+}
+
+#[hegel::test]
+fn test_btree_set_with_min_size(tc: TestCase) {
+    let min_size: usize = tc.draw(gs::integers().max_value(20));
+    let set: BTreeSet<i32> = tc.draw(gs::btree_sets(gs::integers::<i32>()).min_size(min_size));
+    assert!(set.len() >= min_size);
+}
+
+#[hegel::test]
+fn test_btree_set_with_min_and_max_size(tc: TestCase) {
+    let min_size: usize = tc.draw(gs::integers().max_value(10));
+    let max_size = tc.draw(gs::integers().min_value(min_size));
+    let set: BTreeSet<i32> = tc.draw(
+        gs::btree_sets(gs::integers::<i32>())
+            .min_size(min_size)
+            .max_size(max_size),
+    );
+    assert!(set.len() >= min_size && set.len() <= max_size);
+}
+
+#[hegel::test]
+fn test_btree_set_min_size_forces_distinct_elements(tc: TestCase) {
+    let set: BTreeSet<bool> = tc.draw(gs::btree_sets(gs::booleans()).min_size(2));
+    assert_eq!(set.len(), 2);
+}
+
+#[hegel::test]
+fn test_vec_of_btree_sets(tc: TestCase) {
+    let vec_of_sets: Vec<BTreeSet<i32>> = tc.draw(
+        gs::vecs(gs::btree_sets(gs::integers::<i32>().min_value(0).max_value(100)).max_size(5))
+            .max_size(3),
+    );
+    for set in &vec_of_sets {
+        assert!(set.len() <= 5);
+        assert!(set.iter().all(|&x| (0..=100).contains(&x)));
+    }
+}
+
+#[test]
+fn test_btree_maps_default() {
+    check_can_generate_examples(gs::btree_maps(gs::booleans(), gs::booleans()));
+}
+
+#[hegel::test]
+fn test_btree_map_with_max_size(tc: TestCase) {
+    let max_size: usize = tc.draw(gs::integers());
+    let map: BTreeMap<i32, i32> =
+        tc.draw(gs::btree_maps(gs::integers::<i32>(), gs::integers::<i32>()).max_size(max_size));
+    assert!(map.len() <= max_size);
+}
+
+#[hegel::test]
+fn test_btree_map_with_min_size(tc: TestCase) {
+    let min_size: usize = tc.draw(gs::integers().max_value(20));
+    let map: BTreeMap<i32, i32> =
+        tc.draw(gs::btree_maps(gs::integers::<i32>(), gs::integers::<i32>()).min_size(min_size));
+    assert!(map.len() >= min_size);
+}
+
+#[hegel::test]
+fn test_btree_map_with_min_and_max_size(tc: TestCase) {
+    let min_size: usize = tc.draw(gs::integers().max_value(10));
+    let max_size = tc.draw(gs::integers().min_value(min_size));
+    let map: BTreeMap<i32, i32> = tc.draw(
+        gs::btree_maps(gs::integers::<i32>(), gs::integers::<i32>())
+            .min_size(min_size)
+            .max_size(max_size),
+    );
+    assert!(map.len() >= min_size && map.len() <= max_size);
+}
+
+#[hegel::test]
+fn test_btree_map_min_size_forces_distinct_keys(tc: TestCase) {
+    let map: BTreeMap<bool, bool> =
+        tc.draw(gs::btree_maps(gs::booleans(), gs::booleans()).min_size(2));
+    assert_eq!(map.len(), 2);
+}
+
+#[hegel::test]
+fn test_vec_of_btree_maps(tc: TestCase) {
+    let vec_of_maps: Vec<BTreeMap<i32, i32>> = tc.draw(
+        gs::vecs(
+            gs::btree_maps(
+                gs::integers::<i32>().min_value(0).max_value(100),
+                gs::integers::<i32>(),
+            )
+            .max_size(5),
+        )
+        .max_size(3),
+    );
+    for map in &vec_of_maps {
+        assert!(map.len() <= 5);
+        assert!(map.keys().all(|&k| (0..=100).contains(&k)));
+    }
 }
 
 #[hegel::test]

--- a/tests/test_default.rs
+++ b/tests/test_default.rs
@@ -80,6 +80,30 @@ fn test_default_hashset() {
 }
 
 #[test]
+fn test_default_btree_map() {
+    check_can_generate_examples(gs::default::<std::collections::BTreeMap<u8, u8>>());
+    check_can_generate_examples(gs::default::<std::collections::BTreeMap<String, bool>>());
+}
+
+#[test]
+fn test_default_btree_set() {
+    check_can_generate_examples(gs::default::<std::collections::BTreeSet<i32>>());
+    check_can_generate_examples(gs::default::<std::collections::BTreeSet<String>>());
+}
+
+#[test]
+fn test_default_derive_with_btree_fields() {
+    #[derive(Debug, hegel::DefaultGenerator, hegel::PrettyPrintable)]
+    struct HasBTrees {
+        #[allow(dead_code)]
+        map: std::collections::BTreeMap<u8, u8>,
+        #[allow(dead_code)]
+        set: std::collections::BTreeSet<i32>,
+    }
+    check_can_generate_examples(gs::default::<HasBTrees>());
+}
+
+#[test]
 fn test_default_pathbuf() {
     check_can_generate_examples(gs::default::<PathBuf>());
 

--- a/tests/test_printable_generators.rs
+++ b/tests/test_printable_generators.rs
@@ -182,6 +182,18 @@ fn sets_and_maps_print_in_draw_order() {
         lines,
         vec!["let draw_1 = HashMap::from([(\"\".to_string(), false)]);"]
     );
+
+    let lines = failing_lines(|tc| {
+        let _ = tc.draw(gs::btree_sets(gs::sampled_from(vec![1, 2, 3])).min_size(1));
+        panic!("boom");
+    });
+    assert_eq!(lines, vec!["let draw_1 = BTreeSet::from([1]);"]);
+
+    let lines = failing_lines(|tc| {
+        let _ = tc.draw(gs::btree_maps(gs::sampled_from(vec![9]), gs::booleans()).min_size(1));
+        panic!("boom");
+    });
+    assert_eq!(lines, vec!["let draw_1 = BTreeMap::from([(9, false)]);"]);
 }
 
 #[test]
@@ -540,6 +552,16 @@ fn invalid_collection_sizes_report_while_printing() {
         |tc| {
             let _ = tc.draw(
                 gs::hashmaps(gs::booleans(), gs::booleans())
+                    .min_size(5)
+                    .max_size(2),
+            );
+        },
+        |tc| {
+            let _ = tc.draw(gs::btree_sets(gs::booleans()).min_size(5).max_size(2));
+        },
+        |tc| {
+            let _ = tc.draw(
+                gs::btree_maps(gs::booleans(), gs::booleans())
                     .min_size(5)
                     .max_size(2),
             );

--- a/tests/test_validation.rs
+++ b/tests/test_validation.rs
@@ -201,6 +201,24 @@ fn test_hashmaps_min_greater_than_max() {
 }
 
 #[test]
+fn test_btree_sets_min_greater_than_max() {
+    expect_draw_panic(
+        gs::btree_sets(gs::booleans()).min_size(5).max_size(3),
+        "max_size < min_size",
+    );
+}
+
+#[test]
+fn test_btree_maps_min_greater_than_max() {
+    expect_draw_panic(
+        gs::btree_maps(gs::text(), gs::booleans())
+            .min_size(5)
+            .max_size(3),
+        "max_size < min_size",
+    );
+}
+
+#[test]
 fn test_samples_min_greater_than_max() {
     expect_draw_panic(
         gs::samples(vec![1, 2, 3]).min_size(3).max_size(2),


### PR DESCRIPTION
Fixes #445.

<details>
<summary>Description written by Claude (AI-generated)</summary>

Adds `gs::btree_sets()` and `gs::btree_maps()`, mirroring `hashsets()` and `hashmaps()`, plus `DefaultGenerator` impls for `BTreeSet` and `BTreeMap`. Values print as `BTreeSet::from([...])` / `BTreeMap::from([...])`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)