### PR TITLE
Refuse to serialize clone values nested past MAX_CLONE_DEPTH

### DIFF
--- a/hegel-c/RELEASE.md
+++ b/hegel-c/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch closes a gap between the failure-blob and database encoders and their decoders. The decoders reject choice sequences whose cloned streams nest deeper than the engine's limit of 100, but the encoders accepted such sequences, producing blobs and database entries that could never be read back. The encoders now refuse them too, so every blob or database entry they emit decodes ([#477](https://github.com/hegeldev/hegel-rust/issues/477)). No sequence the engine itself produces is affected: a test case cannot nest clones past that limit.

--- a/hegel-c/RELEASE.md
+++ b/hegel-c/RELEASE.md
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-This patch closes a gap between the failure-blob and database encoders and their decoders. The decoders reject choice sequences whose cloned streams nest deeper than the engine's limit of 100, but the encoders accepted such sequences, producing blobs and database entries that could never be read back. The encoders now refuse them too, so every blob or database entry they emit decodes ([#477](https://github.com/hegeldev/hegel-rust/issues/477)). No sequence the engine itself produces is affected: a test case cannot nest clones past that limit.
+This patch fixes an encode/decode gap in the Hegel test case format where an encoder would allow a sequence that the decoder rejected ([#477](https://github.com/hegeldev/hegel-rust/issues/477)). This code path was unreachable in normal test execution so this is mostly an internal change.

--- a/hegel-c/src/native/blob.rs
+++ b/hegel-c/src/native/blob.rs
@@ -34,6 +34,12 @@
 //! blob can't be replayed" and panic. Compressed payloads decode under the
 //! [`MAX_DECOMPRESSED_LEN`] bound, and a stream that inflates past it counts
 //! as malformed.
+//!
+//! Every blob [`encode_failure`] returns decodes: the one input it refuses
+//! (returning `None`) is a sequence whose clone values nest deeper than
+//! [`MAX_CLONE_DEPTH`](crate::native::core::MAX_CLONE_DEPTH), which
+//! [`serialize_choices`] rejects for the same reason the decoder does. The
+//! engine never produces one.
 
 use crate::native::base64::{base64_decode, base64_encode};
 use crate::native::core::ChoiceValue;
@@ -60,9 +66,12 @@ const MAX_DECOMPRESSED_LEN: usize = 16 << 20;
 
 /// Encode a choice sequence into a failure blob (see the module docs for the
 /// format). The returned string is safe to embed in source as a string
-/// literal and to round-trip through [`decode_failure`].
-pub fn encode_failure(choices: &[ChoiceValue]) -> String {
-    let raw = serialize_choices(choices);
+/// literal and to round-trip through [`decode_failure`]. Returns `None` only
+/// for a sequence [`serialize_choices`] rejects (clone values nested deeper
+/// than [`MAX_CLONE_DEPTH`](crate::native::core::MAX_CLONE_DEPTH)), which no
+/// blob could represent.
+pub fn encode_failure(choices: &[ChoiceValue]) -> Option<String> {
+    let raw = serialize_choices(choices)?;
     let compressed = miniz_oxide::deflate::compress_to_vec_zlib(&raw, ZLIB_LEVEL);
 
     let (prefix, body) = if compressed.len() < raw.len() && raw.len() <= MAX_DECOMPRESSED_LEN {
@@ -74,7 +83,7 @@ pub fn encode_failure(choices: &[ChoiceValue]) -> String {
     let mut payload = Vec::with_capacity(body.len() + 1);
     payload.push(prefix);
     payload.extend_from_slice(&body);
-    base64_encode(&payload)
+    Some(base64_encode(&payload))
 }
 
 /// Decode a failure blob produced by [`encode_failure`] back into a choice

--- a/hegel-c/src/native/core/mod.rs
+++ b/hegel-c/src/native/core/mod.rs
@@ -20,8 +20,10 @@ pub const BUFFER_SIZE: usize = 8 * 1024;
 
 /// Maximum nesting depth of cloned streams (a clone made from a clone made
 /// from …). The engine rejects deeper clones the same way it rejects
-/// over-deep spans, and the choice deserializer refuses deeper nesting so
-/// corrupt storage can't drive unbounded recursion.
+/// over-deep spans, and the choice serializer and deserializer both refuse
+/// deeper nesting — the deserializer so corrupt storage can't drive
+/// unbounded recursion, the serializer so it never emits bytes the
+/// deserializer would then reject.
 pub const MAX_CLONE_DEPTH: usize = 100;
 
 /// Probability of drawing a boundary/special value per special candidate. Used

--- a/hegel-c/src/native/database.rs
+++ b/hegel-c/src/native/database.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 use core::sync::atomic::{AtomicU64, Ordering};
 
 use crate::native::bignum::BigInt;
-use crate::native::core::{ChoiceValue, ChoiceValueRef};
+use crate::native::core::{ChoiceValue, ChoiceValueRef, CloneRecord, MAX_CLONE_DEPTH};
 use crate::sys;
 
 /// Multi-value key/value store backing the native engine's replay phase.
@@ -215,42 +215,65 @@ pub(super) fn fnv1a(s: &[u8]) -> u64 {
 ///     - Clone: the cloned stream's child choice values in this same
 ///       count-then-entries layout, recursively. Only the values are
 ///       persisted — spans and kinds are recreated on replay.
-pub fn serialize_choices(choices: &[ChoiceValue]) -> Vec<u8> {
+///
+/// Returns `None` if clone values nest deeper than [`MAX_CLONE_DEPTH`]: the
+/// engine never produces such a sequence (`clone_stream` rejects the clone
+/// that would exceed the depth), and [`deserialize_choices`] refuses it, so
+/// encoding one would only yield bytes that can never be read back.
+pub fn serialize_choices(choices: &[ChoiceValue]) -> Option<Vec<u8>> {
     let mut buf = Vec::with_capacity(4 + choices.len() * 17);
     serialize_choice_list(
         &mut buf,
         choices.len(),
         choices.iter().map(ChoiceValueRef::from),
-    );
-    buf
+        0,
+    )?;
+    Some(buf)
 }
 
 /// Serialize the realized values of `nodes` with the same encoding (and so
-/// the same key semantics) as [`serialize_choices`].
-pub(crate) fn serialize_nodes(nodes: &[crate::native::core::ChoiceNode]) -> Vec<u8> {
+/// the same key semantics and the same [`MAX_CLONE_DEPTH`] bound) as
+/// [`serialize_choices`].
+pub(crate) fn serialize_nodes(nodes: &[crate::native::core::ChoiceNode]) -> Option<Vec<u8>> {
     let mut buf = Vec::with_capacity(4 + nodes.len() * 17);
     serialize_choice_list(
         &mut buf,
         nodes.len(),
         nodes.iter().map(|n| n.data.value_ref()),
-    );
-    buf
+        0,
+    )?;
+    Some(buf)
 }
 
 fn serialize_choice_list<'a>(
     buf: &mut Vec<u8>,
     count: usize,
     choices: impl Iterator<Item = ChoiceValueRef<'a>>,
-) {
+    depth: usize,
+) -> Option<()> {
+    if depth > MAX_CLONE_DEPTH {
+        return None;
+    }
     buf.extend_from_slice(&(count as u32).to_le_bytes());
     for choice in choices {
-        serialize_one_choice(buf, choice);
+        serialize_one_choice_at(buf, choice, depth)?;
     }
+    Some(())
 }
 
-/// Serialize one value with its type tag — the per-position unit of the
-/// [`serialize_choices`] encoding, exposed for prefix-incremental hashing.
-pub(crate) fn serialize_one_choice(buf: &mut Vec<u8>, choice: ChoiceValueRef<'_>) {
+/// Serialize one top-level value with its type tag — the per-position unit
+/// of the [`serialize_choices`] encoding, exposed for prefix-incremental
+/// hashing. Returns `None` under the same [`MAX_CLONE_DEPTH`] bound as
+/// [`serialize_choices`].
+pub(crate) fn serialize_one_choice(buf: &mut Vec<u8>, choice: ChoiceValueRef<'_>) -> Option<()> {
+    serialize_one_choice_at(buf, choice, 0)
+}
+
+fn serialize_one_choice_at(
+    buf: &mut Vec<u8>,
+    choice: ChoiceValueRef<'_>,
+    depth: usize,
+) -> Option<()> {
     match choice {
         ChoiceValueRef::Integer(v) => {
             buf.push(0);
@@ -280,9 +303,10 @@ pub(crate) fn serialize_one_choice(buf: &mut Vec<u8>, choice: ChoiceValueRef<'_>
         }
         ChoiceValueRef::Clone(children) => {
             buf.push(5);
-            serialize_choice_list(buf, children.len(), children.values());
+            serialize_choice_list(buf, children.len(), children.values(), depth + 1)?;
         }
     }
+    Some(())
 }
 
 /// Encode a [`BigInt`] as sub-tag 10 followed by a length-prefixed
@@ -337,9 +361,9 @@ fn deserialize_any_integer(bytes: &[u8], pos: usize) -> Option<(BigInt, usize)> 
 /// Decode a byte slice produced by [`serialize_choices`].
 ///
 /// Returns `None` if the data is truncated, malformed, contains an unknown
-/// type tag, or nests clone values deeper than
-/// [`MAX_CLONE_DEPTH`](crate::native::core::MAX_CLONE_DEPTH) (defensive
-/// against filesystem corruption).
+/// type tag, or nests clone values deeper than [`MAX_CLONE_DEPTH`]
+/// (defensive against filesystem corruption; the same bound
+/// [`serialize_choices`] enforces, so every sequence it encodes decodes).
 pub fn deserialize_choices(bytes: &[u8]) -> Option<Vec<ChoiceValue>> {
     let (choices, _) = deserialize_choice_list(bytes, 0, 0)?;
     Some(choices)
@@ -350,7 +374,7 @@ fn deserialize_choice_list(
     start: usize,
     depth: usize,
 ) -> Option<(Vec<ChoiceValue>, usize)> {
-    if depth > crate::native::core::MAX_CLONE_DEPTH {
+    if depth > MAX_CLONE_DEPTH {
         return None;
     }
     if start + 4 > bytes.len() {
@@ -423,7 +447,7 @@ fn deserialize_choice_list(
                 let (children, new_pos) = deserialize_choice_list(bytes, pos, depth + 1)?;
                 pos = new_pos;
                 choices.push(ChoiceValue::Clone(alloc::sync::Arc::new(
-                    crate::native::core::CloneRecord::from_values(children),
+                    CloneRecord::from_values(children),
                 )));
             }
             _ => return None,

--- a/hegel-c/src/native/exec_cache.rs
+++ b/hegel-c/src/native/exec_cache.rs
@@ -23,6 +23,7 @@ use alloc::format;
 use alloc::string::String;
 use alloc::vec::Vec;
 
+use crate::control::{InternalError, hegel_internal_unwrap};
 use crate::native::HashMap;
 use crate::native::core::{ChoiceKind, ChoiceNode, Span, Status};
 
@@ -208,20 +209,25 @@ pub(crate) struct KindLedger {
 
 impl KindLedger {
     /// Fold one execution's realized nodes into the ledger, returning the
-    /// tree's kind-mismatch diagnostic on the first contradiction.
-    pub(crate) fn observe(&mut self, nodes: &[ChoiceNode]) -> Option<String> {
+    /// tree's kind-mismatch diagnostic on the first contradiction. The engine
+    /// bounds clone nesting at `MAX_CLONE_DEPTH` as a case runs, so the
+    /// serializer refusing an executed node is a violated internal invariant.
+    pub(crate) fn observe(
+        &mut self,
+        nodes: &[ChoiceNode],
+    ) -> Result<Option<String>, InternalError> {
         let mut prefix = Digest::new();
         let mut scratch = Vec::new();
         for node in nodes {
             let kind = node.kind();
             match self.entries.get(&prefix) {
                 Some(expected) if *expected != kind => {
-                    return Some(format!(
+                    return Ok(Some(format!(
                         "Your data generation is non-deterministic: at the same choice \
                          position with the same prefix, the choice kind changed from {:?} to {:?}. \
                          This usually means a generator depends on global mutable state.",
                         expected, kind
-                    ));
+                    )));
                 }
                 None if self.entries.len() < KIND_LEDGER_CAP => {
                     self.entries.insert(prefix, kind);
@@ -229,10 +235,13 @@ impl KindLedger {
                 _ => {}
             }
             scratch.clear();
-            crate::native::database::serialize_one_choice(&mut scratch, node.data.value_ref());
+            hegel_internal_unwrap!(
+                crate::native::database::serialize_one_choice(&mut scratch, node.data.value_ref()),
+                "an executed test case's clone values nest deeper than MAX_CLONE_DEPTH"
+            );
             prefix.update(&scratch);
         }
-        None
+        Ok(None)
     }
 
     pub(crate) fn clear(&mut self) {

--- a/hegel-c/src/native/test_runner.rs
+++ b/hegel-c/src/native/test_runner.rs
@@ -30,6 +30,7 @@ use hashbrown::hash_map::Entry;
 use rand::RngExt;
 
 use crate::backend::{Failure, RunError, TestCaseResult, TestRunResult};
+use crate::control::{InternalError, hegel_internal_unwrap};
 use crate::exchange::CaseExchange;
 use crate::native::core::{
     BUFFER_SIZE, ChoiceNode, ChoiceValue, MAX_SHRINKING_SECONDS, NativeTestCase, Span, Spans,
@@ -478,10 +479,9 @@ impl<'a> Engine<'a> {
                 let primary_max: Option<Vec<u8>> = self
                     .interesting
                     .values()
-                    .map(|nodes| {
-                        let choices: Vec<ChoiceValue> = nodes.iter().map(|n| n.value()).collect();
-                        serialize_choices(&choices)
-                    })
+                    .map(|nodes| serialize_executed_nodes(nodes))
+                    .collect::<Result<Vec<_>, _>>()?
+                    .into_iter()
                     .max_by(|a, b| shortlex(a, b));
                 for raw in entries {
                     if primary_max
@@ -571,7 +571,7 @@ impl<'a> Engine<'a> {
             output.line("Skipping shrink: reused aligned database replay");
         }
 
-        self.reconcile_database();
+        self.reconcile_database()?;
 
         if verbosity == Verbosity::Debug {
             output.line(&format!(
@@ -598,21 +598,22 @@ impl<'a> Engine<'a> {
         }
 
         let nondeterministic = self.nondeterministic;
-        let failures = origins_sorted
-            .into_iter()
-            .map(|(origin, nodes)| {
-                let reproduce_blob = if nondeterministic {
-                    None
-                } else {
-                    let choices: Vec<ChoiceValue> = nodes.iter().map(|n| n.value()).collect();
-                    Some(crate::native::blob::encode_failure(&choices))
-                };
-                Failure {
-                    origin,
-                    reproduce_blob,
-                }
-            })
-            .collect();
+        let mut failures = Vec::with_capacity(origins_sorted.len());
+        for (origin, nodes) in origins_sorted {
+            let reproduce_blob = if nondeterministic {
+                None
+            } else {
+                let choices: Vec<ChoiceValue> = nodes.iter().map(|n| n.value()).collect();
+                Some(hegel_internal_unwrap!(
+                    crate::native::blob::encode_failure(&choices),
+                    "a failing test case's clone values nest deeper than MAX_CLONE_DEPTH"
+                ))
+            };
+            failures.push(Failure {
+                origin,
+                reproduce_blob,
+            });
+        }
         Ok(TestRunResult {
             failures,
             nondeterministic,
@@ -793,6 +794,16 @@ fn within_invalid_budget(
     (invalid_test_cases + overrun_test_cases) <= base + per_valid * valid_test_cases
 }
 
+/// The database bytes for an executed test case's nodes. The engine bounds
+/// clone nesting at `MAX_CLONE_DEPTH` as the case runs, so the serializer
+/// refusing its values is a violated internal invariant.
+fn serialize_executed_nodes(nodes: &[ChoiceNode]) -> Result<Vec<u8>, InternalError> {
+    Ok(hegel_internal_unwrap!(
+        serialize_nodes(nodes),
+        "an executed test case's clone values nest deeper than MAX_CLONE_DEPTH"
+    ))
+}
+
 /// Shortlex ordering over serialized choice sequences: by length first, then
 /// lexicographically. Mirrors Hypothesis's `shortlex` database ordering.
 fn shortlex(a: &[u8], b: &[u8]) -> core::cmp::Ordering {
@@ -897,19 +908,22 @@ impl<'a> Persister<'a> {
     /// sighting, or shortlex-precedes the previous save, the new bytes are
     /// written to the primary key and any previously-saved bytes for this
     /// origin are then deleted (or demoted, for a run-start entry).
-    fn record(&mut self, origin: &str, nodes: &[ChoiceNode]) {
-        let Some(db) = self.db.as_deref() else { return };
-        let Some(key) = self.database_key else { return };
+    fn record(&mut self, origin: &str, nodes: &[ChoiceNode]) -> Result<(), InternalError> {
+        let Some(db) = self.db.as_deref() else {
+            return Ok(());
+        };
+        let Some(key) = self.database_key else {
+            return Ok(());
+        };
         let key_bytes = key.as_bytes();
-        let new_choices: Vec<ChoiceValue> = nodes.iter().map(|n| n.value()).collect();
-        let new_bytes = serialize_choices(&new_choices);
+        let new_bytes = serialize_executed_nodes(nodes)?;
 
         let needs_save = match self.last_saved.get(origin) {
             None => true,
             Some((prev, _)) => sort_key(nodes) < sort_key(prev),
         };
         if !needs_save {
-            return;
+            return Ok(());
         }
 
         db.save(key_bytes, &new_bytes);
@@ -933,6 +947,7 @@ impl<'a> Persister<'a> {
         self.saved_this_run.insert(new_bytes.clone());
         self.last_saved
             .insert(origin.to_string(), (nodes.to_vec(), new_bytes));
+        Ok(())
     }
 }
 
@@ -1051,7 +1066,7 @@ impl<'a> Engine<'a> {
     /// same-run leftovers are deleted, run-start entries demote to the
     /// secondary key — and evict the shortlex-largest secondary entries
     /// above [`SECONDARY_CORPUS_CAP`].
-    fn reconcile_database(&self) {
+    fn reconcile_database(&self) -> Result<(), InternalError> {
         if let (false, Some(db), Some(key)) = (self.nondeterministic, self.db(), self.database_key)
         {
             let key_bytes = key.as_bytes();
@@ -1059,11 +1074,8 @@ impl<'a> Engine<'a> {
             let new_entries: crate::native::HashSet<Vec<u8>> = self
                 .interesting
                 .values()
-                .map(|nodes| {
-                    let choices: Vec<ChoiceValue> = nodes.iter().map(|n| n.value()).collect();
-                    serialize_choices(&choices)
-                })
-                .collect();
+                .map(|nodes| serialize_executed_nodes(nodes))
+                .collect::<Result<_, _>>()?;
             let primary_now = db.fetch(key_bytes);
             for new_bytes in &new_entries {
                 db.save(key_bytes, new_bytes);
@@ -1088,6 +1100,7 @@ impl<'a> Engine<'a> {
                 }
             }
         }
+        Ok(())
     }
 
     /// Spawn an independent RNG from the engine's, for components (probes,
@@ -1125,7 +1138,7 @@ impl<'a> Engine<'a> {
                 self.settings.output.line(concurrent_machine_notice());
             }
         }
-        let mismatch = self.record_run(&run, elapsed);
+        let mismatch = self.record_run(&run, elapsed)?;
         Ok((run, mismatch))
     }
 
@@ -1133,11 +1146,15 @@ impl<'a> Engine<'a> {
     /// (via [`Self::record_execution`]), counters, test time, triviality,
     /// the targeting observations, the per-origin interesting map (with its
     /// incremental database save), and the bug-window markers.
-    fn record_run(&mut self, run: &RunResult, elapsed: core::time::Duration) -> Option<RunError> {
+    fn record_run(
+        &mut self,
+        run: &RunResult,
+        elapsed: core::time::Duration,
+    ) -> Result<Option<RunError>, InternalError> {
         let mismatch = if self.nondeterministic {
             None
         } else {
-            self.record_execution(run)
+            self.record_execution(run)?
         };
         self.calls += 1;
         self.total_test_time += elapsed;
@@ -1163,12 +1180,12 @@ impl<'a> Engine<'a> {
                 self.last_bug_at = Some(self.calls);
                 let origin = run.origin.clone().unwrap_or_default();
                 if !self.nondeterministic {
-                    self.persister.record(&origin, &run.nodes);
+                    self.persister.record(&origin, &run.nodes)?;
                 }
                 update_interesting(&mut self.interesting, origin, run.nodes.clone());
             }
         }
-        mismatch
+        Ok(mismatch)
     }
 
     /// Feed one executed run to the detectors the tree used to be: the kind
@@ -1177,15 +1194,15 @@ impl<'a> Engine<'a> {
     /// counter (generation-window cases only) and, on a verdict change,
     /// reports the flake the tree could never see. The returned error is
     /// `NonDeterministic` for kind drift and `Flaky` for a verdict change.
-    fn record_execution(&mut self, run: &RunResult) -> Option<RunError> {
-        if let Some(msg) = self.kind_ledger.observe(&run.nodes) {
-            return Some(RunError::NonDeterministic(msg));
+    fn record_execution(&mut self, run: &RunResult) -> Result<Option<RunError>, InternalError> {
+        if let Some(msg) = self.kind_ledger.observe(&run.nodes)? {
+            return Ok(Some(RunError::NonDeterministic(msg)));
         }
         if run.status == Status::EarlyStop {
-            return None;
+            return Ok(None);
         }
         let recorded = self.exec_cache.record(
-            serialize_nodes(&run.nodes),
+            serialize_executed_nodes(&run.nodes)?,
             run.status,
             run.origin.as_deref(),
             &run.nodes,
@@ -1199,9 +1216,9 @@ impl<'a> Engine<'a> {
                 self.consecutive_duplicates = 0;
             }
         }
-        recorded
+        Ok(recorded
             .verdict_mismatch
-            .then(|| RunError::Flaky(flaky_diagnostic()))
+            .then(|| RunError::Flaky(flaky_diagnostic())))
     }
 
     /// Whether the generation-phase invalid/overrun budget still has room.
@@ -1275,7 +1292,11 @@ impl<'a> Engine<'a> {
         extend: usize,
     ) -> Result<RunResult, RunError> {
         if !self.nondeterministic {
-            if let Some(hit) = self.exec_cache.serve(&serialize_choices(choices)) {
+            let key = hegel_internal_unwrap!(
+                serialize_choices(choices),
+                "a replayed test case's clone values nest deeper than MAX_CLONE_DEPTH"
+            );
+            if let Some(hit) = self.exec_cache.serve(&key) {
                 return Ok(RunResult {
                     status: hit.status,
                     nodes: hit.nodes,

--- a/hegel-c/src/native/test_runner.rs
+++ b/hegel-c/src/native/test_runner.rs
@@ -909,10 +909,7 @@ impl<'a> Persister<'a> {
     /// written to the primary key and any previously-saved bytes for this
     /// origin are then deleted (or demoted, for a run-start entry).
     fn record(&mut self, origin: &str, nodes: &[ChoiceNode]) -> Result<(), InternalError> {
-        let Some(db) = self.db.as_deref() else {
-            return Ok(());
-        };
-        let Some(key) = self.database_key else {
+        let (Some(db), Some(key)) = (self.db.as_deref(), self.database_key) else {
             return Ok(());
         };
         let key_bytes = key.as_bytes();

--- a/hegel-c/tests/embedded/native/blob_tests.rs
+++ b/hegel-c/tests/embedded/native/blob_tests.rs
@@ -1,8 +1,18 @@
 use super::*;
 use crate::native::base64::{base64_decode, base64_encode};
 use crate::native::bignum::BigInt;
-use crate::native::core::ChoiceValue;
+use crate::native::core::{ChoiceValue, CloneRecord, MAX_CLONE_DEPTH};
 use alloc::vec;
+
+fn nested_clones(depth: usize) -> Vec<ChoiceValue> {
+    let mut choices = vec![ChoiceValue::Boolean(true)];
+    for _ in 0..depth {
+        choices = vec![ChoiceValue::Clone(std::sync::Arc::new(
+            CloneRecord::from_values(choices),
+        ))];
+    }
+    choices
+}
 
 fn sample_choices() -> Vec<ChoiceValue> {
     vec![
@@ -20,20 +30,20 @@ fn sample_choices() -> Vec<ChoiceValue> {
 #[test]
 fn round_trips_a_mixed_choice_sequence() {
     let choices = sample_choices();
-    let blob = encode_failure(&choices);
+    let blob = encode_failure(&choices).unwrap();
     let decoded = decode_failure(&blob).unwrap();
     assert_eq!(decoded, choices);
 }
 
 #[test]
 fn round_trips_an_empty_choice_sequence() {
-    let blob = encode_failure(&[]);
+    let blob = encode_failure(&[]).unwrap();
     assert_eq!(decode_failure(&blob).unwrap(), Vec::<ChoiceValue>::new());
 }
 
 #[test]
 fn small_sequence_uses_the_raw_prefix() {
-    let blob = encode_failure(&[ChoiceValue::Boolean(true)]);
+    let blob = encode_failure(&[ChoiceValue::Boolean(true)]).unwrap();
     let bytes = base64_decode(&blob).unwrap();
     assert_eq!(bytes[0], PREFIX_RAW);
     assert_eq!(
@@ -47,7 +57,7 @@ fn long_repetitive_sequence_uses_the_zlib_prefix() {
     let choices: Vec<ChoiceValue> = (0..500)
         .map(|_| ChoiceValue::Integer(BigInt::from(1)))
         .collect();
-    let blob = encode_failure(&choices);
+    let blob = encode_failure(&choices).unwrap();
     let bytes = base64_decode(&blob).unwrap();
     assert_eq!(bytes[0], PREFIX_ZLIB);
     assert_eq!(decode_failure(&blob).unwrap(), choices);
@@ -67,7 +77,7 @@ fn decode_rejects_empty_payload() {
 #[test]
 fn decode_rejects_unknown_prefix_byte() {
     let mut payload = vec![9u8];
-    payload.extend_from_slice(&serialize_choices(&sample_choices()));
+    payload.extend_from_slice(&serialize_choices(&sample_choices()).unwrap());
     let blob = base64_encode(&payload);
     assert!(decode_failure(&blob).is_none());
 }
@@ -86,7 +96,7 @@ fn decode_rejects_raw_payload_that_is_not_valid_choices() {
 
 #[test]
 fn decode_rejects_zlib_bomb() {
-    let raw = serialize_choices(&[ChoiceValue::Bytes(vec![0u8; MAX_DECOMPRESSED_LEN])]);
+    let raw = serialize_choices(&[ChoiceValue::Bytes(vec![0u8; MAX_DECOMPRESSED_LEN])]).unwrap();
     assert!(raw.len() > MAX_DECOMPRESSED_LEN);
     let mut payload = vec![PREFIX_ZLIB];
     payload.extend_from_slice(&miniz_oxide::deflate::compress_to_vec_zlib(
@@ -99,7 +109,7 @@ fn decode_rejects_zlib_bomb() {
 #[test]
 fn over_bound_payload_takes_the_raw_prefix_and_round_trips() {
     let choices = vec![ChoiceValue::Bytes(vec![0u8; MAX_DECOMPRESSED_LEN])];
-    let blob = encode_failure(&choices);
+    let blob = encode_failure(&choices).unwrap();
     let bytes = base64_decode(&blob).unwrap();
     assert_eq!(bytes[0], PREFIX_RAW);
     assert_eq!(decode_failure(&blob).unwrap(), choices);
@@ -108,8 +118,11 @@ fn over_bound_payload_takes_the_raw_prefix_and_round_trips() {
 #[test]
 fn zlib_decode_limit_admits_large_legitimate_blobs() {
     let choices = vec![ChoiceValue::Bytes(vec![0u8; MAX_DECOMPRESSED_LEN - 9])];
-    assert_eq!(serialize_choices(&choices).len(), MAX_DECOMPRESSED_LEN);
-    let blob = encode_failure(&choices);
+    assert_eq!(
+        serialize_choices(&choices).unwrap().len(),
+        MAX_DECOMPRESSED_LEN
+    );
+    let blob = encode_failure(&choices).unwrap();
     let bytes = base64_decode(&blob).unwrap();
     assert_eq!(bytes[0], PREFIX_ZLIB);
     assert_eq!(decode_failure(&blob).unwrap(), choices);
@@ -128,6 +141,18 @@ fn blob_roundtrips_clone_values() {
             ]),
         )),
     ];
-    let blob = encode_failure(&choices);
+    let blob = encode_failure(&choices).unwrap();
     assert_eq!(decode_failure(&blob), Some(choices));
+}
+
+#[test]
+fn blob_round_trips_clones_nested_to_max_depth() {
+    let choices = nested_clones(MAX_CLONE_DEPTH);
+    let blob = encode_failure(&choices).unwrap();
+    assert_eq!(decode_failure(&blob), Some(choices));
+}
+
+#[test]
+fn encode_refuses_clones_nested_beyond_max_depth() {
+    assert!(encode_failure(&nested_clones(MAX_CLONE_DEPTH + 1)).is_none());
 }

--- a/hegel-c/tests/embedded/native/database_tests.rs
+++ b/hegel-c/tests/embedded/native/database_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::native::bignum::BigInt;
-use crate::native::core::ChoiceValue;
 use crate::native::core::choices::BooleanChoice;
+use crate::native::core::{ChoiceValue, CloneRecord, MAX_CLONE_DEPTH};
 use alloc::string::ToString;
 use alloc::vec;
 use tempfile::TempDir;
@@ -106,7 +106,7 @@ fn round_trip_mixed_choices() {
         ChoiceValue::Integer(BigInt::from(42)),
         ChoiceValue::Boolean(true),
     ];
-    let bytes = serialize_choices(&choices);
+    let bytes = serialize_choices(&choices).unwrap();
     assert_eq!(deserialize_choices(&bytes), Some(choices));
 }
 
@@ -229,7 +229,7 @@ fn serialize_roundtrips_various_integer_values() {
         ChoiceValue::Integer(BigInt::from(i128::MIN) * BigInt::from(7)),
         ChoiceValue::Integer(BigInt::from(0)),
     ];
-    let bytes = serialize_choices(&values);
+    let bytes = serialize_choices(&values).unwrap();
     assert_eq!(deserialize_choices(&bytes), Some(values));
 }
 
@@ -260,7 +260,7 @@ fn round_trip_float_choices_preserves_bit_pattern() {
         ChoiceValue::Float(f64::MAX),
         ChoiceValue::Float(f64::MIN_POSITIVE),
     ];
-    let bytes = serialize_choices(&choices);
+    let bytes = serialize_choices(&choices).unwrap();
     let round_tripped = deserialize_choices(&bytes).unwrap();
     assert_eq!(round_tripped.len(), choices.len());
     for (got, want) in round_tripped.iter().zip(choices.iter()) {
@@ -289,7 +289,7 @@ fn round_trip_bytes_choices() {
         ChoiceValue::Bytes(vec![0xff, 0x00, 0x80, 0x7f]),
         ChoiceValue::Bytes(vec![1; 1024]),
     ];
-    let bytes = serialize_choices(&choices);
+    let bytes = serialize_choices(&choices).unwrap();
     assert_eq!(deserialize_choices(&bytes), Some(choices));
 }
 
@@ -318,7 +318,7 @@ fn round_trip_string_choices() {
         ChoiceValue::String(vec![b'a' as u32, b'b' as u32, b'c' as u32]),
         ChoiceValue::String(vec![0x2603, 0x1F600, 0]),
     ];
-    let bytes = serialize_choices(&choices);
+    let bytes = serialize_choices(&choices).unwrap();
     assert_eq!(deserialize_choices(&bytes), Some(choices));
 }
 
@@ -445,7 +445,7 @@ fn serialize_roundtrips_clone_values() {
         ]),
         ChoiceValue::Bytes(vec![7]),
     ];
-    let bytes = serialize_choices(&choices);
+    let bytes = serialize_choices(&choices).unwrap();
     assert_eq!(deserialize_choices(&bytes), Some(choices));
 }
 
@@ -463,7 +463,7 @@ fn serialize_clone_drops_realized_info_but_preserves_equality() {
             discarded: false,
         }],
     )));
-    let bytes = serialize_choices(std::slice::from_ref(&realized));
+    let bytes = serialize_choices(std::slice::from_ref(&realized)).unwrap();
     let round_tripped = deserialize_choices(&bytes).unwrap();
     assert_eq!(round_tripped.len(), 1);
     assert_eq!(round_tripped[0], realized);
@@ -511,4 +511,26 @@ fn deserialize_rejects_clone_nesting_beyond_max_depth() {
     ok_bytes.extend_from_slice(&0u32.to_le_bytes());
     let decoded = deserialize_choices(&ok_bytes).unwrap();
     assert_eq!(decoded.len(), 1);
+}
+
+fn nested_clones(depth: usize) -> Vec<ChoiceValue> {
+    let mut choices = vec![ChoiceValue::Boolean(true)];
+    for _ in 0..depth {
+        choices = vec![ChoiceValue::Clone(std::sync::Arc::new(
+            CloneRecord::from_values(choices),
+        ))];
+    }
+    choices
+}
+
+#[test]
+fn serialize_round_trips_clone_nesting_at_max_depth() {
+    let choices = nested_clones(MAX_CLONE_DEPTH);
+    let bytes = serialize_choices(&choices).unwrap();
+    assert_eq!(deserialize_choices(&bytes), Some(choices));
+}
+
+#[test]
+fn serialize_rejects_clone_nesting_beyond_max_depth() {
+    assert!(serialize_choices(&nested_clones(MAX_CLONE_DEPTH + 1)).is_none());
 }

--- a/hegel-c/tests/embedded/native/database_tests.rs
+++ b/hegel-c/tests/embedded/native/database_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::native::bignum::BigInt;
-use crate::native::core::choices::BooleanChoice;
-use crate::native::core::{ChoiceValue, CloneRecord, MAX_CLONE_DEPTH};
+use crate::native::core::choices::{BooleanChoice, RealizedStream};
+use crate::native::core::{ChoiceNode, ChoiceValue, CloneRecord, MAX_CLONE_DEPTH};
 use alloc::string::ToString;
 use alloc::vec;
 use tempfile::TempDir;
@@ -533,4 +533,31 @@ fn serialize_round_trips_clone_nesting_at_max_depth() {
 #[test]
 fn serialize_rejects_clone_nesting_beyond_max_depth() {
     assert!(serialize_choices(&nested_clones(MAX_CLONE_DEPTH + 1)).is_none());
+}
+
+fn nested_clone_nodes(depth: usize) -> Vec<ChoiceNode> {
+    let mut nodes = vec![ChoiceNode::boolean(BooleanChoice { p: 0.5 }, true, false)];
+    for _ in 0..depth {
+        nodes = vec![ChoiceNode::clone_stream(
+            std::sync::Arc::new(RealizedStream::new(nodes, Vec::new())),
+            false,
+        )];
+    }
+    nodes
+}
+
+#[test]
+fn serialize_nodes_matches_serialize_choices_at_max_depth() {
+    let nodes = nested_clone_nodes(MAX_CLONE_DEPTH);
+    let choices: Vec<ChoiceValue> = nodes.iter().map(|n| n.value()).collect();
+    assert_eq!(serialize_nodes(&nodes), serialize_choices(&choices));
+    assert_eq!(
+        deserialize_choices(&serialize_nodes(&nodes).unwrap()),
+        Some(choices)
+    );
+}
+
+#[test]
+fn serialize_nodes_rejects_clone_nesting_beyond_max_depth() {
+    assert!(serialize_nodes(&nested_clone_nodes(MAX_CLONE_DEPTH + 1)).is_none());
 }

--- a/hegel-c/tests/embedded/native/exec_cache_tests.rs
+++ b/hegel-c/tests/embedded/native/exec_cache_tests.rs
@@ -139,17 +139,17 @@ fn clear_drops_both_tiers() {
 fn the_kind_ledger_accepts_consistent_reexecution() {
     let mut ledger = KindLedger::default();
     let nodes = alloc::vec![int_node(0, 5), bool_node(true)];
-    assert!(ledger.observe(&nodes).is_none());
-    assert!(ledger.observe(&nodes).is_none());
+    assert!(ledger.observe(&nodes).unwrap().is_none());
+    assert!(ledger.observe(&nodes).unwrap().is_none());
     let other_values = alloc::vec![int_node(0, 6), bool_node(false)];
-    assert!(ledger.observe(&other_values).is_none());
+    assert!(ledger.observe(&other_values).unwrap().is_none());
 }
 
 #[test]
 fn the_kind_ledger_reports_kind_drift_at_a_shared_prefix() {
     let mut ledger = KindLedger::default();
-    assert!(ledger.observe(&[bool_node(true)]).is_none());
-    let msg = ledger.observe(&[int_node(0, 5)]).unwrap();
+    assert!(ledger.observe(&[bool_node(true)]).unwrap().is_none());
+    let msg = ledger.observe(&[int_node(0, 5)]).unwrap().unwrap();
     assert!(msg.contains("choice kind changed from"), "{msg}");
     assert!(msg.contains("global mutable state"), "{msg}");
 }
@@ -157,23 +157,30 @@ fn the_kind_ledger_reports_kind_drift_at_a_shared_prefix() {
 #[test]
 fn the_kind_ledger_treats_a_constraint_change_as_kind_drift() {
     let mut ledger = KindLedger::default();
-    assert!(ledger.observe(&[int_node(0, 5)]).is_none());
-    assert!(ledger.observe(&[int_node(1, 5)]).is_some());
+    assert!(ledger.observe(&[int_node(0, 5)]).unwrap().is_none());
+    assert!(ledger.observe(&[int_node(1, 5)]).unwrap().is_some());
 }
 
 #[test]
 fn kind_drift_is_scoped_to_the_value_prefix() {
     let mut ledger = KindLedger::default();
-    assert!(ledger.observe(&[bool_node(true), int_node(0, 5)]).is_none());
+    assert!(
+        ledger
+            .observe(&[bool_node(true), int_node(0, 5)])
+            .unwrap()
+            .is_none()
+    );
     assert!(
         ledger
             .observe(&[bool_node(false), bool_node(true)])
+            .unwrap()
             .is_none(),
         "a different position-0 value opens an independent prefix"
     );
     assert!(
         ledger
             .observe(&[bool_node(true), bool_node(true)])
+            .unwrap()
             .is_some(),
         "the same position-0 value must reuse the recorded prefix"
     );
@@ -183,9 +190,9 @@ fn kind_drift_is_scoped_to_the_value_prefix() {
 fn the_kind_ledger_stops_learning_at_its_cap_but_keeps_checking() {
     let mut ledger = KindLedger::default();
     let long: Vec<ChoiceNode> = (0..KIND_LEDGER_CAP + 10).map(|_| bool_node(true)).collect();
-    assert!(ledger.observe(&long).is_none());
+    assert!(ledger.observe(&long).unwrap().is_none());
     assert_eq!(ledger.entries.len(), KIND_LEDGER_CAP);
-    assert!(ledger.observe(&[int_node(0, 5)]).is_some());
+    assert!(ledger.observe(&[int_node(0, 5)]).unwrap().is_some());
     ledger.clear();
-    assert!(ledger.observe(&[int_node(0, 5)]).is_none());
+    assert!(ledger.observe(&[int_node(0, 5)]).unwrap().is_none());
 }

--- a/hegel-c/tests/embedded/native/state_clone_tests.rs
+++ b/hegel-c/tests/embedded/native/state_clone_tests.rs
@@ -1,5 +1,7 @@
 use super::*;
+use crate::native::blob::{decode_failure, encode_failure};
 use crate::native::core::{BUFFER_SIZE, MAX_CLONE_DEPTH};
+use crate::native::database::{deserialize_choices, serialize_choices};
 use crate::native::rng::EngineRng;
 
 fn draw(ntc: &mut NativeTestCase) -> i128 {
@@ -227,6 +229,28 @@ fn clone_nesting_beyond_max_depth_is_invalid() {
     let too_deep = current.lock().clone_stream();
     assert!(matches!(too_deep, Err(EngineError::InvalidTestCase)));
     assert_eq!(parent.status(), Some(Status::Invalid));
+}
+
+#[test]
+fn clone_nesting_at_max_depth_encodes_and_round_trips() {
+    let mut parent = NativeTestCase::new_random(EngineRng::seeded(7)).unwrap();
+    let mut handles = Vec::new();
+    let mut current = parent.clone_stream().unwrap();
+    for _ in 1..MAX_CLONE_DEPTH {
+        let next = current.lock().clone_stream().unwrap();
+        handles.push(current);
+        current = next;
+    }
+    draw(&mut current.lock());
+    handles.push(current);
+    parent.conclude(Status::Valid, None);
+    parent.reassemble();
+
+    let choices: Vec<ChoiceValue> = parent.nodes.iter().map(|n| n.value()).collect();
+    let bytes = serialize_choices(&choices).unwrap();
+    assert_eq!(deserialize_choices(&bytes), Some(choices.clone()));
+    let blob = encode_failure(&choices).unwrap();
+    assert_eq!(decode_failure(&blob), Some(choices));
 }
 
 #[test]

--- a/hegel-c/tests/embedded/native/test_runner_tests.rs
+++ b/hegel-c/tests/embedded/native/test_runner_tests.rs
@@ -475,7 +475,9 @@ fn the_execution_cache_is_flushed_and_serving_stops_at_the_flip() {
             assert_eq!(count.get(), 2);
             assert!(ctx.nondeterministic);
             assert!(
-                ctx.exec_cache.serve(&serialize_choices(&choices)).is_none(),
+                ctx.exec_cache
+                    .serve(&serialize_choices(&choices).unwrap())
+                    .is_none(),
                 "the flip flushes the cache"
             );
 
@@ -1183,7 +1185,10 @@ fn reuse_replay_extends_past_stored_prefix() {
     let dir = tempfile::TempDir::new().unwrap();
     let path = dir.path().to_str().unwrap().to_string();
     let db = DirectoryTestCaseDatabase::new(&path);
-    db.save(b"k", &serialize_choices(&[ChoiceValue::Boolean(true)]));
+    db.save(
+        b"k",
+        &serialize_choices(&[ChoiceValue::Boolean(true)]).unwrap(),
+    );
 
     let result = reuse_run(
         Settings::new()
@@ -1221,12 +1226,12 @@ fn reuse_consults_secondary_corpus_when_primary_fails_to_reproduce() {
     let db = DirectoryTestCaseDatabase::new(&path);
     db.save(
         b"k",
-        &serialize_choices(&[ChoiceValue::Integer(BigInt::from(7))]),
+        &serialize_choices(&[ChoiceValue::Integer(BigInt::from(7))]).unwrap(),
     );
     let secondary_key = crate::native::database::sub_key(b"k", b"secondary");
     db.save(
         &secondary_key,
-        &serialize_choices(&[ChoiceValue::Integer(BigInt::from(4242))]),
+        &serialize_choices(&[ChoiceValue::Integer(BigInt::from(4242))]).unwrap(),
     );
 
     let result = reuse_run(
@@ -1256,13 +1261,13 @@ fn reuse_randomly_samples_secondary_corpus_when_it_overflows_the_shortfall() {
     let db = DirectoryTestCaseDatabase::new(&path);
     db.save(
         b"k",
-        &serialize_choices(&[ChoiceValue::Integer(BigInt::from(7))]),
+        &serialize_choices(&[ChoiceValue::Integer(BigInt::from(7))]).unwrap(),
     );
     let secondary_key = crate::native::database::sub_key(b"k", b"secondary");
     for n in [4242, 4243, 4244, 4245] {
         db.save(
             &secondary_key,
-            &serialize_choices(&[ChoiceValue::Integer(BigInt::from(n))]),
+            &serialize_choices(&[ChoiceValue::Integer(BigInt::from(n))]).unwrap(),
         );
     }
 
@@ -1292,7 +1297,7 @@ fn shrink_phase_drains_stale_secondary_corpus_entries() {
     let path = dir.path().to_str().unwrap().to_string();
     let db = DirectoryTestCaseDatabase::new(&path);
     let secondary_key = crate::native::database::sub_key(b"k", b"secondary");
-    let stale = serialize_choices(&[ChoiceValue::Integer(BigInt::from(5))]);
+    let stale = serialize_choices(&[ChoiceValue::Integer(BigInt::from(5))]).unwrap();
     db.save(&secondary_key, &stale);
 
     let result = reuse_run(
@@ -1348,11 +1353,11 @@ fn reuse_stops_after_first_reproduced_bug_without_multiple_reporting() {
     let db = DirectoryTestCaseDatabase::new(&path);
     db.save(
         b"k",
-        &serialize_choices(&[ChoiceValue::Integer(BigInt::from(1111))]),
+        &serialize_choices(&[ChoiceValue::Integer(BigInt::from(1111))]).unwrap(),
     );
     db.save(
         b"k",
-        &serialize_choices(&[ChoiceValue::Integer(BigInt::from(2222))]),
+        &serialize_choices(&[ChoiceValue::Integer(BigInt::from(2222))]).unwrap(),
     );
 
     let calls = AtomicUsize::new(0);
@@ -1392,7 +1397,7 @@ fn reuse_found_bug_skips_generation_entirely() {
     let db = DirectoryTestCaseDatabase::new(&path);
     db.save(
         b"k",
-        &serialize_choices(&[ChoiceValue::Integer(BigInt::from(4242))]),
+        &serialize_choices(&[ChoiceValue::Integer(BigInt::from(4242))]).unwrap(),
     );
 
     let calls = AtomicUsize::new(0);
@@ -1579,7 +1584,7 @@ fn nondeterministic_run_discards_stale_entries_and_persists_nothing() {
     let dir = tempfile::TempDir::new().unwrap();
     let path = dir.path().to_str().unwrap().to_string();
     let db = DirectoryTestCaseDatabase::new(&path);
-    let seeded = serialize_choices(&[ChoiceValue::Boolean(true)]);
+    let seeded = serialize_choices(&[ChoiceValue::Boolean(true)]).unwrap();
     db.save(b"k", &seeded);
 
     let result = reuse_run(
@@ -1680,8 +1685,14 @@ fn reuse_detects_nondeterministic_generator_across_replays() {
     let dir = tempfile::TempDir::new().unwrap();
     let path = dir.path().to_str().unwrap().to_string();
     let db = DirectoryTestCaseDatabase::new(&path);
-    db.save(b"k", &serialize_choices(&[ChoiceValue::Boolean(true)]));
-    db.save(b"k", &serialize_choices(&[ChoiceValue::Boolean(false)]));
+    db.save(
+        b"k",
+        &serialize_choices(&[ChoiceValue::Boolean(true)]).unwrap(),
+    );
+    db.save(
+        b"k",
+        &serialize_choices(&[ChoiceValue::Boolean(false)]).unwrap(),
+    );
 
     let flip = AtomicUsize::new(0);
     let result = reuse_run(
@@ -1719,7 +1730,10 @@ fn nondeterministic_generator_contradicts_the_reuse_fed_kind_ledger_at_simplest_
     let dir = tempfile::TempDir::new().unwrap();
     let path = dir.path().to_str().unwrap().to_string();
     let db = DirectoryTestCaseDatabase::new(&path);
-    db.save(b"k", &serialize_choices(&[ChoiceValue::Boolean(true)]));
+    db.save(
+        b"k",
+        &serialize_choices(&[ChoiceValue::Boolean(true)]).unwrap(),
+    );
 
     let flip = AtomicUsize::new(0);
     let result = reuse_run(
@@ -1952,11 +1966,11 @@ impl TestCaseDatabase for LoggingDatabase {
 fn persister_saves_new_bytes_before_deleting_superseded() {
     let db = LoggingDatabase::default();
     let mut persister = Persister::new(Some(Box::new(db.clone())), Some("k"));
-    persister.record("Panic: bug", &[int_node(5)]);
-    persister.record("Panic: bug", &[int_node(3)]);
+    persister.record("Panic: bug", &[int_node(5)]).unwrap();
+    persister.record("Panic: bug", &[int_node(3)]).unwrap();
 
-    let old = serialize_choices(&[ChoiceValue::Integer(BigInt::from(5))]);
-    let new = serialize_choices(&[ChoiceValue::Integer(BigInt::from(3))]);
+    let old = serialize_choices(&[ChoiceValue::Integer(BigInt::from(5))]).unwrap();
+    let new = serialize_choices(&[ChoiceValue::Integer(BigInt::from(3))]).unwrap();
     let ops = db.ops();
     let saved_new = ops
         .iter()
@@ -1979,12 +1993,12 @@ fn persister_saves_new_bytes_before_deleting_superseded() {
 fn persister_deletes_superseded_same_run_saves() {
     let db = LoggingDatabase::default();
     let mut persister = Persister::new(Some(Box::new(db.clone())), Some("k"));
-    persister.record("Panic: bug", &[int_node(5)]);
-    persister.record("Panic: bug", &[int_node(3)]);
+    persister.record("Panic: bug", &[int_node(5)]).unwrap();
+    persister.record("Panic: bug", &[int_node(3)]).unwrap();
 
     assert_eq!(
         db.fetch(b"k"),
-        vec![serialize_choices(&[ChoiceValue::Integer(BigInt::from(3))])]
+        vec![serialize_choices(&[ChoiceValue::Integer(BigInt::from(3))]).unwrap()]
     );
     let secondary = crate::native::database::sub_key(b"k", b"secondary");
     assert!(
@@ -2001,7 +2015,8 @@ fn end_of_run_reconciliation_demotes_only_the_run_start_primary() {
     let run_start = serialize_choices(&[
         ChoiceValue::Integer(BigInt::from(1005)),
         ChoiceValue::Boolean(true),
-    ]);
+    ])
+    .unwrap();
     db.save(b"k", &run_start);
 
     let result = reuse_run(
@@ -2020,9 +2035,7 @@ fn end_of_run_reconciliation_demotes_only_the_run_start_primary() {
     assert_eq!(result.failures.len(), 1);
     assert_eq!(
         db.fetch(b"k"),
-        vec![serialize_choices(&[ChoiceValue::Integer(BigInt::from(
-            1000
-        ))])]
+        vec![serialize_choices(&[ChoiceValue::Integer(BigInt::from(1000))]).unwrap()]
     );
     let secondary = crate::native::database::sub_key(b"k", b"secondary");
     assert_eq!(
@@ -2038,7 +2051,7 @@ fn secondary_corpus_cap_evicts_shortlex_largest() {
     let path = dir.path().to_str().unwrap().to_string();
     let db = DirectoryTestCaseDatabase::new(&path);
     let secondary = crate::native::database::sub_key(b"k", b"secondary");
-    let entry = |n: i64| serialize_choices(&[ChoiceValue::Integer(BigInt::from(n))]);
+    let entry = |n: i64| serialize_choices(&[ChoiceValue::Integer(BigInt::from(n))]).unwrap();
     for n in 0..55 {
         db.save(&secondary, &entry(n));
     }
@@ -2071,11 +2084,12 @@ fn superseding_a_reused_run_start_entry_demotes_it_to_secondary() {
     let dir = tempfile::TempDir::new().unwrap();
     let path = dir.path().to_str().unwrap().to_string();
     let db = DirectoryTestCaseDatabase::new(&path);
-    let run_start = serialize_choices(&[ChoiceValue::Integer(BigInt::from(90))]);
+    let run_start = serialize_choices(&[ChoiceValue::Integer(BigInt::from(90))]).unwrap();
     let misaligned = serialize_choices(&[
         ChoiceValue::Integer(BigInt::from(95)),
         ChoiceValue::Integer(BigInt::from(3)),
-    ]);
+    ])
+    .unwrap();
     db.save(b"k", &run_start);
     db.save(b"k", &misaligned);
     let mut run_case = |ds: Box<dyn DataSource + Send + Sync>| {
@@ -2099,7 +2113,7 @@ fn superseding_a_reused_run_start_entry_demotes_it_to_secondary() {
     )
     .unwrap();
     assert_eq!(result.failures.len(), 1);
-    let shrunk = serialize_choices(&[ChoiceValue::Integer(BigInt::from(50))]);
+    let shrunk = serialize_choices(&[ChoiceValue::Integer(BigInt::from(50))]).unwrap();
     assert_eq!(db.fetch(b"k"), vec![shrunk]);
     let secondary = crate::native::database::sub_key(b"k", b"secondary");
     assert!(
@@ -2112,14 +2126,14 @@ fn superseding_a_reused_run_start_entry_demotes_it_to_secondary() {
 fn superseding_one_origin_keeps_a_byte_identical_entry_shared_with_another() {
     let db = LoggingDatabase::default();
     let mut persister = Persister::new(Some(Box::new(db.clone())), Some("k"));
-    persister.record("Panic: a", &[int_node(90)]);
-    persister.record("Panic: b", &[int_node(90)]);
+    persister.record("Panic: a", &[int_node(90)]).unwrap();
+    persister.record("Panic: b", &[int_node(90)]).unwrap();
     assert_eq!(db.fetch(b"k").len(), 1);
 
-    persister.record("Panic: a", &[int_node(50)]);
+    persister.record("Panic: a", &[int_node(50)]).unwrap();
 
-    let shared = serialize_choices(&[ChoiceValue::Integer(BigInt::from(90))]);
-    let smaller = serialize_choices(&[ChoiceValue::Integer(BigInt::from(50))]);
+    let shared = serialize_choices(&[ChoiceValue::Integer(BigInt::from(90))]).unwrap();
+    let smaller = serialize_choices(&[ChoiceValue::Integer(BigInt::from(50))]).unwrap();
     let primary = db.fetch(b"k");
     assert!(
         primary.contains(&shared),
@@ -2137,14 +2151,16 @@ fn shrink_phase_drain_stops_at_entries_above_the_largest_surviving_failure() {
     let run_start = serialize_choices(&[
         ChoiceValue::Integer(BigInt::from(90)),
         ChoiceValue::Boolean(true),
-    ]);
+    ])
+    .unwrap();
     db.save(b"k", &run_start);
     let secondary = crate::native::database::sub_key(b"k", b"secondary");
-    let small = serialize_choices(&[ChoiceValue::Integer(BigInt::from(10))]);
+    let small = serialize_choices(&[ChoiceValue::Integer(BigInt::from(10))]).unwrap();
     let large = serialize_choices(&[
         ChoiceValue::Integer(BigInt::from(80)),
         ChoiceValue::Integer(BigInt::from(4)),
-    ]);
+    ])
+    .unwrap();
     db.save(&secondary, &small);
     db.save(&secondary, &large);
 
@@ -2162,7 +2178,7 @@ fn shrink_phase_drain_stops_at_entries_above_the_largest_surviving_failure() {
     )
     .unwrap();
     assert_eq!(result.failures.len(), 1);
-    let shrunk = serialize_choices(&[ChoiceValue::Integer(BigInt::from(50))]);
+    let shrunk = serialize_choices(&[ChoiceValue::Integer(BigInt::from(50))]).unwrap();
     assert_eq!(db.fetch(b"k"), vec![shrunk]);
     let kept = db.fetch(&secondary);
     assert!(
@@ -2184,14 +2200,14 @@ fn reconciliation_deletes_a_same_run_leftover_absent_from_the_final_failures() {
     let settings = Settings::new().database(Some(path));
     let exchange = CaseExchange::new();
     let mut ctx = Engine::new(&settings, Some("k"), &exchange).unwrap();
-    ctx.persister.record("Panic: bug", &[int_node(90)]);
+    ctx.persister.record("Panic: bug", &[int_node(90)]).unwrap();
     ctx.interesting
         .insert("Panic: bug".to_string(), vec![int_node(50)]);
-    ctx.reconcile_database();
+    ctx.reconcile_database().unwrap();
 
     assert_eq!(
         db.fetch(b"k"),
-        vec![serialize_choices(&[ChoiceValue::Integer(BigInt::from(50))])]
+        vec![serialize_choices(&[ChoiceValue::Integer(BigInt::from(50))]).unwrap()]
     );
     let secondary = crate::native::database::sub_key(b"k", b"secondary");
     assert!(


### PR DESCRIPTION
<details>
<summary>This text was written by an AI agent</summary>

_Written by a Claude agent working through Andon, reviewed by David before posting._

Fixes #477.

`serialize_choices` and `encode_failure` accepted choice sequences whose `Clone` values nest deeper than `MAX_CLONE_DEPTH` (100), but `deserialize_choices` and `decode_failure` reject that depth, so the encoders could emit database entries and reproduce blobs that never read back. Both encoders now return `None` for such a sequence, matching the decoders' bound.

The engine bounds clone nesting as a test case runs (`clone_stream` rejects the clone that would exceed the depth), so the callers in `test_runner` — the persister, end-of-run database reconciliation, the reuse-phase shortlex comparison, and the final reproduce blobs — treat a refusal as a violated internal invariant via `hegel_internal_unwrap!` rather than a user-facing error.

Tests: depth 100 round-trips and depth 101 is refused, for both `serialize_choices` and `encode_failure`; an engine-built clone chain at `MAX_CLONE_DEPTH` serializes and encodes and round-trips; existing callers updated for the `Option` return.

`hegel-c/RELEASE.md` added as a patch release.

</details>