### PR TITLE
Anchor the default failure database at the crate root

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch fixes where the default failure database is created ([#439](https://github.com/hegeldev/hegel-rust/issues/439)). It was the relative path `.hegel/examples`, resolved against the process's current directory at failure time, so a test that changed the current directory (or ran concurrently with one that did) could write `.hegel/` into a temporary directory that was then deleted, losing the stored failure. The default is now anchored at the crate root, taken from `CARGO_MANIFEST_DIR` at the test's compile time or from the environment at runtime. Explicitly configured database paths are unchanged.

--- a/hegel-macros/src/hegel_main.rs
+++ b/hegel-macros/src/hegel_main.rs
@@ -112,6 +112,7 @@ pub fn expand_main(attr: TokenStream, item: TokenStream) -> TokenStream {
             .settings(__hegel_settings)
             .__single_test_case()
             .__database_key(format!("{}::{}", module_path!(), #fn_name))
+            .__database_root(env!("CARGO_MANIFEST_DIR").to_string())
             .test_location(::hegel::TestLocation {
                 function: #fn_name.to_string(),
                 file: file!().replace('\\', "/"),
@@ -132,3 +133,7 @@ pub fn expand_main(attr: TokenStream, item: TokenStream) -> TokenStream {
         #func
     }
 }
+
+#[cfg(test)]
+#[path = "../tests/embedded/hegel_main_tests.rs"]
+mod tests;

--- a/hegel-macros/src/hegel_test.rs
+++ b/hegel-macros/src/hegel_test.rs
@@ -129,6 +129,7 @@ pub fn expand_test(attr: TokenStream, item: TokenStream) -> TokenStream {
             .settings(__hegel_settings)
             #reproduce_call
             .__database_key(format!("{}::{}", module_path!(), #test_name))
+            .__database_root(env!("CARGO_MANIFEST_DIR").to_string())
             .test_location(::hegel::TestLocation {
                 function: #test_name.to_string(),
                 file: file!().replace('\\', "/"),
@@ -165,3 +166,7 @@ pub fn expand_test(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "../tests/embedded/hegel_test_tests.rs"]
+mod tests;

--- a/hegel-macros/src/standalone_function.rs
+++ b/hegel-macros/src/standalone_function.rs
@@ -97,6 +97,7 @@ pub fn expand_standalone_function(attr: TokenStream, item: TokenStream) -> Token
             ::hegel::Hegel::new(move |#tc_pat: #tc_ty| #body)
             .settings(__hegel_settings)
             .__database_key(format!("{}::{}", module_path!(), #fn_name))
+            .__database_root(env!("CARGO_MANIFEST_DIR").to_string())
             .test_location(::hegel::TestLocation {
                 function: #fn_name.to_string(),
                 file: file!().replace('\\', "/"),
@@ -117,3 +118,7 @@ pub fn expand_standalone_function(attr: TokenStream, item: TokenStream) -> Token
         #func
     }
 }
+
+#[cfg(test)]
+#[path = "../tests/embedded/standalone_function_tests.rs"]
+mod tests;

--- a/hegel-macros/tests/embedded/hegel_main_tests.rs
+++ b/hegel-macros/tests/embedded/hegel_main_tests.rs
@@ -1,0 +1,21 @@
+use super::*;
+use quote::quote;
+
+#[test]
+fn test_expansion_passes_compile_time_database_root() {
+    let out = expand_main(
+        quote! {},
+        quote! {
+            fn main(tc: TestCase) {
+                let b: bool = tc.draw(gs::booleans());
+                assert!(b);
+            }
+        },
+    )
+    .to_string();
+    let expected = quote! { .__database_root(env!("CARGO_MANIFEST_DIR").to_string()) }.to_string();
+    assert!(
+        out.contains(&expected),
+        "expected expansion to contain `{expected}`, got: {out}"
+    );
+}

--- a/hegel-macros/tests/embedded/hegel_test_tests.rs
+++ b/hegel-macros/tests/embedded/hegel_test_tests.rs
@@ -1,0 +1,21 @@
+use super::*;
+use quote::quote;
+
+#[test]
+fn test_expansion_passes_compile_time_database_root() {
+    let out = expand_test(
+        quote! {},
+        quote! {
+            fn prop(tc: TestCase) {
+                let b: bool = tc.draw(gs::booleans());
+                assert!(b);
+            }
+        },
+    )
+    .to_string();
+    let expected = quote! { .__database_root(env!("CARGO_MANIFEST_DIR").to_string()) }.to_string();
+    assert!(
+        out.contains(&expected),
+        "expected expansion to contain `{expected}`, got: {out}"
+    );
+}

--- a/hegel-macros/tests/embedded/standalone_function_tests.rs
+++ b/hegel-macros/tests/embedded/standalone_function_tests.rs
@@ -1,0 +1,21 @@
+use super::*;
+use quote::quote;
+
+#[test]
+fn test_expansion_passes_compile_time_database_root() {
+    let out = expand_standalone_function(
+        quote! {},
+        quote! {
+            fn prop(tc: &TestCase) {
+                let b: bool = tc.draw(gs::booleans());
+                assert!(b);
+            }
+        },
+    )
+    .to_string();
+    let expected = quote! { .__database_root(env!("CARGO_MANIFEST_DIR").to_string()) }.to_string();
+    assert!(
+        out.contains(&expected),
+        "expected expansion to contain `{expected}`, got: {out}"
+    );
+}

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -224,6 +224,14 @@ impl Settings {
 
     /// Set the database path for storing failing examples, or `None` to disable.
     ///
+    /// When no path is configured here or via `HEGEL_DATABASE`, the default
+    /// is `.hegel/examples` under the crate root: `CARGO_MANIFEST_DIR` as
+    /// captured at compile time by `#[hegel::test]` / `#[hegel::main]`, or
+    /// read from the environment otherwise. Without either, the path is
+    /// resolved against the current directory at failure time. An explicitly
+    /// configured relative path is always resolved against the current
+    /// directory.
+    ///
     /// The `HEGEL_DATABASE` environment variable, when set and non-empty,
     /// overrides this value at runtime: the literal value `disabled` turns
     /// the database off (matching the `--database` CLI flag's keyword), and
@@ -339,6 +347,23 @@ impl Settings {
         self
     }
 
+    /// Resolve an unset database to `.hegel/examples` under `root`. A
+    /// database that was configured explicitly (or disabled) is untouched,
+    /// as is an unset one when no root is known — the engine then falls
+    /// back to `.hegel/examples` relative to the current directory.
+    fn anchor_default_database(mut self, root: Option<&str>) -> Self {
+        if let (Database::Unset, Some(root)) = (&self.database, root) {
+            self.database = Database::Path(
+                std::path::Path::new(root)
+                    .join(".hegel")
+                    .join("examples")
+                    .to_string_lossy()
+                    .into_owned(),
+            );
+        }
+        self
+    }
+
     /// Control whether multi-bug runs report every distinct failing example
     /// or collapse to just the first one.
     ///
@@ -405,10 +430,18 @@ fn is_in_ci_from(env: impl Fn(&str) -> Option<String>) -> bool {
     })
 }
 
+/// The crate root to anchor the default database at: the compile-time value
+/// the macro expansions pass, or the process's `CARGO_MANIFEST_DIR` when
+/// absent (`None` outside cargo).
+fn database_root(explicit: Option<String>, env: impl Fn(&str) -> Option<String>) -> Option<String> {
+    explicit.or_else(|| env("CARGO_MANIFEST_DIR"))
+}
+
 #[doc(hidden)]
 pub struct Hegel<F> {
     test_fn: F,
     database_key: Option<String>,
+    database_root: Option<String>,
     test_location: Option<TestLocation>,
     settings: Settings,
     reproduce_failure: Option<String>,
@@ -424,6 +457,7 @@ where
         Self {
             test_fn,
             database_key: None,
+            database_root: None,
             settings: Settings::new(),
             test_location: None,
             reproduce_failure: None,
@@ -440,6 +474,12 @@ where
     #[doc(hidden)]
     pub fn __database_key(mut self, key: String) -> Self {
         self.database_key = Some(key);
+        self
+    }
+
+    #[doc(hidden)]
+    pub fn __database_root(mut self, root: String) -> Self {
+        self.database_root = Some(root);
         self
     }
 
@@ -482,7 +522,11 @@ where
     ///
     /// Panics if any test case fails.
     pub fn run(self) {
-        let mut settings = self.settings.with_env_overrides();
+        let root = database_root(self.database_root, env_var);
+        let mut settings = self
+            .settings
+            .with_env_overrides()
+            .anchor_default_database(root.as_deref());
         if self.single_test_case {
             settings.test_cases = 1;
         }

--- a/tests/common/exec.rs
+++ b/tests/common/exec.rs
@@ -20,9 +20,8 @@ pub struct RunOutput {
 pub struct Cmd {
     command: Command,
     expect_failure: Option<String>,
-    /// A fresh scratch cwd for the spawned process, so runs that write a
-    /// default `.hegel/` database can't interfere with each other. Owned by
-    /// `tempfile`, removed on drop.
+    /// A fresh scratch cwd for the spawned process, so cwd-relative writes
+    /// can't interfere across runs. Owned by `tempfile`, removed on drop.
     scratch_cwd: Option<tempfile::TempDir>,
 }
 

--- a/tests/embedded/runner_tests.rs
+++ b/tests/embedded/runner_tests.rs
@@ -120,6 +120,64 @@ fn test_env_override_database_empty_is_ignored() {
 }
 
 #[test]
+fn test_anchor_default_database_anchors_unset_at_root() {
+    use crate::runner::Database;
+    let s = Settings::for_ci(false).anchor_default_database(Some("/crate/root"));
+    let expected = std::path::Path::new("/crate/root")
+        .join(".hegel")
+        .join("examples")
+        .to_string_lossy()
+        .into_owned();
+    assert_eq!(s.database, Database::Path(expected));
+}
+
+#[test]
+fn test_anchor_default_database_without_root_stays_unset() {
+    use crate::runner::Database;
+    let s = Settings::for_ci(false).anchor_default_database(None);
+    assert_eq!(s.database, Database::Unset);
+}
+
+#[test]
+fn test_anchor_default_database_keeps_explicit_path() {
+    use crate::runner::Database;
+    let s = Settings::for_ci(false)
+        .database(Some("relative/db".to_string()))
+        .anchor_default_database(Some("/crate/root"));
+    assert_eq!(s.database, Database::Path("relative/db".to_string()));
+}
+
+#[test]
+fn test_anchor_default_database_keeps_disabled() {
+    use crate::runner::Database;
+    let s = Settings::for_ci(false)
+        .database(None)
+        .anchor_default_database(Some("/crate/root"));
+    assert_eq!(s.database, Database::Disabled);
+}
+
+#[test]
+fn test_database_root_prefers_compile_time_root_over_env() {
+    let root = database_root(Some("/compile/time".to_string()), |_| {
+        Some("/from/env".to_string())
+    });
+    assert_eq!(root, Some("/compile/time".to_string()));
+}
+
+#[test]
+fn test_database_root_falls_back_to_manifest_dir_env() {
+    let root = database_root(None, |key| {
+        (key == "CARGO_MANIFEST_DIR").then(|| "/from/env".to_string())
+    });
+    assert_eq!(root, Some("/from/env".to_string()));
+}
+
+#[test]
+fn test_database_root_absent_everywhere_is_none() {
+    assert_eq!(database_root(None, |_| None), None);
+}
+
+#[test]
 fn test_env_override_statistics_enables_reporting() {
     let s = Settings::new()
         .with_env_overrides_from(|key| (key == "HEGEL_STATISTICS").then(|| "1".to_string()));
@@ -149,7 +207,7 @@ fn test_is_in_ci_from_detects_presence_and_value_variables() {
 }
 
 #[test]
-fn test_native_engine_creates_default_dot_hegel_when_database_unset() {
+fn test_native_engine_creates_default_dot_hegel_when_database_unset_and_no_manifest_dir() {
     use crate::Hegel;
     use crate::generators as gs;
     use crate::runner::Database;
@@ -189,10 +247,11 @@ fn test_native_engine_creates_default_dot_hegel_when_database_unset() {
     child
         .args([
             "--exact",
-            "runner::tests::test_native_engine_creates_default_dot_hegel_when_database_unset",
+            "runner::tests::test_native_engine_creates_default_dot_hegel_when_database_unset_and_no_manifest_dir",
         ])
         .current_dir(tmp.path())
-        .env("HEGEL_DOT_HEGEL_TEST_CHILD", "1");
+        .env("HEGEL_DOT_HEGEL_TEST_CHILD", "1")
+        .env_remove("CARGO_MANIFEST_DIR");
     for name in CI_VAR_NAMES {
         child.env_remove(name);
     }

--- a/tests/test_runtime_dir_isolation.rs
+++ b/tests/test_runtime_dir_isolation.rs
@@ -1,7 +1,7 @@
 //! Regression tests: every integration-test binary should be chdir'd into a
-//! fresh per-process tempdir, so the hegel library (which creates `.hegel/`
-//! in cwd) doesn't leak state across concurrent or successive `cargo test`
-//! runs of this repo.
+//! fresh per-process tempdir, so the hegel library (which resolves relative
+//! database paths against cwd) doesn't leak state across concurrent or
+//! successive `cargo test` runs of this repo.
 //!
 //! The setup lives in `tests/common/mod.rs` behind a `#[ctor::ctor]`; these
 //! tests just assert its observable effects.

--- a/tests/test_settings.rs
+++ b/tests/test_settings.rs
@@ -118,6 +118,44 @@ fn test_hegel_database_env_disables_database() {
         .run();
 }
 
+/// Fixture for `test_default_database_anchors_at_manifest_dir`, run via
+/// self-exec with `CARGO_MANIFEST_DIR` pointing at a fresh tempdir and CI
+/// detection disabled: the default database must be created under that
+/// directory, not the process cwd.
+#[test]
+#[ignore = "fixture: run via exec::self_test"]
+fn default_database_anchor_fixture() {
+    run_failing_test_with_default_database("default_database_anchor_fixture");
+    let root = std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    assert!(root.join(".hegel").join("examples").is_dir());
+    assert!(!std::path::Path::new(".hegel").exists());
+}
+
+#[test]
+fn test_default_database_anchors_at_manifest_dir() {
+    let manifest_dir = tempfile::TempDir::new().unwrap();
+    let mut cmd = self_test("default_database_anchor_fixture")
+        .env("CARGO_MANIFEST_DIR", manifest_dir.path().to_str().unwrap())
+        .env_remove("HEGEL_DATABASE");
+    for var in [
+        "CI",
+        "TF_BUILD",
+        "BUILDKITE",
+        "CIRCLECI",
+        "CIRRUS_CI",
+        "CODEBUILD_BUILD_ID",
+        "GITHUB_ACTIONS",
+        "GITLAB_CI",
+        "HEROKU_TEST_RUN_ID",
+        "TEAMCITY_VERSION",
+        "bamboo.buildKey",
+    ] {
+        cmd = cmd.env_remove(var);
+    }
+    cmd.run();
+    assert!(manifest_dir.path().join(".hegel").join("examples").is_dir());
+}
+
 #[test]
 fn test_settings_verbosity_debug() {
     let mut count = 0;


### PR DESCRIPTION
Fixes #439.

<details>
<summary>Description (written by Claude)</summary>

The default failure database was the relative path `.hegel/examples`, resolved against the process cwd at failure time (`hegel-c/src/native/test_runner.rs`), so a concurrently running test that chdir'd into a tempdir made hegel write `.hegel/` into that tempdir, which was then destroyed with the failure in it.

`CARGO_MANIFEST_DIR` is Rust-specific, so the anchoring lives in the Rust frontend and the engine default is unchanged. The `#[hegel::test]`, `#[hegel::main]`, and standalone-function expansions now pass `env!("CARGO_MANIFEST_DIR")`, captured at the user crate's compile time, to the runner through a hidden `__database_root` builder method. Runs built directly with `Hegel::new` fall back to the runtime `CARGO_MANIFEST_DIR`, and the engine's cwd-relative default applies only when neither is available. Only the unset default is anchored: paths configured via `Settings::database`, `HEGEL_DATABASE`, or `--database` behave as before, including relative ones.

One consequence for this repo's own suite: failing tests that use the default database now write to the repo root `.hegel/` (gitignored) when run locally, instead of the per-binary tempdir cwd. The suite's helpers disable the database wherever a test asserts on generation behaviour, so this only affects tests that merely require a failure, and a replayed failure satisfies those.

Tests: an end-to-end regression test in `tests/test_settings.rs` that fails before this change, unit tests for the anchoring and root-resolution logic in `tests/embedded/runner_tests.rs`, and expansion tests for the three macros under `hegel-macros/tests/embedded/`. The pre-existing engine-default test in `tests/embedded/runner_tests.rs` now removes `CARGO_MANIFEST_DIR` from its child's environment, since it exercises the cwd fallback.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
