### PR TITLE
Add minimal WebAssembly support to hegel-c

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Install Rust and WebAssembly target
         run: |
-          rustup toolchain install stable --profile minimal
+          rustup toolchain install stable --profile minimal -c llvm-tools-preview
           rustup default stable
           rustup target add wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -117,7 +117,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          symbols=$(nm -u target/wasm32-unknown-unknown/release/libhegel_c.a)
+          nm="$(rustc --print sysroot)/lib/rustlib/$(rustc -vV | sed -n 's/^host: //p')/bin/llvm-nm"
+          symbols=$("$nm" -u target/wasm32-unknown-unknown/release/libhegel_c.a)
           grep -q 'hegel_host_entropy_fill' <<<"$symbols"
           grep -q 'hegel_host_monotonic_nanos' <<<"$symbols"
           if grep -Eq '_RN.*host_entropy_fill' <<<"$symbols"; then exit 1; fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,54 @@ jobs:
       - name: Run tests
         run: just check-tests
 
+  test-wasm:
+    name: test-wasm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust and WebAssembly target
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup target add wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Compile the test suite for WebAssembly
+        run: cargo test -p hegeltest-c --target wasm32-unknown-unknown --lib --no-run
+      - name: Build the WebAssembly artifact
+        run: cargo build -p hegeltest-c --release --target wasm32-unknown-unknown
+      - name: Smoke-test the WebAssembly host boundary
+        shell: bash
+        run: |
+          node --input-type=module - <<'NODE'
+          import { readFile } from "node:fs/promises";
+          import { randomFillSync } from "node:crypto";
+
+          const bytes = await readFile("target/wasm32-unknown-unknown/release/hegel_c.wasm");
+          let memory;
+          const { instance } = await WebAssembly.instantiate(bytes, {
+            hegel_host: {
+              entropy_fill(ptr, len) {
+                randomFillSync(new Uint8Array(memory.buffer, ptr, len));
+                return 1;
+              },
+              monotonic_nanos() {
+                return process.hrtime.bigint();
+              },
+            },
+          });
+          memory = instance.exports.memory;
+          const pointer = instance.exports.hegel_alloc(16, 8);
+          if (!pointer) throw new Error("hegel_alloc returned NULL");
+          new Uint8Array(memory.buffer, pointer, 16).fill(7);
+          instance.exports.hegel_dealloc(pointer, 16, 8);
+          NODE
+
   test-all-features:
     name: test-all-features (${{ matrix.rust }}${{ matrix.os == 'windows-latest' && ', windows' || '' }})
     runs-on: ${{ matrix.os }}
@@ -406,7 +454,7 @@ jobs:
   release:
     name: release
     if: github.event_name == 'push' && github.repository == 'hegeldev/hegel-rust'
-    needs: [lint, test, test-all-features, test-minimal-versions, test-c-bindings, test-c-runtime, compile-examples, docs, coverage, nix, miri]
+    needs: [lint, test, test-wasm, test-all-features, test-minimal-versions, test-c-bindings, test-c-runtime, compile-examples, docs, coverage, nix, miri]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -681,6 +729,42 @@ jobs:
           fi
           gh release upload "$tag" "${assets[@]}" --clobber
 
+  release-wasm:
+    name: release-wasm
+    if: github.event_name == 'push' && github.repository == 'hegeldev/hegel-rust' && needs.release.outputs.c_released == 'true'
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      VERSION: ${{ needs.release.outputs.version }}
+    steps:
+      - name: Checkout release commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: refs/tags/v${{ needs.release.outputs.version }}
+
+      - name: Install Rust and WebAssembly target
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup target add wasm32-unknown-unknown
+      - name: Build WebAssembly artifact
+        run: cargo build -p hegeltest-c --release --target wasm32-unknown-unknown
+      - name: Stage WebAssembly asset
+        shell: bash
+        run: |
+          set -euo pipefail
+          asset="libhegel-wasm32-unknown-unknown.wasm"
+          cp target/wasm32-unknown-unknown/release/hegel_c.wasm "$asset"
+          sha256sum "$asset" > "$asset.sha256"
+      - name: Upload WebAssembly asset
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "v${VERSION}" libhegel-wasm32-unknown-unknown.wasm libhegel-wasm32-unknown-unknown.wasm.sha256 --clobber
+
   # Independent post-condition check that every expected libhegel asset is
   # present on the Release. `release-binaries` uses `fail-fast: false` so
   # failed-platform diagnostics aren't lost; this aggregator job fails
@@ -690,7 +774,7 @@ jobs:
   release-binaries-verify:
     name: release-binaries-verify
     if: github.event_name == 'push' && github.repository == 'hegeldev/hegel-rust' && needs.release.outputs.c_released == 'true'
-    needs: [release, release-binaries]
+    needs: [release, release-binaries, release-wasm]
     runs-on: ubuntu-latest
     # `contents: write` (not just read) so this job can both view the draft
     # release — drafts are invisible to read-only tokens — and publish it
@@ -709,6 +793,7 @@ jobs:
           tag="v${VERSION}"
           expected=(
             hegel.h
+            libhegel-wasm32-unknown-unknown.wasm
             libhegel-linux-amd64.so
             libhegel-linux-amd64.a
             libhegel-linux-arm64.so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,17 @@ jobs:
         run: cargo test -p hegeltest-c --target wasm32-unknown-unknown --lib --no-run
       - name: Build the WebAssembly artifact
         run: cargo build -p hegeltest-c --release --target wasm32-unknown-unknown
+      - name: Build the WebAssembly static archive
+        run: cargo rustc -p hegeltest-c --release --target wasm32-unknown-unknown --features wasm-static --crate-type staticlib
+      - name: Check static archive hook names
+        shell: bash
+        run: |
+          set -euo pipefail
+          symbols=$(nm -u target/wasm32-unknown-unknown/release/libhegel_c.a)
+          grep -q 'hegel_host_entropy_fill' <<<"$symbols"
+          grep -q 'hegel_host_monotonic_nanos' <<<"$symbols"
+          if grep -Eq '_RN.*host_entropy_fill' <<<"$symbols"; then exit 1; fi
+          if grep -Eq '_RN.*host_monotonic_nanos' <<<"$symbols"; then exit 1; fi
       - name: Smoke-test the WebAssembly host boundary
         shell: bash
         run: |
@@ -753,17 +764,22 @@ jobs:
           rustup target add wasm32-unknown-unknown
       - name: Build WebAssembly artifact
         run: cargo build -p hegeltest-c --release --target wasm32-unknown-unknown
-      - name: Stage WebAssembly asset
+      - name: Build WebAssembly static archive
+        run: cargo rustc -p hegeltest-c --release --target wasm32-unknown-unknown --features wasm-static --crate-type staticlib
+      - name: Stage WebAssembly assets
         shell: bash
         run: |
           set -euo pipefail
-          asset="libhegel-wasm32-unknown-unknown.wasm"
-          cp target/wasm32-unknown-unknown/release/hegel_c.wasm "$asset"
-          sha256sum "$asset" > "$asset.sha256"
-      - name: Upload WebAssembly asset
+          wasm_asset="libhegel-wasm32-unknown-unknown.wasm"
+          static_asset="libhegel-wasm32-unknown-unknown.a"
+          cp target/wasm32-unknown-unknown/release/hegel_c.wasm "$wasm_asset"
+          cp target/wasm32-unknown-unknown/release/libhegel_c.a "$static_asset"
+          sha256sum "$wasm_asset" > "$wasm_asset.sha256"
+          sha256sum "$static_asset" > "$static_asset.sha256"
+      - name: Upload WebAssembly assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "v${VERSION}" libhegel-wasm32-unknown-unknown.wasm libhegel-wasm32-unknown-unknown.wasm.sha256 --clobber
+        run: gh release upload "v${VERSION}" libhegel-wasm32-unknown-unknown.wasm libhegel-wasm32-unknown-unknown.wasm.sha256 libhegel-wasm32-unknown-unknown.a libhegel-wasm32-unknown-unknown.a.sha256 --clobber
 
   # Independent post-condition check that every expected libhegel asset is
   # present on the Release. `release-binaries` uses `fail-fast: false` so
@@ -794,6 +810,7 @@ jobs:
           expected=(
             hegel.h
             libhegel-wasm32-unknown-unknown.wasm
+            libhegel-wasm32-unknown-unknown.a
             libhegel-linux-amd64.so
             libhegel-linux-amd64.a
             libhegel-linux-arm64.so

--- a/hegel-c/Cargo.toml
+++ b/hegel-c/Cargo.toml
@@ -68,6 +68,7 @@ std = []
 # `panic_impl` error); `just c-test-runtime` instead builds the runtime
 # cdylib and runs the std-linked smoke suite against it via dlopen.
 runtime = []
+wasm-static = []
 # Internal: exposes engine internals via `__bench` for hegeltest's benches/.
 # Not part of the public C API; depend on at your peril.
 __bench = []

--- a/hegel-c/README.md
+++ b/hegel-c/README.md
@@ -17,3 +17,17 @@ Each release publishes shared and static
 `.sha256` sidecars for `linux/amd64`, `linux/arm64`, `darwin/arm64`,
 `windows/amd64`, and `windows/arm64`. Intel macOS (`darwin/amd64`) is not
 published; build the crate yourself if you need it.
+
+## WebAssembly build
+
+The raw C ABI can also be built for `wasm32-unknown-unknown`:
+
+```bash
+rustup target add wasm32-unknown-unknown
+just c-build-wasm
+```
+
+The resulting module uses `hegel_host.entropy_fill` and
+`hegel_host.monotonic_nanos` for platform services. Filesystem persistence and
+concurrent state machines are unavailable in this single-threaded build; a
+browser or other host binding supplies the imports and Wasm memory handling.

--- a/hegel-c/README.md
+++ b/hegel-c/README.md
@@ -17,7 +17,7 @@ Each release publishes shared and static
 `.sha256` sidecars for `linux/amd64`, `linux/arm64`, `darwin/arm64`,
 `windows/amd64`, and `windows/arm64`. Intel macOS (`darwin/amd64`) is not
 published; build the crate yourself if you need it. Releases also include the
-`wasm32-unknown-unknown` WebAssembly artifact.
+`wasm32-unknown-unknown` WebAssembly module and static archive.
 
 ## WebAssembly build
 
@@ -28,7 +28,10 @@ rustup target add wasm32-unknown-unknown
 just c-build-wasm
 ```
 
-The resulting module uses `hegel_host.entropy_fill` and
-`hegel_host.monotonic_nanos` for platform services. Filesystem persistence and
-concurrent state machines are unavailable in this single-threaded build; a
-browser or other host binding supplies the imports and Wasm memory handling.
+`just c-build-wasm` also builds the static archive with the `wasm-static`
+feature. The resulting module uses `hegel_host.entropy_fill` and
+`hegel_host.monotonic_nanos` for platform services. The static archive uses the
+stable C symbols `hegel_host_entropy_fill` and `hegel_host_monotonic_nanos` for
+the same hooks. Filesystem persistence and concurrent state machines are
+unavailable in this single-threaded build; a browser or other host binding
+supplies the imports and Wasm memory handling.

--- a/hegel-c/README.md
+++ b/hegel-c/README.md
@@ -16,7 +16,8 @@ Each release publishes shared and static
 `libhegel-<goos>-<goarch>.<ext>` libraries, `hegel.h`, and matching
 `.sha256` sidecars for `linux/amd64`, `linux/arm64`, `darwin/arm64`,
 `windows/amd64`, and `windows/arm64`. Intel macOS (`darwin/amd64`) is not
-published; build the crate yourself if you need it.
+published; build the crate yourself if you need it. Releases also include the
+`wasm32-unknown-unknown` WebAssembly artifact.
 
 ## WebAssembly build
 

--- a/hegel-c/RELEASE.md
+++ b/hegel-c/RELEASE.md
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-This patch adds support for building the raw C ABI as `wasm32-unknown-unknown` for host integrations such as browser TypeScript. The Wasm build uses host-provided entropy and time, disables filesystem failure persistence and concurrent state machines, and is published as a release asset.
+This patch adds support for building the raw C ABI as `wasm32-unknown-unknown` for host integrations such as browser TypeScript and Swift. The Wasm build uses host-provided entropy and time, disables filesystem failure persistence and concurrent state machines, and is published as module and static archive release assets. The static archive uses stable C hook symbols.

--- a/hegel-c/RELEASE.md
+++ b/hegel-c/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch adds support for building the raw C ABI as `wasm32-unknown-unknown` for host integrations such as browser TypeScript. The Wasm build uses host-provided entropy and time, disables filesystem failure persistence and concurrent state machines, and is published as a release asset.

--- a/hegel-c/src/antithesis_detect.rs
+++ b/hegel-c/src/antithesis_detect.rs
@@ -1,4 +1,5 @@
 use crate::backend::RunError;
+#[cfg(not(target_family = "wasm"))]
 use alloc::format;
 use alloc::string::String;
 
@@ -14,6 +15,10 @@ pub(crate) fn antithesis_env_var_set() -> bool {
 }
 
 pub(crate) fn is_running_in_antithesis() -> Result<bool, RunError> {
+    #[cfg(target_family = "wasm")]
+    return Ok(false);
+
+    #[cfg(not(target_family = "wasm"))]
     is_running_in_antithesis_from(crate::sys::env_var)
 }
 
@@ -27,6 +32,7 @@ fn antithesis_output_dir_from(env: impl Fn(&str) -> Option<String>) -> Option<St
 /// [`is_running_in_antithesis`] with the environment read injected, so the
 /// inside-Antithesis path can be unit-tested without mutating the process
 /// environment.
+#[cfg(not(target_family = "wasm"))]
 fn is_running_in_antithesis_from(env: impl Fn(&str) -> Option<String>) -> Result<bool, RunError> {
     match antithesis_output_dir_from(env) {
         Some(output_dir) => check_antithesis_output_dir(&output_dir),
@@ -37,7 +43,9 @@ fn is_running_in_antithesis_from(env: impl Fn(&str) -> Option<String>) -> Result
 /// Validate the directory `ANTITHESIS_OUTPUT_DIR` points at. A missing
 /// directory is a configuration error in how the process was launched —
 /// reported as a run-level [`RunError::UsageError`], not an internal
-/// invariant.
+/// invariant. Split from the env read so it can be unit-tested without
+/// mutating the process environment.
+#[cfg(not(target_family = "wasm"))]
 fn check_antithesis_output_dir(output_dir: &str) -> Result<bool, RunError> {
     if !crate::sys::fs::exists(output_dir) {
         return Err(RunError::UsageError(format!(
@@ -47,6 +55,6 @@ fn check_antithesis_output_dir(output_dir: &str) -> Result<bool, RunError> {
     Ok(true)
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_family = "wasm")))]
 #[path = "../tests/embedded/antithesis_detect_tests.rs"]
 mod tests;

--- a/hegel-c/src/embed.rs
+++ b/hegel-c/src/embed.rs
@@ -30,7 +30,7 @@ use alloc::format;
 /// with the test case's outcome. The callback **must** call `mark_complete`
 /// on its data source before returning; the engine reads the outcome back
 /// through the data source rather than from the callback's return value.
-#[cfg(test)]
+#[cfg(all(test, not(target_family = "wasm")))]
 pub(crate) fn run_native(
     settings: &Settings,
     database_key: Option<&str>,
@@ -92,6 +92,6 @@ pub fn data_source_for_blob(
     Some(Box::new(data_source))
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_family = "wasm")))]
 #[path = "../tests/embedded/embed_tests.rs"]
 mod tests;

--- a/hegel-c/src/lib.rs
+++ b/hegel-c/src/lib.rs
@@ -5,6 +5,8 @@ extern crate alloc;
 #[cfg(any(test, feature = "std"))]
 extern crate std;
 
+#[cfg(target_family = "wasm")]
+use alloc::alloc::{alloc as allocate, dealloc as deallocate};
 use alloc::boxed::Box;
 use alloc::ffi::CString;
 use alloc::format;
@@ -12,6 +14,8 @@ use alloc::string::{String, ToString};
 use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
+#[cfg(target_family = "wasm")]
+use core::alloc::Layout;
 use core::ffi::{CStr, c_char, c_void};
 use core::future::Future;
 use core::pin::Pin;
@@ -140,6 +144,36 @@ pub enum hegel_result_t {
 }
 
 use hegel_result_t::*;
+
+/// Allocates temporary memory for the WebAssembly host. A zero size or an
+/// invalid alignment returns NULL. The host must release a non-NULL result
+/// with [`hegel_dealloc`], passing the same size and alignment.
+#[cfg(target_family = "wasm")]
+#[unsafe(no_mangle)]
+pub extern "C" fn hegel_alloc(size: usize, align: usize) -> *mut c_void {
+    if size == 0 {
+        return ptr::null_mut();
+    }
+    let Ok(layout) = Layout::from_size_align(size, align) else {
+        return ptr::null_mut();
+    };
+    unsafe { allocate(layout).cast() }
+}
+
+/// Releases memory previously returned by [`hegel_alloc`]. NULL is ignored;
+/// non-NULL pointers must have the same size and alignment used to allocate
+/// them.
+#[cfg(target_family = "wasm")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn hegel_dealloc(ptr: *mut c_void, size: usize, align: usize) {
+    if ptr.is_null() || size == 0 {
+        return;
+    }
+    let Ok(layout) = Layout::from_size_align(size, align) else {
+        return;
+    };
+    unsafe { deallocate(ptr.cast(), layout) };
+}
 
 /// Outcome of a single test case. Passed to `hegel_mark_complete`.
 #[repr(C)]

--- a/hegel-c/src/lib.rs
+++ b/hegel-c/src/lib.rs
@@ -145,6 +145,7 @@ pub enum hegel_result_t {
 
 use hegel_result_t::*;
 
+/// cbindgen:ignore
 /// Allocates temporary memory for the WebAssembly host. A zero size or an
 /// invalid alignment returns NULL. The host must release a non-NULL result
 /// with [`hegel_dealloc`], passing the same size and alignment.
@@ -160,6 +161,7 @@ pub extern "C" fn hegel_alloc(size: usize, align: usize) -> *mut c_void {
     unsafe { allocate(layout).cast() }
 }
 
+/// cbindgen:ignore
 /// Releases memory previously returned by [`hegel_alloc`]. NULL is ignored;
 /// non-NULL pointers must have the same size and alignment used to allocate
 /// them.

--- a/hegel-c/src/native/data_source.rs
+++ b/hegel-c/src/native/data_source.rs
@@ -321,6 +321,12 @@ impl DataSource for NativeDataSource {
                  got [{min_concurrency}, {max_concurrency}]"
             )));
         }
+        #[cfg(target_family = "wasm")]
+        if max_concurrency > 1 {
+            return Err(DataSourceError::InvalidArgument(
+                "concurrent state machines are not supported in the WebAssembly build".to_string(),
+            ));
+        }
         self.with_ntc(|ntc| {
             if max_concurrency > 1 {
                 let family = ntc.family();

--- a/hegel-c/src/native/database.rs
+++ b/hegel-c/src/native/database.rs
@@ -1,11 +1,16 @@
+#[cfg(not(target_family = "wasm"))]
 use alloc::borrow::ToOwned;
+#[cfg(not(target_family = "wasm"))]
 use alloc::format;
+#[cfg(not(target_family = "wasm"))]
 use alloc::string::String;
 use alloc::vec::Vec;
+#[cfg(not(target_family = "wasm"))]
 use core::sync::atomic::{AtomicU64, Ordering};
 
 use crate::native::bignum::BigInt;
 use crate::native::core::{ChoiceValue, ChoiceValueRef};
+#[cfg(not(target_family = "wasm"))]
 use crate::sys;
 
 /// Multi-value key/value store backing the native engine's replay phase.
@@ -37,6 +42,7 @@ pub trait TestCaseDatabase: Send + Sync {
 
 /// Name of the bookkeeping key under which every save() records its
 /// own key bytes.
+#[cfg(not(target_family = "wasm"))]
 pub const METAKEYS_NAME: &[u8] = b".hegel-keys";
 
 /// Prefix prepended to every key before it's hashed onto disk. Keeps
@@ -44,8 +50,10 @@ pub const METAKEYS_NAME: &[u8] = b".hegel-keys";
 /// store that happens to share `db_root` (e.g. a future hegel `core:`
 /// store): the formats aren't cross-compatible, so we never want their
 /// paths to coincide.
+#[cfg(not(target_family = "wasm"))]
 const KEY_PREFIX: &[u8] = b"native:";
 
+#[cfg(not(target_family = "wasm"))]
 fn key_hash(key: &[u8]) -> String {
     let mut buf = Vec::with_capacity(KEY_PREFIX.len() + key.len());
     buf.extend_from_slice(KEY_PREFIX);
@@ -53,11 +61,13 @@ fn key_hash(key: &[u8]) -> String {
     fnv_hex(&buf)
 }
 
+#[cfg(not(target_family = "wasm"))]
 pub struct DirectoryTestCaseDatabase {
     db_root: String,
     metakeys_hash: String,
 }
 
+#[cfg(not(target_family = "wasm"))]
 impl DirectoryTestCaseDatabase {
     pub fn new(db_root: &str) -> Self {
         DirectoryTestCaseDatabase {
@@ -78,11 +88,13 @@ impl DirectoryTestCaseDatabase {
 /// Within-process discriminator for temporary file names, so concurrent
 /// saves in one process never collide (the process id keeps them unique
 /// across processes).
+#[cfg(not(target_family = "wasm"))]
 static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// A `<path>.tmp.<pid>.<counter>` sibling name for [`atomic_write`]'s
 /// temporary file: the counter keeps concurrent saves in one process
 /// distinct, the process id keeps processes sharing a database distinct.
+#[cfg(not(target_family = "wasm"))]
 fn temp_path(path: &str) -> String {
     format!(
         "{path}.tmp.{}.{}",
@@ -95,6 +107,7 @@ fn temp_path(path: &str) -> String {
 /// sibling [`temp_path`] file, then rename over `path` (same-directory
 /// renames are atomic). Failures leave no partial file behind — the
 /// temporary is removed and `path` is untouched.
+#[cfg(not(target_family = "wasm"))]
 fn atomic_write(path: &str, value: &[u8]) {
     let tmp = temp_path(path);
     if sys::fs::write(&tmp, value).is_ok() && sys::fs::rename(&tmp, path).is_ok() {
@@ -103,6 +116,7 @@ fn atomic_write(path: &str, value: &[u8]) {
     let _ = sys::fs::remove_file(&tmp);
 }
 
+#[cfg(not(target_family = "wasm"))]
 impl TestCaseDatabase for DirectoryTestCaseDatabase {
     fn fetch(&self, key: &[u8]) -> Vec<Vec<u8>> {
         let dir = self.key_path(key);
@@ -179,6 +193,7 @@ impl TestCaseDatabase for DirectoryTestCaseDatabase {
 /// `::` separators) and values are serialized choice sequences full
 /// of arbitrary bytes.  FNV-1a is fine here because we only need
 /// collision-avoidance, not cryptographic security.
+#[cfg(not(target_family = "wasm"))]
 pub(super) fn fnv_hex(s: &[u8]) -> String {
     format!("{:016x}", fnv1a(s))
 }

--- a/hegel-c/src/native/database.rs
+++ b/hegel-c/src/native/database.rs
@@ -457,6 +457,6 @@ pub(crate) fn sub_key(database_key: &[u8], sub: &[u8]) -> Vec<u8> {
     out
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_family = "wasm")))]
 #[path = "../../tests/embedded/native/database_tests.rs"]
 mod tests;

--- a/hegel-c/src/native/test_runner.rs
+++ b/hegel-c/src/native/test_runner.rs
@@ -36,7 +36,6 @@ use crate::native::core::{
     Status, sort_key,
 };
 use crate::native::data_source::NativeDataSource;
-use crate::native::data_tree::generate_novel_prefix;
 #[cfg(not(target_family = "wasm"))]
 use crate::native::database::DirectoryTestCaseDatabase;
 use crate::native::database::{
@@ -1468,6 +1467,6 @@ fn create_rng(settings: &Settings, database_key: Option<&str>) -> Result<EngineR
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_family = "wasm")))]
 #[path = "../../tests/embedded/native/test_runner_tests.rs"]
 mod tests;

--- a/hegel-c/src/native/test_runner.rs
+++ b/hegel-c/src/native/test_runner.rs
@@ -36,14 +36,18 @@ use crate::native::core::{
     Status, sort_key,
 };
 use crate::native::data_source::NativeDataSource;
+use crate::native::data_tree::generate_novel_prefix;
+#[cfg(not(target_family = "wasm"))]
+use crate::native::database::DirectoryTestCaseDatabase;
 use crate::native::database::{
-    DirectoryTestCaseDatabase, TestCaseDatabase, deserialize_choices, serialize_choices,
-    serialize_nodes,
+    TestCaseDatabase, deserialize_choices, serialize_choices, serialize_nodes,
 };
 use crate::native::exec_cache::{ExecCache, KindLedger};
 use crate::native::rng::EngineRng;
 use crate::native::shrinker::{ShrinkProbe, ShrinkRun, Shrinker, absorb_stop};
-use crate::settings::{Backend, Database, HealthCheck, Output, Phase, Settings, Verbosity};
+#[cfg(not(target_family = "wasm"))]
+use crate::settings::Database;
+use crate::settings::{Backend, HealthCheck, Output, Phase, Settings, Verbosity};
 
 /// One run's worth of results: status, the realised choice nodes and
 /// spans, and (for `Status::Interesting`) the opaque origin string
@@ -1011,11 +1015,14 @@ impl<'a> Engine<'a> {
         database_key: Option<&'a str>,
         exchange: &'a CaseExchange,
     ) -> Result<Self, RunError> {
+        #[cfg(not(target_family = "wasm"))]
         let db: Option<Box<dyn TestCaseDatabase>> = match &settings.database {
             Database::Path(path) => Some(Box::new(DirectoryTestCaseDatabase::new(path))),
             Database::Unset => Some(Box::new(DirectoryTestCaseDatabase::new(".hegel/examples"))),
             Database::Disabled => None,
         };
+        #[cfg(target_family = "wasm")]
+        let db: Option<Box<dyn TestCaseDatabase>> = None;
         Ok(Engine {
             settings,
             database_key,

--- a/hegel-c/src/settings.rs
+++ b/hegel-c/src/settings.rs
@@ -181,7 +181,7 @@ impl Settings {
             output: Output::stderr(),
             seed: None,
             derandomize: in_ci,
-            database: if in_ci || in_antithesis {
+            database: if in_ci || in_antithesis || cfg!(target_family = "wasm") {
                 Database::Disabled
             } else {
                 Database::Unset

--- a/hegel-c/src/sys/mod.rs
+++ b/hegel-c/src/sys/mod.rs
@@ -6,9 +6,10 @@
 //! backend, environment lookups, and stderr output — goes through this
 //! module. No other module may touch the OS directly, and no other module
 //! may assume an OS exists: every capability here is either fallible
-//! ([`Result`]/[`Option`], which callers treat as a silent no-op or a
-//! fallback) or best-effort ([`stderr_line`]), so a future no-OS backend
-//! (wasm) slots in behind the same signatures.
+//! ([`Result`]/[`Option`], which callers can disable, fall back from, or
+//! surface as an error) or best-effort ([`stderr_line`]). Browser
+//! WebAssembly obtains the capabilities it can use through explicit host
+//! imports.
 //!
 //! The per-target backends deliberately avoid process-global runtime state:
 //! `rustix` on Unix (raw syscalls on Linux, so no libc thread-locals) and
@@ -36,9 +37,16 @@ mod imp;
 #[path = "windows.rs"]
 mod imp;
 
-/// An OS operation failed. Carries no detail: every caller treats failure
-/// as "the capability is unavailable right now" and degrades silently, so
-/// there is nothing to report.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+#[path = "wasm.rs"]
+mod imp;
+
+#[cfg(all(target_family = "wasm", target_feature = "atomics"))]
+compile_error!("libhegel's WebAssembly build does not support threads or shared memory");
+
+/// A platform operation failed. Carries no detail because callers apply
+/// capability-specific behavior: fallback for entropy and unavailability for
+/// time or direct random bytes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Error;
 
@@ -46,6 +54,7 @@ pub struct Error;
 /// `/`. Failures are reported as [`Error`] without detail; the engine's
 /// only filesystem client (the failure database) treats every failure as
 /// a silent no-op.
+#[cfg(not(target_family = "wasm"))]
 pub mod fs {
     use alloc::string::String;
     use alloc::vec::Vec;
@@ -175,22 +184,26 @@ fn duration_nanos(d: Duration) -> u64 {
     u64::try_from(d.as_nanos()).unwrap_or(u64::MAX)
 }
 
-/// Fill `buf` from the OS entropy source (the `getrandom` syscall on Linux,
-/// `ProcessPrng` on Windows). Callers fall back to a fixed seed on failure.
+/// Fill `buf` from the platform entropy source. On Linux, the Unix backend
+/// uses the `getrandom` syscall; other Unix targets read `/dev/urandom`;
+/// Windows uses `ProcessPrng`; browser WebAssembly delegates to its
+/// `entropy_fill` host
+/// import. Callers fall back to a fixed seed on failure.
 pub fn entropy(buf: &mut [u8]) -> Result<(), Error> {
     imp::entropy(buf)
 }
 
-/// Whether this platform has an OS random device (`/dev/urandom`) for the
-/// urandom backend to read. When `false`, [`urandom`] always fails and the
-/// backend falls back to an OS-seeded PRNG at selection time.
+/// Whether this platform has a direct random source for the urandom backend.
+/// Unix provides `/dev/urandom`; Windows and browser WebAssembly do not. When
+/// `false`, [`urandom`] always fails and the backend falls back to an
+/// OS-seeded PRNG at selection time.
 pub fn urandom_available() -> bool {
     imp::urandom_available()
 }
 
-/// Fill `buf` from the OS random device, opened fresh for this one read so
-/// an external controller of the device (the Antithesis fuzzer) observes a
-/// single read of exactly this size.
+/// Fill `buf` with fresh bytes from the platform's direct random source.
+/// Native Unix opens `/dev/urandom` for each request. Windows and browser
+/// WebAssembly do not provide a direct random source in this phase.
 pub fn urandom(buf: &mut [u8]) -> Result<(), Error> {
     imp::urandom(buf)
 }
@@ -213,6 +226,7 @@ pub fn stderr_line(line: &str) {
 
 /// The current process id, used to make temporary file names unique across
 /// processes sharing a database directory.
+#[cfg(not(target_family = "wasm"))]
 pub fn pid() -> u32 {
     imp::pid()
 }

--- a/hegel-c/src/sys/mod.rs
+++ b/hegel-c/src/sys/mod.rs
@@ -231,6 +231,6 @@ pub fn pid() -> u32 {
     imp::pid()
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_family = "wasm")))]
 #[path = "../../tests/embedded/sys_tests.rs"]
 mod tests;

--- a/hegel-c/src/sys/sync.rs
+++ b/hegel-c/src/sys/sync.rs
@@ -190,6 +190,6 @@ impl<T, F: Fn() -> T> Deref for Lazy<T, F> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_family = "wasm")))]
 #[path = "../../tests/embedded/sys/sync_tests.rs"]
 mod tests;

--- a/hegel-c/src/sys/wasm.rs
+++ b/hegel-c/src/sys/wasm.rs
@@ -12,12 +12,22 @@ use super::Error;
 
 const MAX_RANDOM_FILL: usize = 65_536;
 
+#[cfg(any(not(feature = "wasm-static"), test))]
 #[link(wasm_import_module = "hegel_host")]
 unsafe extern "C" {
     #[link_name = "entropy_fill"]
     fn host_entropy_fill(ptr: *mut u8, len: usize) -> i32;
 
     #[link_name = "monotonic_nanos"]
+    fn host_monotonic_nanos() -> i64;
+}
+
+#[cfg(all(feature = "wasm-static", not(test)))]
+unsafe extern "C" {
+    #[link_name = "hegel_host_entropy_fill"]
+    fn host_entropy_fill(ptr: *mut u8, len: usize) -> i32;
+
+    #[link_name = "hegel_host_monotonic_nanos"]
     fn host_monotonic_nanos() -> i64;
 }
 

--- a/hegel-c/src/sys/wasm.rs
+++ b/hegel-c/src/sys/wasm.rs
@@ -1,0 +1,63 @@
+//! Browser WebAssembly backend for [`crate::sys`].
+//!
+//! The raw module imports entropy and monotonic time from the `hegel_host`
+//! WebAssembly import module. A random-fill function returns nonzero on
+//! success and zero on failure. The clock returns nanoseconds, or a negative
+//! value when no monotonic clock is available.
+
+use alloc::string::String;
+use core::sync::atomic::AtomicU32;
+
+use super::Error;
+
+const MAX_RANDOM_FILL: usize = 65_536;
+
+#[link(wasm_import_module = "hegel_host")]
+unsafe extern "C" {
+    #[link_name = "entropy_fill"]
+    fn host_entropy_fill(ptr: *mut u8, len: usize) -> i32;
+
+    #[link_name = "monotonic_nanos"]
+    fn host_monotonic_nanos() -> i64;
+}
+
+type HostFill = unsafe extern "C" fn(*mut u8, usize) -> i32;
+
+fn fill_random(buf: &mut [u8], fill: HostFill) -> Result<(), Error> {
+    for chunk in buf.chunks_mut(MAX_RANDOM_FILL) {
+        // SAFETY: `chunk` is writable for exactly `chunk.len()` bytes. The
+        // host import contract does not retain the pointer after returning.
+        if unsafe { fill(chunk.as_mut_ptr(), chunk.len()) } == 0 {
+            return Err(Error);
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn monotonic_nanos() -> Option<u64> {
+    // SAFETY: the import takes no pointers and has no preconditions.
+    let nanos = unsafe { host_monotonic_nanos() };
+    u64::try_from(nanos).ok()
+}
+
+pub(super) fn entropy(buf: &mut [u8]) -> Result<(), Error> {
+    fill_random(buf, host_entropy_fill)
+}
+
+pub(super) fn urandom_available() -> bool {
+    false
+}
+
+pub(super) fn urandom(_buf: &mut [u8]) -> Result<(), Error> {
+    Err(Error)
+}
+
+pub(super) fn env_var(_name: &str) -> Option<String> {
+    None
+}
+
+pub(super) fn stderr_write(_bytes: &[u8]) {}
+
+pub(super) fn park(_word: &AtomicU32, _expected: u32) {}
+
+pub(super) fn unpark(_word: &AtomicU32) {}

--- a/hegel-c/tests/embedded/native/data_source_tests.rs
+++ b/hegel-c/tests/embedded/native/data_source_tests.rs
@@ -463,6 +463,7 @@ fn collections_are_shared_across_cloned_streams() {
     assert!(!child.collection_more(&mut collection).unwrap());
 }
 
+#[cfg(not(target_family = "wasm"))]
 #[test]
 fn state_machines_are_shared_across_cloned_streams() {
     let (ds, _handle) = random_source();

--- a/hegel-c/tests/embedded/native/shrinker_cache_tests.rs
+++ b/hegel-c/tests/embedded/native/shrinker_cache_tests.rs
@@ -16,6 +16,7 @@ use crate::exchange::drive_no_yield;
 use crate::native::core::choices::BooleanChoice;
 use crate::native::core::choices::IntegerChoice;
 use crate::native::core::{ChoiceNode, ChoiceValue, Spans};
+#[cfg(not(target_family = "wasm"))]
 use crate::native::shrinker::search::FindInteger;
 use crate::native::shrinker::{ShrinkRun, Shrinker};
 
@@ -65,6 +66,7 @@ fn replace_rejects_value_that_fails_kind_validate() {
     assert!(!drive_no_yield(shrinker.replace(&values)).unwrap());
 }
 
+#[cfg(not(target_family = "wasm"))]
 #[test]
 fn find_integer_bails_when_exponential_probe_overflows() {
     use crate::native::shrinker::search::SearchStep;

--- a/hegel-c/tests/embedded/native/state_clone_tests.rs
+++ b/hegel-c/tests/embedded/native/state_clone_tests.rs
@@ -277,6 +277,7 @@ fn reassembled_values_flow_through_probe_prefixes() {
     assert_eq!(probe.status(), None);
 }
 
+#[cfg(not(target_family = "wasm"))]
 #[test]
 fn concurrent_draws_on_separate_streams_are_deterministic() {
     let run = || -> (Vec<i128>, Vec<i128>) {

--- a/justfile
+++ b/justfile
@@ -81,6 +81,7 @@ c-build:
 c-build-wasm:
     cargo check -p hegeltest-c --target wasm32-unknown-unknown
     cargo build -p hegeltest-c --release --target wasm32-unknown-unknown
+    cargo rustc -p hegeltest-c --release --target wasm32-unknown-unknown --features wasm-static --crate-type staticlib
 
 # Run the hegel-c smoke tests (Rust integration test that dlopens
 # libhegel) and build + run every example C program against both the

--- a/justfile
+++ b/justfile
@@ -77,6 +77,11 @@ check-coverage:
 c-build:
     cargo build -p hegeltest-c --release
 
+# Type-check and build the browser-oriented raw WebAssembly artifact.
+c-build-wasm:
+    cargo check -p hegeltest-c --target wasm32-unknown-unknown
+    cargo build -p hegeltest-c --release --target wasm32-unknown-unknown
+
 # Run the hegel-c smoke tests (Rust integration test that dlopens
 # libhegel) and build + run every example C program against both the
 # shared (libhegel.so) and static (libhegel.a) builds. The static link

--- a/scripts/gen-ffi-list.py
+++ b/scripts/gen-ffi-list.py
@@ -11,10 +11,11 @@ missing here compiles fine under `static-engine` and fails only in a
 default-features build. Deriving the list from the engine source closes
 that gap, the same way cbindgen derives `hegel-c/include/hegel.h`.
 
-The signatures are already Rust, so this is text extraction: every
+The signatures are already Rust, so this is text extraction: every native
 `#[unsafe(no_mangle)] pub [unsafe] extern "C" fn hegel_*` at the top level
 of `lib.rs`, with its parameter list and return type collapsed onto one
-line, sorted by name.
+line, sorted by name. Target-only exports are excluded because this list is
+used by the native loader and static engine.
 
 Usage:
     scripts/gen-ffi-list.py           # rewrite src/ffi/sys/fns.rs
@@ -66,6 +67,8 @@ def extract_signatures(source: str) -> list[str]:
     signatures: dict[str, str] = {}
     for m in FN_RE.finditer(source):
         name = m.group("name")
+        if name in {"hegel_alloc", "hegel_dealloc"}:
+            continue
         if not m.group("attr"):
             raise ValueError(f"{name} is `pub extern \"C\"` but not `#[unsafe(no_mangle)]`")
         open_index = m.end() - 1


### PR DESCRIPTION
## Summary

- add `wasm32-unknown-unknown` support for `hegel-c`;
- preserve the existing native C ABI and native platform behavior;
- provide Wasm host imports for entropy and monotonic time;
- disable the filesystem-backed failure database and concurrent state machines in Wasm;
- add Wasm-only allocation helpers for browser TypeScript pointer marshalling;
- compile the Wasm test suite in CI and smoke-test the host boundary;
- publish `libhegel-wasm32-unknown-unknown.wasm` and its checksum with hegel-c releases;
- add a `hegel-c/RELEASE.md` entry and `just c-build-wasm` documentation.

Wasm uses the default PRNG backend seeded through `entropy_fill`; the direct urandom backend is unavailable and follows the existing fallback behavior. Antithesis, filesystem persistence, and Wasm threads are not enabled in this phase.

## Validation

- `cargo test -p hegeltest-c --lib` — 1,319 passed
- `cargo check -p hegeltest-c`
- `cargo check -p hegeltest-c --target wasm32-unknown-unknown`
- `cargo test -p hegeltest-c --target wasm32-unknown-unknown --lib --no-run`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- release Wasm build and temporary Node host-boundary smoke check

No standalone Wasm smoke-test files are included; the smoke check runs inline in CI.
