### PR TITLE
Add a reproduction pointer to failure output

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+RELEASE_TYPE: patch
+
+This patch adds a reproduction pointer to failure output
+([#438](https://github.com/hegeldev/hegel-rust/issues/438)). A failing test
+now ends with a line naming the database directory the shrunk example was
+saved to. When nothing was saved (the database is disabled, as in CI by
+default, or the test has no database key) the copy-pasteable
+`reproduce_failure` line is printed instead. Previously that line required
+enabling the `print_blob` setting.

--- a/hegel-c/RELEASE.md
+++ b/hegel-c/RELEASE.md
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch adds `hegel_run_result_database_path`, which reports the database
+directory a failing run saved its counterexamples to (NULL when nothing was
+saved), so frontends can point at the saved example in their failure output.

--- a/hegel-c/include/hegel.h
+++ b/hegel-c/include/hegel.h
@@ -2400,6 +2400,20 @@ hegel_result_t hegel_run_result_error(hegel_context_t *ctx,
 
 /*
  Parameters:
+ `out_path`: Receives the database directory the run persisted its
+   failures to, or NULL when nothing was persisted — the database is
+   disabled, the run has no database key, or the run was
+   nondeterministic. Owned by the run result and valid until
+   `hegel_run_result_free`.
+
+ Returns `HEGEL_OK`.
+ */
+hegel_result_t hegel_run_result_database_path(hegel_context_t *ctx,
+                                              const hegel_run_result_t *r,
+                                              const char **out_path);
+
+/*
+ Parameters:
  `out_count`: Receives the number of distinct failures, by origin, that
    the run surfaced.
 

--- a/hegel-c/src/backend.rs
+++ b/hegel-c/src/backend.rs
@@ -425,6 +425,10 @@ pub struct TestRunResult {
     /// reproduce blob — there is no final replay — so the caller should
     /// report them from whatever it captured at discovery time.
     pub nondeterministic: bool,
+    /// The database directory this run persisted its failures to, or `None`
+    /// when nothing was persisted (the database is disabled, the run has no
+    /// database key, or the run was nondeterministic).
+    pub database_path: Option<String>,
 }
 
 #[cfg(test)]

--- a/hegel-c/src/lib.rs
+++ b/hegel-c/src/lib.rs
@@ -640,6 +640,10 @@ pub struct HegelRunResult {
     /// `HEGEL_RUN_STATUS_FAILED_NONDETERMINISTIC` and its failures carry no
     /// reproduce blob.
     nondeterministic: bool,
+    /// The database directory the run persisted its failures to, or `None`
+    /// when nothing was persisted. Read via
+    /// `hegel_run_result_database_path`.
+    database_path: Option<CString>,
 }
 
 /// One distinct interesting test case surfaced by the run.
@@ -677,6 +681,7 @@ impl From<TestRunResult> for HegelRunResult {
             failures: r.failures.into_iter().map(HegelFailure::from).collect(),
             error: None,
             nondeterministic: r.nondeterministic,
+            database_path: r.database_path.map(|p| cstring_lossy(&p)),
         }
     }
 }
@@ -689,6 +694,7 @@ impl HegelRunResult {
             failures: Vec::new(),
             error: Some(cstring_lossy(message)),
             nondeterministic: false,
+            database_path: None,
         }
     }
 
@@ -5048,6 +5054,39 @@ pub unsafe extern "C" fn hegel_run_result_error(
         return HEGEL_E_INVALID_ARG;
     }
     unsafe { *out_error = r.error.as_ref().map(|e| e.as_ptr()).unwrap_or(ptr::null()) };
+    HEGEL_OK
+}
+
+/// Parameters:
+/// `out_path`: Receives the database directory the run persisted its
+///   failures to, or NULL when nothing was persisted — the database is
+///   disabled, the run has no database key, or the run was
+///   nondeterministic. Owned by the run result and valid until
+///   `hegel_run_result_free`.
+///
+/// Returns `HEGEL_OK`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn hegel_run_result_database_path(
+    ctx: *mut HegelContext,
+    r: *const HegelRunResult,
+    out_path: *mut *const c_char,
+) -> hegel_result_t {
+    clear_last_error(ctx);
+    let r = match unsafe { result_ref(ctx, r, "hegel_run_result_database_path") } {
+        Ok(r) => r,
+        Err(rc) => return rc,
+    };
+    if out_path.is_null() {
+        set_last_error(ctx, "hegel_run_result_database_path: out parameter is null");
+        return HEGEL_E_INVALID_ARG;
+    }
+    unsafe {
+        *out_path = r
+            .database_path
+            .as_ref()
+            .map(|p| p.as_ptr())
+            .unwrap_or(ptr::null())
+    };
     HEGEL_OK
 }
 

--- a/hegel-c/src/native/test_runner.rs
+++ b/hegel-c/src/native/test_runner.rs
@@ -616,9 +616,15 @@ impl<'a> Engine<'a> {
                 }
             })
             .collect();
+        let database_path = if nondeterministic || database_key.is_none() {
+            None
+        } else {
+            database_directory(&settings.database).map(str::to_string)
+        };
         Ok(TestRunResult {
             failures,
             nondeterministic,
+            database_path,
         })
     }
 }
@@ -1007,11 +1013,8 @@ impl<'a> Engine<'a> {
         database_key: Option<&'a str>,
         exchange: &'a CaseExchange,
     ) -> Result<Self, RunError> {
-        let db: Option<Box<dyn TestCaseDatabase>> = match &settings.database {
-            Database::Path(path) => Some(Box::new(DirectoryTestCaseDatabase::new(path))),
-            Database::Unset => Some(Box::new(DirectoryTestCaseDatabase::new(".hegel/examples"))),
-            Database::Disabled => None,
-        };
+        let db: Option<Box<dyn TestCaseDatabase>> = database_directory(&settings.database)
+            .map(|path| Box::new(DirectoryTestCaseDatabase::new(path)) as _);
         Ok(Engine {
             settings,
             database_key,
@@ -1411,6 +1414,16 @@ impl<'a> Engine<'a> {
             }
         }
         Ok(())
+    }
+}
+
+/// The directory the failure database lives in, resolving [`Database::Unset`]
+/// to the default location, or `None` when the database is disabled.
+fn database_directory(database: &Database) -> Option<&str> {
+    match database {
+        Database::Path(path) => Some(path),
+        Database::Unset => Some(".hegel/examples"),
+        Database::Disabled => None,
     }
 }
 

--- a/hegel-c/tests/c_abi_inprocess.rs
+++ b/hegel-c/tests/c_abi_inprocess.rs
@@ -22,11 +22,11 @@ use hegel_c::{
     hegel_new_collection, hegel_new_pool, hegel_new_recursion, hegel_new_state_machine,
     hegel_next_test_case, hegel_pool_add, hegel_pool_free, hegel_pool_generate,
     hegel_recursion_branch, hegel_recursion_finish, hegel_recursion_free, hegel_recursion_leaf,
-    hegel_recursion_retry, hegel_run_free, hegel_run_result, hegel_run_result_error,
-    hegel_run_result_failure, hegel_run_result_failure_count, hegel_run_result_free,
-    hegel_run_result_status, hegel_run_start, hegel_run_status_t, hegel_settings_free,
-    hegel_settings_new, hegel_settings_set_backend, hegel_settings_set_database,
-    hegel_settings_set_database_key, hegel_settings_set_phases,
+    hegel_recursion_retry, hegel_run_free, hegel_run_result, hegel_run_result_database_path,
+    hegel_run_result_error, hegel_run_result_failure, hegel_run_result_failure_count,
+    hegel_run_result_free, hegel_run_result_status, hegel_run_start, hegel_run_status_t,
+    hegel_settings_free, hegel_settings_new, hegel_settings_set_backend,
+    hegel_settings_set_database, hegel_settings_set_database_key, hegel_settings_set_phases,
     hegel_settings_set_report_multiple_failures, hegel_settings_set_suppress_health_check,
     hegel_start_span, hegel_state_machine_free, hegel_state_machine_next_group,
     hegel_state_machine_next_rule, hegel_state_machine_rule_rejected,
@@ -97,6 +97,15 @@ unsafe fn repro_blob_of(ctx: *mut HegelContext, f: *const HegelFailure) -> *cons
 unsafe fn run_error_of(ctx: *mut HegelContext, r: *const HegelRunResult) -> *const c_char {
     let mut p: *const c_char = ptr::null();
     assert_eq!(unsafe { hegel_run_result_error(ctx, r, &mut p) }, HEGEL_OK);
+    p
+}
+
+unsafe fn database_path_of(ctx: *mut HegelContext, r: *const HegelRunResult) -> *const c_char {
+    let mut p: *const c_char = ptr::null();
+    assert_eq!(
+        unsafe { hegel_run_result_database_path(ctx, r, &mut p) },
+        HEGEL_OK
+    );
     p
 }
 
@@ -198,6 +207,10 @@ fn null_handles_are_rejected_without_crashing() {
         let mut p: *const c_char = ptr::null();
         assert_eq!(
             hegel_run_result_error(ctx, ptr::null(), &mut p),
+            HEGEL_E_INVALID_HANDLE
+        );
+        assert_eq!(
+            hegel_run_result_database_path(ctx, ptr::null(), &mut p),
             HEGEL_E_INVALID_HANDLE
         );
         let mut n = 0usize;
@@ -393,6 +406,10 @@ fn out_parameters_are_rejected_when_null() {
         );
         assert_eq!(
             hegel_run_result_error(ctx, res, ptr::null_mut()),
+            HEGEL_E_INVALID_ARG
+        );
+        assert_eq!(
+            hegel_run_result_database_path(ctx, res, ptr::null_mut()),
             HEGEL_E_INVALID_ARG
         );
         assert_eq!(
@@ -1096,6 +1113,7 @@ fn interesting_with_null_origin_synthesizes_placeholder() {
         let res = result(ctx, run);
         assert!(status_of(ctx, res) == hegel_run_status_t::HEGEL_RUN_STATUS_FAILED);
         assert!(run_error_of(ctx, res).is_null());
+        assert!(database_path_of(ctx, res).is_null());
         let count = failure_count_of(ctx, res);
         assert!(
             count >= 1,
@@ -1124,6 +1142,52 @@ fn interesting_with_null_origin_synthesizes_placeholder() {
         assert!(origin.contains("Panic at <unknown>"), "got {origin:?}");
         let _ = repro_blob_of(ctx, f);
         ok(hegel_failure_free(ctx, f));
+        ok(hegel_run_result_free(ctx, res));
+
+        ok(hegel_run_free(ctx, run));
+        ok(hegel_settings_free(ctx, s));
+        ok(hegel_context_free(ctx));
+    }
+}
+
+/// A failing run with a database and a database key reports the database
+/// directory its counterexamples were persisted to.
+#[test]
+fn failed_run_with_database_reports_database_path() {
+    let db_dir = tempfile::TempDir::new().unwrap();
+    let db_path = CString::new(db_dir.path().to_str().unwrap()).unwrap();
+    let ctx = hegel_context_new();
+    unsafe {
+        let s = make_settings(ctx);
+        ok(hegel_settings_set_database(ctx, s, db_path.as_ptr()));
+        ok(hegel_settings_set_database_key(
+            ctx,
+            s,
+            c"failed_run_with_database_reports_database_path".as_ptr(),
+        ));
+        ok(hegel_c::hegel_settings_set_test_cases(ctx, s, 5));
+        ok(hegel_c::hegel_settings_set_seed(ctx, s, 1, true));
+        let run = start(ctx, s);
+        loop {
+            let tc = next_case(ctx, run);
+            if tc.is_null() {
+                break;
+            }
+            ok(hegel_mark_complete(
+                ctx,
+                tc,
+                hegel_status_t::HEGEL_STATUS_INTERESTING as u32,
+                c"bug".as_ptr(),
+            ));
+            ok(hegel_test_case_free(ctx, tc));
+        }
+
+        let res = result(ctx, run);
+        assert!(status_of(ctx, res) == hegel_run_status_t::HEGEL_RUN_STATUS_FAILED);
+        let reported = std::ffi::CStr::from_ptr(database_path_of(ctx, res))
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(reported, db_dir.path().to_str().unwrap());
         ok(hegel_run_result_free(ctx, res));
 
         ok(hegel_run_free(ctx, run));

--- a/hegel-c/tests/embedded/native/test_runner_tests.rs
+++ b/hegel-c/tests/embedded/native/test_runner_tests.rs
@@ -72,6 +72,19 @@ fn concurrent_machine(ds: &dyn DataSource) -> Result<(), TestCaseResult> {
 }
 
 #[test]
+fn database_directory_resolves_each_database_setting() {
+    assert_eq!(
+        database_directory(&Database::Unset),
+        Some(".hegel/examples")
+    );
+    assert_eq!(
+        database_directory(&Database::Path("my-db".to_string())),
+        Some("my-db")
+    );
+    assert_eq!(database_directory(&Database::Disabled), None);
+}
+
+#[test]
 fn too_slow_check_reports_when_under_threshold_and_unsuppressed() {
     let msg = too_slow_check(1, Duration::from_secs(60), Duration::from_secs(30), false);
     assert!(msg.is_some(), "expected too_slow_check to report a failure");

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1434,6 +1434,18 @@ impl RunResult {
         cstr_opt(p)
     }
 
+    /// The database directory the run persisted its failures to, or `None`
+    /// when nothing was persisted (the database is disabled, the run has no
+    /// database key, or the run was nondeterministic).
+    pub(crate) fn database_path(&self) -> Option<String> {
+        let mut p: *const c_char = ptr::null();
+        // SAFETY: self.raw is this snapshot's live pointer; &mut p is valid.
+        require_ok(with_context(|ctx| unsafe {
+            hegel_c::hegel_run_result_database_path(ctx, self.raw, &mut p)
+        }));
+        cstr_opt(p)
+    }
+
     pub(crate) fn failure_count(&self) -> usize {
         let mut count = 0;
         // SAFETY: self.raw is this snapshot's live pointer; &mut count is valid.

--- a/src/ffi/sys.rs
+++ b/src/ffi/sys.rs
@@ -81,6 +81,7 @@ macro_rules! for_each_hegel_fn {
             fn hegel_recursion_retry(ctx: *mut HegelContext, tc: *mut HegelTestCase, recursion: *mut HegelRecursion) -> hegel_result_t;
             fn hegel_run_free(ctx: *mut HegelContext, run: *mut HegelRun) -> hegel_result_t;
             fn hegel_run_result(ctx: *mut HegelContext, run: *mut HegelRun, out_result: *mut *mut HegelRunResult) -> hegel_result_t;
+            fn hegel_run_result_database_path(ctx: *mut HegelContext, r: *const HegelRunResult, out_path: *mut *const c_char) -> hegel_result_t;
             fn hegel_run_result_error(ctx: *mut HegelContext, r: *const HegelRunResult, out_error: *mut *const c_char) -> hegel_result_t;
             fn hegel_run_result_failure(ctx: *mut HegelContext, r: *const HegelRunResult, index: usize, out_failure: *mut *mut HegelFailure) -> hegel_result_t;
             fn hegel_run_result_failure_count(ctx: *mut HegelContext, r: *const HegelRunResult, out_count: *mut usize) -> hegel_result_t;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -518,8 +518,9 @@ pub use hegel_macros::explicit_test_case;
 
 /// Replay a single failing example from a base64 *failure blob*.
 ///
-/// When a test fails on the native backend and the
-/// [`print_blob`](Settings::print_blob) setting is enabled, Hegel prints a
+/// When a test fails on the native backend without saving the failing
+/// example to the database (or with the
+/// [`print_blob`](Settings::print_blob) setting enabled), Hegel prints a
 /// reproducer line of the form:
 ///
 /// ```text

--- a/src/run_lifecycle.rs
+++ b/src/run_lifecycle.rs
@@ -434,18 +434,56 @@ fn render_diagnostic(
 /// The copy-pasteable reproduce failure text to append after a failure's diagnostic,
 /// or `None` when nothing should be printed.
 ///
-/// `Some` only when [`Settings::print_blob`](crate::Settings::print_blob) is
-/// enabled *and* the failure carries a reproduce blob. A replayed
-/// counterexample always has one; a blobless failure prints nothing.
-fn reproducer_line(settings: &Settings, reproduce_blob: Option<&str>) -> Option<String> {
-    if !settings.print_blob {
+/// Printed when [`Settings::print_blob`](crate::Settings::print_blob) is
+/// enabled, and also (unless quiet) when the failure was not saved to the
+/// database, where the blob is the only reproduction pointer. Requires a
+/// reproduce blob, which a replayed counterexample always has. `attribute`
+/// selects the phrasing: the `#[hegel::reproduce_failure]` attribute for a
+/// macro-defined test (one with a database key), the builder method
+/// otherwise.
+fn reproducer_line(
+    settings: &Settings,
+    reproduce_blob: Option<&str>,
+    saved: bool,
+    attribute: bool,
+) -> Option<String> {
+    let quiet = settings.verbosity == Verbosity::Quiet;
+    if !settings.print_blob && (saved || quiet) {
         return None;
     }
     let blob = reproduce_blob?;
-    Some(format!(
-        "\nTo reproduce this failure, add the attribute below \
-         #[hegel::test]:\n    #[hegel::reproduce_failure(\"{blob}\")]"
-    ))
+    Some(if attribute {
+        format!(
+            "\nTo reproduce this failure, add the attribute below \
+             #[hegel::test]:\n    #[hegel::reproduce_failure(\"{blob}\")]"
+        )
+    } else {
+        format!(
+            "\nTo reproduce this failure, call reproduce_failure on the \
+             test's builder:\n    Hegel::new(...).reproduce_failure(\"{blob}\")"
+        )
+    })
+}
+
+/// The run-level line pointing at the saved counterexample(s), or `None`
+/// when nothing was saved (the [`reproducer_line`] is the pointer then) or
+/// the run is quiet.
+fn saved_to_database_line(
+    settings: &Settings,
+    database_path: Option<&str>,
+    count: usize,
+) -> Option<String> {
+    if settings.verbosity == Verbosity::Quiet {
+        return None;
+    }
+    let path = database_path?;
+    Some(if count > 1 {
+        format!(
+            "The failing examples were saved to '{path}'. Rerunning this test will replay them."
+        )
+    } else {
+        format!("The failing example was saved to '{path}'. Rerunning this test will replay it.")
+    })
 }
 
 /// The run's failure candidate: everything captured at discovery time from
@@ -580,6 +618,7 @@ pub(crate) fn drive<F>(
         }
         RunStatus::HEGEL_RUN_STATUS_FAILED => {
             let count = result.failure_count();
+            let database_path = result.database_path();
             let multiple = count > 1;
             if multiple && !quiet {
                 output.line(&format!(
@@ -607,10 +646,19 @@ pub(crate) fn drive<F>(
                 if let Some(diagnostic) = diagnostic {
                     output.block(&diagnostic);
                 }
-                if let Some(line) = reproducer_line(settings, Some(blob.as_str())) {
+                if let Some(line) = reproducer_line(
+                    settings,
+                    Some(blob.as_str()),
+                    database_path.is_some(),
+                    database_key.is_some(),
+                ) {
                     output.block(&format!("{line}\n"));
                 }
                 last_payload = payload;
+            }
+
+            if let Some(line) = saved_to_database_line(settings, database_path.as_deref(), count) {
+                output.block(&format!("\n{line}\n"));
             }
 
             if multiple {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -261,8 +261,12 @@ impl Settings {
     /// Print a copy-pasteable `#[hegel::reproduce_failure("…")]` line for the
     /// counterexample when a test fails. Defaults to `false`.
     ///
-    /// The reproduce blob is always *attached* to the failure. This setting only controls whether it is printed to
-    /// the failure output. Has effect only on the native backend.
+    /// By default the line is printed only when the failing example was not
+    /// saved to the database (and the run is not quiet). A saved failure is
+    /// pointed at with its database path instead, since rerunning the test
+    /// replays it. Enabling this prints the line unconditionally. The
+    /// reproduce blob is always *attached* to the failure either way. Has
+    /// effect only on the native backend.
     pub fn print_blob(mut self, print_blob: bool) -> Self {
         self.print_blob = print_blob;
         self

--- a/tests/embedded/run_lifecycle_tests.rs
+++ b/tests/embedded/run_lifecycle_tests.rs
@@ -126,26 +126,82 @@ fn format_backtrace_short_strips_through_filter() {
 }
 
 #[test]
-fn reproducer_line_none_when_print_blob_disabled() {
+fn reproducer_line_none_when_saved_and_print_blob_disabled() {
     let settings = Settings::new();
     assert!(!settings.print_blob);
-    assert!(reproducer_line(&settings, Some("AAEC")).is_none());
+    assert!(reproducer_line(&settings, Some("AAEC"), true, true).is_none());
+}
+
+#[test]
+fn reproducer_line_none_when_unsaved_but_quiet() {
+    let settings = Settings::new().verbosity(Verbosity::Quiet);
+    assert!(reproducer_line(&settings, Some("AAEC"), false, true).is_none());
 }
 
 #[test]
 fn reproducer_line_none_when_no_blob_attached() {
     let settings = Settings::new().print_blob(true);
-    assert!(reproducer_line(&settings, None).is_none());
+    assert!(reproducer_line(&settings, None, true, true).is_none());
 }
 
 #[test]
-fn reproducer_line_emits_attribute_when_enabled_and_present() {
+fn reproducer_line_emits_attribute_when_print_blob_enabled() {
     let settings = Settings::new().print_blob(true);
-    let line = reproducer_line(&settings, Some("AAEC")).unwrap();
+    let line = reproducer_line(&settings, Some("AAEC"), true, true).unwrap();
     assert!(
         line.contains("#[hegel::reproduce_failure(\"AAEC\")]"),
         "expected the reproducer attribute, got: {line}"
     );
+}
+
+#[test]
+fn reproducer_line_emits_attribute_when_unsaved() {
+    let settings = Settings::new();
+    let line = reproducer_line(&settings, Some("AAEC"), false, true).unwrap();
+    assert!(
+        line.contains("#[hegel::reproduce_failure(\"AAEC\")]"),
+        "expected the reproducer attribute, got: {line}"
+    );
+}
+
+#[test]
+fn reproducer_line_uses_builder_wording_without_database_key() {
+    let settings = Settings::new();
+    let line = reproducer_line(&settings, Some("AAEC"), false, false).unwrap();
+    assert!(
+        line.contains("Hegel::new(...).reproduce_failure(\"AAEC\")"),
+        "expected the builder wording, got: {line}"
+    );
+}
+
+#[test]
+fn saved_to_database_line_is_singular_for_one_failure() {
+    let line = saved_to_database_line(&Settings::new(), Some(".hegel/examples"), 1).unwrap();
+    assert!(
+        line.contains("The failing example was saved to '.hegel/examples'")
+            && line.contains("replay it"),
+        "unexpected wording: {line}"
+    );
+}
+
+#[test]
+fn saved_to_database_line_is_plural_for_several_failures() {
+    let line = saved_to_database_line(&Settings::new(), Some("my-db"), 2).unwrap();
+    assert!(
+        line.contains("The failing examples were saved to 'my-db'") && line.contains("replay them"),
+        "unexpected wording: {line}"
+    );
+}
+
+#[test]
+fn saved_to_database_line_none_when_quiet() {
+    let settings = Settings::new().verbosity(Verbosity::Quiet);
+    assert!(saved_to_database_line(&settings, Some("my-db"), 1).is_none());
+}
+
+#[test]
+fn saved_to_database_line_none_when_nothing_was_saved() {
+    assert!(saved_to_database_line(&Settings::new(), None, 1).is_none());
 }
 
 fn test_settings() -> Settings {

--- a/tests/test_multi_failure.rs
+++ b/tests/test_multi_failure.rs
@@ -199,9 +199,15 @@ fn test_multi_failure_report_groups_draws_with_their_diagnostics() {
             r"thread '[^']+' \(\d+\) panicked at tests[/\\]fixtures[/\\]two_bugs\.rs:\d+:\d+:\n",
             r"(?:big|small) branch: \d+\n",
             r"\n",
+            r"To reproduce this failure, call reproduce_failure on the test's builder:\n",
+            r"    Hegel::new\(\.\.\.\)\.reproduce_failure\(\S+\)\n",
+            r"\n",
             r"let draw_1 = \d+;\n",
             r"thread '[^']+' \(\d+\) panicked at tests[/\\]fixtures[/\\]two_bugs\.rs:\d+:\d+:\n",
-            r"(?:big|small) branch: \d+$",
+            r"(?:big|small) branch: \d+\n",
+            r"\n",
+            r"To reproduce this failure, call reproduce_failure on the test's builder:\n",
+            r"    Hegel::new\(\.\.\.\)\.reproduce_failure\(\S+\)$",
         ),
     );
 }

--- a/tests/test_output.rs
+++ b/tests/test_output.rs
@@ -637,8 +637,10 @@ mod override_captures_run_output {
             "expected the reproducer line in the sink, got {lines:?}"
         );
         assert!(
-            lines.iter().any(|l| l.contains("hegel::reproduce_failure")),
-            "expected the reproduce_failure attribute in the sink, got {lines:?}"
+            lines
+                .iter()
+                .any(|l| l.contains("Hegel::new(...).reproduce_failure(")),
+            "expected the reproduce_failure pointer in the sink, got {lines:?}"
         );
     }
 

--- a/tests/test_print_blob.rs
+++ b/tests/test_print_blob.rs
@@ -1,19 +1,29 @@
-//! The `print_blob` setting controls whether a failing run prints a
-//! copy-pasteable `#[hegel::reproduce_failure("…")]` reproducer line.
+//! A failing run always ends with a reproduction pointer: the line naming
+//! the database directory the example was saved to, or, when nothing was
+//! saved, a copy-pasteable `#[hegel::reproduce_failure("…")]` reproducer
+//! line (the `print_blob` setting forces the reproducer line on).
 //!
-//! The reproducer line is written straight to stderr at the catch site, so
-//! these run an `#[ignore]`d failing fixture test in a subprocess (this same
-//! binary, via `exec::self_test`) and assert the line is present when
-//! `print_blob` is set and absent otherwise.
+//! These lines are written straight to stderr at the catch site, so the
+//! tests run an `#[ignore]`d failing fixture test in a subprocess (this same
+//! binary, via `exec::self_test`) or a fixture binary, and assert on the
+//! combined output. `HEGEL_DATABASE` pins the database state so the
+//! assertions hold both locally (database on by default) and in CI
+//! (database off by default).
 
 mod common;
 
-use common::exec::self_test;
+use common::exec::{fixture, self_test};
 use hegel::TestCase;
 use hegel::generators as gs;
 
 /// Marker printed by the reproducer line (see `run_lifecycle::reproducer_line`).
 const REPRODUCER_MARKER: &str = "To reproduce this failure";
+
+/// Marker printed by the saved-to-database line (see
+/// `run_lifecycle::saved_to_database_line`).
+const SAVED_MARKER: &str = "was saved to";
+
+const OUTPUT_FAILING: &str = env!("CARGO_BIN_EXE_fixture_output_failing");
 
 #[hegel::test(print_blob = true)]
 #[ignore = "fixture: run via exec::self_test"]
@@ -32,18 +42,74 @@ fn print_blob_default_fixture(tc: TestCase) {
 #[test]
 fn print_blob_true_prints_reproducer_line() {
     self_test("print_blob_true_fixture")
+        .env("HEGEL_DATABASE", "disabled")
         .expect_failure(REPRODUCER_MARKER)
         .run();
 }
 
 #[test]
-fn print_blob_default_suppresses_reproducer_line() {
+fn print_blob_true_with_database_prints_reproducer_and_saved_lines() {
+    let out = self_test("print_blob_true_fixture")
+        .env("HEGEL_DATABASE", "print-blob-true-db")
+        .expect_failure(REPRODUCER_MARKER)
+        .run();
+    let combined = format!("{}\n{}", out.stdout, out.stderr);
+    assert!(
+        combined.contains("The failing example was saved to 'print-blob-true-db'"),
+        "expected the saved-to-database line:\n{combined}"
+    );
+}
+
+#[test]
+fn database_save_replaces_reproducer_line_with_saved_line() {
     let out = self_test("print_blob_default_fixture")
+        .env("HEGEL_DATABASE", "print-blob-default-db")
         .expect_failure("x was")
         .run();
     let combined = format!("{}\n{}", out.stdout, out.stderr);
     assert!(
+        combined.contains("The failing example was saved to 'print-blob-default-db'"),
+        "expected the saved-to-database line:\n{combined}"
+    );
+    assert!(
+        combined.contains("Rerunning this test will replay it."),
+        "expected the replay pointer:\n{combined}"
+    );
+    assert!(
         !combined.contains(REPRODUCER_MARKER),
-        "reproducer line should be suppressed without print_blob:\n{combined}"
+        "reproducer line should be suppressed when the example was saved:\n{combined}"
+    );
+}
+
+#[test]
+fn disabled_database_prints_reproducer_line_by_default() {
+    let out = self_test("print_blob_default_fixture")
+        .env("HEGEL_DATABASE", "disabled")
+        .expect_failure(REPRODUCER_MARKER)
+        .run();
+    let combined = format!("{}\n{}", out.stdout, out.stderr);
+    assert!(
+        combined.contains("#[hegel::reproduce_failure(\""),
+        "expected the attribute wording:\n{combined}"
+    );
+    assert!(
+        !combined.contains(SAVED_MARKER),
+        "saved-to-database line should be absent without a database:\n{combined}"
+    );
+}
+
+#[test]
+fn bare_hegel_run_prints_builder_reproducer_wording() {
+    let out = fixture(OUTPUT_FAILING)
+        .expect_failure(REPRODUCER_MARKER)
+        .run();
+    let combined = format!("{}\n{}", out.stdout, out.stderr);
+    assert!(
+        combined.contains("Hegel::new(...).reproduce_failure(\""),
+        "expected the builder wording for a run without a database key:\n{combined}"
+    );
+    assert!(
+        !combined.contains(SAVED_MARKER),
+        "a run without a database key saves nothing:\n{combined}"
     );
 }


### PR DESCRIPTION
Fixes #438.

<details>
<summary>Description written by Claude (AI generated)</summary>

A failing test previously printed the shrunk draws and the panic, then stopped. There was no pointer to the saved example, the reproduce blob, or `#[hegel::reproduce_failure]`.

Failure output now ends with a reproduction pointer:

- When the failing example was saved, one line names the database directory and says a rerun replays it:

  ```
  The failing example was saved to '.hegel/examples'. Rerunning this test will replay it.
  ```

- When nothing was saved (database disabled, as in CI by default, or no database key), the reproducer line that used to require `print_blob` is printed instead. Macro-defined tests get the `#[hegel::reproduce_failure("…")]` attribute wording, and bare `hegel()` / `Hegel::new` runs get the builder wording:

  ```
  To reproduce this failure, call reproduce_failure on the test's builder:
      Hegel::new(...).reproduce_failure("AAEAAAAACgEAAAAA")
  ```

`print_blob = true` still forces the reproducer line, including on quiet runs. Quiet runs print neither line otherwise.

The engine owns the database, so it reports the persisted directory on the run result (`TestRunResult::database_path`, exposed as the new `hegel_run_result_database_path` C ABI function), and the frontend renders the trailer in `run_lifecycle::drive`.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
