### PR TITLE
Spin instead of futex-parking under Miri on Linux

### DIFF
--- a/hegel-c/RELEASE.md
+++ b/hegel-c/RELEASE.md
@@ -1,3 +1,5 @@
 RELEASE_TYPE: patch
 
 This patch fixes a memory leak in string draws. The engine memoises, per alphabet, which of its built-in constant strings fit that alphabet, and that memo was kept in a process-global table that never dropped entries for freed generators. A caller that built and freed a string generator around every draw grew without bound; the memo now lives with the alphabet and is freed with it ([#434](https://github.com/hegeldev/hegel-rust/issues/434)).
+
+It also makes the engine's mutexes spin instead of futex-parking when built under Miri on Linux, so the test suite runs under current nightly Miri. Behaviour outside Miri is unchanged.

--- a/hegel-c/src/sys/unix.rs
+++ b/hegel-c/src/sys/unix.rs
@@ -239,28 +239,33 @@ pub(super) fn pid() -> u32 {
 /// caller must tolerate spurious returns anyway — but burns time under
 /// contention. The engine's locks are essentially always uncontended, so
 /// this costs nothing in practice.
-#[cfg(target_os = "linux")]
+///
+/// Miri also takes the spinning path on Linux: rustix's libc-backend futex
+/// wrapper passes the lock word as `*const AtomicU32` to the variadic
+/// `syscall`, and Miri's c-variadic type check rejects that in favour of
+/// `*mut u32`.
+#[cfg(all(target_os = "linux", not(miri)))]
 pub(super) fn park(word: &AtomicU32, expected: u32) {
     let _ =
         rustix::thread::futex::wait(word, rustix::thread::futex::Flags::PRIVATE, expected, None);
 }
 
 /// Wake one thread parked on `word` by [`park`].
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", not(miri)))]
 pub(super) fn unpark(word: &AtomicU32) {
     let _ = rustix::thread::futex::wake(word, rustix::thread::futex::Flags::PRIVATE, 1);
 }
 
 /// Yield the CPU so a thread waiting on `word` makes progress; see the
 /// Linux [`park`] for the contract.
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(all(target_os = "linux", not(miri))))]
 pub(super) fn park(_word: &AtomicU32, _expected: u32) {
     rustix::thread::sched_yield();
 }
 
-/// No-op: the non-Linux [`park`] spins rather than sleeping, so there is
-/// nobody to wake.
-#[cfg(not(target_os = "linux"))]
+/// No-op: this [`park`] spins rather than sleeping, so there is nobody to
+/// wake.
+#[cfg(not(all(target_os = "linux", not(miri))))]
 pub(super) fn unpark(_word: &AtomicU32) {}
 
 #[cfg(all(feature = "runtime", not(feature = "std"), not(test)))]


### PR DESCRIPTION
<details>
<summary>This text was written by an AI agent</summary>

The `miri` job started failing on main with the nightly from 2026-09-09: rust-lang/rust#161734 makes Miri type-check c-variadic arguments in its shims, and rustix 1.1.4's libc-backend futex wrapper (the backend rustix selects under Miri) passes the lock word as `*const AtomicU32` to `syscall(SYS_futex, …)`, where Miri now expects `*mut u32`. The `c_abi_miri` test `two_clones_used_concurrently_then_freed` hits this whenever an engine mutex is contended, so the failure is intermittent under default Miri flags and deterministic with `-Zmiri-preemption-rate=1`.

Real Linux builds keep the futex path. Under `cfg(miri)`, `park`/`unpark` take the yield-based implementation every other Unix already uses. Verified with the same nightly (`a36d05efab`) against `--target x86_64-unknown-linux-gnu`: the forced-contention reproducer passes on several seeds, and both `just check-miri` targets pass with the CI flags.

This costs Miri its interpretation of the futex wait/wake path in `sys/sync.rs`. It can be reverted once rustix casts `uaddr` to `*mut u32` and ships a release.

</details>