### PR TITLE
Memoise the string-constants mask on the IntervalSet, not in a global table

### DIFF
--- a/hegel-c/RELEASE.md
+++ b/hegel-c/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch fixes a memory leak in string draws. The engine memoises, per alphabet, which of its built-in constant strings fit that alphabet, and that memo was kept in a process-global table that never dropped entries for freed generators. A caller that built and freed a string generator around every draw grew without bound; the memo now lives with the alphabet and is freed with it ([#434](https://github.com/hegeldev/hegel-rust/issues/434)).

--- a/hegel-c/src/native/core/state.rs
+++ b/hegel-c/src/native/core/state.rs
@@ -985,37 +985,21 @@ static GLOBAL_CONSTANTS_STRINGS: Lazy<Vec<Vec<u32>>> = Lazy::new(|| {
 /// from the full alphabet (~1.1M codepoints) almost never produces the
 /// `XXY`-shape strings that property tests of, for example, run-length
 /// encoding need to find.
-/// Per-alphabet cache of which [`GLOBAL_CONSTANTS_STRINGS`] entries consist
-/// solely of codepoints the alphabet contains. Validating the ~60 constants
-/// (some 40+ codepoints long) against the alphabet on every string draw is
-/// the dominant cost of `biased_string_sample`, and the containment result
-/// depends only on the immutable `IntervalSet`, so it is memoised per
-/// allocation. Entries are keyed by the `Arc`'s address with a `Weak`
-/// identity check, so an address reused after a drop cannot serve a stale
-/// mask — it recomputes and overwrites its slot.
-fn constants_in_alphabet(intervals: &Arc<IntervalSet>) -> Arc<[bool]> {
-    type Cache = Mutex<HashMap<usize, (alloc::sync::Weak<IntervalSet>, Arc<[bool]>)>>;
-    static CACHE: Lazy<Cache> = Lazy::new(|| Mutex::new(HashMap::default()));
-    let key = Arc::as_ptr(intervals) as usize;
-    {
-        let guard = CACHE.lock();
-        if let Some((weak, mask)) = guard.get(&key) {
-            if weak
-                .upgrade()
-                .is_some_and(|live| Arc::ptr_eq(&live, intervals))
-            {
-                return Arc::clone(mask);
-            }
-        }
-    }
-    let mask: Arc<[bool]> = GLOBAL_CONSTANTS_STRINGS
-        .iter()
-        .map(|cps| cps.iter().all(|&cp| intervals.contains(cp)))
-        .collect();
-    CACHE
-        .lock()
-        .insert(key, (Arc::downgrade(intervals), Arc::clone(&mask)));
-    mask
+/// Which [`GLOBAL_CONSTANTS_STRINGS`] entries consist solely of codepoints
+/// the alphabet contains. Validating the ~60 constants (some 40+ codepoints
+/// long) against the alphabet on every string draw is the dominant cost of
+/// `biased_string_sample`, and the containment result depends only on the
+/// immutable `IntervalSet`, so it is memoised on the set itself and lives
+/// exactly as long as the alphabet does.
+fn constants_in_alphabet(intervals: &IntervalSet) -> &[bool] {
+    intervals.string_constants_mask.get_or_init(|| {
+        Box::new(
+            GLOBAL_CONSTANTS_STRINGS
+                .iter()
+                .map(|cps| cps.iter().all(|&cp| intervals.contains(cp)))
+                .collect(),
+        )
+    })
 }
 
 pub(crate) fn biased_string_sample(

--- a/hegel-c/src/native/intervalsets.rs
+++ b/hegel-c/src/native/intervalsets.rs
@@ -4,6 +4,7 @@
 
 use crate::control::{InternalError, hegel_internal_assert};
 use alloc::vec::Vec;
+use once_cell::race::OnceBox;
 
 /// A sorted, disjoint set of `(start, end)` codepoint intervals. Inclusive on
 /// both endpoints. Acts like a sorted sequence of the covered integers.
@@ -14,6 +15,10 @@ pub struct IntervalSet {
     size: usize,
     idx_of_zero: usize,
     idx_of_z: isize,
+    /// Memo slot for the string draw's per-alphabet mask of which global
+    /// constant strings this alphabet contains. Living on the set, the memo
+    /// is computed once per alphabet and freed with it.
+    pub(crate) string_constants_mask: OnceBox<Vec<bool>>,
 }
 
 impl IntervalSet {
@@ -37,6 +42,7 @@ impl IntervalSet {
             size,
             idx_of_zero: 0,
             idx_of_z: -1,
+            string_constants_mask: OnceBox::new(),
         };
         set.idx_of_zero = set.index_above('0' as u32);
         let z_above = set.index_above('Z' as u32);

--- a/hegel-c/tests/embedded/native/state_tests.rs
+++ b/hegel-c/tests/embedded/native/state_tests.rs
@@ -1055,6 +1055,30 @@ fn biased_string_sample_caps_constant_pool_probability() {
 }
 
 #[test]
+fn constants_in_alphabet_is_memoised_on_the_interval_set() {
+    let intervals =
+        crate::native::intervalsets::IntervalSet::new(vec![('a' as u32, 'z' as u32)]).unwrap();
+    assert!(intervals.string_constants_mask.get().is_none());
+
+    let mask = constants_in_alphabet(&intervals);
+    assert_eq!(mask.len(), GLOBAL_CONSTANTS_STRINGS.len());
+    for (cps, &contained) in GLOBAL_CONSTANTS_STRINGS.iter().zip(mask) {
+        assert_eq!(contained, cps.iter().all(|&cp| intervals.contains(cp)));
+    }
+    assert!(mask.iter().any(|&m| m));
+    assert!(mask.iter().any(|&m| !m));
+
+    let again = constants_in_alphabet(&intervals);
+    assert!(core::ptr::eq(mask.as_ptr(), again.as_ptr()));
+    assert!(intervals.string_constants_mask.get().is_some());
+
+    let other =
+        crate::native::intervalsets::IntervalSet::new(vec![('A' as u32, 'Z' as u32)]).unwrap();
+    assert!(other.string_constants_mask.get().is_none());
+    assert_ne!(constants_in_alphabet(&other), mask);
+}
+
+#[test]
 fn biased_string_sample_empty_alphabet_returns_empty_string() {
     let sc = StringChoice {
         intervals: crate::native::intervalsets::IntervalSet::new(vec![])


### PR DESCRIPTION
Fixes #434.

The `constants_in_alphabet` mask now lives in a `OnceBox<Vec<bool>>` on the `IntervalSet` itself, so we can't leak memory here any more. This also removes a source of lock contention.