### PR TITLE
Document and pin libhegel's behavior under fork(2)

### DIFF
--- a/hegel-c/RELEASE.md
+++ b/hegel-c/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+libhegel is now documented as fork-compatible ([#186](https://github.com/hegeldev/hegel-rust/issues/186)). No libhegel call starts a thread, retains a file descriptor, or holds a lock after it returns, so a process may fork between calls. In particular a C harness can run each test case's body in a forked child for crash isolation, with the parent making every libhegel call and mapping the child's exit status onto `hegel_mark_complete`. The contract is in a new "Forking" section of the `hegel.h` preamble, with a worked example in `examples/fork.c`.

--- a/hegel-c/cbindgen.toml
+++ b/hegel-c/cbindgen.toml
@@ -100,6 +100,23 @@ header = """
  *   Concurrent operations on it return HEGEL_E_CONCURRENT_USE. To generate
  *   from several threads, hegel_test_case_clone the handle and give each
  *   thread its own clone.
+ *
+ * Forking
+ * -------
+ * libhegel is compatible with fork(2). No libhegel call starts a thread,
+ * retains a file descriptor, or holds a lock after it returns, so a
+ * process may fork between calls whenever forking is otherwise sound for
+ * it (in particular, no other thread may be inside libhegel at that
+ * moment).
+ *
+ * For per-test-case crash isolation, make every libhegel call in the
+ * parent and run each test case's body in a forked child that reports
+ * through its exit status, which the parent maps onto hegel_mark_complete
+ * (see examples/fork.c). The child inherits a private copy of all engine
+ * state, so any calls it does make are valid but invisible to the parent,
+ * and nothing it does can advance or corrupt the parent's run. Parent and
+ * children may share a database directory: writes go to pid-unique
+ * temporary files renamed into place.
  */"""
 include_guard = "HEGEL_H"
 pragma_once = false

--- a/hegel-c/examples/fork.c
+++ b/hegel-c/examples/fork.c
@@ -1,0 +1,141 @@
+/*
+ * fork.c — demo: fork-per-test-case, the pattern a C test harness uses
+ * for crash isolation.
+ *
+ * The parent owns the run and makes every libhegel call. Each test case's
+ * body runs in a forked child, so a crash kills only that child, and the
+ * parent maps the child's exit status onto hegel_mark_complete. libhegel
+ * then shrinks a crashing input like any other failure. This is fork-safe
+ * because the engine runs entirely on the calling thread, holds no locks
+ * or file descriptors between calls, and the child never touches it.
+ *
+ * Property: every integer in [0, 100] is < 5. A violating child abort()s,
+ * standing in for a real crash. We expect the run to fail and to shrink
+ * to the minimal crashing input, 5, verified by replaying the reproduce
+ * blob.
+ *
+ * Build (same incantation as echo.c):
+ *   cc -o fork fork.c -I../include -L../../target/release -lhegel \
+ *      -Wl,-rpath,$PWD/../../target/release
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "hegel.h"
+#include "hegel_check.h"
+
+#define ORIGIN "child crashed"
+
+static void run_body(int64_t n) {
+    if (n >= 5) abort();
+}
+
+int main(void) {
+    hegel_context_t *ctx = hegel_context_new();
+
+    hegel_settings_t *s;
+    HEGEL_CHECK(hegel_settings_new, ctx, &s);
+    HEGEL_CHECK(hegel_settings_set_test_cases, ctx, s, 200);
+    HEGEL_CHECK(hegel_settings_set_database, ctx, s, "");
+    HEGEL_CHECK(hegel_settings_set_derandomize, ctx, s, true);
+    HEGEL_CHECK(hegel_settings_set_seed, ctx, s, 0xc0ffee, true);
+
+    hegel_run_t *run;
+    HEGEL_CHECK(hegel_run_start, ctx, s, NULL, NULL, &run);
+
+    while (true) {
+        hegel_test_case_t *tc;
+        HEGEL_CHECK(hegel_next_test_case, ctx, run, &tc);
+        if (tc == NULL) break;
+
+        int64_t n;
+        hegel_result_t rc = hegel_generate_integer(ctx, tc, 0, 100, &n);
+        if (rc == HEGEL_E_STOP_TEST) {
+            HEGEL_CHECK(hegel_mark_complete, ctx, tc, HEGEL_STATUS_OVERRUN, NULL);
+            HEGEL_CHECK(hegel_test_case_free, ctx, tc);
+            continue;
+        }
+        if (rc != HEGEL_OK) {
+            fprintf(stderr, "hegel_generate_integer: rc=%d %s\n", rc,
+                    hegel_context_last_error(ctx));
+            return 1;
+        }
+
+        /* All draws happen before the fork, so the parent's engine sees
+         * them. The child only runs the body. */
+        fflush(stdout);
+        fflush(stderr);
+        pid_t pid = fork();
+        if (pid < 0) {
+            perror("fork");
+            return 1;
+        }
+        if (pid == 0) {
+            run_body(n);
+            _exit(0);
+        }
+
+        int wstatus = 0;
+        while (waitpid(pid, &wstatus, 0) < 0) { /* EINTR */ }
+        if (WIFEXITED(wstatus) && WEXITSTATUS(wstatus) == 0) {
+            HEGEL_CHECK(hegel_mark_complete, ctx, tc, HEGEL_STATUS_VALID, NULL);
+        } else {
+            HEGEL_CHECK(hegel_mark_complete, ctx, tc, HEGEL_STATUS_INTERESTING, ORIGIN);
+        }
+        HEGEL_CHECK(hegel_test_case_free, ctx, tc);
+    }
+
+    hegel_run_result_t *result;
+    HEGEL_CHECK(hegel_run_result, ctx, run, &result);
+    hegel_run_status_t status;
+    HEGEL_CHECK(hegel_run_result_status, ctx, result, &status);
+    if (status != HEGEL_RUN_STATUS_FAILED) {
+        fprintf(stderr, "FAIL: expected a failing run, got status %d\n", (int)status);
+        return 1;
+    }
+
+    size_t nf;
+    HEGEL_CHECK(hegel_run_result_failure_count, ctx, result, &nf);
+    if (nf != 1) {
+        fprintf(stderr, "FAIL: expected one failure, got %zu\n", nf);
+        return 1;
+    }
+
+    hegel_failure_t *f;
+    HEGEL_CHECK(hegel_run_result_failure, ctx, result, 0, &f);
+    const char *origin;
+    HEGEL_CHECK(hegel_failure_origin, ctx, f, &origin);
+    if (strstr(origin, ORIGIN) == NULL) {
+        fprintf(stderr, "FAIL: expected origin to contain %s, got: %s\n", ORIGIN, origin);
+        return 1;
+    }
+
+    /* Replay the blob to recover the minimal crashing input. */
+    const char *blob;
+    HEGEL_CHECK(hegel_failure_reproduction_blob, ctx, f, &blob);
+    hegel_test_case_t *replay;
+    HEGEL_CHECK(hegel_test_case_from_blob, ctx, s, blob, NULL, NULL, &replay);
+    int64_t shrunk;
+    HEGEL_CHECK(hegel_generate_integer, ctx, replay, 0, 100, &shrunk);
+    HEGEL_CHECK(hegel_mark_complete, ctx, replay, HEGEL_STATUS_INTERESTING, ORIGIN);
+    HEGEL_CHECK(hegel_test_case_free, ctx, replay);
+    if (shrunk != 5) {
+        fprintf(stderr, "FAIL: expected the minimal crash at 5, got %lld\n",
+                (long long)shrunk);
+        return 1;
+    }
+
+    printf("shrunk the crashing input to n=%lld\n", (long long)shrunk);
+
+    HEGEL_CHECK(hegel_failure_free, ctx, f);
+    HEGEL_CHECK(hegel_run_result_free, ctx, result);
+    HEGEL_CHECK(hegel_run_free, ctx, run);
+    HEGEL_CHECK(hegel_settings_free, ctx, s);
+    HEGEL_CHECK(hegel_context_free, ctx);
+    return 0;
+}

--- a/hegel-c/include/hegel.h
+++ b/hegel-c/include/hegel.h
@@ -98,6 +98,23 @@
  *   Concurrent operations on it return HEGEL_E_CONCURRENT_USE. To generate
  *   from several threads, hegel_test_case_clone the handle and give each
  *   thread its own clone.
+ *
+ * Forking
+ * -------
+ * libhegel is compatible with fork(2). No libhegel call starts a thread,
+ * retains a file descriptor, or holds a lock after it returns, so a
+ * process may fork between calls whenever forking is otherwise sound for
+ * it (in particular, no other thread may be inside libhegel at that
+ * moment).
+ *
+ * For per-test-case crash isolation, make every libhegel call in the
+ * parent and run each test case's body in a forked child that reports
+ * through its exit status, which the parent maps onto hegel_mark_complete
+ * (see examples/fork.c). The child inherits a private copy of all engine
+ * state, so any calls it does make are valid but invisible to the parent,
+ * and nothing it does can advance or corrupt the parent's run. Parent and
+ * children may share a database directory: writes go to pid-unique
+ * temporary files renamed into place.
  */
 
 #ifndef HEGEL_H

--- a/hegel-c/tests/c_abi_fork.rs
+++ b/hegel-c/tests/c_abi_fork.rs
@@ -1,0 +1,200 @@
+//! Pins libhegel's behavior under `fork(2)`.
+//!
+//! The engine runs entirely on the calling thread and holds no locks or
+//! file descriptors between C-ABI calls, so a single-threaded client may
+//! fork between them. One test drives fork-per-test-case with every engine
+//! call in the parent, the pattern a C harness uses for crash isolation.
+//! The other has the child call into its copy of the engine and checks
+//! that the parent's run is undisturbed.
+
+#![cfg(unix)]
+
+mod common;
+
+use common::{make_settings, make_settings_no_db, next_case, ok, start};
+use hegel_c::hegel_result_t::*;
+use hegel_c::{
+    hegel_context_free, hegel_context_new, hegel_failure_free, hegel_failure_reproduction_blob,
+    hegel_generate_boolean, hegel_generate_integer, hegel_mark_complete, hegel_run_free,
+    hegel_run_result, hegel_run_result_failure, hegel_run_result_failure_count,
+    hegel_run_result_free, hegel_run_result_status, hegel_run_status_t, hegel_settings_free,
+    hegel_settings_set_database, hegel_settings_set_database_key, hegel_status_t,
+    hegel_test_case_free, hegel_test_case_from_blob,
+};
+use std::ffi::CString;
+use std::ptr;
+
+unsafe extern "C" {
+    fn fork() -> i32;
+    fn waitpid(pid: i32, status: *mut i32, options: i32) -> i32;
+    fn _exit(code: i32) -> !;
+}
+
+fn wait_for_exit_code(pid: i32) -> i32 {
+    let mut status = 0;
+    loop {
+        let r = unsafe { waitpid(pid, &mut status, 0) };
+        if r == pid {
+            break;
+        }
+        assert_eq!(r, -1);
+    }
+    assert_eq!(status & 0x7f, 0, "child did not exit normally: {status}");
+    (status >> 8) & 0xff
+}
+
+#[test]
+fn fork_per_case_with_parent_driving_the_engine_finds_and_shrinks_failures() {
+    let dir = tempfile::tempdir().unwrap();
+    let ctx = hegel_context_new();
+    unsafe {
+        let s = make_settings(ctx);
+        let db = CString::new(dir.path().to_str().unwrap()).unwrap();
+        ok(hegel_settings_set_database(ctx, s, db.as_ptr()));
+        ok(hegel_settings_set_database_key(
+            ctx,
+            s,
+            c"fork-test".as_ptr(),
+        ));
+        let run = start(ctx, s);
+        loop {
+            let tc = next_case(ctx, run);
+            if tc.is_null() {
+                break;
+            }
+            let mut n = 0i64;
+            let rc = hegel_generate_integer(ctx, tc, 0, 1000, &mut n);
+            if rc == HEGEL_E_STOP_TEST {
+                ok(hegel_mark_complete(
+                    ctx,
+                    tc,
+                    hegel_status_t::HEGEL_STATUS_OVERRUN as u32,
+                    ptr::null(),
+                ));
+                ok(hegel_test_case_free(ctx, tc));
+                continue;
+            }
+            ok(rc);
+            let pid = fork();
+            assert!(pid >= 0);
+            if pid == 0 {
+                _exit(if n >= 100 { 1 } else { 0 });
+            }
+            let status = if wait_for_exit_code(pid) == 0 {
+                hegel_status_t::HEGEL_STATUS_VALID
+            } else {
+                hegel_status_t::HEGEL_STATUS_INTERESTING
+            };
+            ok(hegel_mark_complete(
+                ctx,
+                tc,
+                status as u32,
+                c"n >= 100".as_ptr(),
+            ));
+            ok(hegel_test_case_free(ctx, tc));
+        }
+
+        let mut res = ptr::null_mut();
+        ok(hegel_run_result(ctx, run, &mut res));
+        let mut status = hegel_run_status_t::HEGEL_RUN_STATUS_PASSED;
+        ok(hegel_run_result_status(ctx, res, &mut status));
+        assert!(status == hegel_run_status_t::HEGEL_RUN_STATUS_FAILED);
+        let mut count = 0usize;
+        ok(hegel_run_result_failure_count(ctx, res, &mut count));
+        assert_eq!(count, 1);
+
+        let mut f = ptr::null_mut();
+        ok(hegel_run_result_failure(ctx, res, 0, &mut f));
+        let mut blob = ptr::null();
+        ok(hegel_failure_reproduction_blob(ctx, f, &mut blob));
+        assert!(!blob.is_null());
+
+        let mut replay = ptr::null_mut();
+        ok(hegel_test_case_from_blob(
+            ctx,
+            s,
+            blob,
+            None,
+            ptr::null_mut(),
+            &mut replay,
+        ));
+        let mut shrunk = 0i64;
+        ok(hegel_generate_integer(ctx, replay, 0, 1000, &mut shrunk));
+        assert_eq!(shrunk, 100);
+        ok(hegel_mark_complete(
+            ctx,
+            replay,
+            hegel_status_t::HEGEL_STATUS_INTERESTING as u32,
+            c"n >= 100".as_ptr(),
+        ));
+        ok(hegel_test_case_free(ctx, replay));
+
+        assert!(std::fs::read_dir(dir.path()).unwrap().count() > 0);
+
+        ok(hegel_failure_free(ctx, f));
+        ok(hegel_run_result_free(ctx, res));
+        ok(hegel_run_free(ctx, run));
+        ok(hegel_settings_free(ctx, s));
+        ok(hegel_context_free(ctx));
+    }
+}
+
+#[test]
+fn engine_calls_in_a_forked_child_leave_the_parent_run_intact() {
+    let ctx = hegel_context_new();
+    unsafe {
+        let s = make_settings_no_db(ctx);
+        let run = start(ctx, s);
+        let mut cases = 0u64;
+        loop {
+            let tc = next_case(ctx, run);
+            if tc.is_null() {
+                break;
+            }
+            cases += 1;
+            let pid = fork();
+            assert!(pid >= 0);
+            if pid == 0 {
+                let mut b = false;
+                let drew = hegel_generate_boolean(ctx, tc, 0.5, false, false, &mut b);
+                let marked = hegel_mark_complete(
+                    ctx,
+                    tc,
+                    hegel_status_t::HEGEL_STATUS_VALID as u32,
+                    ptr::null(),
+                );
+                let freed = hegel_test_case_free(ctx, tc);
+                _exit(
+                    if drew == HEGEL_OK && marked == HEGEL_OK && freed == HEGEL_OK {
+                        0
+                    } else {
+                        1
+                    },
+                );
+            }
+            assert_eq!(wait_for_exit_code(pid), 0);
+
+            let mut b = false;
+            ok(hegel_generate_boolean(ctx, tc, 0.5, false, false, &mut b));
+            ok(hegel_mark_complete(
+                ctx,
+                tc,
+                hegel_status_t::HEGEL_STATUS_VALID as u32,
+                ptr::null(),
+            ));
+            ok(hegel_test_case_free(ctx, tc));
+        }
+        assert!(cases > 0);
+
+        let mut res = ptr::null_mut();
+        ok(hegel_run_result(ctx, run, &mut res));
+        let mut status = hegel_run_status_t::HEGEL_RUN_STATUS_FAILED;
+        ok(hegel_run_result_status(ctx, res, &mut status));
+        assert!(status == hegel_run_status_t::HEGEL_RUN_STATUS_PASSED);
+
+        ok(hegel_run_result_free(ctx, res));
+        ok(hegel_run_free(ctx, run));
+        ok(hegel_settings_free(ctx, s));
+        ok(hegel_context_free(ctx));
+    }
+}


### PR DESCRIPTION
Fixes #186.

<details>
<summary>Description (written by Claude, AI-generated)</summary>

The issue predates the current architecture. There is no hegel-core server and there are no background threads. The engine is a future polled on the calling thread (`hegel-c/src/exchange.rs`), its locks are taken and released within each C-ABI call, database files are opened per operation with CLOEXEC, and database temp files are named by live pid. Forking between C-ABI calls is therefore sound. c4ffein/hegel-c "seems to work" for an even stronger reason: its fork mode never calls libhegel from the child at all. The child proxies draw requests over a pipe and the parent makes every engine call.

This takes option 1 from the issue and supports fork properly:

- A "Forking" section in the `hegel.h` preamble states the contract: forking between calls is fine when no other thread is inside libhegel, a child's engine calls act on a private copy and cannot corrupt the parent's run, and a database directory can be shared across the fork.
- `hegel-c/examples/fork.c` demonstrates fork-per-test-case with crash isolation: the child abort()s on a violating input, the parent maps the exit status onto `hegel_mark_complete`, and the run shrinks the crash to the minimal input. Run by `just c-test`.
- `hegel-c/tests/c_abi_fork.rs` pins both patterns: the parent drives the engine while children evaluate cases (including database writes and blob replay of the shrunk failure), and a child that calls into the engine and exits leaves the parent's run intact.

The remaining caveats are ordinary POSIX fork caveats rather than libhegel ones: forking while another thread holds any lock, and continuing the same run in both processes, which duplicates it.
</details>
