### PR TITLE
Compute coverage features from cargo metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,8 @@ MSRV is 1.86 (enforced in CI and Cargo.toml). If you bump it, also bump `ci.yml`
 - **`rand`**, **`chrono`**, **`jiff`**, **`serde_json`**, **`serde_json_raw_value`**: gate the corresponding `extras::` generator modules
 - **`__bench`**: internal, re-exports engine internals for `benches/`; not part of the public API
 
+The `__` prefix marks a feature as internal. The coverage run enables every root-crate feature except internal ones, computed from `cargo metadata` by `public_features()` in `scripts/check-coverage.py`, so a new feature needs no coverage wiring.
+
 ## Architecture
 
 ### How It Works

--- a/scripts/check-coverage.py
+++ b/scripts/check-coverage.py
@@ -459,6 +459,33 @@ def _ensure_smoke_cdylib() -> None:
     os.environ["HEGEL_C_LIB_DIR"] = str((Path("target") / "debug").resolve())
 
 
+def public_features() -> str:
+    """Every root-crate feature except `default` and internal `__*` ones.
+
+    The `__` prefix marks internal features. `__bench` gates bench-only
+    code that would report as permanently uncovered.
+    """
+    result = subprocess.run(
+        ["cargo", "metadata", "--no-deps", "--format-version=1"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        if result.stderr:
+            print(result.stderr, file=sys.stderr)
+        print("ERROR: cargo metadata failed", file=sys.stderr)
+        sys.exit(1)
+    metadata = json.loads(result.stdout)
+    root_manifest = Path(metadata["workspace_root"]) / "Cargo.toml"
+    package = next(
+        p for p in metadata["packages"] if Path(p["manifest_path"]) == root_manifest
+    )
+    features = sorted(
+        f for f in package["features"] if f != "default" and not f.startswith("__")
+    )
+    return ",".join(features)
+
+
 def run_coverage() -> Path:
     """Run coverage analysis and generate LCOV report.
 
@@ -504,7 +531,7 @@ def run_coverage() -> Path:
         cargo_args=[
             "--workspace",
             "--features",
-            "rand,chrono,jiff,serde_json,serde_json_raw_value",
+            public_features(),
             # proc-macro compile-time execution isn't runtime coverage; keep
             # hegel-macros out of the report rather than count it as uncovered.
             "--ignore-filename-regex",


### PR DESCRIPTION
Fixes #269.

<details>
<summary>Description written by Claude (AI-generated)</summary>

The whitelists this issue was about are mostly gone already: the `native` and `antithesis` features were removed, so every CI and justfile site now uses plain `--all-features`. One remained: `scripts/check-coverage.py` hard-coded `rand,chrono,jiff,serde_json,serde_json_raw_value` (all features except `__bench`, whose bench-only code would report as permanently uncovered), and a new feature would not join it.

The coverage script now computes the list from `cargo metadata`: every root-crate feature except `default` and those with the internal `__` prefix. Only the prefix convention is maintained, so new features are covered automatically. AGENTS.md documents the convention.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
