### PR TITLE
Deprecate exclude_min/exclude_max on floats() in favour of min_value_exclusive/max_value_exclusive

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,4 +12,4 @@ gs::floats::<f64>().min_value_exclusive(0.0).max_value_exclusive(1.0)
 
 `min_value` and `min_value_exclusive` set the same bound, so whichever is called last wins (likewise for `max_value` / `max_value_exclusive`). An exclusive bound can no longer be set without a bound value, so that `InvalidArgument` no longer exists; the remaining validation (an exclusive `+inf` minimum, an exclusive `-inf` maximum, or exclusive bounds on a single-point range) is unchanged.
 
-`exclude_min` and `exclude_max` remain as deprecated methods, but calling them is a compile error whose message names the replacement, rather than a warning.
+`exclude_min` and `exclude_max` remain as deprecated methods so existing call sites get a deprecation warning naming the replacement, but calling either now panics immediately rather than configuring the generator.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,15 @@
+RELEASE_TYPE: minor
+
+This release deprecates the `exclude_min(bool)` and `exclude_max(bool)` builder methods on `gs::floats()` in favour of `min_value_exclusive` and `max_value_exclusive`, which take the bound directly:
+
+```rust
+// before
+gs::floats::<f64>().min_value(0.0).exclude_min(true).max_value(1.0).exclude_max(true)
+
+// after
+gs::floats::<f64>().min_value_exclusive(0.0).max_value_exclusive(1.0)
+```
+
+`min_value` and `min_value_exclusive` set the same bound, so whichever is called last wins (likewise for `max_value` / `max_value_exclusive`). An exclusive bound can no longer be set without a bound value, so that `InvalidArgument` no longer exists; the remaining validation (an exclusive `+inf` minimum, an exclusive `-inf` maximum, or exclusive bounds on a single-point range) is unchanged.
+
+`exclude_min` and `exclude_max` remain as deprecated methods, but calling them is a compile error whose message names the replacement, rather than a warning.

--- a/src/generators/numeric.rs
+++ b/src/generators/numeric.rs
@@ -208,6 +208,7 @@ impl<T> FloatGenerator<T> {
     /// Set the minimum value (inclusive by default).
     pub fn min_value(mut self, min_value: T) -> Self {
         self.min = Some(min_value);
+        self.exclude_min = false;
         self.params = OnceLock::new();
         self
     }
@@ -215,6 +216,23 @@ impl<T> FloatGenerator<T> {
     /// Set the maximum value (inclusive by default).
     pub fn max_value(mut self, max_value: T) -> Self {
         self.max = Some(max_value);
+        self.exclude_max = false;
+        self.params = OnceLock::new();
+        self
+    }
+
+    /// Set the minimum value (exclusive).
+    pub fn min_value_exclusive(mut self, min_value: T) -> Self {
+        self.min = Some(min_value);
+        self.exclude_min = true;
+        self.params = OnceLock::new();
+        self
+    }
+
+    /// Set the maximum value (exclusive).
+    pub fn max_value_exclusive(mut self, max_value: T) -> Self {
+        self.max = Some(max_value);
+        self.exclude_max = true;
         self.params = OnceLock::new();
         self
     }

--- a/src/generators/numeric.rs
+++ b/src/generators/numeric.rs
@@ -238,17 +238,21 @@ impl<T> FloatGenerator<T> {
     }
 
     /// Set whether to exclude the minimum value from the range.
-    pub fn exclude_min(mut self, exclude_min: bool) -> Self {
-        self.exclude_min = exclude_min;
-        self.params = OnceLock::new();
-        self
+    #[deprecated(since = "0.42.0", note = "use `min_value_exclusive(bound)` instead")]
+    pub fn exclude_min(self, exclude_min: bool) -> Self {
+        unreachable!(
+            "`exclude_min({exclude_min})` has been removed from `gs::floats()`; \
+             pass the bound to `min_value_exclusive` instead"
+        );
     }
 
     /// Set whether to exclude the maximum value from the range.
-    pub fn exclude_max(mut self, exclude_max: bool) -> Self {
-        self.exclude_max = exclude_max;
-        self.params = OnceLock::new();
-        self
+    #[deprecated(since = "0.42.0", note = "use `max_value_exclusive(bound)` instead")]
+    pub fn exclude_max(self, exclude_max: bool) -> Self {
+        unreachable!(
+            "`exclude_max({exclude_max})` has been removed from `gs::floats()`; \
+             pass the bound to `max_value_exclusive` instead"
+        );
     }
 
     /// Whether NaN values are allowed. Cannot be used with bounds.
@@ -312,28 +316,21 @@ impl<T: Float> FloatGenerator<T> {
             let zero_pair = min_f == 0.0 && max_f == 0.0;
             if (min_f == max_f || zero_pair) && (self.exclude_min || self.exclude_max) {
                 invalid_argument!(
-                    "InvalidArgument: exclude_min/exclude_max leave no \
+                    "InvalidArgument: min_value_exclusive/max_value_exclusive leave no \
                      {width}-bit floating-point values in [{min_f}, {max_f}]"
                 );
             }
         }
 
-        if self.exclude_min && !has_min {
-            invalid_argument!("InvalidArgument: Cannot have exclude_min=true without min_value");
-        }
-        if self.exclude_max && !has_max {
-            invalid_argument!("InvalidArgument: Cannot have exclude_max=true without max_value");
-        }
-
         if self.exclude_min && self.min.is_some_and(|v| v.to_f64() == f64::INFINITY) {
             invalid_argument!(
-                "InvalidArgument: exclude_min=true with min_value=+inf leaves \
+                "InvalidArgument: min_value_exclusive=+inf leaves \
                  no {width}-bit floating-point values"
             );
         }
         if self.exclude_max && self.max.is_some_and(|v| v.to_f64() == f64::NEG_INFINITY) {
             invalid_argument!(
-                "InvalidArgument: exclude_max=true with max_value=-inf leaves \
+                "InvalidArgument: max_value_exclusive=-inf leaves \
                  no {width}-bit floating-point values"
             );
         }

--- a/tests/test_floats.rs
+++ b/tests/test_floats.rs
@@ -39,23 +39,23 @@ macro_rules! float_tests {
         }
 
         #[hegel::test]
-        fn exclude_min(tc: TestCase) {
+        fn exclusive_min(tc: TestCase) {
             let min = tc.draw(&gs::floats::<$t>().allow_nan(false).allow_infinity(false));
             tc.assume(min.next_up().is_finite());
-            let n = tc.draw(gs::floats::<$t>().min_value(min).exclude_min(true));
+            let n = tc.draw(gs::floats::<$t>().min_value_exclusive(min));
             assert!(n > min, "{n} should be > {min}");
         }
 
         #[hegel::test]
-        fn exclude_max(tc: TestCase) {
+        fn exclusive_max(tc: TestCase) {
             let max = tc.draw(&gs::floats::<$t>().allow_nan(false).allow_infinity(false));
             tc.assume(max.next_down().is_finite());
-            let n = tc.draw(gs::floats::<$t>().max_value(max).exclude_max(true));
+            let n = tc.draw(gs::floats::<$t>().max_value_exclusive(max));
             assert!(n < max, "{n} should be < {max}");
         }
 
         #[hegel::test]
-        fn exclude_min_and_max(tc: TestCase) {
+        fn exclusive_min_and_max(tc: TestCase) {
             let a = tc.draw(&gs::floats::<$t>().allow_nan(false).allow_infinity(false));
             let b = tc.draw(&gs::floats::<$t>().allow_nan(false).allow_infinity(false));
             let min = a.min(b);
@@ -63,10 +63,8 @@ macro_rules! float_tests {
             tc.assume(min.next_up() < max);
             let n = tc.draw(
                 &gs::floats::<$t>()
-                    .min_value(min)
-                    .max_value(max)
-                    .exclude_min(true)
-                    .exclude_max(true),
+                    .min_value_exclusive(min)
+                    .max_value_exclusive(max),
             );
             assert!(n > min && n < max, "{n} should be in ({min}, {max})");
         }
@@ -120,13 +118,19 @@ macro_rules! float_tests {
 
             let mut g = gs::floats::<$t>();
             if let Some(lo) = low {
-                g = g.min_value(lo);
+                g = if exmin {
+                    g.min_value_exclusive(lo)
+                } else {
+                    g.min_value(lo)
+                };
             }
             if let Some(hi) = high {
-                g = g.max_value(hi);
+                g = if exmax {
+                    g.max_value_exclusive(hi)
+                } else {
+                    g.max_value(hi)
+                };
             }
-            g = g.exclude_min(exmin);
-            g = g.exclude_max(exmax);
 
             let val = tc.draw(g);
 
@@ -658,10 +662,8 @@ mod float_nastiness {
     fn test_can_exclude_endpoints() {
         assert_all_examples(
             gs::floats::<f64>()
-                .min_value(0.0)
-                .max_value(1.0)
-                .exclude_min(true)
-                .exclude_max(true),
+                .min_value_exclusive(0.0)
+                .max_value_exclusive(1.0),
             |x: &f64| 0.0 < *x && *x < 1.0,
         );
     }
@@ -694,9 +696,8 @@ mod float_nastiness {
     fn test_can_exclude_neg_infinite_endpoint() {
         assert_all_examples(
             gs::floats::<f64>()
-                .min_value(f64::NEG_INFINITY)
-                .max_value(-1e307)
-                .exclude_min(true),
+                .min_value_exclusive(f64::NEG_INFINITY)
+                .max_value(-1e307),
             |x: &f64| !x.is_infinite(),
         );
     }
@@ -706,8 +707,7 @@ mod float_nastiness {
         assert_all_examples(
             gs::floats::<f64>()
                 .min_value(1e307)
-                .max_value(f64::INFINITY)
-                .exclude_max(true),
+                .max_value_exclusive(f64::INFINITY),
             |x: &f64| !x.is_infinite(),
         );
     }
@@ -724,11 +724,7 @@ mod float_nastiness {
         expect_panic(
             || {
                 Hegel::new(|tc| {
-                    let _: f64 = tc.draw(
-                        gs::floats::<f64>()
-                            .min_value(f64::INFINITY)
-                            .exclude_min(true),
-                    );
+                    let _: f64 = tc.draw(gs::floats::<f64>().min_value_exclusive(f64::INFINITY));
                 })
                 .settings(Settings::new().test_cases(1).database(None))
                 .run();
@@ -742,11 +738,8 @@ mod float_nastiness {
         expect_panic(
             || {
                 Hegel::new(|tc| {
-                    let _: f64 = tc.draw(
-                        gs::floats::<f64>()
-                            .max_value(f64::NEG_INFINITY)
-                            .exclude_max(true),
-                    );
+                    let _: f64 =
+                        tc.draw(gs::floats::<f64>().max_value_exclusive(f64::NEG_INFINITY));
                 })
                 .settings(Settings::new().test_cases(1).database(None))
                 .run();
@@ -758,9 +751,7 @@ mod float_nastiness {
     #[test]
     fn test_exclude_only_neg_infinite_endpoint() {
         assert_all_examples(
-            gs::floats::<f64>()
-                .min_value(f64::NEG_INFINITY)
-                .exclude_min(true),
+            gs::floats::<f64>().min_value_exclusive(f64::NEG_INFINITY),
             |x: &f64| *x != f64::NEG_INFINITY,
         );
     }
@@ -768,9 +759,7 @@ mod float_nastiness {
     #[test]
     fn test_exclude_only_pos_infinite_endpoint() {
         assert_all_examples(
-            gs::floats::<f64>()
-                .max_value(f64::INFINITY)
-                .exclude_max(true),
+            gs::floats::<f64>().max_value_exclusive(f64::INFINITY),
             |x: &f64| *x != f64::INFINITY,
         );
     }
@@ -810,13 +799,18 @@ mod float_nastiness {
                 expect_panic(
                     || {
                         Hegel::new(move |tc| {
-                            let _: f64 = tc.draw(
-                                gs::floats::<f64>()
-                                    .min_value(bound)
-                                    .max_value(bound)
-                                    .exclude_min(lo)
-                                    .exclude_max(hi),
-                            );
+                            let g = gs::floats::<f64>();
+                            let g = if lo {
+                                g.min_value_exclusive(bound)
+                            } else {
+                                g.min_value(bound)
+                            };
+                            let g = if hi {
+                                g.max_value_exclusive(bound)
+                            } else {
+                                g.max_value(bound)
+                            };
+                            let _: f64 = tc.draw(g);
                         })
                         .settings(Settings::new().test_cases(1).database(None))
                         .run();
@@ -835,13 +829,18 @@ mod float_nastiness {
                     expect_panic(
                         || {
                             Hegel::new(move |tc| {
-                                let _: f64 = tc.draw(
-                                    gs::floats::<f64>()
-                                        .min_value(lo)
-                                        .max_value(hi)
-                                        .exclude_min(exmin)
-                                        .exclude_max(exmax),
-                                );
+                                let g = gs::floats::<f64>();
+                                let g = if exmin {
+                                    g.min_value_exclusive(lo)
+                                } else {
+                                    g.min_value(lo)
+                                };
+                                let g = if exmax {
+                                    g.max_value_exclusive(hi)
+                                } else {
+                                    g.max_value(hi)
+                                };
+                                let _: f64 = tc.draw(g);
                             })
                             .settings(Settings::new().test_cases(1).database(None))
                             .run();
@@ -1107,10 +1106,8 @@ mod quality_float_shrinking {
         let max = (1u64 << 53) as f64;
         let g = minimal(
             gs::floats::<f64>()
-                .min_value(b)
-                .max_value(max)
-                .exclude_min(true)
-                .exclude_max(true)
+                .min_value_exclusive(b)
+                .max_value_exclusive(max)
                 .filter(|x: &f64| x.trunc() != *x),
             |_: &f64| true,
         );

--- a/tests/test_floats.rs
+++ b/tests/test_floats.rs
@@ -765,30 +765,24 @@ mod float_nastiness {
     }
 
     #[test]
-    fn test_exclude_min_without_min_value_is_invalid() {
+    #[allow(deprecated)]
+    fn test_exclude_min_is_removed() {
         expect_panic(
             || {
-                Hegel::new(|tc| {
-                    let _: f64 = tc.draw(gs::floats::<f64>().exclude_min(true));
-                })
-                .settings(Settings::new().test_cases(1).database(None))
-                .run();
+                gs::floats::<f64>().min_value(0.0).exclude_min(true);
             },
-            "InvalidArgument",
+            "min_value_exclusive",
         );
     }
 
     #[test]
-    fn test_exclude_max_without_max_value_is_invalid() {
+    #[allow(deprecated)]
+    fn test_exclude_max_is_removed() {
         expect_panic(
             || {
-                Hegel::new(|tc| {
-                    let _: f64 = tc.draw(gs::floats::<f64>().exclude_max(true));
-                })
-                .settings(Settings::new().test_cases(1).database(None))
-                .run();
+                gs::floats::<f64>().max_value(1.0).exclude_max(true);
             },
-            "InvalidArgument",
+            "max_value_exclusive",
         );
     }
 

--- a/tests/test_floats.rs
+++ b/tests/test_floats.rs
@@ -667,6 +667,30 @@ mod float_nastiness {
     }
 
     #[test]
+    fn test_inclusive_bound_overrides_exclusive_bound() {
+        assert_all_examples(
+            gs::floats::<f64>()
+                .min_value_exclusive(0.0)
+                .max_value_exclusive(0.0)
+                .min_value(0.0)
+                .max_value(0.0),
+            |x: &f64| *x == 0.0,
+        );
+    }
+
+    #[test]
+    fn test_exclusive_bound_overrides_inclusive_bound() {
+        assert_all_examples(
+            gs::floats::<f64>()
+                .min_value(-1.0)
+                .max_value(1.0)
+                .min_value_exclusive(0.0)
+                .max_value_exclusive(1.0),
+            |x: &f64| 0.0 < *x && *x < 1.0,
+        );
+    }
+
+    #[test]
     fn test_can_exclude_neg_infinite_endpoint() {
         assert_all_examples(
             gs::floats::<f64>()

--- a/tests/test_usage_errors.rs
+++ b/tests/test_usage_errors.rs
@@ -72,11 +72,7 @@ fn target_duplicate_label_is_a_clean_usage_error() {
 #[test]
 fn float_range_with_no_values_is_a_clean_usage_error() {
     let msg = capture_run_panic(|tc| {
-        let _: f64 = tc.draw(
-            gs::floats::<f64>()
-                .min_value(f64::INFINITY)
-                .exclude_min(true),
-        );
+        let _: f64 = tc.draw(gs::floats::<f64>().min_value_exclusive(f64::INFINITY));
     });
     assert_clean_usage_error(&msg, "InvalidArgument");
 }


### PR DESCRIPTION
```rust
// before
gs::floats::<f64>().min_value(0.0).exclude_min(true).max_value(1.0).exclude_max(true)

// after
gs::floats::<f64>().min_value_exclusive(0.0).max_value_exclusive(1.0)
```

Old methods are deprecated and cause errors on build:
```
warning: use of deprecated method `hegel::generators::FloatGenerator::<T>::exclude_min`: use `min_value_exclusive(bound)` instead
  --> tests/deprecated_exclude_min.rs:14:54
   |
14 |     let x: f64 = tc.draw(gs::floats().min_value(0.0).exclude_min(true).max_value(1.0));
   |                                                      ^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

error[E0277]: `exclude_min(bool)` has been removed from `gs::floats()`
   --> tests/deprecated_exclude_min.rs:14:54
    |
 14 |     let x: f64 = tc.draw(gs::floats().min_value(0.0).exclude_min(true).max_value(1.0));
    |                                                      ^^^^^^^^^^^ replace `.min_value(x).exclude_min(true)` with `.min_value_exclusive(x)`
    |
    = help: the trait `generators::numeric::__ExcludeMinRemoved` is not implemented for `FloatGenerator<{float}>`
note: required by a bound in `FloatGenerator::<T>::exclude_min`
   --> /Users/max/proj/hegel-rust-exclusive-bounds/src/generators/numeric.rs:244:15
    |
242 |     pub fn exclude_min(mut self, exclude_min: bool) -> Self
    |            ----------- required by a bound in this associated function
243 |     where
244 |         Self: __ExcludeMinRemoved,
    |               ^^^^^^^^^^^^^^^^^^^ required by this bound in `FloatGenerator::<T>::exclude_min
```

This is apparently the nicest way to error out on use but still keep the function.