### PR TITLE
Make the C-example and coverage scripts honour the cargo target directory

### DIFF
--- a/hegel-c/tests/smoke.rs
+++ b/hegel-c/tests/smoke.rs
@@ -44,8 +44,14 @@ fn lib_path() -> PathBuf {
             }
         }
     }
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let target_dir = manifest_dir.parent().unwrap().join("target");
+    let target_dir = std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .unwrap()
+                .join("target")
+        });
     for profile in ["debug", "release"] {
         let candidate = target_dir.join(profile).join(filename);
         if candidate.exists() {

--- a/justfile
+++ b/justfile
@@ -101,7 +101,6 @@ c-test-smoke:
 # follow-up.
 [unix]
 c-test-examples:
-    mkdir -p target/c-examples
     scripts/c-examples-run.sh
 
 [windows]
@@ -121,7 +120,6 @@ c-test-examples:
 c-test-abort:
     RUSTFLAGS="-C panic=abort" CARGO_TARGET_DIR=target/abort cargo build -p hegeltest-c
     HEGEL_C_LIB_DIR={{justfile_directory()}}/target/abort/debug cargo test -p hegeltest-c
-    mkdir -p target/c-examples
     HEGEL_C_LIB_DIR={{justfile_directory()}}/target/abort/debug scripts/c-examples-run.sh
 
 [windows]

--- a/scripts/c-examples-run.sh
+++ b/scripts/c-examples-run.sh
@@ -8,10 +8,16 @@ set -euo pipefail
 
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
 INCLUDE="$ROOT/hegel-c/include"
+TARGET_DIR=$(cd "$ROOT" && cargo metadata --format-version 1 --no-deps \
+    | grep -o '"target_directory":"[^"]*"' | cut -d'"' -f4)
+if [ -z "$TARGET_DIR" ]; then
+    echo "could not read target_directory from cargo metadata" >&2
+    exit 1
+fi
 # HEGEL_C_LIB_DIR lets the caller point at a library built into a separate
 # target dir — e.g. the panic=abort build produced by `just c-test-abort`.
-LIBDIR="${HEGEL_C_LIB_DIR:-$ROOT/target/debug}"
-OUT="$ROOT/target/c-examples"
+LIBDIR="${HEGEL_C_LIB_DIR:-$TARGET_DIR/debug}"
+OUT="$TARGET_DIR/c-examples"
 mkdir -p "$OUT"
 
 # System libraries the Rust standard library needs when libhegel is

--- a/scripts/check-coverage.py
+++ b/scripts/check-coverage.py
@@ -338,14 +338,14 @@ def _run_lcov_phase(
     cargo_args: list[str],
     output: Path,
     label: str,
-    target_dir: Path | None = None,
+    target_dir: Path,
 ) -> None:
     """Run `cargo llvm-cov <cargo_args>`, emitting LCOV to `output`.
 
-    `target_dir` redirects the whole cargo build (and therefore
+    `target_dir` is where the whole cargo build (and therefore
     cargo-llvm-cov's coverage tree, profile data, and the set of binary
-    objects it exports from) into its own directory, making the phase
-    hermetic: nothing another phase built can leak into its report.
+    objects it exports from) goes. Giving a phase its own directory makes
+    it hermetic: nothing another phase built can leak into its report.
     """
     print(f"  Cleaning previous coverage data ({label})...")
     # Fully remove the coverage build tree, not just the profile data
@@ -353,12 +353,10 @@ def _run_lcov_phase(
     # instrumentation can never leak into this run's coverage.
     import shutil
 
-    cov_tree = (target_dir or Path("target")) / "llvm-cov-target"
-    shutil.rmtree(cov_tree, ignore_errors=True)
+    shutil.rmtree(target_dir / "llvm-cov-target", ignore_errors=True)
 
     env = os.environ.copy()
-    if target_dir is not None:
-        env["CARGO_TARGET_DIR"] = str(target_dir)
+    env["CARGO_TARGET_DIR"] = str(target_dir)
 
     print(f"  Running tests with coverage ({label})...")
     result = subprocess.run(
@@ -435,7 +433,7 @@ def _merge_lcov(inputs: list[Path], output: Path) -> None:
             f.write("end_of_record\n")
 
 
-def _ensure_smoke_cdylib() -> None:
+def _ensure_smoke_cdylib(target_dir: Path) -> None:
     """Build the libhegel cdylib and point the dlopen smoke test at it.
 
     `cargo llvm-cov` runs `cargo test`, which builds rlibs and test binaries
@@ -443,8 +441,8 @@ def _ensure_smoke_cdylib() -> None:
     (`hegel-c/tests/smoke.rs`) dlopens that cdylib, so without it every smoke
     test fails to find `libhegel_c.so` and the whole coverage run errors out.
 
-    Build it into the default target dir (separate from
-    `target/llvm-cov-target`, so no instrumentation-flag thrash) and export
+    Build it into cargo's target dir (separate from its `llvm-cov-target`
+    subtree, so no instrumentation-flag thrash) and export
     `HEGEL_C_LIB_DIR` so the smoke test loads it. The default-features
     hegeltest phase rides on the same export: hegeltest's build.rs honours
     `HEGEL_C_LIB_DIR` instead of nested-building the engine, and its loader
@@ -459,15 +457,11 @@ def _ensure_smoke_cdylib() -> None:
     if result.returncode != 0:
         print("ERROR: failed to build the hegeltest-c cdylib", file=sys.stderr)
         sys.exit(1)
-    os.environ["HEGEL_C_LIB_DIR"] = str((Path("target") / "debug").resolve())
+    os.environ["HEGEL_C_LIB_DIR"] = str(target_dir / "debug")
 
 
-def public_features() -> str:
-    """Every root-crate feature except `default` and internal `__*` ones.
-
-    The `__` prefix marks internal features, which gate code that would
-    report as permanently uncovered.
-    """
+def cargo_metadata() -> dict:
+    """`cargo metadata --no-deps` for the workspace, parsed."""
     result = subprocess.run(
         ["cargo", "metadata", "--no-deps", "--format-version=1"],
         capture_output=True,
@@ -478,7 +472,26 @@ def public_features() -> str:
             print(result.stderr, file=sys.stderr)
         print("ERROR: cargo metadata failed", file=sys.stderr)
         sys.exit(1)
-    metadata = json.loads(result.stdout)
+    return json.loads(result.stdout)
+
+
+def cargo_target_dir() -> Path:
+    """The target directory cargo resolves for this workspace.
+
+    Honours `CARGO_TARGET_DIR` and `.cargo/config.toml` the same way cargo
+    itself does, so the artifacts this script builds and the ones it
+    looks for agree on where they live.
+    """
+    return Path(cargo_metadata()["target_directory"])
+
+
+def public_features() -> str:
+    """Every root-crate feature except `default` and internal `__*` ones.
+
+    The `__` prefix marks internal features, which gate code that would
+    report as permanently uncovered.
+    """
+    metadata = cargo_metadata()
     root_manifest = Path(metadata["workspace_root"]) / "Cargo.toml"
     package = next(
         p for p in metadata["packages"] if Path(p["manifest_path"]) == root_manifest
@@ -536,8 +549,9 @@ def run_coverage() -> Path:
     raw_lcov = Path("lcov-all.info")
     hegel_c_lib_lcov = Path("lcov-hegel-c-lib.info")
     ffi_lcov = Path("lcov-hegeltest-ffi.info")
+    target_dir = cargo_target_dir()
 
-    _ensure_smoke_cdylib()
+    _ensure_smoke_cdylib(target_dir)
 
     _run_lcov_phase(
         cargo_args=[
@@ -551,20 +565,21 @@ def run_coverage() -> Path:
         ],
         output=raw_lcov,
         label="workspace, all features",
+        target_dir=target_dir,
     )
 
     _run_lcov_phase(
         cargo_args=["-p", "hegeltest-c", "--lib"],
         output=hegel_c_lib_lcov,
         label="hegel-c lib tests, isolated no_mangle records",
-        target_dir=Path("target/coverage-hegel-c-lib"),
+        target_dir=target_dir / "coverage-hegel-c-lib",
     )
 
     _run_lcov_phase(
         cargo_args=["-p", "hegeltest"],
         output=ffi_lcov,
         label="hegeltest default features, shared-library engine",
-        target_dir=Path("target/coverage-hegeltest-ffi"),
+        target_dir=target_dir / "coverage-hegeltest-ffi",
     )
 
     print("  Merging LCOV output...")


### PR DESCRIPTION
`scripts/c-examples-run.sh` and `scripts/check-coverage.py` assumed the `libhegel_c` cdylib lived under `./target`. With `CARGO_TARGET_DIR` redirected elsewhere, the example C programs failed to link (`ld: library 'hegel_c' not found`) and every test in `hegel-c/tests/smoke.rs` failed to find the library, aborting the coverage run before it produced a report. This PR fixes that.