### PR TITLE
Drive hegel_note, hegel_printer_is_live and hegel_failure_origin from the frontend

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+This patch improves the diagnostic for a flaky test. When a shrunk failure no longer fails on its final replay, the `Flaky test detected` message now also names the failure that did not reproduce, as the panic location the engine recorded for it.
+
+`PrettyPrinter::should_print` now also reports `false` for a printer whose region has died — a clone that outlived the document it was printing into — since its writes are discarded.
+
+Internally, `TestCase::note` now goes through the engine's own note primitive instead of assembling note lines from lower-level printing calls.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,4 +4,6 @@ This patch improves the diagnostic for a flaky test. When a shrunk failure no lo
 
 `PrettyPrinter::should_print` now also reports `false` for a printer whose region has died — a clone that outlived the document it was printing into — since its writes are discarded.
 
-Internally, `TestCase::note` now goes through the engine's own note primitive instead of assembling note lines from lower-level printing calls.
+In a concurrent state machine's failure report, every line of a multi-line `tc.note()` made from a worker thread now carries the `[worker N +X.XXXms]` attribution; previously only the note's first line did.
+
+Internally, the frontend now leaves the shape of its output to the engine: `TestCase::note` goes through the engine's own note primitive, the indentation of stateful rule bodies and `tc.repeat` iterations is the engine's block regions, and the worker attribution on concurrent workers' lines is stamped by the engine rather than assembled from lower-level printing calls.

--- a/hegel-c/RELEASE.md
+++ b/hegel-c/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch changes when `hegel_note` appends its text. A note appended while a speculative region is open on the handle's print region — the client is mid-way through printing a drawn value, and the note comes from inside that value's generation — is now held back and appended once the outermost region closes, whether it is committed or aborted. Previously the note's lines were spliced into the value being printed. Notes appended outside a speculative region are unaffected.

--- a/hegel-c/RELEASE.md
+++ b/hegel-c/RELEASE.md
@@ -1,3 +1,11 @@
 RELEASE_TYPE: patch
 
-This patch changes when `hegel_note` appends its text. A note appended while a speculative region is open on the handle's print region — the client is mid-way through printing a drawn value, and the note comes from inside that value's generation — is now held back and appended once the outermost region closes, whether it is committed or aborted. Previously the note's lines were spliced into the value being printed. Notes appended outside a speculative region are unaffected.
+This patch adds two functions for shaping a test case's printed output without decorating every line by hand.
+
+`hegel_test_case_block` opens a handle onto the same choice stream as an existing handle whose print region is a block nested in the parent's: every line printed or noted through it — and through the clones and blocks derived from it — is indented a given number of columns further than the parent's lines, and the indentation ends exactly with the block. This is how a binding prints the body of a stateful rule under its `Step 3: add {` heading.
+
+`hegel_test_case_set_worker` attributes a handle's output to a concurrent worker: every line recorded through it from then on, notes and printer lines alike, is prefixed with `[worker N +X.XXXms] `, stamped with the time since the test case started at which the line was recorded. Blocks and clones derived from the handle inherit the attribution.
+
+To make block indentation possible, a line's indentation is now written when the line gets its first content rather than at the newline that started it. Documents without blocks render exactly as before, including the padding of blank lines and of a trailing hard break.
+
+This patch also changes when `hegel_note` appends its text. A note appended while a speculative region is open on the handle's print region — the client is mid-way through printing a drawn value, and the note comes from inside that value's generation — is now held back and appended once the outermost region closes, whether it is committed or aborted. Previously the note's lines were spliced into the value being printed. Notes appended outside a speculative region are unaffected.

--- a/hegel-c/include/hegel.h
+++ b/hegel-c/include/hegel.h
@@ -2333,6 +2333,13 @@ hegel_result_t hegel_test_case_printer(hegel_context_t *ctx,
  handle* appear in the order they were appended; a clone's notes appear
  in the clone's region.
 
+ A note appended while a speculative region is open on the handle's
+ region — the client is mid-way through printing a drawn value, and the
+ note comes from inside that value's generation — is held back rather
+ than spliced into the value's line, and appended once the outermost
+ region closes, whether it is committed or aborted. Held notes are lost
+ if the document is read first (the writer was a straggler).
+
  Notes never configure the document's width; they render at whatever
  width ends up configured (default 79).
 

--- a/hegel-c/include/hegel.h
+++ b/hegel-c/include/hegel.h
@@ -1184,6 +1184,67 @@ hegel_result_t hegel_test_case_clone(hegel_context_t *ctx,
                                      hegel_test_case_t **out_test_case);
 
 /*
+ Parameters:
+ `indent`: How many columns further than `tc`'s own lines every line of
+   the block is indented.
+ `out_test_case`: Receives a new handle onto the *same* choice stream as
+   `tc`.
+
+ Returns `HEGEL_OK`, `HEGEL_E_INVALID_HANDLE` for a NULL `tc`, and
+ `HEGEL_E_INVALID_ARG` for a NULL `out_test_case`.
+
+ A block handle is how a client prints an indented section under a
+ heading — the body of a stateful rule under its `Step 3: add {` line, the
+ body of a repeated section — without touching every line itself. Its
+ print region (see `hegel_test_case_printer`) is a block nested in `tc`'s
+ region at the current position: everything printed or noted through the
+ handle, and through the clones and blocks derived from it, lands there,
+ each line indented `indent` columns further than `tc`'s lines (blocks
+ nest, and their indentation adds up). The indentation is applied to a
+ line when it gets its first content, so it covers the continuation lines
+ of a value broken across lines too, and it ends exactly with the block:
+ a line `tc` writes after the block's last one is back at `tc`'s
+ indentation. It is independent of the break-point indentation
+ `hegel_printer_begin_group` / `hegel_printer_shift_indent` manage.
+
+ Unlike a clone, a block handle draws from `tc`'s own choice sequence:
+ drawing through it and through `tc` are the same thing, so the two must
+ not be driven concurrently (give a thread a clone instead). It shares
+ everything else with `tc` — outcome, budgets, worker attribution as of
+ its creation — and is released with `hegel_test_case_free` like any
+ other handle. If `tc`'s region is dead (the document was read), the
+ block shares the dead region and its prints are no-ops.
+ */
+hegel_result_t hegel_test_case_block(hegel_context_t *ctx,
+                                     const hegel_test_case_t *tc,
+                                     uint64_t indent,
+                                     hegel_test_case_t **out_test_case);
+
+/*
+ Attribute this handle's output to concurrent worker `worker_index`:
+ every line recorded from now on through the handle — `hegel_note` lines,
+ and lines started through a printer fetched from it with
+ `hegel_test_case_printer`, before or after this call — is prefixed with
+ `[worker N +X.XXXms] `, where `X.XXX` is the time since the test case
+ started at which the line was recorded. Blocks and clones derived from
+ the handle after this call inherit the attribution (a worker's rule
+ bodies and their clones print as that worker's), and may be attributed
+ afresh on their own. Lines a group breaks across are stamped on their
+ first line only.
+
+ This is the attribution a concurrent stateful runner gives the clone it
+ hands each worker thread (see `hegel_state_machine_next_rule`), so the
+ report can be read across workers: regions order a worker's lines
+ together, and the offsets say how they interleaved in time.
+
+ Returns `HEGEL_OK`, `HEGEL_E_INVALID_HANDLE` for a NULL `tc`, and
+ `HEGEL_E_INVALID_ARG` for a negative `worker_index`.
+ */
+hegel_result_t hegel_test_case_set_worker(hegel_context_t *ctx,
+                                          const hegel_test_case_t *tc,
+                                          int64_t worker_index);
+
+/*
  A span groups a set of draws so the shrinker can treat them as a unit.
  Libraries should wrap each compound generator in a span.
 

--- a/hegel-c/src/lib.rs
+++ b/hegel-c/src/lib.rs
@@ -4854,6 +4854,13 @@ pub unsafe extern "C" fn hegel_test_case_printer(
 /// handle* appear in the order they were appended; a clone's notes appear
 /// in the clone's region.
 ///
+/// A note appended while a speculative region is open on the handle's
+/// region — the client is mid-way through printing a drawn value, and the
+/// note comes from inside that value's generation — is held back rather
+/// than spliced into the value's line, and appended once the outermost
+/// region closes, whether it is committed or aborted. Held notes are lost
+/// if the document is read first (the writer was a straggler).
+///
 /// Notes never configure the document's width; they render at whatever
 /// width ends up configured (default 79).
 ///

--- a/hegel-c/src/lib.rs
+++ b/hegel-c/src/lib.rs
@@ -16,7 +16,7 @@ use core::ffi::{CStr, c_char, c_void};
 use core::future::Future;
 use core::pin::Pin;
 use core::ptr;
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 use core::task::{Context, Poll, Waker};
 
 use crate::sys::sync::{Mutex, MutexGuard};
@@ -530,6 +530,10 @@ struct FamilyShared {
     /// wins; later conflicting ones error. Only read and written under the
     /// `printer` lock.
     printer_width_configured: AtomicBool,
+    /// When the test case started — the zero of the `+X.XXXms` offsets in
+    /// the worker attribution `hegel_test_case_set_worker` turns on. `None`
+    /// on a platform without a monotonic clock, where the offsets read 0.
+    started: Option<crate::sys::Instant>,
 }
 
 impl FamilyShared {
@@ -578,7 +582,41 @@ pub struct HegelTestCase {
     /// clone's output appears in the final document — is deterministic,
     /// however the threads are later scheduled.
     print_target: PrinterTarget,
+    /// The concurrent worker this handle's output is attributed to
+    /// (`hegel_test_case_set_worker`), or [`NO_WORKER`]. Shared with the
+    /// printer handles fetched from this handle, so an attribution set after
+    /// a printer was fetched still applies to it; copied — not shared — into
+    /// the handles derived from this one, which may be attributed on their
+    /// own.
+    worker: Arc<AtomicI64>,
     local: Mutex<LocalState>,
+}
+
+/// The `worker` value of a handle attributed to no worker.
+const NO_WORKER: i64 = -1;
+
+/// The state a printer handle stamps lines from: the worker attribution
+/// cell of the test-case handle it was fetched from and the family's start
+/// time.
+struct Attribution {
+    worker: Arc<AtomicI64>,
+    started: Option<crate::sys::Instant>,
+}
+
+impl Attribution {
+    /// The `[worker N +X.XXXms] ` prefix for a line recorded now, or `None`
+    /// while no worker is set.
+    fn line_prefix(&self) -> Option<String> {
+        let worker = self.worker.load(Ordering::Acquire);
+        if worker == NO_WORKER {
+            return None;
+        }
+        let elapsed = self
+            .started
+            .map_or(core::time::Duration::ZERO, |started| started.elapsed());
+        let ms = elapsed.as_secs_f64() * 1000.0;
+        Some(format!("[worker {worker} +{ms:.3}ms] "))
+    }
 }
 
 /// Box `value` and leak it to a raw pointer for the C ABI.
@@ -1542,8 +1580,120 @@ pub unsafe extern "C" fn hegel_test_case_clone(
         // the clone's prints are no-ops like its parent's.
         Err(_) => src.print_target,
     };
-    let clone = handle_from_stream(Arc::clone(&src.family), Arc::from(stream), print_target);
+    let clone = handle_from_stream(
+        Arc::clone(&src.family),
+        Arc::from(stream),
+        print_target,
+        src.worker.load(Ordering::Acquire),
+    );
     unsafe { *out_test_case = clone };
+    HEGEL_OK
+}
+
+/// Parameters:
+/// `indent`: How many columns further than `tc`'s own lines every line of
+///   the block is indented.
+/// `out_test_case`: Receives a new handle onto the *same* choice stream as
+///   `tc`.
+///
+/// Returns `HEGEL_OK`, `HEGEL_E_INVALID_HANDLE` for a NULL `tc`, and
+/// `HEGEL_E_INVALID_ARG` for a NULL `out_test_case`.
+///
+/// A block handle is how a client prints an indented section under a
+/// heading — the body of a stateful rule under its `Step 3: add {` line, the
+/// body of a repeated section — without touching every line itself. Its
+/// print region (see `hegel_test_case_printer`) is a block nested in `tc`'s
+/// region at the current position: everything printed or noted through the
+/// handle, and through the clones and blocks derived from it, lands there,
+/// each line indented `indent` columns further than `tc`'s lines (blocks
+/// nest, and their indentation adds up). The indentation is applied to a
+/// line when it gets its first content, so it covers the continuation lines
+/// of a value broken across lines too, and it ends exactly with the block:
+/// a line `tc` writes after the block's last one is back at `tc`'s
+/// indentation. It is independent of the break-point indentation
+/// `hegel_printer_begin_group` / `hegel_printer_shift_indent` manage.
+///
+/// Unlike a clone, a block handle draws from `tc`'s own choice sequence:
+/// drawing through it and through `tc` are the same thing, so the two must
+/// not be driven concurrently (give a thread a clone instead). It shares
+/// everything else with `tc` — outcome, budgets, worker attribution as of
+/// its creation — and is released with `hegel_test_case_free` like any
+/// other handle. If `tc`'s region is dead (the document was read), the
+/// block shares the dead region and its prints are no-ops.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn hegel_test_case_block(
+    ctx: *mut HegelContext,
+    tc: *const HegelTestCase,
+    indent: u64,
+    out_test_case: *mut *mut HegelTestCase,
+) -> hegel_result_t {
+    clear_last_error(ctx);
+    let Some(src) = (unsafe { tc.as_ref() }) else {
+        set_last_error(ctx, "hegel_test_case_block: test case pointer is null");
+        return HEGEL_E_INVALID_HANDLE;
+    };
+    if out_test_case.is_null() {
+        set_last_error(ctx, "hegel_test_case_block: out parameter is null");
+        return HEGEL_E_INVALID_ARG;
+    }
+    let print_target = match src
+        .family
+        .printer
+        .lock()
+        .block(src.print_target, size_arg(indent))
+    {
+        Ok(slot) => PrinterTarget::Slot(slot),
+        Err(_) => src.print_target,
+    };
+    let block = handle_from_stream(
+        Arc::clone(&src.family),
+        Arc::clone(&src.stream),
+        print_target,
+        src.worker.load(Ordering::Acquire),
+    );
+    unsafe { *out_test_case = block };
+    HEGEL_OK
+}
+
+/// Attribute this handle's output to concurrent worker `worker_index`:
+/// every line recorded from now on through the handle — `hegel_note` lines,
+/// and lines started through a printer fetched from it with
+/// `hegel_test_case_printer`, before or after this call — is prefixed with
+/// `[worker N +X.XXXms] `, where `X.XXX` is the time since the test case
+/// started at which the line was recorded. Blocks and clones derived from
+/// the handle after this call inherit the attribution (a worker's rule
+/// bodies and their clones print as that worker's), and may be attributed
+/// afresh on their own. Lines a group breaks across are stamped on their
+/// first line only.
+///
+/// This is the attribution a concurrent stateful runner gives the clone it
+/// hands each worker thread (see `hegel_state_machine_next_rule`), so the
+/// report can be read across workers: regions order a worker's lines
+/// together, and the offsets say how they interleaved in time.
+///
+/// Returns `HEGEL_OK`, `HEGEL_E_INVALID_HANDLE` for a NULL `tc`, and
+/// `HEGEL_E_INVALID_ARG` for a negative `worker_index`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn hegel_test_case_set_worker(
+    ctx: *mut HegelContext,
+    tc: *const HegelTestCase,
+    worker_index: i64,
+) -> hegel_result_t {
+    clear_last_error(ctx);
+    let Some(tc) = (unsafe { tc.as_ref() }) else {
+        set_last_error(ctx, "hegel_test_case_set_worker: test case pointer is null");
+        return HEGEL_E_INVALID_HANDLE;
+    };
+    if worker_index < 0 {
+        set_last_error(
+            ctx,
+            &format!(
+                "hegel_test_case_set_worker: worker_index must be non-negative, got {worker_index}"
+            ),
+        );
+        return HEGEL_E_INVALID_ARG;
+    }
+    tc.worker.store(worker_index, Ordering::Release);
     HEGEL_OK
 }
 
@@ -1556,6 +1706,7 @@ fn new_family(ds: Box<dyn DataSource + Send + Sync>) -> Arc<FamilyShared> {
             DEFAULT_PRINTER_MAX_WIDTH,
         )))),
         printer_width_configured: AtomicBool::new(false),
+        started: crate::sys::Instant::now(),
     })
 }
 
@@ -1563,22 +1714,24 @@ fn new_family(ds: Box<dyn DataSource + Send + Sync>) -> Arc<FamilyShared> {
 /// stream, printing into the document body — and return its raw pointer.
 fn handle_from_family(family: Arc<FamilyShared>) -> *mut HegelTestCase {
     let stream = Arc::clone(&family.ds);
-    handle_from_stream(family, stream, PrinterTarget::Main)
+    handle_from_stream(family, stream, PrinterTarget::Main, NO_WORKER)
 }
 
 /// Allocate a handle holding one reference to `family` that draws from
-/// `stream` and prints into `print_target`, and return its raw pointer. Each
-/// handle has its own `local` buffer so concurrent handles do not stomp each
-/// other's borrowed values.
+/// `stream`, prints into `print_target` and starts out attributed to
+/// `worker`, and return its raw pointer. Each handle has its own `local`
+/// buffer so concurrent handles do not stomp each other's borrowed values.
 fn handle_from_stream(
     family: Arc<FamilyShared>,
     stream: Arc<dyn DataSource + Send + Sync>,
     print_target: PrinterTarget,
+    worker: i64,
 ) -> *mut HegelTestCase {
     into_raw_send_sync(HegelTestCase {
         family,
         stream,
         print_target,
+        worker: Arc::new(AtomicI64::new(worker)),
         local: Mutex::new(LocalState { completed: false }),
     })
 }
@@ -4022,6 +4175,30 @@ pub struct HegelPrinter {
     /// and this flag is how a second thread caught racing the same handle
     /// gets `HEGEL_E_CONCURRENT_USE` instead of silently interleaving.
     busy: AtomicBool,
+    /// Where worker line prefixes come from for a handle fetched from a
+    /// test-case handle (and the deferred handles opened from it); `None`
+    /// for a standalone document.
+    attribution: Option<Arc<Attribution>>,
+}
+
+impl HegelPrinter {
+    /// Run a content-recording operation on this handle's target, first
+    /// stamping the line it starts with the worker prefix when the handle
+    /// is attributed and the target is at a line start.
+    fn record(
+        &self,
+        op: impl FnOnce(&mut Printer, PrinterTarget) -> Result<(), PrinterError>,
+    ) -> Result<(), PrinterError> {
+        let mut printer = self.inner.lock();
+        if let Some(attribution) = &self.attribution {
+            if printer.at_line_start(self.target) {
+                if let Some(prefix) = attribution.line_prefix() {
+                    printer.line_prefix(self.target, &prefix)?;
+                }
+            }
+        }
+        op(&mut printer, self.target)
+    }
 }
 
 /// The line width a printer document is laid out to when the client does not
@@ -4242,6 +4419,7 @@ pub unsafe extern "C" fn hegel_printer_new(
         inner: Arc::new(Mutex::new(Printer::new(size_arg(max_width)))),
         target: PrinterTarget::Main,
         busy: AtomicBool::new(false),
+        attribution: None,
     };
     unsafe { *out_printer = into_raw_send_sync(handle) };
     HEGEL_OK
@@ -4296,7 +4474,7 @@ pub unsafe extern "C" fn hegel_printer_if_break(
         Ok(t) => t,
         Err(rc) => return rc,
     };
-    match handle.inner.lock().if_break(handle.target, &text) {
+    match handle.record(|printer, target| printer.if_break(target, &text)) {
         Ok(()) => HEGEL_OK,
         Err(e) => translate_printer_error(ctx, FN, e),
     }
@@ -4327,7 +4505,7 @@ pub unsafe extern "C" fn hegel_printer_text(
         Ok(t) => t,
         Err(rc) => return rc,
     };
-    match handle.inner.lock().text(handle.target, &text) {
+    match handle.record(|printer, target| printer.text(target, &text)) {
         Ok(()) => HEGEL_OK,
         Err(e) => translate_printer_error(ctx, FN, e),
     }
@@ -4447,11 +4625,7 @@ pub unsafe extern "C" fn hegel_printer_begin_group(
         Ok(t) => t,
         Err(rc) => return rc,
     };
-    match handle
-        .inner
-        .lock()
-        .begin_group(handle.target, size_arg(indent), &open)
-    {
+    match handle.record(|printer, target| printer.begin_group(target, size_arg(indent), &open)) {
         Ok(()) => HEGEL_OK,
         Err(e) => translate_printer_error(ctx, FN, e),
     }
@@ -4481,7 +4655,7 @@ pub unsafe extern "C" fn hegel_printer_end_group(
         Ok(t) => t,
         Err(rc) => return rc,
     };
-    match handle.inner.lock().end_group(handle.target, &close) {
+    match handle.record(|printer, target| printer.end_group(target, &close)) {
         Ok(()) => HEGEL_OK,
         Err(e) => translate_printer_error(ctx, FN, e),
     }
@@ -4548,6 +4722,7 @@ pub unsafe extern "C" fn hegel_printer_deferred(
                 inner: Arc::clone(&handle.inner),
                 target: PrinterTarget::Slot(slot),
                 busy: AtomicBool::new(false),
+                attribution: handle.attribution.clone(),
             };
             unsafe { *out_printer = into_raw_send_sync(child) };
             HEGEL_OK
@@ -4842,6 +5017,10 @@ pub unsafe extern "C" fn hegel_test_case_printer(
         inner,
         target: tc.print_target,
         busy: AtomicBool::new(false),
+        attribution: Some(Arc::new(Attribution {
+            worker: Arc::clone(&tc.worker),
+            started: tc.family.started,
+        })),
     };
     unsafe { *out_printer = into_raw_send_sync(handle) };
     HEGEL_OK
@@ -4890,7 +5069,17 @@ pub unsafe extern "C" fn hegel_note(
         }
         Err(rc) => return rc,
     };
-    match tc.family.printer.lock().note(tc.print_target, &text) {
+    let attribution = Attribution {
+        worker: Arc::clone(&tc.worker),
+        started: tc.family.started,
+    };
+    let prefix = attribution.line_prefix();
+    match tc
+        .family
+        .printer
+        .lock()
+        .note(tc.print_target, &text, prefix.as_deref())
+    {
         Ok(()) => HEGEL_OK,
         Err(e) => translate_printer_error(ctx, FN, e),
     }

--- a/hegel-c/src/native/printer.rs
+++ b/hegel-c/src/native/printer.rs
@@ -50,6 +50,16 @@
 //! how draw-time printing survives rejection (filters, collection rejection,
 //! failed assumptions).
 //!
+//! Two line decorations sit outside the layout stream. [`Printer::block`]
+//! opens a deferred slot whose every line is indented further than its
+//! parent's: a block's indentation is applied to a line when the line gets
+//! its first content, not folded into the break-point indentation, so it
+//! ends exactly with the block — the parent's next line, written after the
+//! block's last hard break, is back at the parent's indentation.
+//! [`Printer::line_prefix`] puts text ahead of a line's indentation (a
+//! worker attribution, say) when the target is at a hard line start;
+//! [`Printer::at_line_start`] is how a client decides to record one.
+//!
 //! Text passed to [`Printer::text`] and [`Printer::comment`] must not
 //! contain newlines; use [`Printer::hard_break`] instead so column and
 //! indentation accounting stay correct. Widths are counted in `char`s.
@@ -120,6 +130,7 @@ enum Cmd {
     ShiftIndent(isize),
     Comment(String),
     Splice(SlotId),
+    LinePrefix(String),
 }
 
 #[derive(Debug)]
@@ -161,27 +172,32 @@ struct Group {
     comment: bool,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct Slot {
     commands: Vec<Cmd>,
     speculation: Vec<Vec<Cmd>>,
-    pending_notes: Vec<String>,
+    pending_notes: Vec<Vec<Cmd>>,
     dead: bool,
+    /// Columns every line of this slot is indented beyond its parent's
+    /// lines (see [`Printer::block`]); 0 for a plain deferred slot.
+    block_indent: usize,
+    /// Whether the slot was opened at a hard line start of its parent, which
+    /// is where its own first content stands until it has any.
+    starts_line: bool,
 }
 
-fn note_cmds(text: &str) -> Vec<Cmd> {
+fn note_cmds(text: &str, line_prefix: Option<&str>) -> Vec<Cmd> {
     let mut cmds = Vec::new();
     for segment in text.split('\n') {
+        if let Some(prefix) = line_prefix {
+            cmds.push(Cmd::LinePrefix(prefix.to_string()));
+        }
         if !segment.is_empty() {
             cmds.push(Cmd::Text(segment.to_string()));
         }
         cmds.push(Cmd::HardBreak);
     }
     cmds
-}
-
-fn spaces(n: isize) -> String {
-    " ".repeat(n.max(0) as usize)
 }
 
 fn splice_ids(cmds: &[Cmd]) -> Vec<usize> {
@@ -228,7 +244,7 @@ pub struct Printer {
     main: Vec<Cmd>,
     open_groups: isize,
     speculation: Vec<Vec<Cmd>>,
-    pending_notes: Vec<String>,
+    pending_notes: Vec<Vec<Cmd>>,
     slots: Vec<Slot>,
     pending_resolve: bool,
     sealed: bool,
@@ -344,6 +360,22 @@ impl Printer {
     /// Open a deferred hole at the current position of `target` and return
     /// its slot. Writes to the slot are spliced in at the hole's position.
     pub fn deferred(&mut self, target: Target) -> Result<SlotId, PrinterError> {
+        self.open_slot(target, 0)
+    }
+
+    /// Open a block at the current position of `target`: a deferred slot
+    /// whose every line is indented `indent` columns further than the lines
+    /// of `target` (blocks nest, and their indentation adds up). The
+    /// indentation is applied when a line gets its first content and is
+    /// independent of the break-point indentation `begin_group` and
+    /// `shift_indent` manage, so it also pads the continuation lines of a
+    /// group broken inside the block. A block opened mid-line continues that
+    /// line; its indentation shows from its first whole line on.
+    pub fn block(&mut self, target: Target, indent: usize) -> Result<SlotId, PrinterError> {
+        self.open_slot(target, indent)
+    }
+
+    fn open_slot(&mut self, target: Target, block_indent: usize) -> Result<SlotId, PrinterError> {
         if self.sealed {
             return Err(PrinterError::DeadSlot);
         }
@@ -353,9 +385,71 @@ impl Printer {
             }
         }
         let slot = SlotId(self.slots.len());
-        self.slots.push(Slot::default());
+        self.slots.push(Slot {
+            commands: Vec::new(),
+            speculation: Vec::new(),
+            pending_notes: Vec::new(),
+            dead: false,
+            block_indent,
+            starts_line: self.at_line_start(target),
+        });
         self.dispatch(target, Cmd::Splice(slot))?;
         Ok(slot)
+    }
+
+    /// Whether the next content recorded on `target` starts a line: nothing
+    /// has been recorded there yet (for a slot, it was opened at a line
+    /// start), or the last thing recorded — in the innermost open
+    /// speculative region, or committed — was a hard break, or a splice
+    /// whose slot ends at one. Indentation shifts are looked past.
+    /// Break points are not line starts: whether one breaks is decided at
+    /// layout time.
+    pub fn at_line_start(&self, target: Target) -> bool {
+        let (commands, speculation) = match target {
+            Target::Main => (&self.main, &self.speculation),
+            Target::Slot(SlotId(id)) => (&self.slots[id].commands, &self.slots[id].speculation),
+        };
+        let last = speculation
+            .iter()
+            .rev()
+            .flat_map(|buf| buf.iter().rev())
+            .chain(commands.iter().rev())
+            .find(|cmd| !matches!(cmd, Cmd::ShiftIndent(_)));
+        match last {
+            Some(cmd) => self.ends_line(cmd),
+            None => match target {
+                Target::Main => true,
+                Target::Slot(SlotId(id)) => self.slots[id].starts_line,
+            },
+        }
+    }
+
+    fn ends_line(&self, cmd: &Cmd) -> bool {
+        match cmd {
+            Cmd::HardBreak => true,
+            Cmd::Splice(SlotId(id)) => {
+                let slot = &self.slots[*id];
+                match slot
+                    .commands
+                    .iter()
+                    .rev()
+                    .find(|cmd| !matches!(cmd, Cmd::ShiftIndent(_)))
+                {
+                    Some(cmd) => self.ends_line(cmd),
+                    None => slot.starts_line,
+                }
+            }
+            _ => false,
+        }
+    }
+
+    /// Put `s` ahead of the line about to start on `target`: it renders
+    /// before the line's indentation (block and break-point indentation
+    /// alike) and counts toward the line's width. Meant for a target that
+    /// [`Printer::at_line_start`] reports true for; anywhere else it is
+    /// plain text. Must not contain newlines.
+    pub fn line_prefix(&mut self, target: Target, s: &str) -> Result<(), PrinterError> {
+        self.dispatch(target, Cmd::LinePrefix(s.to_string()))
     }
 
     /// Open a speculative region on `target`: subsequent writes to it buffer
@@ -472,8 +566,8 @@ impl Printer {
                 (core::mem::take(&mut slot.pending_notes), &mut slot.commands)
             }
         };
-        for note in &notes {
-            commands.extend(note_cmds(note));
+        for note in notes {
+            commands.extend(note);
         }
     }
 
@@ -541,7 +635,8 @@ impl Printer {
     /// Append a note to `target`: each `\n`-separated line of `text` is
     /// emitted as literal text followed by a hard break, so a note always
     /// occupies whole lines and keeps width accounting correct even when the
-    /// note contains newlines.
+    /// note contains newlines. With a `line_prefix`, every line of the note
+    /// gets it (see [`Printer::line_prefix`]).
     ///
     /// A note appended while a speculative region is open on `target` — a
     /// value is being printed, and the note comes from inside its generation
@@ -550,7 +645,12 @@ impl Printer {
     /// [`Printer::commit_speculative`] or [`Printer::abort_speculative`].
     /// Held notes die with the target if the document is sealed first.
     /// Errors only for a dead target.
-    pub fn note(&mut self, target: Target, text: &str) -> Result<(), PrinterError> {
+    pub fn note(
+        &mut self,
+        target: Target,
+        text: &str,
+        line_prefix: Option<&str>,
+    ) -> Result<(), PrinterError> {
         if self.sealed {
             return Err(PrinterError::DeadSlot);
         }
@@ -564,11 +664,12 @@ impl Printer {
                 (!slot.speculation.is_empty()).then_some(&mut slot.pending_notes)
             }
         };
+        let cmds = note_cmds(text, line_prefix);
         if let Some(held) = held {
-            held.push(text.to_string());
+            held.push(cmds);
             return Ok(());
         }
-        for cmd in note_cmds(text) {
+        for cmd in cmds {
             self.dispatch(target, cmd)?;
         }
         Ok(())
@@ -642,6 +743,13 @@ struct Renderer<'a> {
     out: String,
     output_width: usize,
     at_line_start: bool,
+    /// The break-point indentation of the line being written, held until
+    /// the line's first content arrives: the padding actually written is
+    /// this plus the block indentation current at that moment, behind any
+    /// line prefix. `None` once the line has content (or its padding out).
+    pending_pad: Option<isize>,
+    /// Summed indentation of the blocks whose splices are being rendered.
+    block_indent: usize,
     buffer: VecDeque<Token>,
     buffer_width: usize,
     pending_comments: String,
@@ -660,6 +768,8 @@ impl<'a> Renderer<'a> {
             out: String::new(),
             output_width: 0,
             at_line_start: true,
+            pending_pad: Some(0),
+            block_indent: 0,
             buffer: VecDeque::new(),
             buffer_width: 0,
             pending_comments: String::new(),
@@ -694,28 +804,75 @@ impl<'a> Renderer<'a> {
             Cmd::ShiftIndent(delta) => self.indentation += delta,
             Cmd::Comment(s) => self.comment(s),
             Cmd::Splice(SlotId(id)) => {
-                let spliced = self.slots[*id].commands.as_slice();
-                return self.run(spliced);
+                let slot = &self.slots[*id];
+                self.block_indent += slot.block_indent;
+                self.run(&slot.commands)?;
+                self.block_indent -= slot.block_indent;
             }
+            Cmd::LinePrefix(s) => self.line_prefix(s),
         }
         Ok(())
     }
 
     fn finish(mut self) -> String {
         self.flush();
+        self.emit_pending_pad();
         let pending = core::mem::take(&mut self.pending_comments);
         self.out.push_str(&pending);
         self.out
     }
 
-    fn text(&mut self, s: &str) {
-        let width = s.chars().count();
-        if self.buffer.is_empty() {
+    /// Write the padding of a line that has none yet: its held break-point
+    /// indentation plus the block indentation in force now.
+    fn emit_pending_pad(&mut self) {
+        if let Some(indent) = self.pending_pad.take() {
+            let pad = self.block_indent + indent.max(0) as usize;
+            self.out.push_str(&" ".repeat(pad));
+            self.output_width = pad;
+        }
+    }
+
+    /// Write `s`, `width` chars wide, to the current line, padding the line
+    /// first if this is its first content.
+    fn push_content(&mut self, s: &str, width: usize) {
+        if width > 0 {
+            self.emit_pending_pad();
+            self.at_line_start = false;
+        }
+        self.out.push_str(s);
+        self.output_width += width;
+    }
+
+    /// End the current line — writing its padding if it never got content,
+    /// and its comments — and start the next at break-point indentation
+    /// `indent`.
+    fn start_line(&mut self, indent: isize) {
+        self.emit_pending_pad();
+        self.emit_pending_comments();
+        self.out.push('\n');
+        self.pending_pad = Some(indent);
+        self.output_width = self.block_indent + indent.max(0) as usize;
+        self.at_line_start = true;
+    }
+
+    fn line_prefix(&mut self, s: &str) {
+        if self.buffer.is_empty() && self.pending_pad.is_some() {
+            let width = s.chars().count();
             self.out.push_str(s);
+            self.emit_pending_pad();
             self.output_width += width;
             if width > 0 {
                 self.at_line_start = false;
             }
+        } else {
+            self.text(s);
+        }
+    }
+
+    fn text(&mut self, s: &str) {
+        let width = s.chars().count();
+        if self.buffer.is_empty() {
+            self.push_content(s, width);
         } else {
             match self.buffer.back_mut() {
                 Some(Token::Text { content, width: w }) => {
@@ -779,11 +936,7 @@ impl<'a> Renderer<'a> {
 
     fn newline(&mut self) {
         self.flush();
-        self.emit_pending_comments();
-        self.out.push('\n');
-        self.out.push_str(&spaces(self.indentation));
-        self.output_width = self.indentation.max(0) as usize;
-        self.at_line_start = true;
+        self.start_line(self.indentation);
     }
 
     fn begin_group(&mut self, indent: usize, open: &str) {
@@ -882,21 +1035,11 @@ impl<'a> Renderer<'a> {
 
     fn output_token(&mut self, token: Token) {
         match token {
-            Token::Text { content, width } => {
-                self.out.push_str(&content);
-                self.output_width += width;
-                if width > 0 {
-                    self.at_line_start = false;
-                }
-            }
+            Token::Text { content, width } => self.push_content(&content, width),
             Token::IfBreak { content, group } => {
                 if self.groups[group].want_break {
                     let width = content.chars().count();
-                    self.out.push_str(&content);
-                    self.output_width += width;
-                    if width > 0 {
-                        self.at_line_start = false;
-                    }
+                    self.push_content(&content, width);
                 }
             }
             Token::Comment { content } => {
@@ -910,20 +1053,12 @@ impl<'a> Renderer<'a> {
             } => {
                 self.groups[group].pending -= 1;
                 if self.groups[group].want_break {
-                    self.emit_pending_comments();
-                    self.out.push('\n');
-                    self.out.push_str(&spaces(indent));
-                    self.output_width = indent.max(0) as usize;
-                    self.at_line_start = true;
+                    self.start_line(indent);
                 } else {
                     if self.groups[group].pending == 0 {
                         self.queue_remove(group);
                     }
-                    self.out.push_str(&sep);
-                    self.output_width += width;
-                    if width > 0 {
-                        self.at_line_start = false;
-                    }
+                    self.push_content(&sep, width);
                 }
             }
         }

--- a/hegel-c/src/native/printer.rs
+++ b/hegel-c/src/native/printer.rs
@@ -165,7 +165,19 @@ struct Group {
 struct Slot {
     commands: Vec<Cmd>,
     speculation: Vec<Vec<Cmd>>,
+    pending_notes: Vec<String>,
     dead: bool,
+}
+
+fn note_cmds(text: &str) -> Vec<Cmd> {
+    let mut cmds = Vec::new();
+    for segment in text.split('\n') {
+        if !segment.is_empty() {
+            cmds.push(Cmd::Text(segment.to_string()));
+        }
+        cmds.push(Cmd::HardBreak);
+    }
+    cmds
 }
 
 fn spaces(n: isize) -> String {
@@ -216,6 +228,7 @@ pub struct Printer {
     main: Vec<Cmd>,
     open_groups: isize,
     speculation: Vec<Vec<Cmd>>,
+    pending_notes: Vec<String>,
     slots: Vec<Slot>,
     pending_resolve: bool,
     sealed: bool,
@@ -233,6 +246,7 @@ impl Printer {
             main: Vec::new(),
             open_groups: 0,
             speculation: Vec::new(),
+            pending_notes: Vec::new(),
             slots: Vec::new(),
             pending_resolve: false,
             sealed: false,
@@ -366,7 +380,9 @@ impl Printer {
 
     /// Close the innermost speculative region on `target`, keeping its
     /// content. Committing into the main output validates group balance and
-    /// rejects atomically, leaving the region open.
+    /// rejects atomically, leaving the region open. Closing the outermost
+    /// region releases the notes held while it was open (see
+    /// [`Printer::note`]).
     pub fn commit_speculative(&mut self, target: Target) -> Result<(), PrinterError> {
         if self.sealed {
             return Err(PrinterError::DeadSlot);
@@ -410,32 +426,55 @@ impl Printer {
                 let buf = slot.speculation.pop().ok_or(PrinterError::NoSpeculation)?;
                 if let Some(outer) = slot.speculation.last_mut() {
                     outer.extend(buf);
-                } else {
-                    slot.commands.extend(buf);
+                    return Ok(());
                 }
+                slot.commands.extend(buf);
             }
         }
+        self.release_held_notes(target);
         Ok(())
     }
 
     /// Close the innermost speculative region on `target`, discarding its
-    /// content. Deferred slots opened inside the region die with it.
+    /// content. Deferred slots opened inside the region die with it. Closing
+    /// the outermost region releases the notes held while it was open (see
+    /// [`Printer::note`]): a note is never part of the retracted content.
     pub fn abort_speculative(&mut self, target: Target) -> Result<(), PrinterError> {
         if self.sealed {
             return Err(PrinterError::DeadSlot);
         }
-        let buf = match target {
-            Target::Main => self.speculation.pop().ok_or(PrinterError::NoSpeculation)?,
+        let (buf, outermost) = match target {
+            Target::Main => {
+                let buf = self.speculation.pop().ok_or(PrinterError::NoSpeculation)?;
+                (buf, self.speculation.is_empty())
+            }
             Target::Slot(SlotId(id)) => {
                 let slot = &mut self.slots[id];
                 if slot.dead {
                     return Err(PrinterError::DeadSlot);
                 }
-                slot.speculation.pop().ok_or(PrinterError::NoSpeculation)?
+                let buf = slot.speculation.pop().ok_or(PrinterError::NoSpeculation)?;
+                (buf, slot.speculation.is_empty())
             }
         };
         self.kill_splices(&buf);
+        if outermost {
+            self.release_held_notes(target);
+        }
         Ok(())
+    }
+
+    fn release_held_notes(&mut self, target: Target) {
+        let (notes, commands) = match target {
+            Target::Main => (core::mem::take(&mut self.pending_notes), &mut self.main),
+            Target::Slot(SlotId(id)) => {
+                let slot = &mut self.slots[id];
+                (core::mem::take(&mut slot.pending_notes), &mut slot.commands)
+            }
+        };
+        for note in &notes {
+            commands.extend(note_cmds(note));
+        }
     }
 
     /// Close the outstanding deferred session and seal the document (see
@@ -502,13 +541,35 @@ impl Printer {
     /// Append a note to `target`: each `\n`-separated line of `text` is
     /// emitted as literal text followed by a hard break, so a note always
     /// occupies whole lines and keeps width accounting correct even when the
-    /// note contains newlines. Errors only for a dead slot target.
+    /// note contains newlines.
+    ///
+    /// A note appended while a speculative region is open on `target` — a
+    /// value is being printed, and the note comes from inside its generation
+    /// — is held back rather than spliced into that value's line, and
+    /// appended when the outermost region on the target closes, whether by
+    /// [`Printer::commit_speculative`] or [`Printer::abort_speculative`].
+    /// Held notes die with the target if the document is sealed first.
+    /// Errors only for a dead target.
     pub fn note(&mut self, target: Target, text: &str) -> Result<(), PrinterError> {
-        for segment in text.split('\n') {
-            if !segment.is_empty() {
-                self.dispatch(target, Cmd::Text(segment.to_string()))?;
+        if self.sealed {
+            return Err(PrinterError::DeadSlot);
+        }
+        let held = match target {
+            Target::Main => (!self.speculation.is_empty()).then_some(&mut self.pending_notes),
+            Target::Slot(SlotId(id)) => {
+                let slot = &mut self.slots[id];
+                if slot.dead {
+                    return Err(PrinterError::DeadSlot);
+                }
+                (!slot.speculation.is_empty()).then_some(&mut slot.pending_notes)
             }
-            self.dispatch(target, Cmd::HardBreak)?;
+        };
+        if let Some(held) = held {
+            held.push(text.to_string());
+            return Ok(());
+        }
+        for cmd in note_cmds(text) {
+            self.dispatch(target, cmd)?;
         }
         Ok(())
     }

--- a/hegel-c/tests/c_abi_printer.rs
+++ b/hegel-c/tests/c_abi_printer.rs
@@ -552,6 +552,45 @@ fn family_document_is_shared_and_survives_completion() {
 }
 
 #[test]
+fn note_during_a_speculative_draw_lands_after_the_value() {
+    let ctx = hegel_context_new();
+    unsafe {
+        let s = make_settings_no_db(ctx);
+        let run = start(ctx, s);
+        let tc = next_case(ctx, run);
+        assert!(!tc.is_null());
+
+        let mut p: *mut HegelPrinter = ptr::null_mut();
+        ok(hegel_test_case_printer(ctx, tc, ptr::null(), &mut p));
+        ok(hegel_printer_begin_speculative(ctx, p));
+        text(ctx, p, "let x = ");
+        ok(hegel_note(ctx, tc, "mid-draw".as_ptr(), 8));
+        text(ctx, p, "5;");
+        ok(hegel_printer_hard_break(ctx, p));
+        ok(hegel_printer_commit_speculative(ctx, p));
+
+        ok(hegel_printer_begin_speculative(ctx, p));
+        text(ctx, p, "let y = ");
+        ok(hegel_note(ctx, tc, "rejected".as_ptr(), 8));
+        ok(hegel_printer_abort_speculative(ctx, p));
+
+        assert_eq!(value(ctx, p), "let x = 5;\nmid-draw\nrejected\n");
+
+        ok(hegel_printer_free(ctx, p));
+        ok(hegel_mark_complete(
+            ctx,
+            tc,
+            hegel_status_t::HEGEL_STATUS_VALID as u32,
+            ptr::null(),
+        ));
+        ok(hegel_test_case_free(ctx, tc));
+        ok(hegel_run_free(ctx, run));
+        ok(hegel_settings_free(ctx, s));
+        ok(hegel_context_free(ctx));
+    }
+}
+
+#[test]
 fn clone_regions_anchor_where_the_clone_was_made() {
     let ctx = hegel_context_new();
     unsafe {

--- a/hegel-c/tests/c_abi_printer.rs
+++ b/hegel-c/tests/c_abi_printer.rs
@@ -8,15 +8,16 @@ use common::{last_error, make_settings_no_db, next_case, ok, start};
 use hegel_c::hegel_result_t::*;
 use hegel_c::{
     HegelContext, HegelPrinter, HegelPrinterOptions, hegel_context_free, hegel_context_new,
-    hegel_mark_complete, hegel_note, hegel_printer_abort_speculative, hegel_printer_begin_group,
-    hegel_printer_begin_speculative, hegel_printer_breakable, hegel_printer_comment,
-    hegel_printer_commit_speculative, hegel_printer_deferred, hegel_printer_end_group,
-    hegel_printer_free, hegel_printer_hard_break, hegel_printer_if_break, hegel_printer_is_live,
-    hegel_printer_new, hegel_printer_options_free, hegel_printer_options_new,
-    hegel_printer_options_set_max_width, hegel_printer_resolve, hegel_printer_shift_indent,
-    hegel_printer_text, hegel_printer_value, hegel_printer_value_result_free,
-    hegel_printer_value_result_t, hegel_run_free, hegel_settings_free, hegel_status_t,
-    hegel_test_case_clone, hegel_test_case_free, hegel_test_case_printer,
+    hegel_generate_integer, hegel_mark_complete, hegel_note, hegel_printer_abort_speculative,
+    hegel_printer_begin_group, hegel_printer_begin_speculative, hegel_printer_breakable,
+    hegel_printer_comment, hegel_printer_commit_speculative, hegel_printer_deferred,
+    hegel_printer_end_group, hegel_printer_free, hegel_printer_hard_break, hegel_printer_if_break,
+    hegel_printer_is_live, hegel_printer_new, hegel_printer_options_free,
+    hegel_printer_options_new, hegel_printer_options_set_max_width, hegel_printer_resolve,
+    hegel_printer_shift_indent, hegel_printer_text, hegel_printer_value,
+    hegel_printer_value_result_free, hegel_printer_value_result_t, hegel_run_free,
+    hegel_settings_free, hegel_status_t, hegel_test_case_block, hegel_test_case_clone,
+    hegel_test_case_free, hegel_test_case_printer, hegel_test_case_set_worker,
 };
 use std::ptr;
 
@@ -804,6 +805,12 @@ fn straggler_clones_share_their_parents_dead_region() {
             hegel_note(ctx, grandchild, "later".as_ptr(), 5),
             HEGEL_E_INVALID_HANDLE
         );
+        let mut block: *mut hegel_c::HegelTestCase = ptr::null_mut();
+        ok(hegel_test_case_block(ctx, straggler, 2, &mut block));
+        assert_eq!(
+            hegel_note(ctx, block, "latest".as_ptr(), 6),
+            HEGEL_E_INVALID_HANDLE
+        );
 
         ok(hegel_mark_complete(
             ctx,
@@ -812,8 +819,158 @@ fn straggler_clones_share_their_parents_dead_region() {
             ptr::null(),
         ));
         ok(hegel_printer_free(ctx, root));
+        ok(hegel_test_case_free(ctx, block));
         ok(hegel_test_case_free(ctx, grandchild));
         ok(hegel_test_case_free(ctx, straggler));
+        ok(hegel_test_case_free(ctx, tc));
+        ok(hegel_run_free(ctx, run));
+        ok(hegel_settings_free(ctx, s));
+        ok(hegel_context_free(ctx));
+    }
+}
+
+#[test]
+fn block_handles_indent_their_region_and_share_the_stream() {
+    let ctx = hegel_context_new();
+    unsafe {
+        let s = make_settings_no_db(ctx);
+        let run = start(ctx, s);
+        let tc = next_case(ctx, run);
+        assert!(!tc.is_null());
+
+        ok(hegel_note(ctx, tc, "Step 1: add {".as_ptr(), 13));
+        let mut block: *mut hegel_c::HegelTestCase = ptr::null_mut();
+        ok(hegel_test_case_block(ctx, tc, 2, &mut block));
+        assert!(!block.is_null());
+        ok(hegel_note(ctx, block, "inside".as_ptr(), 6));
+
+        let mut drawn: i64 = 7;
+        ok(hegel_generate_integer(ctx, block, 0, 0, &mut drawn));
+        assert_eq!(drawn, 0);
+
+        let narrow = max_width_options(ctx, 10);
+        let mut p: *mut HegelPrinter = ptr::null_mut();
+        ok(hegel_test_case_printer(ctx, block, narrow, &mut p));
+        ok(hegel_printer_options_free(ctx, narrow));
+        ok(hegel_printer_begin_group(ctx, p, 1, "[".as_ptr(), 1));
+        text(ctx, p, "aaaa,");
+        ok(hegel_printer_breakable(ctx, p, " ".as_ptr(), 1));
+        text(ctx, p, "bbbb");
+        ok(hegel_printer_end_group(ctx, p, "]".as_ptr(), 1));
+        ok(hegel_printer_hard_break(ctx, p));
+
+        let mut nested: *mut hegel_c::HegelTestCase = ptr::null_mut();
+        ok(hegel_test_case_block(ctx, block, 2, &mut nested));
+        ok(hegel_note(ctx, nested, "deep".as_ptr(), 4));
+        let mut clone: *mut hegel_c::HegelTestCase = ptr::null_mut();
+        ok(hegel_test_case_clone(ctx, block, &mut clone));
+        ok(hegel_note(ctx, clone, "cloned".as_ptr(), 6));
+        ok(hegel_note(ctx, tc, "}".as_ptr(), 1));
+
+        let mut root: *mut HegelPrinter = ptr::null_mut();
+        ok(hegel_test_case_printer(ctx, tc, ptr::null(), &mut root));
+        ok(hegel_printer_resolve(ctx, root));
+        assert_eq!(
+            value(ctx, root),
+            "Step 1: add {\n  inside\n  [aaaa,\n   bbbb]\n    deep\n  cloned\n}\n"
+        );
+
+        assert_eq!(
+            hegel_test_case_block(ctx, ptr::null(), 2, &mut nested),
+            HEGEL_E_INVALID_HANDLE
+        );
+        assert_eq!(
+            hegel_test_case_block(ctx, tc, 2, ptr::null_mut()),
+            HEGEL_E_INVALID_ARG
+        );
+        assert!(last_error(ctx).contains("out parameter is null"));
+
+        ok(hegel_printer_free(ctx, p));
+        ok(hegel_printer_free(ctx, root));
+        ok(hegel_mark_complete(
+            ctx,
+            tc,
+            hegel_status_t::HEGEL_STATUS_VALID as u32,
+            ptr::null(),
+        ));
+        ok(hegel_test_case_free(ctx, clone));
+        ok(hegel_test_case_free(ctx, nested));
+        ok(hegel_test_case_free(ctx, block));
+        ok(hegel_test_case_free(ctx, tc));
+        ok(hegel_run_free(ctx, run));
+        ok(hegel_settings_free(ctx, s));
+        ok(hegel_context_free(ctx));
+    }
+}
+
+#[test]
+fn worker_attribution_stamps_lines_recorded_through_the_handle() {
+    let ctx = hegel_context_new();
+    unsafe {
+        let s = make_settings_no_db(ctx);
+        let run = start(ctx, s);
+        let tc = next_case(ctx, run);
+        assert!(!tc.is_null());
+
+        let narrow = max_width_options(ctx, 30);
+        let mut root: *mut HegelPrinter = ptr::null_mut();
+        ok(hegel_test_case_printer(ctx, tc, narrow, &mut root));
+        ok(hegel_printer_options_free(ctx, narrow));
+
+        let mut worker: *mut hegel_c::HegelTestCase = ptr::null_mut();
+        ok(hegel_test_case_clone(ctx, tc, &mut worker));
+        ok(hegel_test_case_set_worker(ctx, worker, 3));
+        ok(hegel_note(ctx, worker, "Rule: boom {\nsecond".as_ptr(), 19));
+
+        let mut block: *mut hegel_c::HegelTestCase = ptr::null_mut();
+        ok(hegel_test_case_block(ctx, worker, 2, &mut block));
+        let mut p: *mut HegelPrinter = ptr::null_mut();
+        ok(hegel_test_case_printer(ctx, block, ptr::null(), &mut p));
+        ok(hegel_printer_begin_group(ctx, p, 1, "[".as_ptr(), 1));
+        text(ctx, p, "aaaa,");
+        ok(hegel_printer_breakable(ctx, p, " ".as_ptr(), 1));
+        text(ctx, p, "bbbb");
+        ok(hegel_printer_end_group(ctx, p, "]".as_ptr(), 1));
+        ok(hegel_printer_hard_break(ctx, p));
+        let mut grandchild: *mut hegel_c::HegelTestCase = ptr::null_mut();
+        ok(hegel_test_case_clone(ctx, block, &mut grandchild));
+        ok(hegel_note(ctx, grandchild, "nested".as_ptr(), 6));
+        ok(hegel_note(ctx, worker, "}".as_ptr(), 1));
+
+        ok(hegel_note(ctx, tc, "unattributed".as_ptr(), 12));
+        ok(hegel_test_case_set_worker(ctx, tc, 0));
+        text(ctx, root, "root line");
+        ok(hegel_printer_hard_break(ctx, root));
+
+        assert_eq!(
+            hegel_test_case_set_worker(ctx, ptr::null(), 0),
+            HEGEL_E_INVALID_HANDLE
+        );
+        assert_eq!(hegel_test_case_set_worker(ctx, tc, -1), HEGEL_E_INVALID_ARG);
+        assert!(last_error(ctx).contains("worker_index must be non-negative"));
+
+        ok(hegel_printer_resolve(ctx, root));
+        let rendered = value(ctx, root);
+        let stamp = r"\[worker 3 \+\d+\.\d{3}ms\] ";
+        let expected = format!(
+            "^{stamp}Rule: boom \\{{\n{stamp}second\n{stamp}  \\[aaaa,\n   bbbb\\]\n{stamp}  nested\n{stamp}\\}}\nunattributed\n\\[worker 0 \\+\\d+\\.\\d{{3}}ms\\] root line\n$"
+        );
+        assert!(
+            regex::Regex::new(&expected).unwrap().is_match(&rendered),
+            "unexpected document:\n{rendered}"
+        );
+
+        ok(hegel_printer_free(ctx, p));
+        ok(hegel_printer_free(ctx, root));
+        ok(hegel_mark_complete(
+            ctx,
+            tc,
+            hegel_status_t::HEGEL_STATUS_VALID as u32,
+            ptr::null(),
+        ));
+        ok(hegel_test_case_free(ctx, grandchild));
+        ok(hegel_test_case_free(ctx, block));
+        ok(hegel_test_case_free(ctx, worker));
         ok(hegel_test_case_free(ctx, tc));
         ok(hegel_run_free(ctx, run));
         ok(hegel_settings_free(ctx, s));

--- a/hegel-c/tests/embedded/native/printer_tests.rs
+++ b/hegel-c/tests/embedded/native/printer_tests.rs
@@ -979,15 +979,15 @@ fn errors_have_readable_messages() {
 #[test]
 fn note_emits_whole_lines() {
     let mut p = printer(79);
-    p.note(M, "hello").unwrap();
+    p.note(M, "hello", None).unwrap();
     assert_eq!(p.value().unwrap(), "hello\n");
 }
 
 #[test]
 fn note_splits_embedded_newlines_into_hard_breaks() {
     let mut p = printer(5);
-    p.note(M, "aaaaaaaa\nbb").unwrap();
-    p.note(M, "").unwrap();
+    p.note(M, "aaaaaaaa\nbb", None).unwrap();
+    p.note(M, "", None).unwrap();
     assert_eq!(p.value().unwrap(), "aaaaaaaa\nbb\n\n");
 }
 
@@ -996,7 +996,7 @@ fn note_respects_indentation_and_recording() {
     let mut p = printer(79);
     p.shift_indent(M, 2).unwrap();
     let slot = p.deferred(M).unwrap();
-    p.note(M, "after").unwrap();
+    p.note(M, "after", None).unwrap();
     p.text(Target::Slot(slot), "x").unwrap();
     p.resolve().unwrap();
     assert_eq!(p.value().unwrap(), "xafter\n  ");
@@ -1007,7 +1007,7 @@ fn note_during_a_speculation_is_held_until_the_commit() {
     let mut p = printer(79);
     p.begin_speculative(M).unwrap();
     p.text(M, "let x = ").unwrap();
-    p.note(M, "from inside").unwrap();
+    p.note(M, "from inside", None).unwrap();
     p.text(M, "5;").unwrap();
     p.hard_break(M).unwrap();
     p.commit_speculative(M).unwrap();
@@ -1019,7 +1019,7 @@ fn note_during_a_speculation_survives_its_abort() {
     let mut p = printer(79);
     p.begin_speculative(M).unwrap();
     p.text(M, "let x = ").unwrap();
-    p.note(M, "from inside").unwrap();
+    p.note(M, "from inside", None).unwrap();
     p.abort_speculative(M).unwrap();
     assert_eq!(p.value().unwrap(), "from inside\n");
 }
@@ -1031,11 +1031,11 @@ fn held_notes_wait_for_the_outermost_speculation() {
     p.text(M, "let x = [").unwrap();
     p.begin_speculative(M).unwrap();
     p.text(M, "1").unwrap();
-    p.note(M, "first").unwrap();
+    p.note(M, "first", None).unwrap();
     p.abort_speculative(M).unwrap();
     p.begin_speculative(M).unwrap();
     p.text(M, "2").unwrap();
-    p.note(M, "second").unwrap();
+    p.note(M, "second", None).unwrap();
     p.commit_speculative(M).unwrap();
     p.text(M, "];").unwrap();
     p.hard_break(M).unwrap();
@@ -1050,11 +1050,11 @@ fn held_notes_are_per_target() {
     let s = Target::Slot(slot);
     p.begin_speculative(s).unwrap();
     p.text(s, "a").unwrap();
-    p.note(s, "in slot").unwrap();
-    p.note(M, "on main").unwrap();
+    p.note(s, "in slot", None).unwrap();
+    p.note(M, "on main", None).unwrap();
     p.commit_speculative(s).unwrap();
     p.begin_speculative(s).unwrap();
-    p.note(s, "aborted attempt").unwrap();
+    p.note(s, "aborted attempt", None).unwrap();
     p.abort_speculative(s).unwrap();
     p.resolve().unwrap();
     assert_eq!(p.value().unwrap(), "ain slot\naborted attempt\non main\n");
@@ -1067,10 +1067,10 @@ fn note_on_a_slot_killed_by_an_aborted_speculation_errors() {
     let slot = p.deferred(M).unwrap();
     p.abort_speculative(M).unwrap();
     assert_eq!(
-        p.note(Target::Slot(slot), "late"),
+        p.note(Target::Slot(slot), "late", None),
         Err(PrinterError::DeadSlot)
     );
-    p.note(M, "still live").unwrap();
+    p.note(M, "still live", None).unwrap();
     assert_eq!(p.value().unwrap(), "still live\n");
 }
 
@@ -1079,9 +1079,9 @@ fn held_notes_die_when_the_document_is_sealed() {
     let mut p = printer(79);
     p.text(M, "a").unwrap();
     p.begin_speculative(M).unwrap();
-    p.note(M, "never lands").unwrap();
+    p.note(M, "never lands", None).unwrap();
     assert_eq!(p.value().unwrap(), "a");
-    assert_eq!(p.note(M, "late"), Err(PrinterError::DeadSlot));
+    assert_eq!(p.note(M, "late", None), Err(PrinterError::DeadSlot));
 }
 
 #[derive(Debug, Clone)]
@@ -1256,4 +1256,157 @@ fn comments_always_terminate_their_line_and_appear_exactly_once() {
             }
         }
     }
+}
+
+#[test]
+fn block_indents_every_line_and_ends_with_the_block() {
+    let mut p = printer(79);
+    p.note(M, "head {", None).unwrap();
+    let block = p.block(M, 2).unwrap();
+    let b = Target::Slot(block);
+    p.note(b, "x", None).unwrap();
+    let nested = Target::Slot(p.block(b, 2).unwrap());
+    p.note(nested, "y", None).unwrap();
+    p.note(b, "z", None).unwrap();
+    p.note(M, "}", None).unwrap();
+    p.resolve().unwrap();
+    assert_eq!(p.value().unwrap(), "head {\n  x\n    y\n  z\n}\n");
+}
+
+#[test]
+fn block_indentation_pads_continuation_lines_of_broken_groups() {
+    let mut p = printer(10);
+    let b = Target::Slot(p.block(M, 2).unwrap());
+    p.begin_group(b, 1, "[").unwrap();
+    p.text(b, "aaaa,").unwrap();
+    p.breakable(b, " ").unwrap();
+    p.text(b, "bbbb").unwrap();
+    p.end_group(b, "]").unwrap();
+    p.hard_break(b).unwrap();
+    p.text(M, "after").unwrap();
+    p.resolve().unwrap();
+    assert_eq!(p.value().unwrap(), "  [aaaa,\n   bbbb]\nafter");
+}
+
+#[test]
+fn block_opened_mid_line_continues_the_line() {
+    let mut p = printer(79);
+    p.text(M, "a").unwrap();
+    let b = Target::Slot(p.block(M, 2).unwrap());
+    assert!(!p.at_line_start(b));
+    p.text(b, "b").unwrap();
+    p.hard_break(b).unwrap();
+    p.text(b, "c").unwrap();
+    p.resolve().unwrap();
+    assert_eq!(p.value().unwrap(), "ab\n  c");
+}
+
+#[test]
+fn line_prefix_precedes_block_and_break_indentation() {
+    let mut p = printer(79);
+    p.line_prefix(M, "> ").unwrap();
+    p.text(M, "a").unwrap();
+    p.hard_break(M).unwrap();
+    let b = Target::Slot(p.block(M, 2).unwrap());
+    p.shift_indent(b, 3).unwrap();
+    p.line_prefix(b, "> ").unwrap();
+    p.text(b, "x").unwrap();
+    p.hard_break(b).unwrap();
+    p.line_prefix(b, "> ").unwrap();
+    p.text(b, "y").unwrap();
+    p.shift_indent(b, -3).unwrap();
+    p.hard_break(b).unwrap();
+    p.resolve().unwrap();
+    assert_eq!(p.value().unwrap(), "> a\n>   x\n>      y\n");
+}
+
+#[test]
+fn line_prefix_counts_toward_the_width() {
+    let mut p = printer(12);
+    p.line_prefix(M, "> ").unwrap();
+    p.begin_group(M, 1, "[").unwrap();
+    p.text(M, "aaaa,").unwrap();
+    p.breakable(M, " ").unwrap();
+    p.text(M, "bbbb").unwrap();
+    p.end_group(M, "]").unwrap();
+    assert_eq!(p.value().unwrap(), "> [aaaa,\n bbbb]");
+}
+
+#[test]
+fn line_prefix_off_a_line_start_is_plain_text() {
+    let mut p = printer(79);
+    p.text(M, "a").unwrap();
+    p.line_prefix(M, "> ").unwrap();
+    p.text(M, "b").unwrap();
+    p.begin_group(M, 1, "[").unwrap();
+    p.text(M, "1").unwrap();
+    p.breakable(M, " ").unwrap();
+    p.line_prefix(M, "> ").unwrap();
+    p.text(M, "2").unwrap();
+    p.end_group(M, "]").unwrap();
+    assert_eq!(p.value().unwrap(), "a> b[1 > 2]");
+}
+
+#[test]
+fn at_line_start_tracks_hard_breaks_shifts_speculation_and_splices() {
+    let mut p = printer(79);
+    assert!(p.at_line_start(M));
+    p.text(M, "a").unwrap();
+    assert!(!p.at_line_start(M));
+    p.hard_break(M).unwrap();
+    assert!(p.at_line_start(M));
+    p.shift_indent(M, 2).unwrap();
+    assert!(p.at_line_start(M));
+    p.begin_speculative(M).unwrap();
+    assert!(p.at_line_start(M));
+    p.text(M, "b").unwrap();
+    assert!(!p.at_line_start(M));
+    p.abort_speculative(M).unwrap();
+    assert!(p.at_line_start(M));
+    p.breakable(M, " ").unwrap();
+    assert!(!p.at_line_start(M));
+    p.hard_break(M).unwrap();
+
+    let slot = Target::Slot(p.deferred(M).unwrap());
+    assert!(p.at_line_start(slot));
+    assert!(p.at_line_start(M));
+    p.text(slot, "c").unwrap();
+    assert!(!p.at_line_start(slot));
+    assert!(!p.at_line_start(M));
+    p.hard_break(slot).unwrap();
+    p.shift_indent(slot, 1).unwrap();
+    assert!(p.at_line_start(slot));
+    assert!(p.at_line_start(M));
+
+    p.text(M, "d").unwrap();
+    let mid_line = Target::Slot(p.deferred(M).unwrap());
+    assert!(!p.at_line_start(mid_line));
+    assert!(!p.at_line_start(M));
+    p.resolve().unwrap();
+    assert_eq!(p.value().unwrap(), "a\n \n  c\n  d");
+}
+
+#[test]
+fn note_line_prefix_applies_to_every_line_and_survives_holding() {
+    let mut p = printer(79);
+    p.note(M, "a\nb", Some("> ")).unwrap();
+    p.begin_speculative(M).unwrap();
+    p.text(M, "let x = ").unwrap();
+    p.note(M, "held", Some("> ")).unwrap();
+    p.text(M, "1;").unwrap();
+    p.hard_break(M).unwrap();
+    p.commit_speculative(M).unwrap();
+    assert_eq!(p.value().unwrap(), "> a\n> b\nlet x = 1;\n> held\n");
+}
+
+#[test]
+fn blank_lines_and_trailing_breaks_keep_their_padding() {
+    let mut p = printer(79);
+    p.shift_indent(M, 2).unwrap();
+    p.text(M, "a").unwrap();
+    p.hard_break(M).unwrap();
+    p.hard_break(M).unwrap();
+    p.text(M, "b").unwrap();
+    p.hard_break(M).unwrap();
+    assert_eq!(p.value().unwrap(), "a\n  \n  b\n  ");
 }

--- a/hegel-c/tests/embedded/native/printer_tests.rs
+++ b/hegel-c/tests/embedded/native/printer_tests.rs
@@ -1061,6 +1061,20 @@ fn held_notes_are_per_target() {
 }
 
 #[test]
+fn note_on_a_slot_killed_by_an_aborted_speculation_errors() {
+    let mut p = printer(79);
+    p.begin_speculative(M).unwrap();
+    let slot = p.deferred(M).unwrap();
+    p.abort_speculative(M).unwrap();
+    assert_eq!(
+        p.note(Target::Slot(slot), "late"),
+        Err(PrinterError::DeadSlot)
+    );
+    p.note(M, "still live").unwrap();
+    assert_eq!(p.value().unwrap(), "still live\n");
+}
+
+#[test]
 fn held_notes_die_when_the_document_is_sealed() {
     let mut p = printer(79);
     p.text(M, "a").unwrap();

--- a/hegel-c/tests/embedded/native/printer_tests.rs
+++ b/hegel-c/tests/embedded/native/printer_tests.rs
@@ -1002,6 +1002,74 @@ fn note_respects_indentation_and_recording() {
     assert_eq!(p.value().unwrap(), "xafter\n  ");
 }
 
+#[test]
+fn note_during_a_speculation_is_held_until_the_commit() {
+    let mut p = printer(79);
+    p.begin_speculative(M).unwrap();
+    p.text(M, "let x = ").unwrap();
+    p.note(M, "from inside").unwrap();
+    p.text(M, "5;").unwrap();
+    p.hard_break(M).unwrap();
+    p.commit_speculative(M).unwrap();
+    assert_eq!(p.value().unwrap(), "let x = 5;\nfrom inside\n");
+}
+
+#[test]
+fn note_during_a_speculation_survives_its_abort() {
+    let mut p = printer(79);
+    p.begin_speculative(M).unwrap();
+    p.text(M, "let x = ").unwrap();
+    p.note(M, "from inside").unwrap();
+    p.abort_speculative(M).unwrap();
+    assert_eq!(p.value().unwrap(), "from inside\n");
+}
+
+#[test]
+fn held_notes_wait_for_the_outermost_speculation() {
+    let mut p = printer(79);
+    p.begin_speculative(M).unwrap();
+    p.text(M, "let x = [").unwrap();
+    p.begin_speculative(M).unwrap();
+    p.text(M, "1").unwrap();
+    p.note(M, "first").unwrap();
+    p.abort_speculative(M).unwrap();
+    p.begin_speculative(M).unwrap();
+    p.text(M, "2").unwrap();
+    p.note(M, "second").unwrap();
+    p.commit_speculative(M).unwrap();
+    p.text(M, "];").unwrap();
+    p.hard_break(M).unwrap();
+    p.commit_speculative(M).unwrap();
+    assert_eq!(p.value().unwrap(), "let x = [2];\nfirst\nsecond\n");
+}
+
+#[test]
+fn held_notes_are_per_target() {
+    let mut p = printer(79);
+    let slot = p.deferred(M).unwrap();
+    let s = Target::Slot(slot);
+    p.begin_speculative(s).unwrap();
+    p.text(s, "a").unwrap();
+    p.note(s, "in slot").unwrap();
+    p.note(M, "on main").unwrap();
+    p.commit_speculative(s).unwrap();
+    p.begin_speculative(s).unwrap();
+    p.note(s, "aborted attempt").unwrap();
+    p.abort_speculative(s).unwrap();
+    p.resolve().unwrap();
+    assert_eq!(p.value().unwrap(), "ain slot\naborted attempt\non main\n");
+}
+
+#[test]
+fn held_notes_die_when_the_document_is_sealed() {
+    let mut p = printer(79);
+    p.text(M, "a").unwrap();
+    p.begin_speculative(M).unwrap();
+    p.note(M, "never lands").unwrap();
+    assert_eq!(p.value().unwrap(), "a");
+    assert_eq!(p.note(M, "late"), Err(PrinterError::DeadSlot));
+}
+
 #[derive(Debug, Clone)]
 enum Op {
     Text(String),

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -5,10 +5,11 @@
 //! to the engine crate. What remains is the small currency the lifecycle
 //! itself speaks: the result of running one test case, and the failure it
 //! carries. `crate::run_lifecycle::run_test_case` builds these from a caught
-//! panic; `crate::test_case::TestCase::mark_complete` translates them into a
-//! `hegel_mark_complete` status (plus, for a failure, its bug origin), and the
-//! richer failure data (panic message, reproduce blob) is read back out of the
-//! run result afterward as a `crate::ffi::Failure`.
+//! panic and its `report_outcome` translates them into a `hegel_mark_complete`
+//! status (plus, for a failure, its bug origin). Nothing here outlives the
+//! test case it classifies: what the engine made of the report — the origin
+//! it grouped the bug under, the reproduce blob — is read back out of the run
+//! result afterward as a `crate::ffi::Failure`.
 
 /// A single failing test case the lifecycle has classified.
 ///

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -414,6 +414,33 @@ impl CTestCase {
         CTestCase { raw }
     }
 
+    /// Open a block on this handle via `hegel_test_case_block`: a new
+    /// libhegel handle onto the *same* choice stream whose print region is
+    /// nested in this handle's at the current position, every line of it
+    /// indented `indent` columns further. This is how a stateful rule body
+    /// or a `repeat` iteration prints under its heading. The block is used
+    /// in place of this handle, never concurrently with it, and is freed
+    /// independently on drop.
+    pub(crate) fn block_handle(&self, indent: u64) -> CTestCase {
+        let mut raw: *mut hegel_c::HegelTestCase = ptr::null_mut();
+        // SAFETY: self.raw is a live handle; &mut raw is a valid out-param.
+        require_ok(with_context(|ctx| unsafe {
+            hegel_c::hegel_test_case_block(ctx, self.raw, indent, &mut raw)
+        }));
+        CTestCase { raw }
+    }
+
+    /// Attribute the lines recorded through this handle — and through the
+    /// blocks and clones derived from it afterwards — to concurrent worker
+    /// `worker_index` (`hegel_test_case_set_worker`): the engine prefixes
+    /// each with `[worker N +X.XXXms] `, stamped when the line is recorded.
+    pub(crate) fn set_worker(&self, worker_index: i64) {
+        // SAFETY: self.raw is a live handle.
+        require_ok(with_context(|ctx| unsafe {
+            hegel_c::hegel_test_case_set_worker(ctx, self.raw, worker_index)
+        }));
+    }
+
     /// Whether this test case belongs to a run already known to be
     /// nondeterministic (`hegel_test_case_is_nondeterministic`). The engine
     /// stamps the case before it starts, so the answer is stable for the
@@ -950,8 +977,10 @@ impl CTestCase {
     }
 
     /// Append a note to this handle's print region (`hegel_note`): whole
-    /// lines, ordered with the handle's drawn values, and held back by the
-    /// engine while a drawn value is mid-print on the region.
+    /// lines, ordered with the handle's drawn values, indented with the
+    /// region's block, prefixed with the handle's worker attribution, and
+    /// held back by the engine while a drawn value is mid-print on the
+    /// region.
     pub(crate) fn note(&self, text: &str) -> Result<(), PrinterCallError> {
         PrinterHandle::check(with_context(|ctx| unsafe {
             hegel_c::hegel_note(ctx, self.raw, text.as_ptr(), text.len())

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -18,6 +18,7 @@ pub(crate) mod sys;
 
 use self::sys as hegel_c;
 
+use crate::control::hegel_internal_error;
 use crate::runner::{Backend, Database, HealthCheck, Phase, Settings, Verbosity};
 use crate::test_case::OutputSink;
 use hegel_c::hegel_result_t;
@@ -948,6 +949,15 @@ impl CTestCase {
         PrinterHandle { raw }
     }
 
+    /// Append a note to this handle's print region (`hegel_note`): whole
+    /// lines, ordered with the handle's drawn values, and held back by the
+    /// engine while a drawn value is mid-print on the region.
+    pub(crate) fn note(&self, text: &str) -> Result<(), PrinterCallError> {
+        PrinterHandle::check(with_context(|ctx| unsafe {
+            hegel_c::hegel_note(ctx, self.raw, text.as_ptr(), text.len())
+        }))
+    }
+
     /// Report the test case's outcome. `origin` is supplied only for an
     /// interesting (failing) status; libhegel ignores it otherwise.
     pub(crate) fn mark_complete(
@@ -1283,6 +1293,17 @@ impl PrinterHandle {
         }
     }
 
+    /// Whether this handle's region can still be written to: `false` once
+    /// the document has been read, or — for a deferred slot — once the
+    /// speculative region its anchor sat inside was aborted.
+    pub(crate) fn is_live(&self) -> bool {
+        let mut live = false;
+        require_ok(with_context(|ctx| unsafe {
+            hegel_c::hegel_printer_is_live(ctx, self.raw, &mut live)
+        }));
+        live
+    }
+
     /// Emit literal text. Must not contain newlines.
     pub(crate) fn text(&self, s: &str) -> Result<(), PrinterCallError> {
         Self::check(with_context(|ctx| unsafe {
@@ -1445,24 +1466,29 @@ impl RunResult {
 
     /// The `index`-th distinct failure; `index` must be less than
     /// [`failure_count`](Self::failure_count) (libhegel rejects an
-    /// out-of-range index). The blob is copied out and the libhegel failure
-    /// snapshot released before returning.
+    /// out-of-range index). The strings are copied out and the libhegel
+    /// failure snapshot released before returning.
     pub(crate) fn failure(&self, index: usize) -> Failure {
         let mut f: *mut hegel_c::HegelFailure = ptr::null_mut();
         // SAFETY: self.raw is this snapshot's live pointer; &mut f is valid.
         require_ok(with_context(|ctx| unsafe {
             hegel_c::hegel_run_result_failure(ctx, self.raw, index, &mut f)
         }));
+        let mut origin: *const c_char = ptr::null();
         let mut blob: *const c_char = ptr::null();
         // SAFETY: f is the failure snapshot allocated above; it is freed
-        // exactly once, after the blob has been copied out by cstr_opt.
-        let reproduce_blob = with_context(|ctx| unsafe {
+        // exactly once, after both strings have been copied out by cstr_opt.
+        with_context(|ctx| unsafe {
+            require_ok(hegel_c::hegel_failure_origin(ctx, f, &mut origin));
             require_ok(hegel_c::hegel_failure_reproduction_blob(ctx, f, &mut blob));
-            let reproduce_blob = cstr_opt(blob);
+            let failure = Failure {
+                origin: cstr_opt(origin)
+                    .unwrap_or_else(|| hegel_internal_error!("failure {index} has no origin")),
+                reproduce_blob: cstr_opt(blob),
+            };
             require_ok(hegel_c::hegel_failure_free(ctx, f));
-            reproduce_blob
-        });
-        Failure { reproduce_blob }
+            failure
+        })
     }
 }
 
@@ -1473,11 +1499,13 @@ impl Drop for RunResult {
     }
 }
 
-/// A distinct failure read out of a finished run.
-///
-/// The client needs only the reproduce blob: it replays the blob to produce
-/// the diagnostic and re-raise the test's own panic.
+/// A distinct failure read out of a finished run: the origin the engine
+/// grouped the bug's test cases under (the string the frontend passed to
+/// `hegel_mark_complete` when it first reported the bug) and the reproduce
+/// blob the client replays to produce the diagnostic and re-raise the
+/// test's own panic.
 pub(crate) struct Failure {
+    pub(crate) origin: String,
     pub(crate) reproduce_blob: Option<String>,
 }
 

--- a/src/ffi/sys/fns.rs
+++ b/src/ffi/sys/fns.rs
@@ -104,11 +104,13 @@ macro_rules! for_each_hegel_fn {
             fn hegel_string_generator_text(ctx: *mut HegelContext, min_size: u64, max_size: u64, codec: *const c_char, min_codepoint: u32, max_codepoint: u32, categories: *const *const c_char, categories_len: usize, exclude_categories: *const *const c_char, exclude_categories_len: usize, include_characters: *const u8, include_characters_len: usize, exclude_characters: *const u8, exclude_characters_len: usize, out_generator: *mut *mut HegelStringGenerator) -> hegel_result_t;
             fn hegel_string_generator_url(ctx: *mut HegelContext, out_generator: *mut *mut HegelStringGenerator) -> hegel_result_t;
             fn hegel_target(ctx: *mut HegelContext, tc: *mut HegelTestCase, value: f64, label: *const c_char) -> hegel_result_t;
+            fn hegel_test_case_block(ctx: *mut HegelContext, tc: *const HegelTestCase, indent: u64, out_test_case: *mut *mut HegelTestCase) -> hegel_result_t;
             fn hegel_test_case_clone(ctx: *mut HegelContext, tc: *const HegelTestCase, out_test_case: *mut *mut HegelTestCase) -> hegel_result_t;
             fn hegel_test_case_free(ctx: *mut HegelContext, tc: *mut HegelTestCase) -> hegel_result_t;
             fn hegel_test_case_from_blob(ctx: *mut HegelContext, s: *const HegelSettings, blob: *const c_char, callback: hegel_output_callback_t, user_data: *mut c_void, out_test_case: *mut *mut HegelTestCase) -> hegel_result_t;
             fn hegel_test_case_is_nondeterministic(ctx: *mut HegelContext, tc: *const HegelTestCase, out_is_nondeterministic: *mut bool) -> hegel_result_t;
             fn hegel_test_case_printer(ctx: *mut HegelContext, tc: *mut HegelTestCase, options: *const HegelPrinterOptions, out_printer: *mut *mut HegelPrinter) -> hegel_result_t;
+            fn hegel_test_case_set_worker(ctx: *mut HegelContext, tc: *const HegelTestCase, worker_index: i64) -> hegel_result_t;
             fn hegel_version(ctx: *mut HegelContext, out_version: *mut *const c_char) -> hegel_result_t;
         }
     };

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -204,7 +204,7 @@ use std::marker::PhantomData;
 /// after the document was read, or into a region whose anchor was retracted
 /// — is a silent no-op, so a writer that outlives its document never brings
 /// the process down.
-fn tolerate(result: Result<(), PrinterCallError>) {
+pub(crate) fn tolerate(result: Result<(), PrinterCallError>) {
     match result {
         Ok(()) | Err(PrinterCallError::DeadRegion) => {}
         Err(PrinterCallError::Other(message)) => panic!("{message}"),
@@ -348,11 +348,12 @@ impl PrettyPrinter {
     }
 
     /// Whether printing to this printer produces output: `false` for the
-    /// discarding printer returned by [`noop`](PrettyPrinter::noop). Use it
-    /// to skip work — formatting a value, say — whose only purpose is to be
-    /// printed.
+    /// discarding printer returned by [`noop`](PrettyPrinter::noop), and for
+    /// a printer whose region has died (see [`Clone`](PrettyPrinter#impl-Clone-for-PrettyPrinter)),
+    /// whose writes are discarded. Use it to skip work — formatting a value,
+    /// say — whose only purpose is to be printed.
     pub fn should_print(&self) -> bool {
-        self.handle.is_some()
+        self.handle.as_ref().is_some_and(PrinterHandle::is_live)
     }
 
     /// Wrap an existing engine printer handle (e.g. a test case's shared

--- a/src/run_lifecycle.rs
+++ b/src/run_lifecycle.rs
@@ -302,7 +302,7 @@ pub(crate) fn run_test_case(
         should_emit,
         case_sink.or_else(|| output.sink().cloned()),
     );
-    let reporter = tc.child(0);
+    let reporter = tc.reporter();
     let result = with_test_context(|| catch_unwind(AssertUnwindSafe(|| test_fn(tc))));
     reporter.emit_rendered_output();
 

--- a/src/run_lifecycle.rs
+++ b/src/run_lifecycle.rs
@@ -591,8 +591,8 @@ pub(crate) fn drive<F>(
                 if multiple && !quiet {
                     output.line("");
                 }
-                let blob = result
-                    .failure(index)
+                let failure = result.failure(index);
+                let blob = failure
                     .reproduce_blob
                     .unwrap_or_else(|| hegel_internal_error!("failure {index} has no blob"));
                 let c_tc = match CTestCase::from_blob(&c_settings, &blob, output.sink()) {
@@ -602,7 +602,10 @@ pub(crate) fn drive<F>(
                 let (tc_result, payload, diagnostic) =
                     run_test_case(c_tc, &mut test_fn, true, verbosity, &output, None);
                 if !matches!(tc_result, TestCaseResult::Interesting(_)) {
-                    panic!("{FLAKY_DIAGNOSTIC}");
+                    panic!(
+                        "{FLAKY_DIAGNOSTIC}\nThe failure that did not reproduce was: {}",
+                        failure.origin
+                    );
                 }
                 if let Some(diagnostic) = diagnostic {
                     output.block(&diagnostic);

--- a/src/stateful.rs
+++ b/src/stateful.rs
@@ -151,7 +151,7 @@ use crate::ffi::{PoolHandle, StateMachineHandle};
 use crate::generators::Generator;
 use crate::run_lifecycle::{self, PanicInfo};
 use crate::test_case::{labels, raise_for_rc};
-use std::cell::{Cell, RefCell};
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
 use std::sync::{Mutex, mpsc};
@@ -163,21 +163,6 @@ use std::sync::{Mutex, mpsc};
 /// overlap with any named group's rules (see
 /// [`ConcurrentStateMachine`]).
 pub const ANONYMOUS_GROUP: &str = "<anonymous>";
-
-thread_local! {
-    /// The worker-thread index [`run_concurrent`] assigns to each of its
-    /// worker threads, used to tag that worker's draw/note output lines.
-    /// `None` outside a concurrent stateful worker.
-    static WORKER_INDEX: Cell<Option<usize>> = const { Cell::new(None) };
-}
-
-/// The calling thread's concurrent-worker index, if it is one of
-/// [`run_concurrent`]'s worker threads. Read by the output machinery to tag
-/// each worker line with its worker's index and time offset, and to regroup
-/// the failure report's buffered lines worker by worker within each round.
-pub(crate) fn current_worker_index() -> Option<usize> {
-    WORKER_INDEX.with(|cell| cell.get())
-}
 
 /// A rule that can be applied to the state machine during testing.
 pub struct Rule<M: ?Sized> {
@@ -969,7 +954,8 @@ fn run_worker_round<M: ConcurrentStateMachine + ?Sized>(
 /// round lands — is anchored under the header that labels the round.
 /// Cloning once per worker up front would instead pool a worker's output
 /// across all rounds at its single anchor, detaching the headers from the
-/// rounds they label.
+/// rounds they label. The clone is attributed to this worker, so the engine
+/// stamps each of its lines `[worker N +X.XXXms] `.
 ///
 /// The closed channel is what terminates workers: the main thread holds
 /// the senders as locals of its `thread::scope` body, so *any* exit from
@@ -986,7 +972,6 @@ fn worker_loop<M: ConcurrentStateMachine + ?Sized>(
     rounds: mpsc::Receiver<TestCase>,
     events: mpsc::Sender<WorkerEvent>,
 ) {
-    WORKER_INDEX.with(|cell| cell.set(Some(worker)));
     run_lifecycle::set_backtrace_capture(capture_backtraces);
     with_test_context(|| {
         while let Ok(tc) = rounds.recv() {
@@ -1146,8 +1131,10 @@ pub fn run_concurrent<M: ConcurrentStateMachine + Sync>(
                 group_names[group]
             ));
 
-            for tx in &round_txs {
-                let _ = tx.send(tc.clone());
+            for (worker, tx) in round_txs.iter().enumerate() {
+                let worker_tc = tc.clone();
+                worker_tc.with_ctc(|ctc| ctc.set_worker(worker as i64));
+                let _ = tx.send(worker_tc);
             }
             let events: Vec<WorkerEvent> = event_rxs
                 .iter()

--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -110,10 +110,6 @@ pub(crate) struct TestCaseGlobalData {
     /// [`TestCase::record_named_draw`] (display-name allocation + `Debug`
     /// rendering of the value) can be skipped entirely.
     emit: bool,
-    /// When this test case started, shared by every clone so the
-    /// `[worker N +X.XXXms]` offsets stamped on concurrent workers' output
-    /// lines are comparable across workers.
-    case_start: std::time::Instant,
 }
 
 /// The width drawn-value documents are laid out to.
@@ -160,7 +156,6 @@ pub(crate) struct TestCaseLocalData {
     /// Printed draws currently in progress on this instance (see
     /// [`PrintingDrawScope`]).
     printing_depth: usize,
-    indent: usize,
     on_draw: OutputSink,
 }
 
@@ -245,15 +240,18 @@ pub struct TestCase {
     global: Arc<TestCaseGlobalData>,
     local: RefCell<TestCaseLocalData>,
     /// This instance's libhegel handle, shared through the `Arc` with the
-    /// lifecycle that created it and with any [`child`](TestCase::child)
-    /// instances, so a `TestCase` that escapes its test (moved to a thread
-    /// that is never joined) keeps the handle alive rather than dangling —
-    /// its later draws fail cleanly because the case has finished.
-    /// [`clone`](TestCase::clone) instead gets a fresh handle
+    /// lifecycle that created it, so a `TestCase` that escapes its test
+    /// (moved to a thread that is never joined) keeps the handle alive
+    /// rather than dangling — its later draws fail cleanly because the case
+    /// has finished. A [`child`](TestCase::child) gets a block handle
+    /// (`hegel_test_case_block`) onto the same choice stream with its own
+    /// indented print region; [`clone`](TestCase::clone) gets a fresh handle
     /// (`hegel_test_case_clone`) onto an independent stream of the same
     /// test case, so two clones can be driven from different threads
-    /// concurrently without perturbing each other's values.
-    handle: Arc<CTestCase>,
+    /// concurrently without perturbing each other's values. The cell is for
+    /// [`repeat`](TestCase::repeat), which prints each iteration's body
+    /// through a block handle of its own and restores this one after.
+    handle: RefCell<Arc<CTestCase>>,
     /// This instance's printer onto its own region of the family document,
     /// fetched on first use. The engine anchors a clone's region when the
     /// clone is made, so where this instance's output appears is fixed even
@@ -277,7 +275,7 @@ impl Clone for TestCase {
         TestCase {
             global: self.global.clone(),
             local: RefCell::new(self.local.borrow().clone()),
-            handle: Arc::new(self.handle.clone_handle()),
+            handle: RefCell::new(Arc::new(self.handle.borrow().clone_handle())),
             printer: RefCell::new(None),
             draw_state: Arc::clone(&self.draw_state),
         }
@@ -287,6 +285,42 @@ impl Clone for TestCase {
 impl std::fmt::Debug for TestCase {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TestCase").finish_non_exhaustive()
+    }
+}
+
+/// What the run lifecycle keeps of a [`TestCase`] it has handed to the test
+/// body: enough to render the document of drawn values and notes — the root
+/// region and every region forked from it — once the body has finished,
+/// successfully or not.
+pub(crate) struct OutputReporter {
+    emit: bool,
+    handle: Arc<CTestCase>,
+    sink: OutputSink,
+}
+
+impl OutputReporter {
+    /// Render the document and push it, line by line, through the output
+    /// sink. A straggling clone still writing on an unjoined thread loses
+    /// its uncommitted draw and its region dies; its later writes are
+    /// harmless no-ops.
+    pub(crate) fn emit_rendered_output(&self) {
+        if !self.emit {
+            return;
+        }
+        let output = PrettyPrinter::from_handle(self.handle.printer(PRINTER_MAX_WIDTH)).try_value();
+        match output {
+            Ok(output) => {
+                for line in output.lines() {
+                    (self.sink)(line);
+                }
+            }
+            Err(message) => (self.sink)(&format!(
+                "Failed to render this test case's drawn values ({message}). This \
+                 indicates a bug in printing code the test uses: check any \
+                 hand-written PrettyPrintable impl or print_with closure for \
+                 unbalanced begin_group/end_group calls."
+            )),
+        }
     }
 }
 
@@ -411,17 +445,13 @@ impl TestCase {
             Arc::new(|_| {})
         };
         TestCase {
-            global: Arc::new(TestCaseGlobalData {
-                emit,
-                case_start: std::time::Instant::now(),
-            }),
+            global: Arc::new(TestCaseGlobalData { emit }),
             local: RefCell::new(TestCaseLocalData {
                 span_depth: 0,
                 printing_depth: 0,
-                indent: 0,
                 on_draw,
             }),
-            handle,
+            handle: RefCell::new(handle),
             printer: RefCell::new(None),
             draw_state: Arc::new(Mutex::new(DrawState::default())),
         }
@@ -518,19 +548,13 @@ impl TestCase {
         let Some(display_name) = self.allocate_display_name(name, repeatable) else {
             return generator.do_draw(self);
         };
-        let indent = self.local.borrow().indent;
-        let prefix = self.worker_line_prefix();
         let _printing = PrintingDrawScope::new(self);
         self.with_printer(|printer| {
             let mut speculation = printer.speculate();
             let printer = speculation.printer();
-            printer.text(&prefix);
-            printer.text(&" ".repeat(indent));
-            printer.shift_indent(indent as isize);
             printer.text(&format!("let {display_name} = "));
             let value = self.draw_and_print(&generator, printer);
             printer.text(";");
-            printer.shift_indent(-(indent as isize));
             printer.hard_break();
             speculation.commit();
             value
@@ -632,13 +656,7 @@ impl TestCase {
         if !self.global.emit {
             return;
         }
-        let pad = " ".repeat(self.local.borrow().indent);
-        let prefix = self.worker_line_prefix();
-        let text = format!(
-            "{prefix}{pad}{}",
-            message.replace('\n', &format!("\n{pad}"))
-        );
-        tolerate(self.with_ctc(|ctc| ctc.note(&text)));
+        tolerate(self.with_ctc(|ctc| ctc.note(message)));
     }
 
     /// Record a targeting observation to help the engine find extreme inputs.
@@ -784,10 +802,9 @@ impl TestCase {
             iteration += 1;
             self.note(&format!("// Repetition #{}", iteration));
 
-            let prev_indent = self.local.borrow().indent;
-            self.local.borrow_mut().indent = prev_indent + 2;
+            let outer = self.enter_block(2);
             let result = catch_unwind(AssertUnwindSafe(&mut body));
-            self.local.borrow_mut().indent = prev_indent;
+            self.restore_handle(outer);
 
             match result {
                 Ok(()) => {}
@@ -809,20 +826,42 @@ impl TestCase {
         raise_control(LoopDone);
     }
 
+    /// An instance for an indented section of this one's output — a
+    /// stateful rule or invariant body under its heading. It draws from the
+    /// same choice stream through a block handle whose print region is
+    /// nested in this instance's at the current position, every line of it
+    /// `extra_indent` columns further in, and opens a fresh draw-naming
+    /// scope.
     pub(crate) fn child(&self, extra_indent: usize) -> Self {
         let local = self.local.borrow();
+        let block = self.handle.borrow().block_handle(extra_indent as u64);
         TestCase {
             global: self.global.clone(),
             local: RefCell::new(TestCaseLocalData {
                 span_depth: 0,
                 printing_depth: 0,
-                indent: local.indent + extra_indent,
                 on_draw: local.on_draw.clone(),
             }),
-            handle: Arc::clone(&self.handle),
+            handle: RefCell::new(Arc::new(block)),
             printer: RefCell::new(None),
             draw_state: Arc::new(Mutex::new(DrawState::default())),
         }
+    }
+
+    /// Switch this instance onto a block handle nested `indent` columns in
+    /// from its current region, returning the handle to hand back to
+    /// [`restore_handle`](Self::restore_handle) afterwards. Lines printed in
+    /// between land in the block.
+    fn enter_block(&self, indent: usize) -> Arc<CTestCase> {
+        let block = Arc::new(self.handle.borrow().block_handle(indent as u64));
+        self.restore_handle(block)
+    }
+
+    /// Make `handle` this instance's handle again, returning the one it
+    /// replaces. The cached printer is dropped: it was onto the old region.
+    fn restore_handle(&self, handle: Arc<CTestCase>) -> Arc<CTestCase> {
+        *self.printer.borrow_mut() = None;
+        std::mem::replace(&mut *self.handle.borrow_mut(), handle)
     }
 
     /// Run `f` with this instance's printer onto its own region of the
@@ -837,46 +876,13 @@ impl TestCase {
         f(printer)
     }
 
-    /// The `[worker N +X.XXXms] ` attribution for output written from a
-    /// concurrent stateful worker thread, empty elsewhere. Computed when a
-    /// line is recorded — on the worker's own thread, against the case-wide
-    /// start time — so attribution and timing survive into the document
-    /// rendered after the case completes.
-    fn worker_line_prefix(&self) -> String {
-        match crate::stateful::current_worker_index() {
-            Some(worker) => {
-                let ms = self.global.case_start.elapsed().as_secs_f64() * 1000.0;
-                format!("[worker {worker} +{ms:.3}ms] ")
-            }
-            None => String::new(),
-        }
-    }
-
-    /// Render the document of drawn values and notes accumulated so far —
-    /// this instance's region and every region forked from it — and push it,
-    /// line by line, through the output sink. Called by the run lifecycle,
-    /// on the root instance, once the test body has finished (successfully
-    /// or not). A straggling clone still writing on an unjoined thread loses
-    /// its uncommitted draw and its region dies; its later writes are
-    /// harmless no-ops.
-    pub(crate) fn emit_rendered_output(&self) {
-        if !self.global.emit {
-            return;
-        }
-        let output = self.with_printer(|printer| printer.try_value());
-        let local = self.local.borrow();
-        match output {
-            Ok(output) => {
-                for line in output.lines() {
-                    (local.on_draw)(line);
-                }
-            }
-            Err(message) => (local.on_draw)(&format!(
-                "Failed to render this test case's drawn values ({message}). This \
-                 indicates a bug in printing code the test uses: check any \
-                 hand-written PrettyPrintable impl or print_with closure for \
-                 unbalanced begin_group/end_group calls."
-            )),
+    /// The reporter that renders this instance's document once the test
+    /// body — which takes the instance itself — has finished.
+    pub(crate) fn reporter(&self) -> OutputReporter {
+        OutputReporter {
+            emit: self.global.emit,
+            handle: Arc::clone(&self.handle.borrow()),
+            sink: self.local.borrow().on_draw.clone(),
         }
     }
 
@@ -951,7 +957,8 @@ impl TestCase {
     /// itself (returning `HEGEL_E_CONCURRENT_USE`), and clones each carry their
     /// own handle and lock.
     pub(crate) fn with_ctc<R>(&self, f: impl FnOnce(&CTestCase) -> R) -> R {
-        f(&self.handle)
+        let handle = Arc::clone(&self.handle.borrow());
+        f(&handle)
     }
 
     /// The number of currently-open spans on this instance. Lets a generator

--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -5,7 +5,7 @@ use crate::control::{
 use crate::ffi::CTestCase;
 use crate::ffi::sys as hegel_c;
 use crate::generators::{Generator, PrintableGenerator};
-use crate::pretty::PrettyPrinter;
+use crate::pretty::{PrettyPrinter, tolerate};
 use parking_lot::Mutex;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
@@ -120,15 +120,14 @@ pub(crate) struct TestCaseGlobalData {
 const PRINTER_MAX_WIDTH: u64 = crate::pretty::DEFAULT_MAX_WIDTH;
 
 /// Marks a printed draw as in progress: `printing_depth` is raised for the
-/// duration of the enclosing `draw_and_print` call so that a `tc.note()` or
-/// nested `tc.draw` made by a hand-written generator body behaves exactly as
-/// it does inside a combinator span — the note buffers, the nested draw
-/// stays silent — instead of re-entering the printer lock the enclosing draw
-/// already holds. Dropping the scope restores the depth and flushes the
-/// buffered notes, so they land right after their draw's line even when the
-/// draw unwinds (a failed assumption, a budget stop). This scope is the only
-/// thing that defers a note: outside it, notes and draw lines write to the
-/// instance's print region directly, in call order.
+/// duration of the enclosing `draw_and_print` call so that a nested
+/// `tc.draw` made by a hand-written generator body stays silent, exactly as
+/// it does inside a combinator span, instead of re-entering the printer the
+/// enclosing draw is already writing its line through. A `tc.note()` made
+/// during the draw needs no frontend bookkeeping: the engine holds a note
+/// appended while the region's speculative draw is open and appends it once
+/// the draw's line is done — whether the draw commits or unwinds (a failed
+/// assumption, a budget stop).
 struct PrintingDrawScope<'a> {
     tc: &'a TestCase,
 }
@@ -143,20 +142,7 @@ impl<'a> PrintingDrawScope<'a> {
 impl Drop for PrintingDrawScope<'_> {
     fn drop(&mut self) {
         self.tc.local.borrow_mut().printing_depth -= 1;
-        self.tc.flush_pending_notes();
     }
-}
-
-/// Emit one note line: the worker attribution `prefix` (empty outside
-/// concurrent workers), an indent prefix, the message (with any embedded
-/// newlines breaking at the note's indentation), and a closing line break.
-fn emit_note_line(printer: &mut PrettyPrinter, prefix: &str, indent: usize, message: &str) {
-    printer.text(prefix);
-    printer.text(&" ".repeat(indent));
-    printer.shift_indent(indent as isize);
-    printer.text(message);
-    printer.shift_indent(-(indent as isize));
-    printer.hard_break();
 }
 
 #[derive(Default)]
@@ -169,8 +155,7 @@ pub(crate) struct DrawState {
 #[derive(Clone)]
 pub(crate) struct TestCaseLocalData {
     /// Engine spans currently open on this instance (`start_span` without a
-    /// matching `stop_span`). It silences nested named draws and never
-    /// defers notes, which is `printing_depth`'s job.
+    /// matching `stop_span`). It silences nested named draws.
     span_depth: usize,
     /// Printed draws currently in progress on this instance (see
     /// [`PrintingDrawScope`]).
@@ -277,15 +262,6 @@ pub struct TestCase {
     /// clones write concurrently, and the document assembles deterministically
     /// by anchor position.
     printer: RefCell<Option<PrettyPrinter>>,
-    /// Notes recorded while this instance was printing a draw
-    /// (`printing_depth > 0`, e.g. from inside a composite body). Emitting
-    /// them inline would splice text into the middle of the draw's
-    /// `let … = …;` line, so they are buffered here and flushed, in order,
-    /// by the [`PrintingDrawScope`] that deferred them once the draw's line
-    /// is done. A note can only buffer during a printed draw on this same
-    /// instance, so the buffer is instance-local and no other instance can
-    /// flush this one's notes into its own region out of order.
-    pending_notes: RefCell<Vec<(String, usize, String)>>,
     /// Draw-name bookkeeping for this instance's naming scope, behind a
     /// blocking, non-reentrant mutex that only serialises the frontend's own
     /// accounting (no method holds it while calling back into `TestCase`).
@@ -303,7 +279,6 @@ impl Clone for TestCase {
             local: RefCell::new(self.local.borrow().clone()),
             handle: Arc::new(self.handle.clone_handle()),
             printer: RefCell::new(None),
-            pending_notes: RefCell::new(Vec::new()),
             draw_state: Arc::clone(&self.draw_state),
         }
     }
@@ -448,7 +423,6 @@ impl TestCase {
             }),
             handle,
             printer: RefCell::new(None),
-            pending_notes: RefCell::new(Vec::new()),
             draw_state: Arc::new(Mutex::new(DrawState::default())),
         }
     }
@@ -658,18 +632,13 @@ impl TestCase {
         if !self.global.emit {
             return;
         }
-        let (indent, mid_draw) = {
-            let local = self.local.borrow();
-            (local.indent, local.printing_depth > 0)
-        };
+        let pad = " ".repeat(self.local.borrow().indent);
         let prefix = self.worker_line_prefix();
-        if mid_draw {
-            self.pending_notes
-                .borrow_mut()
-                .push((prefix, indent, message.to_string()));
-        } else {
-            self.with_printer(|printer| emit_note_line(printer, &prefix, indent, message));
-        }
+        let text = format!(
+            "{prefix}{pad}{}",
+            message.replace('\n', &format!("\n{pad}"))
+        );
+        tolerate(self.with_ctc(|ctc| ctc.note(&text)));
     }
 
     /// Record a targeting observation to help the engine find extreme inputs.
@@ -852,7 +821,6 @@ impl TestCase {
             }),
             handle: Arc::clone(&self.handle),
             printer: RefCell::new(None),
-            pending_notes: RefCell::new(Vec::new()),
             draw_state: Arc::new(Mutex::new(DrawState::default())),
         }
     }
@@ -882,20 +850,6 @@ impl TestCase {
             }
             None => String::new(),
         }
-    }
-
-    /// Emit any notes recorded while a draw was in progress on this
-    /// instance.
-    fn flush_pending_notes(&self) {
-        let notes = std::mem::take(&mut *self.pending_notes.borrow_mut());
-        if notes.is_empty() {
-            return;
-        }
-        self.with_printer(|printer| {
-            for (prefix, indent, message) in &notes {
-                emit_note_line(printer, prefix, *indent, message);
-            }
-        });
     }
 
     /// Render the document of drawn values and notes accumulated so far —

--- a/tests/embedded/ffi_tests.rs
+++ b/tests/embedded/ffi_tests.rs
@@ -218,8 +218,12 @@ fn ffi_reports_failure_with_blob_then_replays_it() {
     let result = run.result();
     assert!(result.status() == hegel_c::hegel_run_status_t::HEGEL_RUN_STATUS_FAILED);
     assert_eq!(result.failure_count(), 1);
-    let blob = result
-        .failure(0)
+    let failure = result.failure(0);
+    assert_eq!(
+        failure.origin, origin,
+        "the engine reports the origin the failure was marked complete with"
+    );
+    let blob = failure
         .reproduce_blob
         .expect("a shrunk failure carries a blob");
 

--- a/tests/embedded/stateful_tests.rs
+++ b/tests/embedded/stateful_tests.rs
@@ -75,7 +75,7 @@ fn note_panic_trailer_notes_real_panics_and_skips_control_unwinds() {
     note_panic_trailer(&tc, assume.as_ref(), "unwanted");
     note_panic_trailer(&tc, stop.as_ref(), "unwanted");
     note_panic_trailer(&tc, string_panic("boom").as_ref(), "Invariant x failed:");
-    tc.emit_rendered_output();
+    tc.reporter().emit_rendered_output();
     assert_eq!(*lines.lock().unwrap(), vec!["Invariant x failed:"]);
 }
 
@@ -83,7 +83,7 @@ fn note_panic_trailer_notes_real_panics_and_skips_control_unwinds() {
 fn resolve_round_with_all_workers_done_returns_normally() {
     let (_run, tc, lines) = capturing_test_case();
     resolve_round(vec![WorkerEvent::RoundDone, WorkerEvent::RoundDone], &tc);
-    tc.emit_rendered_output();
+    tc.reporter().emit_rendered_output();
     assert!(lines.lock().unwrap().is_empty());
 }
 
@@ -109,7 +109,7 @@ fn resolve_round_overrun_wins_over_panic_and_notes_the_dropped_panic() {
     ];
     let payload = resolve_round_unwind(events, &tc);
     assert!(payload.downcast_ref::<StopTest>().is_some());
-    tc.emit_rendered_output();
+    tc.reporter().emit_rendered_output();
     let lines = lines.lock().unwrap();
     assert_eq!(lines.len(), 1);
     assert!(
@@ -124,7 +124,7 @@ fn resolve_round_invalid_wins_over_panic_and_raises_assume_failed() {
     let events = vec![WorkerEvent::Invalid, panicked_event("induced panic", None)];
     let payload = resolve_round_unwind(events, &tc);
     assert!(payload.downcast_ref::<AssumeFailed>().is_some());
-    tc.emit_rendered_output();
+    tc.reporter().emit_rendered_output();
     assert_eq!(lines.lock().unwrap().len(), 1);
 }
 
@@ -142,7 +142,7 @@ fn resolve_round_lowest_worker_index_panic_wins_and_losers_are_noted() {
     let (thread_name, _, location, _) = run_lifecycle::take_panic_info().unwrap();
     assert_eq!(thread_name, "worker-thread");
     assert_eq!(location, "winner.rs:1:1");
-    tc.emit_rendered_output();
+    tc.reporter().emit_rendered_output();
     let lines = lines.lock().unwrap();
     assert_eq!(lines.len(), 1);
     assert!(
@@ -232,7 +232,7 @@ fn run_worker_round_executes_the_rounds_rule_and_finishes() {
     let event = with_test_context(|| run_worker_round(0, &tc, &m, &rules, &machine));
     assert!(matches!(event, WorkerEvent::RoundDone));
     assert_eq!(m.hits.load(Ordering::SeqCst), 1);
-    tc.emit_rendered_output();
+    tc.reporter().emit_rendered_output();
     assert!(
         lines
             .lock()
@@ -261,7 +261,7 @@ fn run_worker_round_ferries_a_rule_panic_with_its_capture() {
     assert_eq!(run_lifecycle::panic_message(&payload), "rule boom");
     let (_, _, location, _) = info.unwrap();
     assert!(location.contains("stateful_tests.rs"), "{location}");
-    tc.emit_rendered_output();
+    tc.reporter().emit_rendered_output();
     assert!(
         lines
             .lock()

--- a/tests/test_flaky_replay.rs
+++ b/tests/test_flaky_replay.rs
@@ -36,4 +36,9 @@ fn replay_of_a_vanishing_failure_is_reported_as_flaky() {
         .or_else(|| panic.downcast_ref::<&str>().copied())
         .unwrap_or("");
     assert!(msg.contains("Flaky test detected"), "got: {msg:?}");
+    assert!(
+        msg.contains("The failure that did not reproduce was: Panic at "),
+        "the diagnostic names the failure the engine recorded, got: {msg:?}"
+    );
+    assert!(msg.contains("test_flaky_replay.rs"), "got: {msg:?}");
 }

--- a/tests/test_pretty.rs
+++ b/tests/test_pretty.rs
@@ -547,6 +547,16 @@ fn printers_move_between_threads() {
 }
 
 #[test]
+fn a_clone_stops_printing_once_its_document_is_read() {
+    let mut doc = Document::new();
+    let mut child = doc.printer().clone();
+    assert!(child.should_print());
+    doc.finish();
+    assert!(!child.should_print());
+    child.text("ignored");
+}
+
+#[test]
 fn cloning_a_dead_region_yields_a_noop_printer() {
     let mut doc = Document::new();
     let child = doc.printer().clone();


### PR DESCRIPTION
<details>
<summary>This description was written by an AI agent (Claude, via Andon).</summary>

`libhegel` exports `hegel_note`, `hegel_printer_is_live` and `hegel_failure_origin` for bindings to use, but the reference frontend never called them (found via the `for_each_hegel_fn!` gap on #476).

**`hegel_note`.** `TestCase::note` assembled note lines from `hegel_printer_*` primitives and deferred notes made mid-draw itself (`pending_notes`, `flush_pending_notes`, `emit_note_line`, `PrintingDrawScope` flush). `hegel_note` could not express that: a note appended while a drawn value's speculative region is open was spliced into the value's line. The engine now holds such a note per target and appends it once the outermost speculative region on that target closes, committed or aborted (`hegel-c/src/native/printer.rs`; C ABI docs and header updated). The frontend's note is now the worker prefix + block indentation + text handed to `hegel_note`; output is unchanged (all snapshot/stateful/loop/concurrent tests pass). One latent frontend bug goes away: the per-instance buffer did not hold a note from a `child()` instance sharing a target with an instance that was mid-draw; the engine's per-target hold does.

**`hegel_printer_is_live`.** `PrettyPrinter::should_print` consults it, so a clone whose region died (its document was read) reports `false` and callers skip formatting work whose output would be discarded.

**`hegel_failure_origin`.** `RunResult::failure` reads the origin back alongside the blob. It is used in the flaky-replay diagnostic, which now names the failure that did not reproduce (e.g. `Panic at src/lib.rs:12:5`).

Engine exports still absent from `for_each_hegel_fn!` after this: `hegel_printer_if_break` (no Rust counterpart) and `hegel_version` (resolved by hand in the loader for the version check).

Release notes: `hegel-c/RELEASE.md` (patch: the `hegel_note` behaviour change) and `RELEASE.md` (patch: flaky diagnostic, `should_print`).

Not done here, left as open questions: whether block indentation / worker line prefixes should become engine-side region concepts rather than text the frontend bakes into each note, and whether a final replay that fails with a *different* origin than the engine recorded should be reported as flaky (Hypothesis does).
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)